### PR TITLE
feat: add process release upgrades with cincinnati

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   - [Usage](#usage)
     - [Environment Prep](#environment-prep)
     - [Content Discovery](#content-discovery)
+      - [Updates](#updates)
       - [Releases](#releases)
       - [Operators](#operators)
     - [Test](#test)
@@ -25,6 +26,12 @@ Replace this value with a real registry host, or create a `docker.io/library/reg
     ```
 ### Content Discovery
 
+#### Updates
+
+- List updates since the last `oc-mirror` run
+  ```sh
+  ./bin/oc-mirror list updates --config imageset-config.yaml --dir test-create
+  ```
 #### Releases
 1. List all available release payloads for a version of OpenShift (defaults to stable)
    ```sh
@@ -73,7 +80,6 @@ Replace this value with a real registry host, or create a `docker.io/library/reg
     ```sh
     ./bin/oc-mirror describe /path/to/archives
     ```
-
 For configuration and options, see the [expanded overview](./docs/overview.md) and [usage](./docs/usage.md) docs.
 
 <sup>1</sup> For this example, the `create` and `publish` steps are run on the same machine. Therefore your `~/.docker/config.json`

--- a/pkg/bundle/files.go
+++ b/pkg/bundle/files.go
@@ -106,7 +106,7 @@ func ReadImageSet(a archive.Archiver, from string) (map[string]string, error) {
 
 		// Walk the directory and load the files from the archives
 		// into the map
-		logrus.Infoln("Detected multiple archive files")
+		var match int
 		err = filepath.Walk(from, func(path string, info os.FileInfo, err error) error {
 
 			if err != nil {
@@ -118,17 +118,22 @@ func ReadImageSet(a archive.Archiver, from string) (map[string]string, error) {
 
 			extension := filepath.Ext(path)
 			extension = strings.TrimPrefix(extension, ".")
-
 			if extension == a.String() {
 				logrus.Debugf("Found archive %s", path)
 				return a.Walk(path, func(f archiver.File) error {
 					filesinArchive[f.Name()] = path
+					match++
 					return nil
 				})
 			}
 
 			return nil
 		})
+
+		// Make sure the directory is not empty
+		if match == 0 {
+			return nil, fmt.Errorf("no archives found in directory %s", from)
+		}
 
 	} else {
 		// Walk the archive and load the file names into the map

--- a/pkg/cincinnati/find.go
+++ b/pkg/cincinnati/find.go
@@ -1,0 +1,62 @@
+package cincinnati
+
+import (
+	"errors"
+	"sort"
+
+	"github.com/RedHatGov/bundle/pkg/config/v1alpha1"
+	"github.com/blang/semver/v4"
+	"github.com/google/uuid"
+)
+
+var ErrNoPreviousRelease = errors.New("no previous release downloads detected")
+
+// FindLastRelease will find the latest release that has been recorded in the metadata
+func FindLastRelease(meta v1alpha1.Metadata, channel, url string, uuid uuid.UUID) (string, semver.Version, error) {
+	vers, err := findLastReleases(meta, url, uuid)
+	if err != nil {
+		return "", semver.Version{}, err
+	}
+
+	keys := make([]string, 0, len(vers))
+	for k := range vers {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return vers[keys[i]].LT(vers[keys[j]])
+	})
+
+	return keys[len(keys)-1], vers[keys[len(keys)-1]], nil
+}
+
+func findLastReleases(meta v1alpha1.Metadata, url string, uuid uuid.UUID) (map[string]semver.Version, error) {
+	vers := make(map[string]semver.Version)
+	for _, mirror := range meta.PastMirrors {
+		for _, ch := range mirror.Mirror.OCP.Channels {
+			// If the there are no versions specified
+			// for this channel continue
+			if len(ch.Versions) == 0 {
+				continue
+			}
+			// Get the latest semver download in each channel
+			vers[ch.Name] = getLatestSemVer(ch.Versions)
+		}
+	}
+	// Find the latest download version between the channels
+	if len(vers) != 0 {
+		return vers, nil
+	}
+	return nil, ErrNoPreviousRelease
+}
+
+func getLatestSemVer(stringVers []string) semver.Version {
+	vers := []semver.Version{}
+	for _, stringVer := range stringVers {
+		vers = append(vers, semver.MustParse(stringVer))
+	}
+	if len(vers) == 0 {
+		return semver.Version{}
+	}
+	semver.Sort(vers)
+	return vers[len(vers)-1]
+}

--- a/pkg/cincinnati/find_test.go
+++ b/pkg/cincinnati/find_test.go
@@ -1,0 +1,94 @@
+package cincinnati
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/RedHatGov/bundle/pkg/config/v1alpha1"
+	"github.com/blang/semver/v4"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_FindLastestRelease(t *testing.T) {
+
+	clientID := uuid.MustParse("01234567-0123-0123-0123-0123456789ab")
+	channelName := "test-channel"
+
+	tests := []struct {
+		name string
+
+		expectedVer  semver.Version
+		expectedChan string
+		channels     []v1alpha1.ReleaseChannel
+		err          string
+	}{{
+		name: "two previous releases",
+		channels: []v1alpha1.ReleaseChannel{
+			{
+				Name:     channelName,
+				Versions: []string{"4.0.0-5"},
+			},
+			{
+				Name:     "another-channel",
+				Versions: []string{"4.0.0-6"},
+			},
+		},
+		expectedVer:  semver.MustParse("4.0.0-6"),
+		expectedChan: "another-channel",
+	}, {
+		name: "one previous release in another channel",
+		channels: []v1alpha1.ReleaseChannel{
+			{
+				Name:     "another-channel",
+				Versions: []string{"4.0.0-5"},
+			},
+		},
+		expectedVer:  semver.MustParse("4.0.0-5"),
+		expectedChan: "another-channel",
+	}, {
+		name:     "no previous release",
+		channels: []v1alpha1.ReleaseChannel{},
+		err:      ErrNoPreviousRelease.Error(),
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requestQuery := make(chan string, 1)
+			defer close(requestQuery)
+
+			handler := getHandler(t, requestQuery)
+
+			ts := httptest.NewServer(http.HandlerFunc(handler))
+			defer ts.Close()
+
+			meta := v1alpha1.Metadata{
+				MetadataSpec: v1alpha1.MetadataSpec{
+					PastMirrors: []v1alpha1.PastMirror{
+						{
+							Mirror: v1alpha1.Mirror{
+								OCP: v1alpha1.OCP{
+									Graph:    false,
+									Channels: test.channels,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			ch, ver, err := FindLastRelease(meta, channelName, ts.URL, clientID)
+
+			if len(test.err) != 0 {
+				require.Equal(t, err.Error(), test.err)
+			} else {
+				if !ver.EQ(test.expectedVer) {
+					t.Errorf("Test failed. Expected %s, got %s", test.expectedVer.String(), ver.String())
+				}
+				if ch != test.expectedChan {
+					t.Errorf("Test failed. Expected %s, got %s", test.expectedChan, ch)
+				}
+			}
+		})
+	}
+}

--- a/pkg/cli/mirror/list/updates.go
+++ b/pkg/cli/mirror/list/updates.go
@@ -1,11 +1,29 @@
 package list
 
 import (
-	"github.com/RedHatGov/bundle/pkg/cli"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
+
+	"github.com/blang/semver/v4"
+	"github.com/google/uuid"
+	"github.com/operator-framework/operator-registry/alpha/action"
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+	"github.com/operator-framework/operator-registry/alpha/model"
+	"github.com/operator-framework/operator-registry/pkg/image/containerdregistry"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/RedHatGov/bundle/pkg/cincinnati"
+	"github.com/RedHatGov/bundle/pkg/cli"
+	"github.com/RedHatGov/bundle/pkg/config"
+	"github.com/RedHatGov/bundle/pkg/config/v1alpha1"
+	"github.com/RedHatGov/bundle/pkg/metadata/storage"
 )
 
 type UpdatesOptions struct {
@@ -25,9 +43,8 @@ func NewUpdatesCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command {
 			oc-mirror list updates --config mirror-config.yaml
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
-			kcmdutil.CheckErr(o.Complete(cmd, f, args))
 			kcmdutil.CheckErr(o.Validate())
-			kcmdutil.CheckErr(o.Run())
+			kcmdutil.CheckErr(o.Run(cmd.Context()))
 		},
 	}
 
@@ -35,19 +52,198 @@ func NewUpdatesCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command {
 
 	fs := cmd.Flags()
 	fs.StringVarP(&o.ConfigPath, "config", "c", o.ConfigPath, "Path to imageset configuration file")
-
 	return cmd
 }
 
-func (o *UpdatesOptions) Complete(cmd *cobra.Command, f kcmdutil.Factory, args []string) error {
-	return nil
-}
-
 func (o *UpdatesOptions) Validate() error {
+	if len(o.ConfigPath) == 0 {
+		return fmt.Errorf("must specify config using --config")
+	}
 	return nil
 }
 
-func (o *UpdatesOptions) Run() error {
-	logrus.Info("Not implemented")
+func (o *UpdatesOptions) Run(ctx context.Context) error {
+	cfg, err := config.LoadConfig(o.ConfigPath)
+	if err != nil {
+		return err
+	}
+
+	path := filepath.Join(o.Dir, config.SourceDir)
+	backend, err := storage.ByConfig(ctx, path, cfg.StorageConfig)
+	if err != nil {
+		return fmt.Errorf("error opening backend: %v", err)
+	}
+
+	var meta v1alpha1.Metadata
+	switch err := backend.ReadMetadata(ctx, &meta, config.MetadataBasePath); {
+	case err != nil && !errors.Is(err, storage.ErrMetadataNotExist):
+		return err
+	case err != nil && errors.Is(err, storage.ErrMetadataNotExist):
+		return fmt.Errorf("no metadata detected")
+	default:
+		if len(cfg.Mirror.OCP.Channels) != 0 {
+			if err := o.releaseUpdates(ctx, cfg, meta); err != nil {
+				return err
+			}
+		}
+		if len(cfg.Mirror.Operators) != 0 {
+			if err := o.operatorUpdates(ctx, cfg, meta); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
+}
+
+func (o UpdatesOptions) releaseUpdates(ctx context.Context, cfg v1alpha1.ImageSetConfiguration, meta v1alpha1.Metadata) error {
+	uuid := uuid.New()
+	// QUESTION(jpower): Handle multiple arch?
+	arch := "amd64"
+	logrus.Info("Getting release update information")
+	for _, ch := range cfg.Mirror.OCP.Channels {
+		url := cincinnati.UpdateUrl
+		if ch.Name == "okd" {
+			url = cincinnati.OkdUpdateURL
+		}
+
+		client, upstream, err := cincinnati.NewClient(url, uuid)
+		if err != nil {
+			return err
+		}
+
+		// Find the last release downloads if no downloads
+		// have been made in the target channel list
+		// all versions
+		var vers []semver.Version
+		lastCh, ver, err := cincinnati.FindLastRelease(meta, ch.Name, url, uuid)
+		switch {
+		case err != nil && !errors.Is(err, cincinnati.ErrNoPreviousRelease):
+			return err
+		case err != nil:
+			vers, err = client.GetVersions(ctx, upstream, ch.Name)
+			if err != nil {
+				return err
+			}
+		default:
+			latest, err := client.GetChannelLatest(ctx, upstream, arch, ch.Name)
+			if err != nil {
+				return err
+			}
+			logrus.Debugf("Finding releases between %s and %s", ver.String(), latest.String())
+			_, _, upgrades, err := client.CalculateUpgrades(ctx, upstream, arch, lastCh, ch.Name, ver, latest)
+			if err != nil {
+				return err
+			}
+			for _, upgrade := range upgrades {
+				vers = append(vers, upgrade.Version)
+			}
+		}
+
+		if err := o.writeReleaseColumns(vers, ch.Name); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (o UpdatesOptions) operatorUpdates(ctx context.Context, cfg v1alpha1.ImageSetConfiguration, meta v1alpha1.Metadata) error {
+	logrus.Info("Getting operator update information")
+	dstDir, err := os.MkdirTemp(o.Dir, "updatetmp-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(dstDir)
+
+	// Find last operator catalog digest
+	var pin string
+	for _, mirror := range meta.PastMirrors {
+		for _, op := range mirror.Operators {
+			if len(op.ImagePin) != 0 {
+				pin = op.ImagePin
+				break
+			}
+		}
+	}
+
+	// QUESTION(jpower): TLS must be configurable?
+	reg, err := containerdregistry.NewRegistry(
+		containerdregistry.SkipTLS(false),
+		containerdregistry.WithCacheDir(filepath.Join(dstDir, "cache")),
+	)
+	defer reg.Destroy()
+	if err != nil {
+		return err
+	}
+	for _, ctlg := range cfg.Mirror.Operators {
+		catLogger := logrus.WithField("catalog", ctlg.Catalog)
+		diff := action.Diff{
+			Registry:      reg,
+			NewRefs:       []string{ctlg.Catalog},
+			Logger:        catLogger,
+			IncludeConfig: ctlg.DiffIncludeConfig,
+		}
+		if len(pin) != 0 {
+			diff.OldRefs = []string{pin}
+		}
+		dc, err := diff.Run(ctx)
+		if err != nil {
+			return err
+		}
+
+		if err := o.writeCatalogColumns(*dc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (o UpdatesOptions) writeReleaseColumns(upgrades []semver.Version, channel string) error {
+	tw := tabwriter.NewWriter(o.IOStreams.Out, 0, 4, 2, ' ', 0)
+	if _, err := fmt.Fprintf(tw, "TARGET CHANNEL:\t%s\n", channel); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(tw, "VERSIONS"); err != nil {
+		return err
+	}
+	for _, upgrade := range upgrades {
+		if _, err := fmt.Fprintf(tw, "%s\n", upgrade); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func (o UpdatesOptions) writeCatalogColumns(dc declcfg.DeclarativeConfig) error {
+	tw := tabwriter.NewWriter(o.IOStreams.Out, 0, 4, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "PACKAGE\tCHANNEL\tBUNDLE\tREPLACES"); err != nil {
+		return err
+	}
+	mod, err := declcfg.ConvertToModel(dc)
+	if err != nil {
+		return err
+	}
+
+	pkgs := []model.Package{}
+	for _, pkg := range mod {
+		pkgs = append(pkgs, *pkg)
+	}
+
+	bundles := []model.Bundle{}
+	for _, pkg := range pkgs {
+		for _, ch := range pkg.Channels {
+			for _, b := range ch.Bundles {
+				bundles = append(bundles, *b)
+			}
+		}
+	}
+
+	for _, b := range bundles {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", b.Package.Name, b.Channel.Name, b.Name, b.Replaces); err != nil {
+			return err
+		}
+	}
+
+	return tw.Flush()
 }

--- a/pkg/cli/mirror/publish_test.go
+++ b/pkg/cli/mirror/publish_test.go
@@ -129,16 +129,13 @@ func Test_MetadataError(t *testing.T) {
 func prepMetadata(ctx context.Context, host, dir, uuid string) error {
 	var meta v1alpha1.Metadata
 
-	opts := &MirrorOptions{
-		RootOptions: &cli.RootOptions{
-			Dir: dir,
+	cfg := v1alpha1.StorageConfig{
+		Registry: &v1alpha1.RegistryConfig{
+			ImageURL: fmt.Sprintf("%s/oc-mirror:%s", host, uuid),
+			SkipTLS:  true,
 		},
-		DestSkipTLS: true,
 	}
-
-	image := fmt.Sprintf("%s/oc-mirror:%s", host, uuid)
-
-	registry, err := opts.configureBackendForConfig(ctx, image)
+	registry, err := storage.ByConfig(ctx, dir, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/v1alpha1/config_types.go
+++ b/pkg/config/v1alpha1/config_types.go
@@ -65,7 +65,7 @@ type Operator struct {
 	// Channels specified in DiffIncludeConfig will override this setting;
 	// heads will still be included, but prior versions may also be included.
 	HeadsOnly bool `json:"headsOnly,omitempty"`
-	// InlineIndex directs the mirrorer to store the catalog's declarative config
+	// WriteIndex directs the mirrorer to store the catalog's declarative config
 	// index representation as a file.
 	// Only set this option if not using git as a backend, which experiences
 	// degraded performance with file sizes of 100MB.

--- a/pkg/metadata/storage/storage.go
+++ b/pkg/metadata/storage/storage.go
@@ -44,7 +44,7 @@ var backends = []Backend{
 }
 
 // ByConfig returns backend interface based on provided config
-func ByConfig(ctx context.Context, dir string, storage v1alpha1.StorageConfig) (interface{}, error) {
+func ByConfig(ctx context.Context, dir string, storage v1alpha1.StorageConfig) (Backend, error) {
 	var b interface{}
 	for _, bk := range backends {
 		if err := bk.CheckConfig(storage); err == nil {


### PR DESCRIPTION
# Description

This adds and refactors the functionality that processes release payloads. Along with downloading updates between the requested release and the current release, it also adds the ability to download the latest version in the channel on a differential run.

Note: This will only download releases between the latest version downloaded in a channel to the requested version. If the version exists in multiple channels, the target channel will be searched for that version as well.

Closes #119 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] TBD

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules