### PR TITLE
fix: fix logic for returning ErrMetadataNotExist for registry backend

### DIFF
--- a/docs/imageset-config-ref.yaml
+++ b/docs/imageset-config-ref.yaml
@@ -3,7 +3,7 @@ kind: ImageSetConfiguration
 storageConfig:
   registry:
     imageURL: localhost:5000/test:latest # Stores metadata in an image
-    skipTLS: true
+    skipTLS: true # Disable TLS certificate checking or use plain HTTP 
 mirror:
   ocp:
     channels:

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -32,8 +32,8 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.ManifestsOnly, "manifests-only", o.ManifestsOnly, "Generate manifests and do not mirror")
 	fs.BoolVar(&o.DryRun, "dry-run", o.DryRun, "Print actions without mirroring images "+
 		"(experimental: only works for operator catalogs)")
-	fs.BoolVar(&o.SourceSkipTLS, "source-skip-tls", o.SourceSkipTLS, "Skip client-side TLS validation for source")
-	fs.BoolVar(&o.DestSkipTLS, "dest-skip-tls", o.DestSkipTLS, "Skip client-side TLS validation for destination")
+	fs.BoolVar(&o.SourceSkipTLS, "source-skip-tls", o.SourceSkipTLS, "Use plain HTTP for source registry")
+	fs.BoolVar(&o.DestSkipTLS, "dest-skip-tls", o.DestSkipTLS, "Use plain HTTP for destination registry")
 	fs.BoolVar(&o.SkipVerification, "skip-verification", o.SkipVerification, "Skip digest verification")
 	fs.BoolVar(&o.SkipCleanup, "skip-cleanup", o.SkipCleanup, "Skip removal of artifact directories")
 	fs.StringVar(&o.FilterOptions.FilterByOS, "filter-by-os", "", "A regular expression to control which index image is picked when multiple variants are available")

--- a/pkg/metadata/storage/registry.go
+++ b/pkg/metadata/storage/registry.go
@@ -210,9 +210,6 @@ func (b *registryBackend) exists(ctx context.Context) error {
 		return err
 	}
 	_, err = crane.Manifest(b.src.Ref.Exact(), opts...)
-	if err == nil {
-		return nil
-	}
 	var terr *transport.Error
 	switch {
 	case err != nil && errors.As(err, &terr) && terr.StatusCode == 404:


### PR DESCRIPTION
# Description

This PR will clean up some of the logic for testing for the existence of metadata in the registry backend. It originally would create a new workspace on any HTTP error and now it will only create a new workspace for the `404` error code. Also clarified the `SkipTLS` description to explain that this means using plain HTTP.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [X] Unit test to ensure an error is returned that is not ErrMetadataNotExist when the request threw an error that was no 404

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules