### PR TITLE
chore: mark filter-by-os flag as hidden temporarily

### DIFF
--- a/pkg/cli/mirror/additional.go
+++ b/pkg/cli/mirror/additional.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/openshift/oc/pkg/cli/image/imagesource"
+	imagemanifest "github.com/openshift/oc/pkg/cli/image/manifest"
 	"github.com/openshift/oc/pkg/cli/image/mirror"
 	"github.com/sirupsen/logrus"
 
@@ -39,7 +40,7 @@ func (o *AdditionalOptions) GetAdditional(cfg v1alpha1.ImageSetConfiguration, im
 	opts.SecurityOptions.Insecure = o.SourceSkipTLS
 	opts.SecurityOptions.SkipVerification = o.SkipVerification
 	opts.FileDir = filepath.Join(o.Dir, config.SourceDir)
-	opts.FilterOptions = o.FilterOptions
+	opts.FilterOptions = imagemanifest.FilterOptions{FilterByOS: ".*"}
 
 	logrus.Infof("Downloading %d image(s) to %s", len(imageList), opts.FileDir)
 

--- a/pkg/cli/mirror/create.go
+++ b/pkg/cli/mirror/create.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/pflag"
 
 	"github.com/openshift/oc-mirror/pkg/archive"
 	"github.com/openshift/oc-mirror/pkg/bundle"
@@ -21,7 +20,7 @@ import (
 	"github.com/openshift/oc-mirror/pkg/metadata/storage"
 )
 
-func (o *MirrorOptions) Create(ctx context.Context, flags *pflag.FlagSet) error {
+func (o *MirrorOptions) Create(ctx context.Context) error {
 
 	// Read the imageset-config.yaml
 	cfg, err := config.LoadConfig(o.ConfigPath)
@@ -94,7 +93,7 @@ func (o *MirrorOptions) Create(ctx context.Context, flags *pflag.FlagSet) error 
 		meta.Uid = uuid.New()
 		thisRun.Sequence = 1
 
-		assocs, err = o.createFull(ctx, flags, &cfg, meta)
+		assocs, err = o.createFull(ctx, &cfg, meta)
 		if err != nil {
 			return err
 		}
@@ -104,7 +103,7 @@ func (o *MirrorOptions) Create(ctx context.Context, flags *pflag.FlagSet) error 
 		lastRun := meta.PastMirrors[len(meta.PastMirrors)-1]
 		thisRun.Sequence = lastRun.Sequence + 1
 
-		assocs, err = o.createDiff(ctx, flags, &cfg, lastRun, meta)
+		assocs, err = o.createDiff(ctx, &cfg, lastRun, meta)
 		if err != nil {
 			return err
 		}
@@ -168,12 +167,12 @@ func (o *MirrorOptions) Create(ctx context.Context, flags *pflag.FlagSet) error 
 }
 
 // createFull performs all tasks in creating full imagesets
-func (o *MirrorOptions) createFull(ctx context.Context, flags *pflag.FlagSet, cfg *v1alpha1.ImageSetConfiguration, meta v1alpha1.Metadata) (image.AssociationSet, error) {
+func (o *MirrorOptions) createFull(ctx context.Context, cfg *v1alpha1.ImageSetConfiguration, meta v1alpha1.Metadata) (image.AssociationSet, error) {
 
 	allAssocs := image.AssociationSet{}
 
 	if len(cfg.Mirror.OCP.Channels) != 0 {
-		opts := NewReleaseOptions(o, flags)
+		opts := NewReleaseOptions(o)
 		assocs, err := opts.GetReleases(ctx, meta, cfg)
 		if err != nil {
 			return allAssocs, err
@@ -217,12 +216,12 @@ func (o *MirrorOptions) createFull(ctx context.Context, flags *pflag.FlagSet, cf
 }
 
 // createDiff performs all tasks in creating differential imagesets
-func (o *MirrorOptions) createDiff(ctx context.Context, flags *pflag.FlagSet, cfg *v1alpha1.ImageSetConfiguration, lastRun v1alpha1.PastMirror, meta v1alpha1.Metadata) (image.AssociationSet, error) {
+func (o *MirrorOptions) createDiff(ctx context.Context, cfg *v1alpha1.ImageSetConfiguration, lastRun v1alpha1.PastMirror, meta v1alpha1.Metadata) (image.AssociationSet, error) {
 
 	allAssocs := image.AssociationSet{}
 
 	if len(cfg.Mirror.OCP.Channels) != 0 {
-		opts := NewReleaseOptions(o, flags)
+		opts := NewReleaseOptions(o)
 		assocs, err := opts.GetReleases(ctx, meta, cfg)
 		if err != nil {
 			return allAssocs, err

--- a/pkg/cli/mirror/create_test.go
+++ b/pkg/cli/mirror/create_test.go
@@ -71,8 +71,7 @@ func TestCreate(t *testing.T) {
 		ConfigPath: "testdata/configs/test.yaml",
 		OutputDir:  path,
 	}
-	flags := NewMirrorCmd().Flags()
-	err := opts.Create(ctx, flags)
+	err := opts.Create(ctx)
 	require.NoError(t, err)
 }
 
@@ -94,8 +93,7 @@ func TestCreateWithDryRun(t *testing.T) {
 		DryRun:     true,
 		OutputDir:  path,
 	}
-	flags := NewMirrorCmd().Flags()
-	err := opts.Create(ctx, flags)
+	err := opts.Create(ctx)
 	require.NoError(t, err)
 
 	// should not produce an archive
@@ -129,9 +127,7 @@ func TestCreateWithCancel(t *testing.T) {
 	// closing the channel will cause the
 	// command to exit if using a cancellable context
 	close(cancelCh)
-
-	flags := NewMirrorCmd().Flags()
-	err := opts.Create(ctx, flags)
+	err := opts.Create(ctx)
 	require.NoError(t, err)
 
 	require.Equal(t, true, opts.interrupted)

--- a/pkg/cli/mirror/mirror_test.go
+++ b/pkg/cli/mirror/mirror_test.go
@@ -33,6 +33,7 @@ func TestMirrorComplete(t *testing.T) {
 				RootOptions: &cli.RootOptions{
 					Dir: "foo/bar",
 				},
+				FilterOptions: []string{"amd64"},
 			},
 		},
 		{
@@ -48,6 +49,7 @@ func TestMirrorComplete(t *testing.T) {
 				RootOptions: &cli.RootOptions{
 					Dir: "foo/bar",
 				},
+				FilterOptions: []string{"amd64"},
 			},
 		},
 		{
@@ -63,6 +65,7 @@ func TestMirrorComplete(t *testing.T) {
 				RootOptions: &cli.RootOptions{
 					Dir: "bar",
 				},
+				FilterOptions: []string{"amd64"},
 			},
 		},
 		{
@@ -70,7 +73,8 @@ func TestMirrorComplete(t *testing.T) {
 			args: []string{"docker://reg.com"},
 			opts: &MirrorOptions{},
 			expOpts: &MirrorOptions{
-				ToMirror: "reg.com",
+				ToMirror:      "reg.com",
+				FilterOptions: []string{"amd64"},
 			},
 		},
 		{
@@ -80,6 +84,24 @@ func TestMirrorComplete(t *testing.T) {
 			expOpts: &MirrorOptions{
 				ToMirror:      "reg.com",
 				UserNamespace: "foo/bar",
+				FilterOptions: []string{"amd64"},
+			},
+		},
+		{
+			name: "Valid/SetFilterOps",
+			args: []string{"file://foo"},
+			opts: &MirrorOptions{
+				RootOptions: &cli.RootOptions{
+					Dir: "bar",
+				},
+				FilterOptions: []string{"amd64", "ppc64le"},
+			},
+			expOpts: &MirrorOptions{
+				OutputDir: "foo",
+				RootOptions: &cli.RootOptions{
+					Dir: "foo/bar",
+				},
+				FilterOptions: []string{"amd64", "ppc64le"},
 			},
 		},
 		{
@@ -166,6 +188,16 @@ func TestMirrorValidate(t *testing.T) {
 				DryRun:     true,
 			},
 			expError: "--dry-run is not supported for mirror publishing operations",
+		},
+		{
+			name: "Invalid/UnsupportReleaseArch",
+			opts: &MirrorOptions{
+				ConfigPath:    "foo",
+				ToMirror:      u.Host,
+				DryRun:        true,
+				FilterOptions: []string{"arm64"},
+			},
+			expError: "architecture arm64 is not a supported release architecture",
 		},
 		{
 			name: "Valid/MirrortoDisk",

--- a/pkg/cli/mirror/mirror_test.go
+++ b/pkg/cli/mirror/mirror_test.go
@@ -194,10 +194,9 @@ func TestMirrorValidate(t *testing.T) {
 			opts: &MirrorOptions{
 				ConfigPath:    "foo",
 				ToMirror:      u.Host,
-				DryRun:        true,
 				FilterOptions: []string{"arm64"},
 			},
-			expError: "architecture arm64 is not a supported release architecture",
+			expError: "architecture \"arm64\" is not a supported release architecture",
 		},
 		{
 			name: "Valid/MirrortoDisk",

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -8,7 +8,6 @@ import (
 	"syscall"
 
 	"github.com/openshift/oc-mirror/pkg/cli"
-	imagemanifest "github.com/openshift/oc/pkg/cli/image/manifest"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 )
@@ -29,7 +28,7 @@ type MirrorOptions struct {
 	SkipCleanup      bool
 	SkipMissing      bool
 	ContinueOnError  bool
-	FilterOptions    imagemanifest.FilterOptions
+	FilterOptions    []string
 	// cancelCh is a channel listening for command cancellations
 	cancelCh    <-chan struct{}
 	interrupted bool
@@ -47,7 +46,7 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.DestSkipTLS, "dest-skip-tls", o.DestSkipTLS, "Use plain HTTP for destination registry")
 	fs.BoolVar(&o.SkipVerification, "skip-verification", o.SkipVerification, "Skip digest verification")
 	fs.BoolVar(&o.SkipCleanup, "skip-cleanup", o.SkipCleanup, "Skip removal of artifact directories")
-	fs.StringVar(&o.FilterOptions.FilterByOS, "filter-by-os", "", "A regular expression to control which index image is picked when multiple variants are available")
+	fs.StringSliceVar(&o.FilterOptions, "filter-by-os", o.FilterOptions, "A regular expression to control which release image is picked when multiple variants are available")
 	fs.BoolVar(&o.ContinueOnError, "continue-on-error", o.ContinueOnError, "If an error occurs, keep going "+
 		"and attempt to mirror as much as possible")
 	fs.BoolVar(&o.SkipMissing, "skip-missing", o.SkipMissing, "If an input image is not found, skip them. "+

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openshift/oc-mirror/pkg/cli"
 	imagemanifest "github.com/openshift/oc/pkg/cli/image/manifest"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 )
 
@@ -52,6 +53,12 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.SkipMissing, "skip-missing", o.SkipMissing, "If an input image is not found, skip them. "+
 		"404/NotFound errors encountered while pulling images explicitly specified in the config "+
 		"will not be skipped")
+
+	// TODO(jpower432): Make this flag visible again once release architecture selection
+	// has been more thouroughly vetted
+	if err := fs.MarkHidden("filter-by-os"); err != nil {
+		logrus.Panic(err.Error())
+	}
 }
 
 func (o *MirrorOptions) init() {

--- a/pkg/cli/mirror/release.go
+++ b/pkg/cli/mirror/release.go
@@ -15,7 +15,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/openshift/oc/pkg/cli/admin/release"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/pflag"
 
 	"github.com/openshift/oc-mirror/pkg/bundle"
 	"github.com/openshift/oc-mirror/pkg/cincinnati"
@@ -23,8 +22,6 @@ import (
 	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
 	"github.com/openshift/oc-mirror/pkg/image"
 )
-
-var supportedArchs = []string{"amd64", "ppc64le", "s390x"}
 
 // archMap maps Go architecture strings to OpenShift supported values for any that differ.
 var archMap = map[string]string{
@@ -41,19 +38,10 @@ type ReleaseOptions struct {
 }
 
 // NewReleaseOptions defaults ReleaseOptions.
-func NewReleaseOptions(mo *MirrorOptions, flags *pflag.FlagSet) *ReleaseOptions {
-	var arch []string
-	opts := mo.FilterOptions
-	opts.Complete(flags)
-	if opts.IsWildcardFilter() {
-		arch = supportedArchs
-	} else {
-		arch = []string{strings.Join(strings.Split(opts.FilterByOS, "/")[1:], "/")}
-	}
-
+func NewReleaseOptions(mo *MirrorOptions) *ReleaseOptions {
 	return &ReleaseOptions{
 		MirrorOptions: mo,
-		arch:          arch,
+		arch:          mo.FilterOptions,
 		uuid:          uuid.New(),
 	}
 }

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -23,8 +23,9 @@ type RootOptions struct {
 func (o *RootOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&o.Dir, "dir", "d", "oc-mirror-workspace", "Assets directory")
 	fs.StringVar(&o.LogLevel, "log-level", "info", "Log level (e.g. \"debug | info | warn | error\")")
-	// Mark dir as a hidden flag
-	fs.MarkHidden("dir")
+	if err := fs.MarkHidden("dir"); err != nil {
+		logrus.Panic(err.Error())
+	}
 }
 
 func (o *RootOptions) LogfilePreRun(cmd *cobra.Command, _ []string) {


### PR DESCRIPTION
Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

This PR marks the `filter-by-os` flags as hidden temporarily so the default and be used and the OpenShift release architecture can be more thoroughly vetted.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manually tested to ensure the `filter-by-os` does not showup a flag in the help message

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules