### PR TITLE
feat: adding permissions check before publishing to disconnected reg

### DIFF
--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -77,7 +77,7 @@ func TestGetUpdates(t *testing.T) {
 			handler := getHandler(t, requestQuery)
 
 			ts := httptest.NewServer(http.HandlerFunc(handler))
-			defer ts.Close()
+			t.Cleanup(ts.Close)
 
 			c, uri, err := NewClient(ts.URL, clientID)
 			if err != nil {
@@ -148,7 +148,7 @@ func TestGetLatest(t *testing.T) {
 			handler := getHandler(t, requestQuery)
 
 			ts := httptest.NewServer(http.HandlerFunc(handler))
-			defer ts.Close()
+			t.Cleanup(ts.Close)
 
 			c, uri, err := NewClient(ts.URL, clientID)
 			if err != nil {
@@ -215,7 +215,7 @@ func TestGetVersions(t *testing.T) {
 			handler := getHandler(t, requestQuery)
 
 			ts := httptest.NewServer(http.HandlerFunc(handler))
-			defer ts.Close()
+			t.Cleanup(ts.Close)
 
 			c, uri, err := NewClient(ts.URL, clientID)
 			if err != nil {
@@ -326,7 +326,7 @@ func TestCalculateUpgrades(t *testing.T) {
 			handler := getHandlerMulti(t, requestQuery)
 
 			ts := httptest.NewServer(http.HandlerFunc(handler))
-			defer ts.Close()
+			t.Cleanup(ts.Close)
 
 			c, uri, err := NewClient(ts.URL, clientID)
 			if err != nil {

--- a/pkg/cli/mirror/catalog_images.go
+++ b/pkg/cli/mirror/catalog_images.go
@@ -4,12 +4,10 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
-	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -343,10 +341,4 @@ func (o *MirrorOptions) getRemoteOpts(ctx context.Context) (options []remote.Opt
 		remote.WithContext(ctx),
 		remote.WithTransport(o.createRT()),
 	)
-}
-
-func (o *MirrorOptions) createRT() *http.Transport {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: o.DestSkipTLS}
-	return transport
 }

--- a/pkg/cli/mirror/catalog_images_test.go
+++ b/pkg/cli/mirror/catalog_images_test.go
@@ -20,6 +20,7 @@ import (
 func Test_BuildCatalogLayer(t *testing.T) {
 
 	server := httptest.NewServer(registry.New())
+	t.Cleanup(server.Close)
 	u, err := url.Parse(server.URL)
 	if err != nil {
 		t.Error(err)

--- a/pkg/cli/mirror/publish_test.go
+++ b/pkg/cli/mirror/publish_test.go
@@ -70,9 +70,11 @@ func Test_MetadataError(t *testing.T) {
 	for _, tt := range tests {
 
 		server := httptest.NewServer(registry.New())
+		t.Cleanup(server.Close)
 		u, err := url.Parse(server.URL)
 		if err != nil {
 			t.Error(err)
+			continue
 		}
 
 		tmpdir := t.TempDir()

--- a/pkg/cli/mirror/release_test.go
+++ b/pkg/cli/mirror/release_test.go
@@ -98,12 +98,9 @@ func Test_getDownloads(t *testing.T) {
 			handler := getHandlerMulti(t, requestQuery)
 
 			ts := httptest.NewServer(http.HandlerFunc(handler))
-			defer ts.Close()
+			t.Cleanup(ts.Close)
 
 			c, uri, err := cincinnati.NewClient(ts.URL, clientID)
-			if err != nil {
-				t.Fatal(err)
-			}
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/metadata/storage/registry_test.go
+++ b/pkg/metadata/storage/registry_test.go
@@ -40,6 +40,7 @@ func Test_RegistryBackend(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			server := httptest.NewServer(registry.New())
+			t.Cleanup(server.Close)
 			u, err := url.Parse(server.URL)
 			if err != nil {
 				t.Error(err)

--- a/pkg/metadata/storage/storage_test.go
+++ b/pkg/metadata/storage/storage_test.go
@@ -22,6 +22,7 @@ func Test_ByConfig(t *testing.T) {
 	customDir := t.TempDir()
 
 	server := httptest.NewServer(registry.New())
+	t.Cleanup(server.Close)
 	u, err := url.Parse(server.URL)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
# Description

This PR adds a push permissions check before publishing image to registry

Fixes #196 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [ ] Can be tested manually right now by spinning up a registry with auth and trying to publish without credentials in `~/.docker/config.json`

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules