### PR TITLE
fix: set latest as the default if no tag or id is provided on addi…

### DIFF
--- a/pkg/cli/mirror/additional_test.go
+++ b/pkg/cli/mirror/additional_test.go
@@ -90,9 +90,7 @@ func Test_GetAdditional(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			assocs, err := opts.GetAdditional(test.cfg, test.cfg.Mirror.AdditionalImages)
-			t.Log(err)
 			if test.wantErr {
-				t.Log(err)
 				testErr := test.want
 				require.ErrorAs(t, err, &testErr)
 			} else {


### PR DESCRIPTION
…tional images

Fixes #154

# Description

This PR will assume the tag or ID component is none is provided with `AdditionalImage` spec. Tag will be set as latest.

Fixes #154 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit test added to test additional images without tags or digest

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules