### PR TITLE
Switch example comment syntax to be yaml compliant without removing the comments. Ignore local copy of config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ sha256sum.txt
 
 # Local
 .idea
+
+# Local imageset-config.yaml
+imageset-config.yaml

--- a/docs/imageset-config-ref.yaml
+++ b/docs/imageset-config-ref.yaml
@@ -2,30 +2,30 @@ apiVersion: tmp-redhatgov.com/v1alpha1
 kind: ImageSetConfiguration
 storageConfig:
   registry:
-    imageURL: localhost:5000/test:latest << Stores metadata in an image  >>
+    imageURL: localhost:5000/test:latest # Stores metadata in an image
     skipTLS: true
 mirror:
   ocp:
     channels:
-      - name: stable-4.8 << References latest stable release>>
-      - name: stable-4.7 << Version annotation references version, does not pull latest >>
+      - name: stable-4.8 # References latest stable release
+      - name: stable-4.7 # Version annotation references version, does not pull latest
         versions:
           - '4.7.18'
           - '4.6.13'
-    graph: true << Planned, include Cincinnati upgrade graph image in imageset >>
+    graph: true # Planned, include Cincinnati upgrade graph image in imageset
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.8 << References entire catalog >>
-      headsOnly: true << References latest version of each operator in catalog >>
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.8 # References entire catalog
+      headsOnly: true # References latest version of each operator in catalog
       packages:
-        - name: couchbase-operator << Planned, overrides catalog default, respects headsOnly setting >>
+        - name: couchbase-operator # Planned, overrides catalog default, respects headsOnly setting
           versions:
-            - '1.4.0' << Planned, overrides catalog default, overrides headsOnly setting >>
+            - '1.4.0' # Planned, overrides catalog default, overrides headsOnly setting
         - name: crunchy-postgresql-operator
-          channels: << Planned >>
+          channels: # Planned
             - name: 'stable'
-  additionalimages: << List of additional images to be included in imageset >>
+  additionalimages: # List of additional images to be included in imageset
     - name: registry.redhat.io/ubi8/ubi:latest
-  blockedimages: << Planned, list of base images to be blocked (best effort) >>
+  blockedimages: # Planned, list of base images to be blocked (best effort)
     - name: alpine
     - name: redis
   helm:


### PR DESCRIPTION
# Description

Switch example comment syntax to be yaml compliant without removing the comments. Ignore local copy of config file

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] This change requires a documentation update

# How Has This Been Tested?

I used yq to validate the example config yaml file. This failed originally due to the << and >> characters.

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules