### PR TITLE
fix(mirror): change MirrorOptions to be passed by reference due to po…

### DIFF
--- a/pkg/cli/mirror/additional.go
+++ b/pkg/cli/mirror/additional.go
@@ -16,10 +16,10 @@ import (
 )
 
 type AdditionalOptions struct {
-	MirrorOptions
+	*MirrorOptions
 }
 
-func NewAdditionalOptions(mo MirrorOptions) *AdditionalOptions {
+func NewAdditionalOptions(mo *MirrorOptions) *AdditionalOptions {
 	return &AdditionalOptions{MirrorOptions: mo}
 }
 

--- a/pkg/cli/mirror/additional_test.go
+++ b/pkg/cli/mirror/additional_test.go
@@ -28,7 +28,7 @@ func TestGetAdditional(t *testing.T) {
 			},
 		},
 	}
-	opts := NewAdditionalOptions(mo)
+	opts := NewAdditionalOptions(&mo)
 
 	tests := []struct {
 		name    string

--- a/pkg/cli/mirror/create.go
+++ b/pkg/cli/mirror/create.go
@@ -168,7 +168,7 @@ func (o *MirrorOptions) Create(ctx context.Context, flags *pflag.FlagSet) error 
 }
 
 // createFull performs all tasks in creating full imagesets
-func (o MirrorOptions) createFull(ctx context.Context, flags *pflag.FlagSet, cfg *v1alpha1.ImageSetConfiguration, meta v1alpha1.Metadata) (image.AssociationSet, error) {
+func (o *MirrorOptions) createFull(ctx context.Context, flags *pflag.FlagSet, cfg *v1alpha1.ImageSetConfiguration, meta v1alpha1.Metadata) (image.AssociationSet, error) {
 
 	allAssocs := image.AssociationSet{}
 
@@ -217,7 +217,7 @@ func (o MirrorOptions) createFull(ctx context.Context, flags *pflag.FlagSet, cfg
 }
 
 // createDiff performs all tasks in creating differential imagesets
-func (o MirrorOptions) createDiff(ctx context.Context, flags *pflag.FlagSet, cfg *v1alpha1.ImageSetConfiguration, lastRun v1alpha1.PastMirror, meta v1alpha1.Metadata) (image.AssociationSet, error) {
+func (o *MirrorOptions) createDiff(ctx context.Context, flags *pflag.FlagSet, cfg *v1alpha1.ImageSetConfiguration, lastRun v1alpha1.PastMirror, meta v1alpha1.Metadata) (image.AssociationSet, error) {
 
 	allAssocs := image.AssociationSet{}
 
@@ -265,7 +265,7 @@ func (o MirrorOptions) createDiff(ctx context.Context, flags *pflag.FlagSet, cfg
 	return allAssocs, nil
 }
 
-func (o MirrorOptions) prepareArchive(ctx context.Context, cfg v1alpha1.ImageSetConfiguration, backend storage.Backend, seq int, manifests []v1alpha1.Manifest, blobs []v1alpha1.Blob) error {
+func (o *MirrorOptions) prepareArchive(ctx context.Context, cfg v1alpha1.ImageSetConfiguration, backend storage.Backend, seq int, manifests []v1alpha1.Manifest, blobs []v1alpha1.Blob) error {
 
 	// Default to a 500GiB archive size.
 	var segSize int64 = 500
@@ -306,7 +306,7 @@ func (o MirrorOptions) prepareArchive(ctx context.Context, cfg v1alpha1.ImageSet
 
 }
 
-func (o MirrorOptions) getFiles(meta v1alpha1.Metadata) ([]v1alpha1.Manifest, []v1alpha1.Blob, error) {
+func (o *MirrorOptions) getFiles(meta v1alpha1.Metadata) ([]v1alpha1.Manifest, []v1alpha1.Blob, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, nil, err
@@ -332,7 +332,7 @@ func (o MirrorOptions) getFiles(meta v1alpha1.Metadata) ([]v1alpha1.Manifest, []
 	return manifests, blobs, nil
 }
 
-func (o MirrorOptions) writeAssociations(assocs image.AssociationSet) error {
+func (o *MirrorOptions) writeAssociations(assocs image.AssociationSet) error {
 	assocPath := filepath.Join(o.Dir, config.SourceDir, config.AssociationsBasePath)
 	if err := os.MkdirAll(filepath.Dir(assocPath), 0755); err != nil {
 		return fmt.Errorf("mkdir image associations file: %v", err)

--- a/pkg/cli/mirror/helm.go
+++ b/pkg/cli/mirror/helm.go
@@ -25,11 +25,11 @@ import (
 )
 
 type HelmOptions struct {
-	MirrorOptions
+	*MirrorOptions
 	settings *helmcli.EnvSettings
 }
 
-func NewHelmOptions(mo MirrorOptions) *HelmOptions {
+func NewHelmOptions(mo *MirrorOptions) *HelmOptions {
 	settings := helmcli.New()
 	return &HelmOptions{
 		MirrorOptions: mo,

--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -41,7 +41,7 @@ var (
 // OperatorOptions configures either a Full or Diff mirror operation
 // on a particular operator catalog image.
 type OperatorOptions struct {
-	MirrorOptions
+	*MirrorOptions
 
 	SkipImagePin bool
 	Logger       *logrus.Entry
@@ -49,7 +49,7 @@ type OperatorOptions struct {
 	tmp string
 }
 
-func NewOperatorOptions(mo MirrorOptions) *OperatorOptions {
+func NewOperatorOptions(mo *MirrorOptions) *OperatorOptions {
 	return &OperatorOptions{MirrorOptions: mo}
 }
 

--- a/pkg/cli/mirror/operator_test.go
+++ b/pkg/cli/mirror/operator_test.go
@@ -28,7 +28,7 @@ func TestPinImages(t *testing.T) {
 		{
 			desc: "Success/Resolved",
 			opts: &OperatorOptions{
-				MirrorOptions: MirrorOptions{
+				MirrorOptions: &MirrorOptions{
 					ContinueOnError: false,
 					SkipMissing:     false,
 				},
@@ -61,7 +61,7 @@ func TestPinImages(t *testing.T) {
 		{
 			desc: "Error/NotFound",
 			opts: &OperatorOptions{
-				MirrorOptions: MirrorOptions{
+				MirrorOptions: &MirrorOptions{
 					ContinueOnError: false,
 					SkipMissing:     false,
 				},
@@ -83,7 +83,7 @@ func TestPinImages(t *testing.T) {
 		{
 			desc: "Error/NilConfig",
 			opts: &OperatorOptions{
-				MirrorOptions: MirrorOptions{
+				MirrorOptions: &MirrorOptions{
 					ContinueOnError: false,
 					SkipMissing:     false,
 				},
@@ -95,7 +95,7 @@ func TestPinImages(t *testing.T) {
 		{
 			desc: "Success/ContinueOnError",
 			opts: &OperatorOptions{
-				MirrorOptions: MirrorOptions{
+				MirrorOptions: &MirrorOptions{
 					ContinueOnError: true,
 					SkipMissing:     false,
 				},
@@ -116,7 +116,7 @@ func TestPinImages(t *testing.T) {
 		{
 			desc: "Success/SkipMissing",
 			opts: &OperatorOptions{
-				MirrorOptions: MirrorOptions{
+				MirrorOptions: &MirrorOptions{
 					ContinueOnError: false,
 					SkipMissing:     true,
 				},

--- a/pkg/cli/mirror/publish.go
+++ b/pkg/cli/mirror/publish.go
@@ -65,7 +65,7 @@ func (e *ErrArchiveFileNotFound) Error() string {
 	return fmt.Sprintf("file %s not found in archive", e.filename)
 }
 
-func (o MirrorOptions) Publish(ctx context.Context, cmd *cobra.Command, f kcmdutil.Factory) error {
+func (o *MirrorOptions) Publish(ctx context.Context, cmd *cobra.Command, f kcmdutil.Factory) error {
 
 	logrus.Infof("Publishing image set from archive %q to registry %q", o.From, o.ToMirror)
 
@@ -431,7 +431,7 @@ func readAssociations(assocPath string) (assocs image.AssociationSet, err error)
 }
 
 // unpackImageSet unarchives all provided tar archives	if err != nil {
-func (o MirrorOptions) unpackImageSet(a archive.Archiver, dest string) error {
+func (o *MirrorOptions) unpackImageSet(a archive.Archiver, dest string) error {
 
 	// archive that we do not want to unpack
 	exclude := []string{"blobs", "v2", config.HelmDir}
@@ -497,7 +497,7 @@ func copyBlobFile(src io.Reader, dstPath string) error {
 	return nil
 }
 
-func (o MirrorOptions) fetchBlobs(ctx context.Context, meta v1alpha1.Metadata, mapping imgmirror.Mapping, missingLayers map[string][]string) error {
+func (o *MirrorOptions) fetchBlobs(ctx context.Context, meta v1alpha1.Metadata, mapping imgmirror.Mapping, missingLayers map[string][]string) error {
 
 	restctx, err := config.CreateDefaultContext(o.DestSkipTLS)
 	if err != nil {
@@ -521,7 +521,7 @@ func (o MirrorOptions) fetchBlobs(ctx context.Context, meta v1alpha1.Metadata, m
 
 // fetchBlob fetches a blob at <o.ToMirror>/<resource>/blobs/<layerDigest>
 // then copies it to each path in dstPaths.
-func (o MirrorOptions) fetchBlob(ctx context.Context, restctx *registryclient.Context, ref reference.DockerImageReference, layerDigest string, dstPaths []string) error {
+func (o *MirrorOptions) fetchBlob(ctx context.Context, restctx *registryclient.Context, ref reference.DockerImageReference, layerDigest string, dstPaths []string) error {
 
 	logrus.Debugf("copying blob %s from %s", layerDigest, ref.Exact())
 	repo, err := restctx.RepositoryForRef(ctx, ref, o.DestSkipTLS)
@@ -576,7 +576,7 @@ func mktempDir(dir string) (func(), string, error) {
 // mirrorRelease uses the `oc release mirror` library to mirror OCP release
 // QUESTION(jpower): should we just mirror release one by one
 // The namespace is not the same as the image name
-func (o MirrorOptions) mirrorRelease(mapping imgmirror.Mapping, cmd *cobra.Command, f kcmdutil.Factory, fromDir string) error {
+func (o *MirrorOptions) mirrorRelease(mapping imgmirror.Mapping, cmd *cobra.Command, f kcmdutil.Factory, fromDir string) error {
 	logrus.Debugf("mirroring release image: %s", mapping.Source.String())
 	relOpts := release.NewMirrorOptions(o.IOStreams)
 	relOpts.From = mapping.Source.String()
@@ -598,7 +598,7 @@ func (o MirrorOptions) mirrorRelease(mapping imgmirror.Mapping, cmd *cobra.Comma
 }
 
 // mirrorImages uses the `oc mirror` library to mirror generic images
-func (o MirrorOptions) mirrorImage(mappings []imgmirror.Mapping, fromDir string) error {
+func (o *MirrorOptions) mirrorImage(mappings []imgmirror.Mapping, fromDir string) error {
 	// Mirror all file sources of each available image type to mirror registry.
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
 		var srcs []string
@@ -627,7 +627,7 @@ func (o MirrorOptions) mirrorImage(mappings []imgmirror.Mapping, fromDir string)
 	return nil
 }
 
-func (o MirrorOptions) createResultsDir() (resultsDir string, err error) {
+func (o *MirrorOptions) createResultsDir() (resultsDir string, err error) {
 	resultsDir = filepath.Join(
 		o.Dir,
 		fmt.Sprintf("results-%v", time.Now().Unix()),
@@ -638,7 +638,7 @@ func (o MirrorOptions) createResultsDir() (resultsDir string, err error) {
 	return resultsDir, nil
 }
 
-func (o MirrorOptions) findBlobRepo(meta v1alpha1.Metadata, layerDigest string) (imagesource.TypedImageReference, error) {
+func (o *MirrorOptions) findBlobRepo(meta v1alpha1.Metadata, layerDigest string) (imagesource.TypedImageReference, error) {
 	var namespacename string
 	var ref string
 	for _, mirror := range meta.PastMirrors {

--- a/pkg/cli/mirror/release.go
+++ b/pkg/cli/mirror/release.go
@@ -34,14 +34,14 @@ var archMap = map[string]string{
 // ReleaseOptions configures either a Full or Diff mirror operation
 // on a particular release image.
 type ReleaseOptions struct {
-	MirrorOptions
+	*MirrorOptions
 	release string
 	arch    []string
 	uuid    uuid.UUID
 }
 
 // NewReleaseOptions defaults ReleaseOptions.
-func NewReleaseOptions(mo MirrorOptions, flags *pflag.FlagSet) *ReleaseOptions {
+func NewReleaseOptions(mo *MirrorOptions, flags *pflag.FlagSet) *ReleaseOptions {
 	var arch []string
 	opts := mo.FilterOptions
 	opts.Complete(flags)


### PR DESCRIPTION
…ssible bugs that can arise from passing a lock by value

Signed-off-by: jpower432 <barnabei.jennifer@gmail.com>

# Description

This PR changes the MirrorOptions are being passed to other structs to be passed by reference instead of by value. Caught by `GoLand` scans. Need to be done now that MirrorOptions contains a lock.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] Unit Tests
- [X] E2E Test

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules