### PR TITLE
chore: add mod flag to go install for crane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test-unit: tidy
 	$(GO) test $(GO_BUILD_FLAGS) -coverprofile=coverage.out -race -count=1 ./pkg/...
 
 .PHONY: test-e2e
-test-e2e: build
+test-e2e: tidy build
 	./test/e2e-simple.sh ./bin/oc-mirror
 
 .PHONY: test-prow

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -78,7 +78,7 @@ function cleanup() {
 
 # install_deps will install crane and registry2 in go bin dir
 function install_deps() {
-  go install github.com/google/go-containerregistry/cmd/crane@latest
+  go install -mod=mod github.com/google/go-containerregistry/cmd/crane@latest
   crane export registry:2 registry2.tar
   tar xvf registry2.tar bin/registry
   mv bin/registry $GOBIN


### PR DESCRIPTION
# Description

This PR adds `-mod=mod` flag to `go install` command on our e2e test

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

N/A/, Must be tested in CI.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules