### PR TITLE
fix: add namespace to check push permissions ref

### DIFF
--- a/pkg/cli/mirror/list/operators_test.go
+++ b/pkg/cli/mirror/list/operators_test.go
@@ -1,0 +1,125 @@
+package list
+
+import (
+	"testing"
+
+	"github.com/openshift/oc-mirror/pkg/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOperatorsComplete(t *testing.T) {
+	type spec struct {
+		name     string
+		opts     *OperatorsOptions
+		expOpts  *OperatorsOptions
+		expError string
+	}
+
+	cases := []spec{
+		{
+			name: "Valid/VersionSet",
+			opts: &OperatorsOptions{
+				Version: "2.4.0",
+				RootOptions: &cli.RootOptions{
+					Dir: "bar",
+				},
+			},
+			expOpts: &OperatorsOptions{
+				Version:  "2.4.0",
+				Catalogs: true,
+				RootOptions: &cli.RootOptions{
+					Dir: "bar",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.opts.Complete()
+			if c.expError != "" {
+				require.EqualError(t, err, c.expError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, c.expOpts, c.opts)
+			}
+		})
+	}
+}
+
+func TestOperatorsValidate(t *testing.T) {
+
+	type spec struct {
+		name     string
+		opts     *OperatorsOptions
+		expError string
+	}
+
+	cases := []spec{
+		{
+			name: "Invalid/NoVersion",
+			opts: &OperatorsOptions{
+				Catalogs: true,
+			},
+			expError: "must specify --version with --catalogs",
+		},
+		{
+			name: "Invalid/NoCatalog",
+			opts: &OperatorsOptions{
+				Package: "foo",
+			},
+			expError: `must specify --catalog with --package`,
+		},
+		{
+			name: "Invalid/NoPackage",
+			opts: &OperatorsOptions{
+				Channel: "foo-channel",
+			},
+			expError: `must specify --catalog and --package with --channel`,
+		},
+		{
+			name: "Invalid/NoCatalogwithChannel",
+			opts: &OperatorsOptions{
+				Channel: "foo-channel",
+				Package: "foo",
+			},
+			expError: `must specify --catalog and --package with --channel`,
+		},
+		{
+			name: "Valid/Catalogs",
+			opts: &OperatorsOptions{
+				Catalogs: true,
+				Version:  "4.8",
+			},
+			expError: "",
+		},
+		{
+			name: "Valid/Packages",
+			opts: &OperatorsOptions{
+				Catalog: "foo-catalog",
+				Package: "foo",
+			},
+			expError: "",
+		},
+		{
+			name: "Valid/Channels",
+			opts: &OperatorsOptions{
+				Catalog: "foo-catalog",
+				Package: "foo",
+				Channel: "foo-channel",
+			},
+			expError: "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.opts.Validate()
+			if c.expError != "" {
+				require.EqualError(t, err, c.expError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/cli/mirror/list/releases_test.go
+++ b/pkg/cli/mirror/list/releases_test.go
@@ -1,0 +1,101 @@
+package list
+
+import (
+	"testing"
+
+	"github.com/openshift/oc-mirror/pkg/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReleasesComplete(t *testing.T) {
+	type spec struct {
+		name     string
+		opts     *ReleasesOptions
+		expOpts  *ReleasesOptions
+		expError string
+	}
+
+	cases := []spec{
+		{
+			name: "Valid/ChannelEmpty",
+			opts: &ReleasesOptions{
+				Channel: "",
+				Version: "4.8",
+				RootOptions: &cli.RootOptions{
+					Dir: "bar",
+				},
+			},
+			expOpts: &ReleasesOptions{
+				Channel: "stable-4.8",
+				Version: "4.8",
+				RootOptions: &cli.RootOptions{
+					Dir: "bar",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.opts.Complete()
+			if c.expError != "" {
+				require.EqualError(t, err, c.expError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, c.expOpts, c.opts)
+			}
+		})
+	}
+}
+
+func TestReleasesValidate(t *testing.T) {
+
+	type spec struct {
+		name     string
+		opts     *ReleasesOptions
+		expError string
+	}
+
+	cases := []spec{
+		{
+			name: "Invalid/NoVersion",
+			opts: &ReleasesOptions{
+				Channel: "stable-",
+			},
+			expError: "must specify --version or --channel",
+		},
+		{
+			name: "Invalid/NoCatalog",
+			opts: &ReleasesOptions{
+				Channels: true,
+			},
+			expError: `must specify --version`,
+		},
+		{
+			name: "Valid/Channels",
+			opts: &ReleasesOptions{
+				Channels: true,
+				Version:  "4.8",
+			},
+			expError: "",
+		},
+		{
+			name: "Valid/Versions",
+			opts: &ReleasesOptions{
+				Channel: "stable-foo",
+			},
+			expError: "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.opts.Validate()
+			if c.expError != "" {
+				require.EqualError(t, err, c.expError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

This PR changes the image reference passed to `oc-mirror` to add the user-defined namespace.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Manual testing was done here to verify
- [x] Add unit test

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules