### PR TITLE
fix(operator): produce error when invalid packages are provided with …

### DIFF
--- a/docs/imageset-config-ref.yaml
+++ b/docs/imageset-config-ref.yaml
@@ -17,11 +17,10 @@ mirror:
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.8 # References entire catalog
       headsOnly: true # References latest version of each operator in catalog (true is the default value and can be omitted)
       packages:
-        - name: couchbase-operator # Planned, overrides catalog default, respects headsOnly setting
-          startingVersion: '1.4.0' # Planned, overrides catalog default, overrides headsOnly setting
-        - name: crunchy-postgresql-operator
-          channels: # Planned
-            - name: 'stable'
+        - name: rhacs-operator
+          startingVersion: '3.67.0'
+          channels:
+            - name: 'latest'
   additionalimages: # List of additional images to be included in imageset
     - name: registry.redhat.io/ubi8/ubi:latest
   blockedimages: # Planned, list of base images to be blocked (best effort)

--- a/pkg/cli/mirror/operator_test.go
+++ b/pkg/cli/mirror/operator_test.go
@@ -81,6 +81,18 @@ func TestPinImages(t *testing.T) {
 			expErrorStr: "not found",
 		},
 		{
+			desc: "Error/NilConfig",
+			opts: &OperatorOptions{
+				MirrorOptions: MirrorOptions{
+					ContinueOnError: false,
+					SkipMissing:     false,
+				},
+			},
+			dc:          nil,
+			resolver:    mockResolver{digestMapping: map[string]string{}},
+			expErrorStr: "bug: nil declarative config",
+		},
+		{
 			desc: "Success/ContinueOnError",
 			opts: &OperatorOptions{
 				MirrorOptions: MirrorOptions{


### PR DESCRIPTION
…catalog

Fixes #246

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

This PR fixes an uncaught error in `operators.go` when `action.Diff` is run. This error in relation to the ticket it is closing was not reporting an error when invalid packages were passed in the config.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests will be added to validate this fix

- [ ] operator unit test

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules