### PR TITLE
UX implementation for list releases, operators, and describe

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ oc-mirror is an OpenShift Client (oc) plugin that manages OpenShift release, ope
 
 oc-mirror management is a two part process:
 1. oc-mirror Creation (Internet Connected)
-1. oc-mirror Publishing (Disconnected)
+2. oc-mirror Publishing (Disconnected)
 
 ## Usage
 
@@ -15,15 +15,22 @@ Replace this value with a real registry host, or create a `docker.io/library/reg
 
 1. Download pull secret and place at `~/.docker/config.json`<sup>1</sup>.
     - Your mirror registry secret must have both push and pull scopes.
-1. Build:
+2. Build:
     ```sh
     make build
     ```
-1. Create then publish to your mirror registry:
+3. Use the discovery features to build you imageset-config.yaml
+   ```sh
+   /bin/oc-mirror list releases --version=4.9
+   /bin/oc-mirror list operators --version=4.9
+4. Create then publish to your mirror registry:
     ```sh
     ./bin/oc-mirror --config imageset-config.yaml --dir test-create file://archives
-    ./bin/oc-mirror --from archives --dir test-publish docker://reg.mirror.com
+    ./bin/oc-mirror --from /path/to/archives --dir test-publish docker://reg.mirror.com
     ```
+5. If needed, get information on your imageset using `describe`
+    ```sh
+    ./bin/oc-mirror describe /path/to/archives
 
 For configuration and options, see the [expanded overview](./docs/overview.md) and [usage](./docs/usage.md) docs.
 

--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -109,52 +109,9 @@ func (c Client) GetUpdates(ctx context.Context, uri *url.URL, arch string, chann
 	}
 	uri.RawQuery = queryParams.Encode()
 
-	// Download the update graph.
-	req, err := http.NewRequest("GET", uri.String(), nil)
+	graph, err := c.getGraphData(ctx, uri)
 	if err != nil {
-		return current, nil, &Error{Reason: "InvalidRequest", Message: err.Error(), cause: err}
-	}
-	req.Header.Add("Accept", GraphMediaType)
-	if c.transport != nil && c.transport.TLSClientConfig != nil {
-		if c.transport.TLSClientConfig.ClientCAs == nil {
-			klog.V(5).Infof("Using a root CA pool with 0 root CA subjects to request updates from %s", uri)
-		} else {
-			klog.V(5).Infof("Using a root CA pool with %n root CA subjects to request updates from %s", len(c.transport.TLSClientConfig.RootCAs.Subjects()), uri)
-		}
-	}
-
-	if c.transport != nil && c.transport.Proxy != nil {
-		proxy, err := c.transport.Proxy(req)
-		if err == nil && proxy != nil {
-			klog.V(5).Infof("Using proxy %s to request updates from %s", proxy.Host, uri)
-		}
-	}
-
-	client := http.Client{}
-	if c.transport != nil {
-		client.Transport = c.transport
-	}
-	timeoutCtx, cancel := context.WithTimeout(ctx, getUpdatesTimeout)
-	defer cancel()
-	resp, err := client.Do(req.WithContext(timeoutCtx))
-	if err != nil {
-		return current, nil, &Error{Reason: "RemoteFailed", Message: err.Error(), cause: err}
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return current, nil, &Error{Reason: "ResponseFailed", Message: fmt.Sprintf("unexpected HTTP status: %s", resp.Status)}
-	}
-
-	// Parse the graph.
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return current, nil, &Error{Reason: "ResponseFailed", Message: err.Error(), cause: err}
-	}
-
-	var graph graph
-	if err = json.Unmarshal(body, &graph); err != nil {
-		return current, nil, &Error{Reason: "ResponseInvalid", Message: err.Error(), cause: err}
+		return Update{}, nil, fmt.Errorf("error getting graph data for version %s in channel %s", version.String(), channel)
 	}
 
 	// Find the current version within the graph.
@@ -201,52 +158,9 @@ func (c Client) GetChannelLatest(ctx context.Context, uri *url.URL, arch string,
 	}
 	uri.RawQuery = queryParams.Encode()
 
-	// Download the update graph.
-	req, err := http.NewRequest("GET", uri.String(), nil)
+	graph, err := c.getGraphData(ctx, uri)
 	if err != nil {
-		return semver.Version{}, &Error{Reason: "InvalidRequest", Message: err.Error(), cause: err}
-	}
-	req.Header.Add("Accept", GraphMediaType)
-	if c.transport != nil && c.transport.TLSClientConfig != nil {
-		if c.transport.TLSClientConfig.ClientCAs == nil {
-			klog.V(5).Infof("Using a root CA pool with 0 root CA subjects to request updates from %s", uri)
-		} else {
-			klog.V(5).Infof("Using a root CA pool with %n root CA subjects to request updates from %s", len(c.transport.TLSClientConfig.RootCAs.Subjects()), uri)
-		}
-	}
-
-	if c.transport != nil && c.transport.Proxy != nil {
-		proxy, err := c.transport.Proxy(req)
-		if err == nil && proxy != nil {
-			klog.V(5).Infof("Using proxy %s to request updates from %s", proxy.Host, uri)
-		}
-	}
-
-	client := http.Client{}
-	if c.transport != nil {
-		client.Transport = c.transport
-	}
-	timeoutCtx, cancel := context.WithTimeout(ctx, getUpdatesTimeout)
-	defer cancel()
-	resp, err := client.Do(req.WithContext(timeoutCtx))
-	if err != nil {
-		return semver.Version{}, &Error{Reason: "RemoteFailed", Message: err.Error(), cause: err}
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return semver.Version{}, &Error{Reason: "ResponseFailed", Message: fmt.Sprintf("unexpected HTTP status: %s", resp.Status)}
-	}
-
-	// Parse the graph.
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return semver.Version{}, &Error{Reason: "ResponseFailed", Message: err.Error(), cause: err}
-	}
-
-	var graph graph
-	if err = json.Unmarshal(body, &graph); err != nil {
-		return semver.Version{}, &Error{Reason: "ResponseInvalid", Message: err.Error(), cause: err}
+		return semver.Version{}, fmt.Errorf("error getting graph data for channel %s", channel)
 	}
 
 	// Find the all versions within the graph.
@@ -278,52 +192,9 @@ func (c Client) GetChannels(ctx context.Context, uri *url.URL, channel string) (
 	}
 	uri.RawQuery = queryParams.Encode()
 
-	// Download the update graph.
-	req, err := http.NewRequest("GET", uri.String(), nil)
+	graph, err := c.getGraphData(ctx, uri)
 	if err != nil {
-		return nil, &Error{Reason: "InvalidRequest", Message: err.Error(), cause: err}
-	}
-	req.Header.Add("Accept", GraphMediaType)
-	if c.transport != nil && c.transport.TLSClientConfig != nil {
-		if c.transport.TLSClientConfig.ClientCAs == nil {
-			klog.V(5).Infof("Using a root CA pool with 0 root CA subjects to request updates from %s", uri)
-		} else {
-			klog.V(5).Infof("Using a root CA pool with %n root CA subjects to request updates from %s", len(c.transport.TLSClientConfig.RootCAs.Subjects()), uri)
-		}
-	}
-
-	if c.transport != nil && c.transport.Proxy != nil {
-		proxy, err := c.transport.Proxy(req)
-		if err == nil && proxy != nil {
-			klog.V(5).Infof("Using proxy %s to request updates from %s", proxy.Host, uri)
-		}
-	}
-
-	client := http.Client{}
-	if c.transport != nil {
-		client.Transport = c.transport
-	}
-	timeoutCtx, cancel := context.WithTimeout(ctx, getUpdatesTimeout)
-	defer cancel()
-	resp, err := client.Do(req.WithContext(timeoutCtx))
-	if err != nil {
-		return nil, &Error{Reason: "RemoteFailed", Message: err.Error(), cause: err}
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, &Error{Reason: "ResponseFailed", Message: fmt.Sprintf("unexpected HTTP status: %s", resp.Status)}
-	}
-
-	// Parse the graph.
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, &Error{Reason: "ResponseFailed", Message: err.Error(), cause: err}
-	}
-
-	var graph graph
-	if err = json.Unmarshal(body, &graph); err != nil {
-		return nil, &Error{Reason: "ResponseInvalid", Message: err.Error(), cause: err}
+		return nil, fmt.Errorf("error getting graph data for channel %s", channel)
 	}
 
 	channels := make(map[string]struct{})
@@ -348,10 +219,35 @@ func (c Client) GetVersions(ctx context.Context, uri *url.URL, channel string) (
 	}
 	uri.RawQuery = queryParams.Encode()
 
+	graph, err := c.getGraphData(ctx, uri)
+	if err != nil {
+		return nil, fmt.Errorf("error getting graph data for channel %s", channel)
+	}
+	// Find the all versions within the graph.
+	Vers := []semver.Version{}
+	for _, node := range graph.Nodes {
+
+		Vers = append(Vers, node.Version)
+
+	}
+
+	semver.Sort(Vers)
+
+	if len(Vers) == 0 {
+		return nil, &Error{
+			Reason:  "NoVersionsFound",
+			Message: fmt.Sprintf("no cluster versions found in the %q channel", channel),
+		}
+	}
+
+	return Vers, nil
+}
+
+func (c Client) getGraphData(ctx context.Context, uri *url.URL) (graph graph, err error) {
 	// Download the update graph.
 	req, err := http.NewRequest("GET", uri.String(), nil)
 	if err != nil {
-		return nil, &Error{Reason: "InvalidRequest", Message: err.Error(), cause: err}
+		return graph, &Error{Reason: "InvalidRequest", Message: err.Error(), cause: err}
 	}
 	req.Header.Add("Accept", GraphMediaType)
 	if c.transport != nil && c.transport.TLSClientConfig != nil {
@@ -377,43 +273,25 @@ func (c Client) GetVersions(ctx context.Context, uri *url.URL, channel string) (
 	defer cancel()
 	resp, err := client.Do(req.WithContext(timeoutCtx))
 	if err != nil {
-		return nil, &Error{Reason: "RemoteFailed", Message: err.Error(), cause: err}
+		return graph, &Error{Reason: "RemoteFailed", Message: err.Error(), cause: err}
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, &Error{Reason: "ResponseFailed", Message: fmt.Sprintf("unexpected HTTP status: %s", resp.Status)}
+		return graph, &Error{Reason: "ResponseFailed", Message: fmt.Sprintf("unexpected HTTP status: %s", resp.Status)}
 	}
 
 	// Parse the graph.
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, &Error{Reason: "ResponseFailed", Message: err.Error(), cause: err}
+		return graph, &Error{Reason: "ResponseFailed", Message: err.Error(), cause: err}
 	}
 
-	var graph graph
 	if err = json.Unmarshal(body, &graph); err != nil {
-		return nil, &Error{Reason: "ResponseInvalid", Message: err.Error(), cause: err}
+		return graph, &Error{Reason: "ResponseInvalid", Message: err.Error(), cause: err}
 	}
 
-	// Find the all versions within the graph.
-	Vers := []semver.Version{}
-	for _, node := range graph.Nodes {
-
-		Vers = append(Vers, node.Version)
-
-	}
-
-	semver.Sort(Vers)
-
-	if len(Vers) == 0 {
-		return nil, &Error{
-			Reason:  "NoVersionsFound",
-			Message: fmt.Sprintf("no cluster versions found in the %q channel", channel),
-		}
-	}
-
-	return Vers, nil
+	return graph, nil
 }
 
 type graph struct {

--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -1,12 +1,15 @@
-package mirror
+package cincinnati
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -23,6 +26,9 @@ const (
 
 	// Timeout when calling upstream Cincinnati stack.
 	getUpdatesTimeout = time.Minute * 60
+	// Update urls
+	UpdateUrl    = "https://api.openshift.com/api/upgrades_info/v1/graph"
+	OkdUpdateURL = "https://origin-release.ci.openshift.org/graph"
 )
 
 // Client is a Cincinnati client which can be used to fetch update graphs from
@@ -33,8 +39,35 @@ type Client struct {
 }
 
 // NewClient creates a new Cincinnati client with the given client identifier.
-func NewClient(id uuid.UUID, transport *http.Transport) Client {
-	return Client{id: id, transport: transport}
+func NewClient(u string, id uuid.UUID) (Client, *url.URL, error) {
+	upstream, err := url.Parse(u)
+	if err != nil {
+		return Client{}, nil, err
+	}
+
+	tls, err := getTLSConfig()
+	if err != nil {
+		return Client{}, nil, err
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: tls,
+		Proxy:           http.ProxyFromEnvironment,
+	}
+	return Client{id: id, transport: transport}, upstream, nil
+}
+
+func getTLSConfig() (*tls.Config, error) {
+	certPool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, err
+	}
+
+	config := &tls.Config{
+		RootCAs: certPool,
+	}
+
+	return config, nil
 }
 
 // Update is a single node from the update graph.
@@ -234,6 +267,153 @@ func (c Client) GetChannelLatest(ctx context.Context, uri *url.URL, arch string,
 	}
 
 	return Vers[len(Vers)-1], nil
+}
+
+func (c Client) GetChannels(ctx context.Context, uri *url.URL, channel string) (map[string]struct{}, error) {
+	// Prepare parametrized cincinnati query.
+	queryParams := uri.Query()
+	if channel != "okd" {
+		queryParams.Add("channel", channel)
+		queryParams.Add("id", c.id.String())
+	}
+	uri.RawQuery = queryParams.Encode()
+
+	// Download the update graph.
+	req, err := http.NewRequest("GET", uri.String(), nil)
+	if err != nil {
+		return nil, &Error{Reason: "InvalidRequest", Message: err.Error(), cause: err}
+	}
+	req.Header.Add("Accept", GraphMediaType)
+	if c.transport != nil && c.transport.TLSClientConfig != nil {
+		if c.transport.TLSClientConfig.ClientCAs == nil {
+			klog.V(5).Infof("Using a root CA pool with 0 root CA subjects to request updates from %s", uri)
+		} else {
+			klog.V(5).Infof("Using a root CA pool with %n root CA subjects to request updates from %s", len(c.transport.TLSClientConfig.RootCAs.Subjects()), uri)
+		}
+	}
+
+	if c.transport != nil && c.transport.Proxy != nil {
+		proxy, err := c.transport.Proxy(req)
+		if err == nil && proxy != nil {
+			klog.V(5).Infof("Using proxy %s to request updates from %s", proxy.Host, uri)
+		}
+	}
+
+	client := http.Client{}
+	if c.transport != nil {
+		client.Transport = c.transport
+	}
+	timeoutCtx, cancel := context.WithTimeout(ctx, getUpdatesTimeout)
+	defer cancel()
+	resp, err := client.Do(req.WithContext(timeoutCtx))
+	if err != nil {
+		return nil, &Error{Reason: "RemoteFailed", Message: err.Error(), cause: err}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &Error{Reason: "ResponseFailed", Message: fmt.Sprintf("unexpected HTTP status: %s", resp.Status)}
+	}
+
+	// Parse the graph.
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, &Error{Reason: "ResponseFailed", Message: err.Error(), cause: err}
+	}
+
+	var graph graph
+	if err = json.Unmarshal(body, &graph); err != nil {
+		return nil, &Error{Reason: "ResponseInvalid", Message: err.Error(), cause: err}
+	}
+
+	channels := make(map[string]struct{})
+
+	for _, node := range graph.Nodes {
+		values := node.Metadata["io.openshift.upgrades.graph.release.channels"]
+
+		for _, value := range strings.Split(values, ",") {
+			channels[value] = struct{}{}
+		}
+	}
+
+	return channels, nil
+}
+
+func (c Client) GetVersions(ctx context.Context, uri *url.URL, channel string) ([]semver.Version, error) {
+	// Prepare parametrized cincinnati query.
+	queryParams := uri.Query()
+	if channel != "okd" {
+		queryParams.Add("channel", channel)
+		queryParams.Add("id", c.id.String())
+	}
+	uri.RawQuery = queryParams.Encode()
+
+	// Download the update graph.
+	req, err := http.NewRequest("GET", uri.String(), nil)
+	if err != nil {
+		return nil, &Error{Reason: "InvalidRequest", Message: err.Error(), cause: err}
+	}
+	req.Header.Add("Accept", GraphMediaType)
+	if c.transport != nil && c.transport.TLSClientConfig != nil {
+		if c.transport.TLSClientConfig.ClientCAs == nil {
+			klog.V(5).Infof("Using a root CA pool with 0 root CA subjects to request updates from %s", uri)
+		} else {
+			klog.V(5).Infof("Using a root CA pool with %n root CA subjects to request updates from %s", len(c.transport.TLSClientConfig.RootCAs.Subjects()), uri)
+		}
+	}
+
+	if c.transport != nil && c.transport.Proxy != nil {
+		proxy, err := c.transport.Proxy(req)
+		if err == nil && proxy != nil {
+			klog.V(5).Infof("Using proxy %s to request updates from %s", proxy.Host, uri)
+		}
+	}
+
+	client := http.Client{}
+	if c.transport != nil {
+		client.Transport = c.transport
+	}
+	timeoutCtx, cancel := context.WithTimeout(ctx, getUpdatesTimeout)
+	defer cancel()
+	resp, err := client.Do(req.WithContext(timeoutCtx))
+	if err != nil {
+		return nil, &Error{Reason: "RemoteFailed", Message: err.Error(), cause: err}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &Error{Reason: "ResponseFailed", Message: fmt.Sprintf("unexpected HTTP status: %s", resp.Status)}
+	}
+
+	// Parse the graph.
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, &Error{Reason: "ResponseFailed", Message: err.Error(), cause: err}
+	}
+
+	var graph graph
+	if err = json.Unmarshal(body, &graph); err != nil {
+		return nil, &Error{Reason: "ResponseInvalid", Message: err.Error(), cause: err}
+	}
+
+	// Find the all versions within the graph.
+	Vers := []semver.Version{}
+	for _, node := range graph.Nodes {
+
+		Vers = append(Vers, node.Version)
+
+	}
+
+	semver.Sort(Vers)
+
+	if len(Vers) == 0 {
+		return nil, &Error{
+			Reason:  "NoVersionsFound",
+			Message: fmt.Sprintf("no cluster versions found in the %q channel", channel),
+		}
+	}
+
+	return Vers, nil
 }
 
 type graph struct {

--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -1,4 +1,4 @@
-package mirror
+package cincinnati
 
 import (
 	"context"
@@ -16,7 +16,7 @@ import (
 )
 
 func TestGetUpdates(t *testing.T) {
-	clientID := uuid.Must(uuid.Parse("01234567-0123-0123-0123-0123456789ab"))
+	clientID := uuid.MustParse("01234567-0123-0123-0123-0123456789ab")
 	arch := "test-arch"
 	channelName := "test-channel"
 	tests := []struct {
@@ -120,9 +120,7 @@ func TestGetUpdates(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(handler))
 			defer ts.Close()
 
-			c := NewClient(clientID, nil)
-
-			uri, err := url.Parse(ts.URL)
+			c, uri, err := NewClient(ts.URL, clientID)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -166,7 +164,7 @@ func TestGetUpdates(t *testing.T) {
 }
 
 func TestGetLatest(t *testing.T) {
-	clientID := uuid.Must(uuid.Parse("01234567-0123-0123-0123-0123456789ab"))
+	clientID := uuid.MustParse("01234567-0123-0123-0123-0123456789ab")
 	arch := "test-arch"
 	channelName := "test-channel"
 	tests := []struct {
@@ -245,9 +243,10 @@ func TestGetLatest(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(handler))
 			defer ts.Close()
 
-			c := NewClient(clientID, nil)
-
-			uri, err := url.Parse(ts.URL)
+			c, uri, err := NewClient(ts.URL, clientID)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -60,62 +60,7 @@ func TestGetUpdates(t *testing.T) {
 			requestQuery := make(chan string, 1)
 			defer close(requestQuery)
 
-			handler := func(w http.ResponseWriter, r *http.Request) {
-				select {
-				case requestQuery <- r.URL.RawQuery:
-				default:
-					t.Fatalf("received multiple requests at upstream URL")
-				}
-
-				if r.Method != http.MethodGet && r.Method != http.MethodHead {
-					w.WriteHeader(http.StatusMethodNotAllowed)
-					return
-				}
-
-				mtype := r.Header.Get("Accept")
-				if mtype != GraphMediaType {
-					w.WriteHeader(http.StatusUnsupportedMediaType)
-					return
-				}
-
-				_, err := w.Write([]byte(`{
-					"nodes": [
-					  {
-						"version": "4.0.0-4",
-						"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-4"
-					  },
-					  {
-						"version": "4.0.0-5",
-						"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-5"
-					  },
-					  {
-						"version": "4.0.0-6",
-						"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-6"
-					  },
-					  {
-						"version": "4.0.0-6+2",
-						"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-6+2"
-					  },
-					  {
-						"version": "4.0.0-0.okd-0",
-						"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.okd-0"
-					  },
-					  {
-						"version": "4.0.0-0.2",
-						"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.2"
-					  },
-					  {
-						"version": "4.0.0-0.3",
-						"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.3"
-					  }
-					],
-					"edges": [[0,1],[1,2],[1,3],[5,6]]
-				  }`))
-				if err != nil {
-					w.WriteHeader(http.StatusInternalServerError)
-					return
-				}
-			}
+			handler := getHandler(t, requestQuery)
 
 			ts := httptest.NewServer(http.HandlerFunc(handler))
 			defer ts.Close()
@@ -183,62 +128,7 @@ func TestGetLatest(t *testing.T) {
 			requestQuery := make(chan string, 1)
 			defer close(requestQuery)
 
-			handler := func(w http.ResponseWriter, r *http.Request) {
-				select {
-				case requestQuery <- r.URL.RawQuery:
-				default:
-					t.Fatalf("received multiple requests at upstream URL")
-				}
-
-				if r.Method != http.MethodGet && r.Method != http.MethodHead {
-					w.WriteHeader(http.StatusMethodNotAllowed)
-					return
-				}
-
-				mtype := r.Header.Get("Accept")
-				if mtype != GraphMediaType {
-					w.WriteHeader(http.StatusUnsupportedMediaType)
-					return
-				}
-
-				_, err := w.Write([]byte(`{
-					"nodes": [
-					  {
-						"version": "4.0.0-4",
-						"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-4"
-					  },
-					  {
-						"version": "4.0.0-5",
-						"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-5"
-					  },
-					  {
-						"version": "4.0.0-6",
-						"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-6"
-					  },
-					  {
-						"version": "4.0.0-6+2",
-						"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-6+2"
-					  },
-					  {
-						"version": "4.0.0-0.okd-0",
-						"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.okd-0"
-					  },
-					  {
-						"version": "4.0.0-0.2",
-						"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.2"
-					  },
-					  {
-						"version": "4.0.0-0.3",
-						"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.3"
-					  }
-					],
-					"edges": [[0,1],[1,2],[1,3],[5,6]]
-				  }`))
-				if err != nil {
-					w.WriteHeader(http.StatusInternalServerError)
-					return
-				}
-			}
+			handler := getHandler(t, requestQuery)
 
 			ts := httptest.NewServer(http.HandlerFunc(handler))
 			defer ts.Close()
@@ -258,6 +148,73 @@ func TestGetLatest(t *testing.T) {
 				}
 				if !reflect.DeepEqual(latest, test.latest) {
 					t.Fatalf("expected version %v, got: %v", test.latest, latest)
+				}
+			} else {
+				if err == nil || err.Error() != test.err {
+					t.Fatalf("expected err to be %s, got: %v", test.err, err)
+				}
+			}
+
+			actualQuery := ""
+			select {
+			case actualQuery = <-requestQuery:
+			default:
+				t.Fatal("no request received at upstream URL")
+			}
+			expectedQueryValues, err := url.ParseQuery(test.expectedQuery)
+			if err != nil {
+				t.Fatalf("could not parse expected query: %v", err)
+			}
+			actualQueryValues, err := url.ParseQuery(actualQuery)
+			if err != nil {
+				t.Fatalf("could not parse acutal query: %v", err)
+			}
+			if e, a := expectedQueryValues, actualQueryValues; !reflect.DeepEqual(e, a) {
+				t.Errorf("expected query to be %q, got: %q", e, a)
+			}
+		})
+	}
+}
+
+func TestGetVersions(t *testing.T) {
+	clientID := uuid.MustParse("01234567-0123-0123-0123-0123456789ab")
+	channelName := "test-channel"
+	tests := []struct {
+		name string
+
+		expectedQuery string
+		versions      []semver.Version
+		err           string
+	}{{
+		name:          "one update available",
+		expectedQuery: "channel=test-channel&id=01234567-0123-0123-0123-0123456789ab",
+		versions:      getSemVer([]string{"4.0.0-0.2", "4.0.0-0.3", "4.0.0-0.okd-0", "4.0.0-4", "4.0.0-5", "4.0.0-6", "4.0.0-6+2"}),
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requestQuery := make(chan string, 1)
+			defer close(requestQuery)
+
+			handler := getHandler(t, requestQuery)
+
+			ts := httptest.NewServer(http.HandlerFunc(handler))
+			defer ts.Close()
+
+			c, uri, err := NewClient(ts.URL, clientID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			versions, err := c.GetVersions(context.Background(), uri, channelName)
+			if test.err == "" {
+				if err != nil {
+					t.Fatalf("expected nil error, got: %v", err)
+				}
+				if !reflect.DeepEqual(versions, test.versions) {
+					t.Fatalf("expected version %v, got: %v", test.versions, versions)
 				}
 			} else {
 				if err == nil || err.Error() != test.err {
@@ -358,5 +315,71 @@ func Test_nodeUnmarshalJSON(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func getSemVer(stringVers []string) (vers []semver.Version) {
+	for _, stringVer := range stringVers {
+		vers = append(vers, semver.MustParse(stringVer))
+	}
+	return vers
+}
+
+func getHandler(t *testing.T, requestQuery chan<- string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case requestQuery <- r.URL.RawQuery:
+		default:
+			t.Fatalf("received multiple requests at upstream URL")
+		}
+
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		mtype := r.Header.Get("Accept")
+		if mtype != GraphMediaType {
+			w.WriteHeader(http.StatusUnsupportedMediaType)
+			return
+		}
+
+		_, err := w.Write([]byte(`{
+			"nodes": [
+			  {
+				"version": "4.0.0-4",
+				"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-4"
+			  },
+			  {
+				"version": "4.0.0-5",
+				"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-5"
+			  },
+			  {
+				"version": "4.0.0-6",
+				"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-6"
+			  },
+			  {
+				"version": "4.0.0-6+2",
+				"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-6+2"
+			  },
+			  {
+				"version": "4.0.0-0.okd-0",
+				"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.okd-0"
+			  },
+			  {
+				"version": "4.0.0-0.2",
+				"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.2"
+			  },
+			  {
+				"version": "4.0.0-0.3",
+				"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.3"
+			  }
+			],
+			"edges": [[0,1],[1,2],[1,3],[5,6]]
+		  }`))
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 	}
 }

--- a/pkg/cli/mirror/list/operators.go
+++ b/pkg/cli/mirror/list/operators.go
@@ -1,7 +1,13 @@
 package list
 
 import (
+	"errors"
+	"fmt"
+	"io"
+
 	"github.com/RedHatGov/bundle/pkg/cli"
+	"github.com/operator-framework/operator-registry/alpha/action"
+	"github.com/operator-framework/operator-registry/alpha/model"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -10,10 +16,11 @@ import (
 
 type OperatorsOptions struct {
 	*cli.RootOptions
-	Channels bool
-	Versions bool
-	Channel  string
+	Catalog  string
 	Package  string
+	Channel  string
+	Version  string
+	Catalogs bool
 }
 
 func NewOperatorsCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command {
@@ -24,25 +31,28 @@ func NewOperatorsCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command
 		Use:   "operators",
 		Short: "List available operator content and their version",
 		Example: templates.Examples(`
-			# Output default operator channles
-			oc-mirror list operators --channels
-			# List all operators in a channel
-			oc-mirror list operators --channel=channel-name --packages
-			# List all available versions for a specified operator
-			oc-mirror list operators --channel=channel-name --package=operator-name --versions
+			# Output default operator catalogs for OpenShift release 4.8
+			oc-mirror list operators --catalogs --version=4.8
+			# List all operators packages in a catalog
+			oc-mirror list operators --catalog=catalog-name
+			# List all operators channels in an operator package
+			oc-mirror list operators --catalog=catalog-name --package=package-name
+			# List all available versions for a specified operator in a channel
+			oc-mirror list operators --catalog=catalog-name --package=operator-name --channel=channel-name
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(cmd, f, args))
 			kcmdutil.CheckErr(o.Validate())
-			kcmdutil.CheckErr(o.Run())
+			kcmdutil.CheckErr(o.Run(cmd))
 		},
 	}
 
 	fs := cmd.Flags()
-	fs.BoolVar(&o.Channels, "channels", o.Channels, "List all channel information")
-	fs.BoolVar(&o.Versions, "versions", o.Versions, "List all version information")
+	fs.BoolVar(&o.Catalogs, "catalogs", o.Catalogs, "List available catalogs for an OpenShift release version")
+	fs.StringVar(&o.Catalog, "catalog", o.Catalog, "List information for specified package")
 	fs.StringVar(&o.Package, "package", o.Package, "List information for specified package")
 	fs.StringVar(&o.Channel, "channel", o.Channel, "List information for specified channel")
+	fs.StringVar(&o.Version, "version", o.Version, "Specify an OpenShift release version")
 
 	o.BindFlags(cmd.PersistentFlags())
 
@@ -50,14 +60,106 @@ func NewOperatorsCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command
 }
 
 func (o *OperatorsOptions) Complete(cmd *cobra.Command, f kcmdutil.Factory, args []string) error {
+	if len(o.Version) > 0 {
+		o.Catalogs = true
+	}
 	return nil
 }
 
 func (o *OperatorsOptions) Validate() error {
+	if len(o.Version) == 0 && o.Catalogs {
+		return errors.New("must specify --version with --catalogs")
+	}
+	if len(o.Channel) > 0 && (len(o.Package) == 0 || len(o.Catalog) == 0) {
+		return errors.New("must specify --catalog and --package with --channel")
+	}
+	if len(o.Package) > 0 && len(o.Catalog) == 0 {
+		return errors.New("must specify --catalog with --package")
+	}
 	return nil
 }
 
-func (o *OperatorsOptions) Run() error {
-	logrus.Info("Not implemented")
+func (o *OperatorsOptions) Run(cmd *cobra.Command) error {
+
+	w := o.IOStreams.Out
+	ctx := cmd.Context()
+
+	// Process cases from most specific to most broad
+	switch {
+	case len(o.Channel) > 0:
+		// Print Version for all bundles in a channel
+		var ch model.Channel
+		lc := action.ListChannels{
+			IndexReference: o.Catalog,
+			PackageName:    o.Package,
+		}
+		res, err := lc.Run(ctx)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		// Find target channel for searching
+		for _, c := range res.Channels {
+			if c.Name == o.Channel {
+				ch = c
+				break
+			}
+		}
+
+		if _, err := fmt.Fprintln(w, "VERSIONS"); err != nil {
+			return err
+		}
+		// List all bundle versions in channel
+		for _, bndl := range ch.Bundles {
+			if _, err := fmt.Fprintln(w, bndl.Version); err != nil {
+				return err
+			}
+		}
+	case len(o.Package) > 0:
+		lc := action.ListChannels{
+			IndexReference: o.Catalog,
+			PackageName:    o.Package,
+		}
+		res, err := lc.Run(ctx)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		if err := res.WriteColumns(o.IOStreams.Out); err != nil {
+			logrus.Fatal(err)
+		}
+	case len(o.Catalog) > 0:
+		lp := action.ListPackages{
+			IndexReference: o.Catalog,
+		}
+		res, err := lp.Run(ctx)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		if err := res.WriteColumns(o.IOStreams.Out); err != nil {
+			logrus.Fatal(err)
+		}
+	case o.Catalogs:
+		if _, err := fmt.Fprintln(w, "Available OpenShift OperatorHub catalogs:"); err != nil {
+			return err
+		}
+		if err := o.writeIndexRef(w); err != nil {
+			return err
+		}
+	default:
+		return cmd.Help()
+	}
+
+	return nil
+}
+
+func (o *OperatorsOptions) writeIndexRef(w io.Writer) error {
+	catalogs := []string{"redhat", "certified", "community"}
+	if _, err := fmt.Fprintf(w, "OpenShift %s:\n", o.Version); err != nil {
+		return err
+	}
+	for _, catalog := range catalogs {
+		if _, err := fmt.Fprintf(w, "registry.redhat.io/redhat/%s-operator-index:v%v\n", catalog, o.Version); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/pkg/cli/mirror/list/operators.go
+++ b/pkg/cli/mirror/list/operators.go
@@ -41,7 +41,7 @@ func NewOperatorsCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command
 			oc-mirror list operators --catalog=catalog-name --package=operator-name --channel=channel-name
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
-			kcmdutil.CheckErr(o.Complete(cmd, f, args))
+			kcmdutil.CheckErr(o.Complete())
 			kcmdutil.CheckErr(o.Validate())
 			kcmdutil.CheckErr(o.Run(cmd))
 		},
@@ -59,7 +59,7 @@ func NewOperatorsCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command
 	return cmd
 }
 
-func (o *OperatorsOptions) Complete(cmd *cobra.Command, f kcmdutil.Factory, args []string) error {
+func (o *OperatorsOptions) Complete() error {
 	if len(o.Version) > 0 {
 		o.Catalogs = true
 	}

--- a/pkg/cli/mirror/list/releases.go
+++ b/pkg/cli/mirror/list/releases.go
@@ -1,8 +1,13 @@
 package list
 
 import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/RedHatGov/bundle/pkg/cincinnati"
 	"github.com/RedHatGov/bundle/pkg/cli"
-	"github.com/sirupsen/logrus"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -10,9 +15,9 @@ import (
 
 type ReleasesOptions struct {
 	*cli.RootOptions
-	Channels bool
-	Versions bool
 	Channel  string
+	Channels bool
+	Version  string
 }
 
 func NewReleasesCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command {
@@ -23,22 +28,24 @@ func NewReleasesCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command 
 		Use:   "releases",
 		Short: "List available platform content and their version",
 		Example: templates.Examples(`
-			# Output OCP release channel list
-            oc-mirror list releases --channels
+			# Output all OCP release channels list for a release
+            oc-mirror list releases --version=4.8
 			# List all OCP versions in a specified channel
-			oc-mirror list releases --channel=stable-4.8 --versions
+			oc-mirror list releases --channel=stable-4.8
+			# List all OCP channels for a specific version
+			oc-mirror list releases --channels --version=4.8
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(cmd, f, args))
 			kcmdutil.CheckErr(o.Validate())
-			kcmdutil.CheckErr(o.Run())
+			kcmdutil.CheckErr(o.Run(cmd.Context()))
 		},
 	}
 
 	fs := cmd.Flags()
-	fs.BoolVar(&o.Channels, "channels", o.Channels, "List all channel information")
-	fs.BoolVar(&o.Versions, "versions", o.Versions, "List all version information")
 	fs.StringVar(&o.Channel, "channel", o.Channel, "List information for specified channel")
+	fs.BoolVar(&o.Channels, "channels", o.Channels, "List all channel information")
+	fs.StringVar(&o.Version, "version", o.Version, "Specify OpenShift release version")
 
 	o.BindFlags(cmd.PersistentFlags())
 
@@ -50,10 +57,73 @@ func (o *ReleasesOptions) Complete(cmd *cobra.Command, f kcmdutil.Factory, args 
 }
 
 func (o *ReleasesOptions) Validate() error {
+	if len(o.Channel) > 0 && o.Channels {
+		return errors.New("must specify either --channels for channel listing or --channel=<channel-name> for version listing")
+	}
+
+	if len(o.Channel) == 0 && len(o.Version) == 0 {
+		if o.Channels {
+			return errors.New("must specify --version")
+		}
+		return errors.New("must specify --version or --channel")
+	}
 	return nil
 }
 
-func (o *ReleasesOptions) Run() error {
-	logrus.Info("Not implemented")
+func (o *ReleasesOptions) Run(ctx context.Context) error {
+
+	w := o.IOStreams.Out
+
+	if len(o.Channel) == 0 {
+		o.Channel = fmt.Sprintf("stable-%s", o.Version)
+		if !o.Channels {
+			if _, err := fmt.Fprintln(w, "Listing stable channels. Use --channel=<channel-name> to filter."); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintln(w, "User oc-mirror list release --channels to discover other channels."); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintln(w, ""); err != nil {
+				return err
+			}
+		}
+	}
+
+	c, url, err := cincinnati.NewClient(cincinnati.UpdateUrl, uuid.New())
+	if err != nil {
+		return err
+	}
+
+	if o.Channels {
+		channels, err := c.GetChannels(ctx, url, o.Channel)
+		if err != nil {
+			return err
+		}
+
+		if _, err := fmt.Fprintf(w, "Listing channels for version %v.\n\n", o.Version); err != nil {
+			return err
+		}
+		for channel := range channels {
+			if _, err := fmt.Fprintf(w, "%s\n", channel); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	vers, err := c.GetVersions(ctx, url, o.Channel)
+	if err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintf(w, "Channel: %v\n", o.Channel); err != nil {
+		return err
+	}
+	for _, ver := range vers {
+		if _, err := fmt.Fprintf(w, "%s\n", ver); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -57,8 +57,8 @@ func NewMirrorCmd() *cobra.Command {
 		SilenceErrors:     false,
 		SilenceUsage:      false,
 		Run: func(cmd *cobra.Command, args []string) {
-			kcmdutil.CheckErr(o.Complete(cmd, f, args))
-			kcmdutil.CheckErr(o.Validate(cmd, f))
+			kcmdutil.CheckErr(o.Complete(args))
+			kcmdutil.CheckErr(o.Validate())
 			kcmdutil.CheckErr(o.Run(cmd, f))
 		},
 	}
@@ -73,7 +73,7 @@ func NewMirrorCmd() *cobra.Command {
 	return cmd
 }
 
-func (o *MirrorOptions) Complete(cmd *cobra.Command, f kcmdutil.Factory, args []string) error {
+func (o *MirrorOptions) Complete(args []string) error {
 
 	destination := args[0]
 	switch {
@@ -86,7 +86,7 @@ func (o *MirrorOptions) Complete(cmd *cobra.Command, f kcmdutil.Factory, args []
 	return nil
 }
 
-func (o *MirrorOptions) Validate(cmd *cobra.Command, f kcmdutil.Factory) error {
+func (o *MirrorOptions) Validate() error {
 	switch {
 	case len(o.From) > 0 && len(o.ToMirror) == 0:
 		return fmt.Errorf("must specifiy a registry destination")


### PR DESCRIPTION
# Description

This PR completes the implementation for the `oc-mirror describe` command and the release and operator discovery portions of `oc-mirror list`.

Closes #120
Closes #42

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Added test for `GetVersions` function for querying a channel during `oc-mirror list releases`

# Checklist:

- [X] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings (A warning is now coming from the list operations (sqlite3 deprecation)
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes