### PR TITLE
Prow initial test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,7 @@ test-unit: tidy
 .PHONY: test-e2e
 test-e2e: build
 	./test/e2e-simple.sh ./bin/oc-mirror
+
+.PHONY: test-prow
+test-prow: build
+	./test/e2e-prow.sh ./bin/oc-mirror

--- a/test/e2e-prow.sh
+++ b/test/e2e-prow.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -eu
+
+source test/prow/lib.sh
+
+CMD="${1:?cmd bin path is required}"
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+DATA_TMP=$(mktemp -d "${DIR}/operator-test.XXXXX")
+CREATE_FULL_DIR="${DATA_TMP}/create_full"
+CREATE_DIFF_DIR="${DATA_TMP}/create_diff"
+PUBLISH_FULL_DIR="${DATA_TMP}/publish_full"
+PUBLISH_DIFF_DIR="${DATA_TMP}/publish_diff"
+REGISTRY_CONN="localhost"
+REGISTRY_CONN_PORT=5000
+REGISTRY_DISCONN="localhost"
+REGISTRY_DISCONN_PORT=5000
+
+#trap "${DIR}/stop-docker-registry.sh $REGISTRY_CONN; ${DIR}/stop-docker-registry.sh $REGISTRY_DISCONN" EXIT
+
+## Test `create full`
+
+# Test full catalog mode.
+#"${DIR}/start-docker-registry.sh" $REGISTRY_CONN $REGISTRY_CONN_PORT
+"${DIR}/prow/setup-testdata.sh" "$DATA_TMP" "$CREATE_FULL_DIR" "latest/imageset-config-full.yaml" false
+run_cmd create full --dir "$CREATE_FULL_DIR" --config "${CREATE_FULL_DIR}/imageset-config-full.yaml" --output "$DATA_TMP"
+# Stop the connected registry so we're sure nothing is being pulled from it.
+#"${DIR}/stop-docker-registry.sh" $REGISTRY_CONN
+#"${DIR}/start-docker-registry.sh" $REGISTRY_DISCONN $REGISTRY_DISCONN_PORT
+run_cmd publish --dir "$PUBLISH_FULL_DIR" --archive "${DATA_TMP}/bundle_seq1_000000.tar" --to-mirror $REGISTRY_DISCONN:$REGISTRY_DISCONN_PORT
+check_bundles ${REGISTRY_DISCONN}:${REGISTRY_DISCONN_PORT}/test-catalogs/test-catalog:latest \
+  "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.0.0 baz.v1.0.1 baz.v1.1.0 foo.v0.1.0 foo.v0.2.0 foo.v0.3.0 foo.v0.3.1" \
+  ${REGISTRY_DISCONN}:${REGISTRY_DISCONN_PORT}
+#"${DIR}/stop-docker-registry.sh" $REGISTRY_DISCONN
+rm -rf "$DATA_TMP"
+
+# Test heads-only catalog mode.
+mkdir "$DATA_TMP"
+#"${DIR}/start-docker-registry.sh" $REGISTRY_CONN $REGISTRY_CONN_PORT
+"${DIR}/prow/setup-testdata.sh" "$DATA_TMP" "$CREATE_FULL_DIR" "latest/imageset-config-headsonly.yaml" false
+run_cmd create full --dir "$CREATE_FULL_DIR" --config "${CREATE_FULL_DIR}/imageset-config-headsonly.yaml" --output "$DATA_TMP"
+#"${DIR}/start-docker-registry.sh" $REGISTRY_DISCONN $REGISTRY_DISCONN_PORT
+run_cmd publish --dir "$PUBLISH_FULL_DIR" --archive "${DATA_TMP}/bundle_seq1_000000.tar" --to-mirror $REGISTRY_DISCONN:$REGISTRY_DISCONN_PORT
+check_bundles ${REGISTRY_DISCONN}:${REGISTRY_DISCONN_PORT}/test-catalogs/test-catalog:latest \
+  "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
+  ${REGISTRY_DISCONN}:${REGISTRY_DISCONN_PORT}
+
+#test `create diff` with new operator bundles and releases.
+mkdir -p "${CREATE_DIFF_DIR}/src/publish"
+mkdir -p "${PUBLISH_DIFF_DIR}/publish"
+cp "${CREATE_FULL_DIR}/src/publish/.metadata.json" "${CREATE_DIFF_DIR}/src/publish/"
+cp "${PUBLISH_FULL_DIR}/publish/.metadata.json" "${PUBLISH_DIFF_DIR}/publish/"
+cp "${CREATE_FULL_DIR}/imageset-config-headsonly.yaml" ${CREATE_DIFF_DIR}
+"${DIR}/prow/setup-testdata.sh" "$DATA_TMP" "$CREATE_DIFF_DIR" "latest/imageset-config-headsonly.yaml" true
+run_cmd create diff --dir "$CREATE_DIFF_DIR" --config "${CREATE_DIFF_DIR}/imageset-config-headsonly.yaml" --output "$DATA_TMP"
+#"${DIR}/stop-docker-registry.sh" $REGISTRY_CONN
+run_cmd publish --dir "$PUBLISH_DIFF_DIR" --archive "${DATA_TMP}/bundle_seq2_000000.tar" --to-mirror $REGISTRY_DISCONN:$REGISTRY_DISCONN_PORT
+check_bundles ${REGISTRY_DISCONN}:${REGISTRY_DISCONN_PORT}/test-catalogs/test-catalog:latest \
+"bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1 foo.v0.3.2" \
+ ${REGISTRY_DISCONN}:${REGISTRY_DISCONN_PORT}
+#"${DIR}/stop-docker-registry.sh" $REGISTRY_DISCONN
+rm -rf "$DATA_TMP"

--- a/test/prow/lib.sh
+++ b/test/prow/lib.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# run_cmd runs $CMD <args> <test flags> where test flags are arguments
+# needed to run against a local test registry and provide informative
+# debug data in case of test errors.
+function run_cmd() {
+  local test_flags="--log-level debug --skip-tls --skip-cleanup"
+
+  echo "$CMD" $@ $test_flags
+  echo
+  "$CMD" $@ $test_flags
+}
+
+# check_bundles ensures the number and names of bundles in catalog_image's index.json
+# matches that of exp_bundles_list, and that all bundle images are pullable.
+function check_bundles() {
+  local catalog_image="${1:?catalog image required}"
+  local exp_bundles_list="${2:?expected bundles list must be set}"
+  local disconn_registry="${3:?disconnected registry host name must be set}"
+
+  podman pull $catalog_image
+  local container=$(podman create $catalog_image)
+  local index_dir="${DATA_TMP}/unpacked"
+  mkdir -p "$index_dir"
+  local index_path="${index_dir}/index.json"
+  podman cp ${container}:/configs/index.json "$index_path"
+
+  declare -A exp_bundles_set
+  for bundle in $exp_bundles_list; do
+    exp_bundles_set[$bundle]=bundle
+  done
+
+  # Ensure the number of bundles matches.
+  local index_bundle_names=$(cat "$index_path" | jq -sr '.[] | select(.schema == "olm.bundle") | .name')
+  local num_bundles=$(echo $index_bundle_names | wc -w)
+  if (( ${#exp_bundles_set[@]} != $num_bundles )); then
+    echo "number of bundles mirrored (${#exp_bundles_set[@]}) does not match expected number (${num_bundles})"
+    return 1
+  fi
+
+  # Ensure all bundle images are pullable.
+  local index_bundle_images=$(cat "$index_path" | jq -sr '.[] | select(.schema == "olm.bundle") | .image')
+  for image in $index_bundle_images; do
+    image=${disconn_registry}/$(echo $image | cut --complement -d'/' -f1)
+    if ! podman pull $image; then
+      echo "bundle image $image not pushed to registry"
+      return 1
+    fi
+  done
+
+  # Ensure each bundle is an expected bundle.
+  for bundle in $index_bundle_names; do
+    if [[ "${exp_bundles_set[$bundle]}" != "bundle" ]]; then
+      echo "bundle $bundle not in expected bundle set"
+      return 1
+    fi
+  done
+}

--- a/test/prow/setup-testdata.sh
+++ b/test/prow/setup-testdata.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -eu
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+DATA_DIR="${1:?data dir is required}"
+OUTPUT_DIR="${2:?output dir is required}"
+CONFIG_PATH="${3:?config path is required}"
+DIFF="${4:?diff bool is required}"
+REGISTRY="localhost:5000"
+CATALOGNAMESPACE="test-catalogs"
+REGISTRY_CATALOGNAMESPACE="${REGISTRY}/${CATALOGNAMESPACE}"
+BUILDKITD="localhost:1234"
+
+function set_indexdir() {
+  if $DIFF; then
+    export INDEX_PATH="diff"
+  else 
+    export INDEX_PATH="latest"
+  fi
+}
+
+function setup() {
+  echo -e "\nSetting up test directory in $DATA_DIR"
+  cp -r "$DIR/../operator/testdata/bundles/"* "$DATA_DIR"
+  mkdir -p "${DATA_DIR}/index"
+  cp -r "${DIR}/../operator/testdata/indices/${INDEX_PATH}/"* "${DATA_DIR}/index/"
+  find "$DATA_DIR" -type f -exec sed -i -E 's@REGISTRY_ONLY@'"$REGISTRY"'@g' {} \;
+  mkdir -p "$OUTPUT_DIR"
+  cp "${DIR}/../operator/testdata/configs/${CONFIG_PATH}" "${OUTPUT_DIR}/"
+  find "$DATA_DIR" -type f -exec sed -i -E 's@REGISTRY_CATALOGNAMESPACE@'"$REGISTRY_CATALOGNAMESPACE"'@g' {} \;
+
+}
+
+function build_push_bundles() {
+  echo -e "\nBuilding and pushing bundle images"
+  for d in `find "${DATA_DIR}" -maxdepth 1 -name *-bundle-*`; do
+    local img="${REGISTRY}/$(basename $d | cut -d- -f1)-operator/$(basename $d | cut -d- -f1-2):$(basename $d | cut -d- -f3)"
+    pushd $d
+    mkdir bundleDocker 
+    mv bundle.Dockerfile bundleDocker/Dockerfile
+    buildctl --addr tcp://$BUILDKITD build --frontend dockerfile.v0 --local context=. --local dockerfile=bundleDocker --output type=image,name=$img,push=true,registry.insecure=true
+    #docker buildx build --push -t $img -f bundle.Dockerfile .
+    popd
+  done
+}
+
+function build_push_related_images() {
+  echo -e "\nBuilding and pushing related images"
+  for img in `yq eval '.relatedImages[].image' "${DATA_DIR}/index/index/index.yaml" --no-doc`; do
+    local tmp=$(mktemp -d ${DATA_DIR}/bundle-image.XXXXX)
+    pushd "$tmp"
+    echo -e "#!/bin/sh\n\necho \"relatedImage: ${img}\"" > run.sh
+    chmod +x run.sh
+    cat <<EOF > Dockerfile
+FROM gcr.io/distroless/static@sha256:912bd2c2b9704ead25ba91b631e3849d940f9d533f0c15cf4fc625099ad145b1
+COPY run.sh /
+ENTRYPOINT ["/run.sh"]
+EOF
+    # Use buildx to create manifest lists to test image association stuff.
+    #docker buildx build --push --platform linux/amd64,linux/arm64 -t $img -f Dockerfile .
+    buildctl --addr tcp://$BUILDKITD  build --frontend dockerfile.v0 --local context=. --local dockerfile=. --output type=image,name=$img,push=true,registry.insecure=true
+    popd
+    rm -rf "$tmp"
+  done
+}
+
+# TODO(estroz): consider regenerating index.yaml with opm.
+function build_push_catalog() {
+  echo -e "\nBuilding and pushing catalog image"
+  local img="${REGISTRY_CATALOGNAMESPACE}/test-catalog:latest"
+  pushd "${DATA_DIR}/index"
+  mkdir indexDocker
+  mv index.Dockerfile indexDocker/Dockerfile
+  buildctl --addr tcp://$BUILDKITD  build --frontend dockerfile.v0 --local context=. --local dockerfile=indexDocker --output type=image,name=$img,push=true,registry.insecure=true
+  #docker buildx build --push -t $img -f index.Dockerfile .
+  popd
+}
+
+set_indexdir
+setup
+build_push_related_images
+build_push_bundles
+build_push_catalog


### PR DESCRIPTION
**Tested:**

URL: https://prow.sfxworks.net/view/s3/prow-6664d1e2-4f1e-40ff-861c-047120830ff6/pr-logs/pull/sfxnet_bundle/1/presubmit-test-pull/1454222380447567872 note, shows failure due to permissionless mode configured for OpenShift CI

**What this contains:**

Make-e2e test modified for prow
 
- Prow sidecar builds and registries ref with terminating completion: ref https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
- Test type: 'spc_t' for buildkitd rootless against OpenShift CI - ref Rootless on OpenShift without SELinux override moby/buildkit#1634 Note: This PR contains this test as privileged pods are not permitted in our CI environment.

**Planned:**
Split image registry into online & offline registries
Cleanup command/rerun command to adjust for new make e2e vs terraform offline AWS cluster
Git squash (squash with a PR merge, or request on my end if needed)

**Fallback:**
Condition: rootless fails
Move the script to buildah sidecar loop as discussed during week of 10/31
