### PR TITLE
feat(publish): add registry as default backend for publishing

### DIFF
--- a/pkg/cli/mirror/create.go
+++ b/pkg/cli/mirror/create.go
@@ -58,10 +58,11 @@ func (o *MirrorOptions) Create(ctx context.Context, flags *pflag.FlagSet) error 
 	case err != nil && !errors.Is(err, storage.ErrMetadataNotExist):
 		return err
 	case err != nil && errors.Is(err, storage.ErrMetadataNotExist):
-		thisRun, err = o.createFull(ctx, flags, cfg, meta)
+		thisRun, err = o.createFull(ctx, flags, cfg)
 		if err != nil {
 			return err
 		}
+		meta.Uid = uuid.New()
 	case err == nil && len(meta.PastMirrors) != 0:
 		thisRun, err = o.createDiff(ctx, flags, cfg, meta)
 		if err != nil {
@@ -104,9 +105,7 @@ func (o *MirrorOptions) Create(ctx context.Context, flags *pflag.FlagSet) error 
 }
 
 // createFull performs all tasks in creating full imagesets
-func (o *MirrorOptions) createFull(ctx context.Context, flags *pflag.FlagSet, cfg v1alpha1.ImageSetConfiguration, meta v1alpha1.Metadata) (run v1alpha1.PastMirror, err error) {
-
-	meta.Uid = uuid.New()
+func (o *MirrorOptions) createFull(ctx context.Context, flags *pflag.FlagSet, cfg v1alpha1.ImageSetConfiguration) (run v1alpha1.PastMirror, err error) {
 	run = v1alpha1.PastMirror{
 		Sequence:  1,
 		Timestamp: int(time.Now().Unix()),

--- a/pkg/cli/mirror/create.go
+++ b/pkg/cli/mirror/create.go
@@ -41,14 +41,14 @@ func (o *MirrorOptions) Create(ctx context.Context, flags *pflag.FlagSet) error 
 		return err
 	}
 
-	if err := bundle.MakeCreateDirs(o.Dir); err != nil {
-		return err
-	}
-
 	// Configure the metadata backend.
 	backend, err := o.newBackendForConfig(ctx, cfg.StorageConfig)
 	if err != nil {
 		return fmt.Errorf("error opening backend: %v", err)
+	}
+
+	if err := bundle.MakeCreateDirs(o.Dir); err != nil {
+		return err
 	}
 
 	// Run full or diff mirror.

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -101,10 +101,6 @@ func (o *MirrorOptions) Validate(cmd *cobra.Command, f kcmdutil.Factory) error {
 		logrus.Debug("Registry auth check not implemented")
 	}
 
-	if _, err := os.Stat(o.Dir); err != nil {
-		return err
-	}
-
 	if len(o.OutputDir) > 0 {
 		if _, err := os.Stat(o.OutputDir); err != nil {
 			return err

--- a/pkg/cli/mirror/publish.go
+++ b/pkg/cli/mirror/publish.go
@@ -116,7 +116,7 @@ func (o *MirrorOptions) Publish(ctx context.Context, cmd *cobra.Command, f kcmdu
 	}
 
 	// Get current metadata info
-	backendImage := fmt.Sprintf("%s/%s:latest", o.ToMirror, incomingMeta.Uid)
+	backendImage := fmt.Sprintf("%s/oc-mirror:%s", o.ToMirror, incomingMeta.Uid)
 	backend, err := o.configureBackendForConfig(ctx, backendImage)
 	if err != nil {
 		return err
@@ -128,7 +128,7 @@ func (o *MirrorOptions) Publish(ctx context.Context, cmd *cobra.Command, f kcmdu
 	switch err := backend.ReadMetadata(ctx, &currentMeta, config.MetadataBasePath); {
 	case err != nil && !errors.Is(err, storage.ErrMetadataNotExist):
 		return err
-	case (err != nil && errors.Is(err, storage.ErrMetadataNotExist)):
+	case err != nil:
 		logrus.Infof("No existing metadata found. Setting up new workspace")
 		// Check that this is the first imageset
 		incomingRun := incomingMeta.PastMirrors[len(incomingMeta.PastMirrors)-1]

--- a/pkg/cli/mirror/publish_test.go
+++ b/pkg/cli/mirror/publish_test.go
@@ -84,11 +84,11 @@ func Test_MetadataError(t *testing.T) {
 					Out:    os.Stdout,
 					ErrOut: os.Stderr,
 				},
-				Dir:         tmpdir,
-				DestSkipTLS: true,
+				Dir: tmpdir,
 			},
-			From:     tt.fields.archivePath,
-			ToMirror: u.Host,
+			DestSkipTLS: true,
+			From:        tt.fields.archivePath,
+			ToMirror:    u.Host,
 		}
 
 		// Copy metadata in place for tests with existing
@@ -131,9 +131,9 @@ func prepMetadata(ctx context.Context, host, dir, uuid string) error {
 
 	opts := &MirrorOptions{
 		RootOptions: &cli.RootOptions{
-			Dir:         dir,
-			DestSkipTLS: true,
+			Dir: dir,
 		},
+		DestSkipTLS: true,
 	}
 
 	image := fmt.Sprintf("%s/%s:latest", host, uuid)

--- a/pkg/cli/mirror/publish_test.go
+++ b/pkg/cli/mirror/publish_test.go
@@ -136,7 +136,7 @@ func prepMetadata(ctx context.Context, host, dir, uuid string) error {
 		DestSkipTLS: true,
 	}
 
-	image := fmt.Sprintf("%s/%s:latest", host, uuid)
+	image := fmt.Sprintf("%s/oc-mirror:%s", host, uuid)
 
 	registry, err := opts.configureBackendForConfig(ctx, image)
 	if err != nil {

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -21,7 +21,7 @@ type RootOptions struct {
 }
 
 func (o *RootOptions) BindFlags(fs *pflag.FlagSet) {
-	fs.StringVarP(&o.Dir, "dir", "d", ".", "Assets directory")
+	fs.StringVarP(&o.Dir, "dir", "d", "oc-mirror-workspace", "Assets directory")
 	fs.StringVar(&o.LogLevel, "log-level", "info", "Log level (e.g. \"debug | info | warn | error\")")
 }
 


### PR DESCRIPTION
Closes #124 

Blocked by #150 

## What is the current behavior?
Publishing uses a local backend

## What is the new behavior?
Publishing uses a registry backend

## Testing completed
This has been tested using the e2e test and tested locally with an registry using auth.
The publishing unit test has been updated, but the UUID check has been removed since this will now be seen as an empty workspace.