### PR TITLE
fix: add target channel as channel on new runs

### DIFF
--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -128,7 +128,7 @@ func (c Client) GetUpdates(ctx context.Context, uri *url.URL, arch string, chann
 	if !found {
 		return current, requested, nil, &Error{
 			Reason:  "VersionNotFound",
-			Message: fmt.Sprintf("currently reconciling cluster version %s not found in the %q channel", version, channel),
+			Message: fmt.Sprintf("current version %s not found in the %q channel", version, channel),
 		}
 	}
 
@@ -145,7 +145,7 @@ func (c Client) GetUpdates(ctx context.Context, uri *url.URL, arch string, chann
 	if !found {
 		return current, requested, nil, &Error{
 			Reason:  "VersionNotFound",
-			Message: fmt.Sprintf("currently reconciling cluster version %s not found in the %q channel", version, channel),
+			Message: fmt.Sprintf("requested version %s not found in the %q channel", reqVer, channel),
 		}
 	}
 
@@ -187,11 +187,11 @@ func (c Client) CalculateUpgrades(ctx context.Context, uri *url.URL, arch, sourc
 	target := semver.MustParse(fmt.Sprintf("%s.0", targetChannel[targetIdx+1:]))
 	latest, err := c.GetChannelLatest(ctx, uri, arch, sourceChannel)
 	if err != nil {
-		return Update{}, Update{}, nil, err
+		return Update{}, Update{}, nil, fmt.Errorf("cannot get latest: %v", err)
 	}
 	current, _, upgrades, err := c.GetUpdates(ctx, uri, arch, sourceChannel, version, latest)
 	if err != nil {
-		return Update{}, Update{}, nil, err
+		return Update{}, Update{}, nil, fmt.Errorf("cannot get current: %v", err)
 	}
 
 	for {

--- a/pkg/cli/mirror/release.go
+++ b/pkg/cli/mirror/release.go
@@ -150,8 +150,9 @@ func (o *ReleaseOptions) GetReleases(ctx context.Context, meta v1alpha1.Metadata
 				lastCh, lastVer, err := cincinnati.FindLastRelease(meta, ch.Name, url, o.uuid)
 				logrus.Infof("Downloading requested release %s", requested.String())
 				switch {
-				case err != nil && errors.As(err, &cincinnati.ErrNoPreviousRelease):
+				case err != nil && errors.Is(err, cincinnati.ErrNoPreviousRelease):
 					lastVer = requested
+					lastCh = ch.Name
 				case err != nil:
 					return nil, err
 				case requested.LT(lastVer):


### PR DESCRIPTION
# Description

This adds the target channel as the latest channel when `FindReleases` returns an `ErrNoPreviousRelease` error

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Existing tests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules