### PR TITLE
feat(operator): use newer catalog differ to prune content by omission

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/openshift/installer v0.16.1
 	github.com/openshift/library-go v0.0.0-20210831102543-1a08f0c3bd9a
 	github.com/openshift/oc v0.0.0-alpha.0.0.20210721184532-4df50be4d929
-	github.com/operator-framework/operator-registry v1.18.1-0.20210917182743-3880486cea2b
+	github.com/operator-framework/operator-registry v1.19.2-0.20211105235100-29cd8e3f02f9
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
@@ -258,7 +259,7 @@ github.com/containerd/containerd v1.3.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMX
 github.com/containerd/containerd v1.4.0-beta.2.0.20200729163537-40b22ef07410/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.4.3/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
-github.com/containerd/containerd v1.4.8/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/containerd v1.4.11/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.5.0-beta.1/go.mod h1:5HfvG1V2FsKesEGQ17k5/T7V960Tmcumvqn8Mc+pCYQ=
 github.com/containerd/containerd v1.5.0-beta.3/go.mod h1:/wr9AVtEM7x9c+n0+stptlo/uBBoBORwEx6ardVcmKU=
 github.com/containerd/containerd v1.5.0-beta.4/go.mod h1:GmdgZd2zA2GYIBZ0w09ZvgqEq8EfBp/m3lcVZIvPHhI=
@@ -456,6 +457,7 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -1147,8 +1149,8 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/operator-framework/api v0.10.5 h1:/WvLKOPo8zZMyEmuW0kLC0PJBt4Xal8HZkFioKIxqTA=
 github.com/operator-framework/api v0.10.5/go.mod h1:tV0BUNvly7szq28ZPBXhjp1Sqg5yHCOeX19ui9K4vjI=
-github.com/operator-framework/operator-registry v1.18.1-0.20210917182743-3880486cea2b h1:3xAXHlZq4J2Xhl6GWKH811o6Li/9uyy8AmHjiNNDKTU=
-github.com/operator-framework/operator-registry v1.18.1-0.20210917182743-3880486cea2b/go.mod h1:ogmTxGxbWOvc1lqtZHCQny6sB4Xj3JOPzKJb9GOTQxs=
+github.com/operator-framework/operator-registry v1.19.2-0.20211105235100-29cd8e3f02f9 h1:XJ5ppz7ILYaxi0Xe7Zt2y7j8yZVY2xg9Z6LPnJbiF/8=
+github.com/operator-framework/operator-registry v1.19.2-0.20211105235100-29cd8e3f02f9/go.mod h1:VF8DhonwYH+FcauAJLcei5t5WjgmQT/cQrHdujrFpdY=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
@@ -1961,8 +1963,9 @@ google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAG
 google.golang.org/grpc v1.36.1/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.37.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.37.1/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
-google.golang.org/grpc v1.38.0 h1:/9BgsAsa5nWe26HqOlvlgJnqBuktYOLCgjCPqsa56W0=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
+google.golang.org/grpc v1.41.0 h1:f+PlOh7QV4iIJkPrx5NQ7qaNGFQ3OTse67yaDHfju4E=
+google.golang.org/grpc v1.41.0/go.mod h1:U3l9uK9J0sini8mHphKoXyaqDA/8VyGnDee1zzIUK6k=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200709232328-d8193ee9cc3e/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -113,29 +113,15 @@ func (o *OperatorOptions) Full(ctx context.Context, cfg v1alpha1.ImageSetConfigu
 
 	allAssocs := image.AssociationSet{}
 	for _, ctlg := range cfg.Mirror.Operators {
+
 		ctlgRef, err := imagesource.ParseReference(ctlg.Catalog)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing catalog: %v", err)
 		}
 		ctlgRef.Ref = ctlgRef.Ref.DockerClientDefaults()
 
-		catLogger := o.Logger.WithField("catalog", ctlg.Catalog)
-		var dc *declcfg.DeclarativeConfig
-		if ctlg.HeadsOnly {
-			// Generate and mirror a heads-only diff using only the catalog as a new ref.
-			dc, err = action.Diff{
-				Registry:      reg,
-				NewRefs:       []string{ctlg.Catalog},
-				Logger:        catLogger,
-				IncludeConfig: ctlg.DiffIncludeConfig,
-			}.Run(ctx)
-		} else {
-			// Mirror the entire catalog.
-			dc, err = action.Render{
-				Registry: reg,
-				Refs:     []string{ctlg.Catalog},
-			}.Run(ctx)
-		}
+		// Render the catalog to mirror into a declarative config.
+		dc, err := o.renderDCFull(ctx, reg, ctlg)
 		if err != nil {
 			return nil, err
 		}
@@ -156,6 +142,36 @@ func (o *OperatorOptions) Full(ctx context.Context, cfg v1alpha1.ImageSetConfigu
 	}
 
 	return allAssocs, nil
+}
+
+// renderDCFull renders data in ctlg into a declarative config for o.Full().
+func (o *OperatorOptions) renderDCFull(ctx context.Context, reg *containerdregistry.Registry, ctlg v1alpha1.Operator) (dc *declcfg.DeclarativeConfig, err error) {
+
+	hasInclude := len(ctlg.DiffIncludeConfig.Packages) != 0
+	// Only add on top of channel heads if both HeadsOnly and IncludeConfig are specified.
+	includeAdditively := ctlg.HeadsOnly && hasInclude
+	// Render the full catalog if neither HeadsOnly or IncludeConfig are specified (the default).
+	full := !ctlg.HeadsOnly && !hasInclude
+
+	catLogger := o.Logger.WithField("catalog", ctlg.Catalog)
+	if full {
+		// Mirror the entire catalog.
+		dc, err = action.Render{
+			Registry: reg,
+			Refs:     []string{ctlg.Catalog},
+		}.Run(ctx)
+	} else {
+		// Generate and mirror a heads-only diff using only the catalog as a new ref.
+		dc, err = action.Diff{
+			Registry:          reg,
+			NewRefs:           []string{ctlg.Catalog},
+			Logger:            catLogger,
+			IncludeConfig:     ctlg.DiffIncludeConfig,
+			IncludeAdditively: includeAdditively,
+		}.Run(ctx)
+	}
+
+	return dc, err
 }
 
 // Diff mirrors only the diff between each old and new catalog image pair
@@ -179,40 +195,18 @@ func (o *OperatorOptions) Diff(ctx context.Context, cfg v1alpha1.ImageSetConfigu
 
 	allAssocs := image.AssociationSet{}
 	for _, ctlg := range cfg.Mirror.Operators {
-		// Generate and mirror a heads-only diff using the catalog as a new ref,
-		// and an old ref found for this catalog in lastRun.
-		catLogger := o.Logger.WithField("catalog", ctlg.Catalog)
-		a := action.Diff{
-			Registry:      reg,
-			NewRefs:       []string{ctlg.Catalog},
-			Logger:        catLogger,
-			IncludeConfig: ctlg.DiffIncludeConfig,
-		}
-
-		// An old ref is always required to generate a latest diff.
-		for _, operator := range lastRun.Operators {
-			if operator.Catalog != ctlg.Catalog {
-				continue
-			}
-
-			if operator.ImagePin == "" {
-				return nil, fmt.Errorf("metadata sequence %d catalog %q: ImagePin must be set", lastRun.Sequence, ctlg.Catalog)
-			}
-
-			a.OldRefs = []string{operator.ImagePin}
-			break
-		}
-
-		dc, err := a.Run(ctx)
-		if err != nil {
-			return nil, err
-		}
 
 		ctlgRef, err := imagesource.ParseReference(ctlg.Catalog)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing catalog: %v", err)
 		}
 		ctlgRef.Ref = ctlgRef.Ref.DockerClientDefaults()
+
+		// Render the catalog to mirror into a declarative config.
+		dc, err := o.renderDCDiff(ctx, reg, ctlg, lastRun)
+		if err != nil {
+			return nil, err
+		}
 
 		isBlocked := func(ref imgreference.DockerImageReference) bool {
 			return bundle.IsBlocked(cfg, ref)
@@ -230,6 +224,40 @@ func (o *OperatorOptions) Diff(ctx context.Context, cfg v1alpha1.ImageSetConfigu
 	}
 
 	return allAssocs, nil
+}
+
+// renderDCDiff renders data in ctlg into a declarative config for o.Diff().
+func (o *OperatorOptions) renderDCDiff(ctx context.Context, reg *containerdregistry.Registry, ctlg v1alpha1.Operator, lastRun v1alpha1.PastMirror) (dc *declcfg.DeclarativeConfig, err error) {
+
+	// Generate and mirror a heads-only diff using the catalog as a new ref,
+	// and an old ref found for this catalog in lastRun.
+	catLogger := o.Logger.WithField("catalog", ctlg.Catalog)
+	a := action.Diff{
+		Registry:      reg,
+		NewRefs:       []string{ctlg.Catalog},
+		Logger:        catLogger,
+		IncludeConfig: ctlg.DiffIncludeConfig,
+		// This is hard-coded to false because a diff post-metadata creation must always include
+		// newly published catalog data to join graphs. Any included objects previously included
+		// will be added as a diff as part of the latest diff mode.
+		IncludeAdditively: false,
+	}
+
+	// An old ref is always required to generate a latest diff.
+	for _, operator := range lastRun.Operators {
+		if operator.Catalog != ctlg.Catalog {
+			continue
+		}
+
+		if operator.ImagePin == "" {
+			return nil, fmt.Errorf("metadata sequence %d catalog %q: ImagePin must be set", lastRun.Sequence, ctlg.Catalog)
+		}
+
+		a.OldRefs = []string{operator.ImagePin}
+		break
+	}
+
+	return a.Run(ctx)
 }
 
 func (o *OperatorOptions) mirror(ctx context.Context, dc *declcfg.DeclarativeConfig, ctlgRef imagesource.TypedImageReference, ctlg v1alpha1.Operator, isBlocked ...blockedFunc) (map[string]string, error) {

--- a/pkg/config/v1alpha1/config_types.go
+++ b/pkg/config/v1alpha1/config_types.go
@@ -52,6 +52,9 @@ type ReleaseChannel struct {
 
 // Operator configures operator catalog mirroring.
 type Operator struct {
+	// Mirror specific operator packages, channels, and versions, and their dependencies.
+	// If HeadsOnly is true, these objects are mirrored on top of heads of all channels.
+	// Otherwise, only these specific objects are mirrored.
 	action.DiffIncludeConfig `json:",inline"`
 
 	// Catalog image to mirror. This image must be pullable and available for subsequent


### PR DESCRIPTION
`IncludeAdditively: false` directs the differ to ignore all other operator packages/channels/versions except those specified in the config. `IncludeAdditively: true` gives the diff behavior prior to this PR.

Closes #65

/kind feature

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>