### PR TITLE
fix(operator): only add OPM image when needed

### DIFF
--- a/pkg/cli/mirror/create_test.go
+++ b/pkg/cli/mirror/create_test.go
@@ -1,0 +1,50 @@
+package mirror
+
+import (
+	"testing"
+
+	"github.com/RedHatGov/bundle/pkg/config/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddOPMImage(t *testing.T) {
+
+	var cfg v1alpha1.ImageSetConfiguration
+	var meta v1alpha1.Metadata
+
+	// No past OPMImage.
+	cfg = v1alpha1.ImageSetConfiguration{}
+	meta = v1alpha1.Metadata{}
+	meta.MetadataSpec.PastMirrors = []v1alpha1.PastMirror{
+		{
+			Mirror: v1alpha1.Mirror{
+				AdditionalImages: []v1alpha1.AdditionalImages{
+					{Image: v1alpha1.Image{Name: "reg.com/ns/other:latest"}},
+				},
+			},
+		},
+	}
+
+	addOPMImage(&cfg, meta)
+	if assert.Len(t, cfg.Mirror.AdditionalImages, 1) {
+		require.Equal(t, cfg.Mirror.AdditionalImages[0].Image.Name, OPMImage)
+	}
+
+	// Has past OPMImage.
+	cfg = v1alpha1.ImageSetConfiguration{}
+	meta = v1alpha1.Metadata{}
+	meta.MetadataSpec.PastMirrors = []v1alpha1.PastMirror{
+		{
+			Mirror: v1alpha1.Mirror{
+				AdditionalImages: []v1alpha1.AdditionalImages{
+					{Image: v1alpha1.Image{Name: OPMImage}},
+					{Image: v1alpha1.Image{Name: "reg.com/ns/other:latest"}},
+				},
+			},
+		},
+	}
+
+	addOPMImage(&cfg, meta)
+	require.Len(t, cfg.Mirror.AdditionalImages, 0)
+}


### PR DESCRIPTION
# Description

Only add OPM image when catalogs are configured and not previously added to metadata. Also minor refactoring

Fixes #111

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit and e2e

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules