### PR TITLE
chore: change all unit test names to comply with Go convention

### DIFF
--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -18,7 +18,7 @@ import (
 the tar size will end up larger than specified by the
  user because of the tar header being written*/
 
-func Test_SplitArchive(t *testing.T) {
+func TestSplitArchive(t *testing.T) {
 
 	testdir, err := os.MkdirTemp("", "test")
 

--- a/pkg/bundle/files_test.go
+++ b/pkg/bundle/files_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
 )
 
-func Test_ReconcilingBlobs(t *testing.T) {
+func TestReconcilingBlobs(t *testing.T) {
 
 	paths := []string{
 		filepath.Join("v2", "test", "blobs"),
@@ -94,7 +94,7 @@ func Test_ReconcilingBlobs(t *testing.T) {
 	}
 }
 
-func Test_ReconcilingManifest(t *testing.T) {
+func TestReconcilingManifest(t *testing.T) {
 
 	paths := []string{
 		filepath.Join("v2", "blobs"),

--- a/pkg/bundle/image_test.go
+++ b/pkg/bundle/image_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/openshift/oc/pkg/cli/image/imagesource"
 )
 
-func Test_ImageBlocking(t *testing.T) {
+func TestImageBlocking(t *testing.T) {
 	type fields struct {
 		blockedImages []v1alpha1.BlockedImages
 	}

--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -360,7 +360,7 @@ func TestCalculateUpgrades(t *testing.T) {
 	}
 }
 
-func Test_nodeUnmarshalJSON(t *testing.T) {
+func TestnodeUnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		raw []byte
 

--- a/pkg/cincinnati/find_test.go
+++ b/pkg/cincinnati/find_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_FindLastestRelease(t *testing.T) {
+func TestFindLastestRelease(t *testing.T) {
 	channelName := "test-channel"
 
 	tests := []struct {

--- a/pkg/cli/mirror/additional_test.go
+++ b/pkg/cli/mirror/additional_test.go
@@ -16,7 +16,7 @@ import (
 
 // TODO: use some oc lib to mock image mirroring, or mirror from files.
 
-func Test_GetAdditional(t *testing.T) {
+func TestGetAdditional(t *testing.T) {
 	tmpdir := t.TempDir()
 	mo := MirrorOptions{
 		RootOptions: &cli.RootOptions{

--- a/pkg/cli/mirror/catalog_images_test.go
+++ b/pkg/cli/mirror/catalog_images_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 // TODO: Pull image for manifest and index checks
-func Test_BuildCatalogLayer(t *testing.T) {
+func TestBuildCatalogLayer(t *testing.T) {
 	server := httptest.NewServer(registry.New())
 	t.Cleanup(server.Close)
 	u, err := url.Parse(server.URL)
@@ -47,7 +47,7 @@ func Test_BuildCatalogLayer(t *testing.T) {
 	require.NoError(t, o.buildCatalogLayer(context.Background(), targetRef, targetRef, t.TempDir(), []v1.Layer{add, delete}...))
 }
 
-func Test_BuildCatalogLayerCustomNS(t *testing.T) {
+func TestBuildCatalogLayerCustomNS(t *testing.T) {
 
 	server := httptest.NewServer(registry.New())
 	t.Cleanup(server.Close)

--- a/pkg/cli/mirror/create_test.go
+++ b/pkg/cli/mirror/create_test.go
@@ -54,7 +54,7 @@ func TestAddOPMImage(t *testing.T) {
 	require.Len(t, cfg.Mirror.AdditionalImages, 0)
 }
 
-func Test_Create(t *testing.T) {
+func TestCreate(t *testing.T) {
 	path := t.TempDir()
 	ctx := context.Background()
 
@@ -76,7 +76,7 @@ func Test_Create(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func Test_CreateWithDryRun(t *testing.T) {
+func TestCreateWithDryRun(t *testing.T) {
 	path := t.TempDir()
 	ctx := context.Background()
 
@@ -103,7 +103,7 @@ func Test_CreateWithDryRun(t *testing.T) {
 	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
-func Test_CreateWithCancel(t *testing.T) {
+func TestCreateWithCancel(t *testing.T) {
 	path := t.TempDir()
 	ctx := context.Background()
 

--- a/pkg/cli/mirror/helm_test.go
+++ b/pkg/cli/mirror/helm_test.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
-func Test_GetCustomPaths(t *testing.T) {
+func TestGetCustomPaths(t *testing.T) {
 	tests := []struct {
 		name  string
 		paths []string
@@ -42,7 +42,7 @@ func Test_GetCustomPaths(t *testing.T) {
 
 }
 
-func Test_Search(t *testing.T) {
+func TestSearch(t *testing.T) {
 	tests := []struct {
 		name    string
 		path    string
@@ -77,7 +77,7 @@ func Test_Search(t *testing.T) {
 	}
 }
 
-func Test_ParseJSON(t *testing.T) {
+func TestParseJSON(t *testing.T) {
 
 	types := map[string]interface{}{
 		"images": "test",
@@ -119,7 +119,7 @@ func Test_ParseJSON(t *testing.T) {
 	}
 }
 
-func Test_Render(t *testing.T) {
+func TestRender(t *testing.T) {
 	tests := []struct {
 		name    string
 		path    string
@@ -146,7 +146,7 @@ func Test_Render(t *testing.T) {
 	}
 }
 
-func Test_FindImages(t *testing.T) {
+func TestFindImages(t *testing.T) {
 
 	ipaths := []string{}
 	path := "testdata/artifacts/podinfo-6.0.0.tgz"

--- a/pkg/cli/mirror/manifests_test.go
+++ b/pkg/cli/mirror/manifests_test.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Test_ICSPGeneration(t *testing.T) {
+func TestICSPGeneration(t *testing.T) {
 	tests := []struct {
 		name        string
 		sourceImage reference.DockerImageReference

--- a/pkg/cli/mirror/publish_test.go
+++ b/pkg/cli/mirror/publish_test.go
@@ -21,7 +21,7 @@ import (
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
-func Test_MetadataError(t *testing.T) {
+func TestMetadataError(t *testing.T) {
 
 	cmd := &cobra.Command{}
 	ctx := context.Background()

--- a/pkg/cli/mirror/release_test.go
+++ b/pkg/cli/mirror/release_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_getDownloads(t *testing.T) {
+func TestGetDownloads(t *testing.T) {
 	clientID := uuid.MustParse("01234567-0123-0123-0123-0123456789ab")
 
 	opts := ReleaseOptions{

--- a/pkg/image/association_test.go
+++ b/pkg/image/association_test.go
@@ -11,7 +11,7 @@ const (
 	setTestKeyName = "setTestKey"
 )
 
-func Test_AssociateImageLayers(t *testing.T) {
+func TestAssociateImageLayers(t *testing.T) {
 	tests := []struct {
 		name       string
 		imgTyp     ImageType
@@ -196,7 +196,7 @@ func Test_AssociateImageLayers(t *testing.T) {
 
 }
 
-func Test_UpdateKey(t *testing.T) {
+func TestUpdateKey(t *testing.T) {
 	asSet := makeTestAssocationSet()
 	testAssocs, ok := asSet[setTestKeyName]
 	if !ok {
@@ -210,7 +210,7 @@ func Test_UpdateKey(t *testing.T) {
 	require.Equal(t, testAssocs, updateAssocs)
 }
 
-func Test_UpdateValue(t *testing.T) {
+func TestUpdateValue(t *testing.T) {
 	asSet := makeTestAssocationSet()
 	newAssoc := Association{
 		Name:       testKeyName,
@@ -227,7 +227,7 @@ func Test_UpdateValue(t *testing.T) {
 	require.Equal(t, newAssoc, assoc)
 }
 
-func Test_Merge(t *testing.T) {
+func TestMerge(t *testing.T) {
 	asSet := makeTestAssocationSet()
 	newASSet := AssociationSet{}
 	newAssocs := Associations{}
@@ -243,20 +243,20 @@ func Test_Merge(t *testing.T) {
 	asSet.Merge(newASSet)
 }
 
-func Test_ContainsKey(t *testing.T) {
+func TestContainsKey(t *testing.T) {
 	asSet := makeTestAssocationSet()
 	require.Equal(t, true, asSet.ContainsKey(setTestKeyName, testKeyName))
 }
-func Test_SetContainsKey(t *testing.T) {
+func TestSetContainsKey(t *testing.T) {
 	asSet := makeTestAssocationSet()
 	require.Equal(t, true, asSet.SetContainsKey(setTestKeyName))
 }
-func Test_Keys(t *testing.T) {
+func TestKeys(t *testing.T) {
 	asSet := makeTestAssocationSet()
 	require.Equal(t, []string{setTestKeyName}, asSet.Keys())
 }
 
-func Test_Search(t *testing.T) {
+func TestSearch(t *testing.T) {
 	asSet := makeTestAssocationSet()
 	assocs, ok := asSet.Search(setTestKeyName)
 	if !ok {
@@ -265,7 +265,7 @@ func Test_Search(t *testing.T) {
 	require.Len(t, assocs, 1)
 }
 
-func Test_Add(t *testing.T) {
+func TestAdd(t *testing.T) {
 	asSet := AssociationSet{}
 	newAssoc := Association{
 		Name:       testKeyName,

--- a/pkg/metadata/storage/local_test.go
+++ b/pkg/metadata/storage/local_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
 )
 
-func Test_LocalBackend(t *testing.T) {
+func TestLocalBackend(t *testing.T) {
 
 	underlyingFS := afero.NewMemMapFs()
 	backend := localDirBackend{

--- a/pkg/metadata/storage/registry_test.go
+++ b/pkg/metadata/storage/registry_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_RegistryBackend(t *testing.T) {
+func TestRegistryBackend(t *testing.T) {
 
 	tests := []struct {
 		name        string

--- a/pkg/metadata/storage/storage_test.go
+++ b/pkg/metadata/storage/storage_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_ByConfig(t *testing.T) {
+func TestByConfig(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
 	customDir := t.TempDir()


### PR DESCRIPTION
Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

This PR changes unit test function names that do not comply with Go convention for uniformity.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

N/A

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules