### PR TITLE
fix(mirror): add arg parse tests and create output dir for user

### DIFF
--- a/pkg/cli/mirror/mirror_test.go
+++ b/pkg/cli/mirror/mirror_test.go
@@ -1,0 +1,119 @@
+package mirror
+
+import (
+	"testing"
+
+	"github.com/openshift/oc-mirror/pkg/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMirrorComplete(t *testing.T) {
+	type spec struct {
+		name     string
+		args     []string
+		opts     *MirrorOptions
+		expOpts  *MirrorOptions
+		expError string
+	}
+
+	cases := []spec{
+		{
+			name: "Valid/FileDest",
+			args: []string{"file://foo"},
+			opts: &MirrorOptions{
+				RootOptions: &cli.RootOptions{
+					Dir: "bar",
+				},
+			},
+			expOpts: &MirrorOptions{
+				OutputDir: "foo",
+				RootOptions: &cli.RootOptions{
+					Dir: "foo/bar",
+				},
+			},
+		},
+		{
+			name: "Valid/FileDestRel",
+			args: []string{"file://./foo"},
+			opts: &MirrorOptions{
+				RootOptions: &cli.RootOptions{
+					Dir: "bar",
+				},
+			},
+			expOpts: &MirrorOptions{
+				OutputDir: "foo",
+				RootOptions: &cli.RootOptions{
+					Dir: "foo/bar",
+				},
+			},
+		},
+		{
+			name: "Valid/EmptyFileDest",
+			args: []string{"file://"},
+			opts: &MirrorOptions{
+				RootOptions: &cli.RootOptions{
+					Dir: "bar",
+				},
+			},
+			expOpts: &MirrorOptions{
+				OutputDir: ".",
+				RootOptions: &cli.RootOptions{
+					Dir: "bar",
+				},
+			},
+		},
+		{
+			name: "Valid/RegDest",
+			args: []string{"docker://reg.com"},
+			opts: &MirrorOptions{},
+			expOpts: &MirrorOptions{
+				ToMirror: "reg.com",
+			},
+		},
+		{
+			name: "Valid/RegNamespace",
+			args: []string{"docker://reg.com/foo/bar"},
+			opts: &MirrorOptions{},
+			expOpts: &MirrorOptions{
+				ToMirror:      "reg.com",
+				UserNamespace: "foo/bar",
+			},
+		},
+		{
+			name:     "Invalid/TaggedReg",
+			args:     []string{"docker://reg.com/foo/bar:latest"},
+			opts:     &MirrorOptions{},
+			expError: "destination registry must consist of registry host and namespace(s) only",
+		},
+		{
+			name:     "Invalid/EmptyRegistry",
+			args:     []string{"docker://"},
+			opts:     &MirrorOptions{},
+			expError: `"" is not a valid image reference: repository name must have at least one component`,
+		},
+		{
+			name:     "Invalid/EmptyScheme",
+			args:     []string{"://foo"},
+			opts:     &MirrorOptions{},
+			expError: `unknown destination scheme ""`,
+		},
+		{
+			name:     "Invalid/NoSchemeDelim",
+			args:     []string{"foo"},
+			opts:     &MirrorOptions{},
+			expError: "no scheme delimiter in destination argument",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.opts.Complete(c.args)
+			if c.expError != "" {
+				require.EqualError(t, err, c.expError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, c.expOpts, c.opts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

- Unit test arg parsing in `mirror`
- Create dir for user

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Added unit tests

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

/kind bug