### PR TITLE
general docs cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 # oc-mirror
-
-**This repo is under active development. CLI and APIs are unstable**
-
 - [oc-mirror](#oc-mirror)
   - [Usage](#usage)
     - [Configuration Examples](#configuration-examples)
@@ -18,14 +15,14 @@
     - [Build](#build)
     - [Test](#test)
 
-`oc-mirror` is an OpenShift Client (oc) plugin that manages OpenShift release, operator catalog, helm charts, and associated container images.
+`oc-mirror` is an OpenShift Client (oc) plugin that manages OpenShift release, operator catalog, helm charts, and associated container images for mirror registries that support OpenShift environments.
 ## Usage
 [![asciicast](https://asciinema.org/a/uToc11VnzG0RMZrht2dsaTfo9.svg)](https://asciinema.org/a/uToc11VnzG0RMZrht2dsaTfo9)
 
 The mirror registry `reg.mirror.com` is used in this example.
 Replace this value with a real registry host, or create a `docker.io/library/registry:2` container locally.\
 
-> DISCLAIMER: `oc-mirror` is not compatible with Quay under version 3.6.
+> DISCLAIMER: `oc-mirror` is not compatible with Quay below version 3.6.
 
 ### Configuration Examples
 
@@ -71,7 +68,7 @@ storageConfig:
    ```
 2. List all available channels to query for a version of OpenShift
    ```sh
-   ./bin/oc-mirror list releases --channels --version=4.8
+   ./bin/oc-mirror list releases --channels --version=4.9
    ```
 3. List all available release payloads for a version of OpenShift in a specified channel
    ```sh

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,13 @@
+# Troubleshooting
+## Verbose logging
+When troubleshooting, use the `--log-level=debug` flag to get debug messages. Logging information is printed to standard out, but also to a log file in the current directory called .openshift_bundle.log. Attach this file to bug reports.
+
+
+## Content Selection
+To troubleshoot issues with Imageset configuration generation, the `oc-mirror list releases` or `oc-mirror list operators` can be used to discover currently available content for each data type.
+
+## Retrieve oc-mirror metadata
+When submitting bug reports, include the metadata.json from the problem generated tar artifact, called an imageset. The metadata.json can be retrieved from the imageset with: `tar xf <imageset-name> /publish/.metadata.json`. Then retrieve and upload the metadata.json from  `./publish/.metadata.json`. 
+
+## Operator Installation
+To troubleshoot issues with the created file-based catalog, use the following command to get information about the problem package, ‘oc get packagemanifests -n openshift-marketplace <packagename> -o json | jq '.status.channels[]|{name: .name, currentCSV: .currentCSV}'

--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -3,18 +3,18 @@
 # oc-mirror Design Overview
 
 ## Summary 
-oc-mirror assists with lifecycle management of internet-disconnected OpenShift environments by performing differential update operations and synchronization between internet-connected and internet-disconnected environments.   
+oc-mirror assists with lifecycle management of mirror registries that support OpenShift environments by performing differential update operations and synchronizations.   
   
 ## Features
 1. Differential Synchronization of OpenShift Release Images
 2. Differential Synchronization of Operator images
-3. Synchronization of OpenShift cincinnati graph data image
+3. Synchronization of OpenShift cincinnati graph data image (planned)
 4. Synchronization of OpenShift Release images by version or channel latest
-5. Synchronization of Operator Images by full catalog and full catalog at latest operator versions. Also, allows for synchronization of individual operators by version or channel head.
+5. Synchronization of Operator Images by full catalog and full catalog at latest operator versions. Also, allows for synchronization of individual operators by version to channel(s') HEAD.
 6. Synchronization of helm charts
 7. Synchronization of additional images
 8. Remote state backends
-9. Base image filtering
+9. Base image filtering (planned)
 10. (multi) Cluster resource management
 
 ## Design Considerations
@@ -22,7 +22,7 @@ oc-mirror assists with lifecycle management of internet-disconnected OpenShift e
 2. Stateful - Differential operations require tracking downloaded versions and calculating upgrade paths based on previous application runs. State must persist between execution environments.
 3. One-way synchronization - Some internet-disconnected environments are considered confidential and cannot tolerate data spillage from the disconnected environment to any internet connected networks. oc-mirror only synchronizes differential state from internet-connected environments to internet-disconnected environments. oc-mirror assumes that no data can traverse from an internet-disconnected environment to an internet-connected environment at any time. 
 4. User Workloads -  oc-mirror synchronizes helm charts and arbitrary images to streamline the importation of user workloads into their OpenShift deployments. 
-5. Internet Connected Experience - Operator Lifecycle Manager, OpenShift Update Service, Advanced Cluster Management, and oc-mirror; in concert, can facilitate user experience parity with that of internet-connected environments. This ux is achieved by updating cluster resources during the publishing phase of oc-mirror. 
+5. Internet Connected Experience - Operator Lifecycle Manager, OpenShift Update Service, Advanced Cluster Management, and oc-mirror; in concert, can facilitate user experience parity with that of internet-connected environments. This ux is achieved by updating cluster resources during the publishing phase of oc-mirror(planned). 
 6. Artifact Size - oc-mirror attempts to reduce the size of artifacts passed from the internet-connected environment to the internet-disconnected environment. These efficiencies are addressed at two levels: Differential version updates and Differential image layer updates. These artifacts can be further subdivided into user-defined file sizes. During each phase of operation, every effort has been made to reduce duplication of content on disk while contents traverse between image registries and imagesets. Due to image validation requirements, network utilization remains the most inefficient aspect of oc-mirror.
 7. Wide Applicability - oc-mirror provides a means to synchronize container image content for limited connectivity deployments of containerized edge, IoT, and AI/ML offerings. 
 
@@ -82,29 +82,3 @@ During the “publish diff” phase for differential updates:
 5. Output cluster ICSPs / Catalog Source / Cincinnati
 6. Optionally update (multi) cluster ICSPs / Catalog Source / Cincinnati 
 7. Update backend metadata
-
-## Project Milestone Overview
-
-#### Alpha1 - Baseline project structure and behavior
-
-1. Release synchronization (full)
-2. Operator synchronization (full)  
-3. Additional Image synchronization (full)  
-4. Base image filtering (rough)  
-5. GitHub Actions e2e tests automated  
-
-#### Alpha2 - Feature Inclusivity
-1. Operator synchronization (diff)
-2. Helm synchronization
-3. Speed improvements
-4. Archive improvements
-
-#### Alpha3 - UX refinement
-1. Refactor CLI commands
-2. Remote backends
-3. Release synchronization (diff)
-4. Prow tests
-
-#### Tech Preview - Bug Fixes  
-
-#### After - Cluster resource management / cincinnati graph image handling/ publish from s3 / enhanced base image filtering

--- a/docs/examples/imageset-config-catalog-headsonly.yaml
+++ b/docs/examples/imageset-config-catalog-headsonly.yaml
@@ -1,3 +1,7 @@
+# This config uses the headsOnly feature which will mirror the 
+# latest version of each channel within each package contained 
+# within a specified operator catalog
+---
 apiVersion: mirror.openshift.io/v1alpha1
 kind: ImageSetConfiguration
 mirror:

--- a/docs/examples/imageset-config-filter-catalog.yaml
+++ b/docs/examples/imageset-config-filter-catalog.yaml
@@ -1,10 +1,23 @@
+# This config demonstrates how to mirror a single operator. By
+# specifying a startingVersion, that version and every version to the
+# specified channel's latest (HEAD) version will be mirrored. 
+
+# If a package is specified with no startingVersion or channel, all
+# versions within every channel of the specified package will be mirrored.
+
+# Alternatively, omit the channel and leave the startingVersion and all 
+# higher versions within every channel the startingVersion exists within 
+# the specified package will be mirrored.
+---
 apiVersion: mirror.openshift.io/v1alpha1
 kind: ImageSetConfiguration
 mirror:
   ocp:
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.8
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.9
       headsOnly: false
       packages:
         - name: elasticsearch-operator
-          startingVersion: '5.2.3-31'
+          startingVersion: 5.3.2-20
+          channels:
+            - name: stable

--- a/docs/examples/imageset-config-helm.yaml
+++ b/docs/examples/imageset-config-helm.yaml
@@ -1,3 +1,7 @@
+# This example demonstrates how to mirror a helm chart
+# and all referenced images within that chart. A version
+# must be specified for the chart.
+---
 apiVersion: mirror.openshift.io/v1alpha1
 kind: ImageSetConfiguration
 mirror:
@@ -8,7 +12,4 @@ mirror:
         charts:
           - name: podinfo
             version: 5.0.0
-    local:
-      - name: podinfo-local
-        path: /home/user/podinfo-6.0.0.tgz
         

--- a/docs/examples/imageset-config-okd.yaml
+++ b/docs/examples/imageset-config-okd.yaml
@@ -1,3 +1,7 @@
+# This example demonstrates how to mirror a specific
+# okd release. Optionally, omit the version to mirror
+# the latest release.
+---
 apiVersion: mirror.openshift.io/v1alpha1
 kind: ImageSetConfiguration
 mirror:
@@ -5,5 +9,4 @@ mirror:
     channels:
       - name: okd
         versions:
-        - '4.8.0-0.okd-2021-10-10-030117'
-    graph: true
+        - '4.10.0-0.okd-2022-01-20-011141'

--- a/docs/examples/imageset-config-registry-backend.yaml
+++ b/docs/examples/imageset-config-registry-backend.yaml
@@ -1,11 +1,20 @@
+# This config demonstrates how to configure a
+# backend storage location to store oc-mirror 
+# metadata. OCI registries or local filesystems
+# can be used. Optionally, replace the registry
+# subkey with "local" and add a path subkey under
+# local to specify a local backend.
+---
 apiVersion: mirror.openshift.io/v1alpha1
 kind: ImageSetConfiguration
 storageConfig:
   registry:
-    imageURL: localhost:5000/test:latest
-    skipTLS: true
+    imageURL: localhost:5000/namespace/target
+    skipTLS: false
+  #local:
+  #  path: /path/to/dir
 mirror:
   ocp:
     channels:
-      - name: stable-4.8
+      - name: stable-4.9
     graph: true

--- a/docs/examples/imageset-config-release.yaml
+++ b/docs/examples/imageset-config-release.yaml
@@ -1,10 +1,12 @@
+# This config demonstrates how to mirror a specified
+# version(s) of openshift. Optionally, omit the version to mirror
+# the latest release.
+---
 apiVersion: mirror.openshift.io/v1alpha1
 kind: ImageSetConfiguration
 mirror:
   ocp:
     channels:
-      - name: stable-4.8
-      - name: stable-4.7
+      - name: stable-4.9
         versions:
-          - 4.7.36
-    graph: true
+        - 4.9.13

--- a/docs/imageset-config-ref.yaml
+++ b/docs/imageset-config-ref.yaml
@@ -7,7 +7,7 @@ storageConfig:
 mirror:
   ocp:
     channels:
-      - name: stable-4.8 # References latest stable release
+      - name: stable-4.9 # References latest stable release
       - name: stable-4.7 # Version annotation references version, does not pull latest
         versions:
           - '4.7.18'

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -54,7 +54,7 @@ between the last `oc mirror` run and provided configuration to show what new ver
    ```
 2. List all available release channels to query for a version of OpenShift
    ```sh
-   oc-mirror list releases --channels --version=4.8
+   oc-mirror list releases --channels --version=4.9
    ```
 3. List all available release payloads for a version of OpenShift in a specific channel
    ```sh


### PR DESCRIPTION
- Bumps ocp release version refs to 4.9
- Expanded example descriptions
- Add troubleshooting
- Misc housekeeping 