### PR TITLE
Fix/clean build

### DIFF
--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -10,7 +10,8 @@ Let's get started!
 
 ## Building
 
-Please run `hack/build.sh` to build the `oc-mirror` executable for local testing
+Please run `hack/build.sh` to build the `oc-mirror` executable for local testing. If you do not have uncommitted changes that you are testing, you should run `hack/build.sh --clean` in order to clean the working directory of any artifacts possibly left over from your work or a previous build/test.
+
 ## CI
 
 Our CI is automated using Prow. The configuration is located in the `openshift/release` project.
@@ -20,7 +21,3 @@ We are currently running automated unit tests with CI and are working on an auto
 
 We have developed local end-to-end test scripts to verify `oc-mirror` functionality with various imageset configurations.
 When added a new feature or changing a current feature ensure the functionality is covered by the end-to-test located [here](../test/../../test/e2e-simple.sh)
-
-
-
-

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -36,4 +36,13 @@ run () {
   fi
 }
 
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --clean)
+            git clean -dxf ;;
+        *)
+            run_log 1 "Unknown argument, $1" ;;
+    esac; shift
+done
+
 run

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -39,7 +39,12 @@ run () {
 while [ $# -gt 0 ]; do
     case "$1" in
         --clean)
-            git clean -dxf ;;
+            if git clean -dxf; then
+                run_log 0 "Cleaned working directory"
+            else
+                run_log 1 "Failed to clean the working directory"
+            fi
+            ;;
         *)
             run_log 1 "Unknown argument, $1" ;;
     esac; shift

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -15,21 +15,25 @@ run_log () {
 
 build_builder_image () {
   run_log 0 "Starting builder container image build"
-  ${run_cmd} build -f Dockerfile -t ${image_name} .
+  "${run_cmd}" build -f Dockerfile -t "${image_name}" .
 }
 
 build_binary () {
   run_log 0 "Starting binary build"
-  ${run_cmd} run -it --rm --privileged -v ${src_dir}:/build:z ${image_name}
+  "${run_cmd}" run -it --rm --privileged -v "${src_dir}:/build:z" "${image_name}"
 }
 
 run () {
-  build_builder_image \
-    && run_log 0 "Successfully built builder image" \
-    || run_log 1 "Failed to build builder image"
-  build_binary \
-    && run_log 0 "Successfully built binary" \
-    || run_log 1 "Failed to build binary"
+  if build_builder_image; then
+    run_log 0 "Successfully built builder image"
+  else
+    run_log 1 "Failed to build builder image"
+  fi
+  if build_binary; then
+    run_log 0 "Successfully built binary"
+  else
+    run_log 1 "Failed to build binary"
+  fi
 }
 
 run


### PR DESCRIPTION
# Description

- Added `--clean` flag for `hack/build.sh` that runs `git clean -dxf` to remove any and all unexpected files from the directory before building
- Fixed up some shellcheck errors that my IDE has been yelling at me about

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I ran `hack/build.sh --clean` and observed git cleaning my working directory to match the tree before the build:

```
$ hack/build.sh --clean
Removing tags
>>  INFO: Cleaned working directory
>>  INFO: Starting builder container image build
STEP 1/8: FROM registry.access.redhat.com/ubi8/ubi
STEP 2/8: ARG DNF_LIST="  jq   tar   gcc   make "
--> Using cache 9043fa95863feea0e549817ab292acdc5d322dd9b096a7d7b6700e8a2b6507d8
--> 9043fa95863
STEP 3/8: RUN set -ex      && dnf install -y --nodocs --setopt=install_weak_deps=false ${DNF_LIST}         && dnf clean all -y                                                             && GO_VERSION=$(curl -sL https://golang.org/dl/?mode=json                                       | jq -r '.[].files[] | select(.os == "linux").version'                          | grep -v -E 'go[0-9\.]+(beta|rc)'                                              | sort -V | tail -1)                                            && curl -sL https://golang.org/dl/${GO_VERSION}.linux-amd64.tar.gz                 | tar xzvf - --directory /usr/local/                                         && /usr/local/go/bin/go version                                                 && ln -f /usr/local/go/bin/go /usr/bin/go
--> Using cache 052837de652588921f44f43b6a3b8fa3fb7c95bbca1af79e1badbcc710292b13
--> 052837de652
STEP 4/8: WORKDIR /build
--> Using cache ee2dd34197d2067b6e9ca06c3bbff99efb153c70f1e4e2b61c776c56a805e3e0
--> ee2dd34197d
STEP 5/8: ENTRYPOINT ["make"]
--> Using cache b3d164dc63bc3807d395572fd7a32754f405900d84b9e83d26e2a006c9b41bef
--> b3d164dc63b
STEP 6/8: CMD []
--> Using cache 39ae3d4512e2ab3e9de429951cd8961be3d038dbd964dcc8801bbbdd70030340
--> 39ae3d4512e
STEP 7/8: ENV PATH="/root/platform/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
--> Using cache 8cc85f1eb1cbb084b48298b5d3f7617662102cba2fb29be0b284581d6f9346c7
--> 8cc85f1eb1c
STEP 8/8: LABEL   name="go-toolset"                                                               license=GPLv3                                                                   distribution-scope="public"                                                     io.openshift.tags="go-toolset"                                                  summary="oc-mirror compiler image"                                              io.k8s.display-name="go-toolset"                                                build_date="`date +'%Y%m%d%H%M%S'`"                                             project="https://github.com/openshift/oc-mirror"                                description="oc-mirror is an OpenShift Client (oc) plugin that manages OpenShift release, operator catalog, helm charts, and associated container images. This image is designed to build the binary."   io.k8s.description="oc-mirror is an OpenShift Client (oc) plugin that manages OpenShift release, operator catalog, helm charts, and associated container images. This image is designed to build the binary."
--> Using cache f3b26d377548711ab89b044290fedfce1f167e1ffaa2558269dbe8dd46d090a8
COMMIT local/go-toolset
--> f3b26d37754
Successfully tagged localhost/local/go-toolset:latest
f3b26d377548711ab89b044290fedfce1f167e1ffaa2558269dbe8dd46d090a8
>>  INFO: Successfully built builder image
>>  INFO: Starting binary build
go mod tidy
...
<A BUNCH OF GO STUFF>
...
go test -tags=json1 -coverprofile=coverage.out -race -count=1 ./pkg/...
ok      github.com/openshift/oc-mirror/pkg/archive      0.340s  coverage: 39.3% of statements
ok      github.com/openshift/oc-mirror/pkg/bundle       0.189s  coverage: 46.7% of statements
ok      github.com/openshift/oc-mirror/pkg/cincinnati   0.654s  coverage: 80.1% of statements
?       github.com/openshift/oc-mirror/pkg/cli  [no test files]
ok      github.com/openshift/oc-mirror/pkg/cli/mirror   6.849s  coverage: 32.4% of statements
?       github.com/openshift/oc-mirror/pkg/cli/mirror/describe  [no test files]
ok      github.com/openshift/oc-mirror/pkg/cli/mirror/list      0.159s  coverage: 7.6% of statements
?       github.com/openshift/oc-mirror/pkg/cli/mirror/version   [no test files]
ok      github.com/openshift/oc-mirror/pkg/config       0.303s  coverage: 11.8% of statements
ok      github.com/openshift/oc-mirror/pkg/config/v1alpha1      0.175s  coverage: 31.3% of statements
ok      github.com/openshift/oc-mirror/pkg/image        0.063s  coverage: 55.9% of statements
?       github.com/openshift/oc-mirror/pkg/metadata     [no test files]
ok      github.com/openshift/oc-mirror/pkg/metadata/storage     0.451s  coverage: 72.7% of statements
go build -tags=json1 -o bin/oc-mirror ./cmd/oc-mirror
>>  INFO: Successfully built binary
```

**Test Configuration**:
Fedora 35, local development workflow

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules