### PR TITLE
fix: adds ability to disable TLS uniformly throughout oc-mirror

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GO_BUILD_FLAGS := -tags=json1
 all: clean tidy test-unit build
 
 .PHONY: build
-build: clean
+build: clean tidy
 	$(GO) build $(GO_BUILD_FLAGS) -o bin/oc-mirror ./cmd/oc-mirror
 
 .PHONY: tidy

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 replace (
 	//github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.7
 	github.com/apcera/gssapi => github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b
-	github.com/operator-framework/operator-registry => github.com/jpower432/operator-registry v1.19.6-0.20220115001925-b3985d21a611
+	github.com/operator-framework/operator-registry => github.com/jpower432/operator-registry v1.19.6-0.20220120155051-56dc37d68c9e
 	k8s.io/apimachinery => github.com/openshift/kubernetes-apimachinery v0.0.0-20210730111815-c26349f8e2c9
 	k8s.io/cli-runtime => github.com/openshift/kubernetes-cli-runtime v0.0.0-20210730111823-1570202448c3
 	k8s.io/client-go => github.com/openshift/kubernetes-client-go v0.0.0-20210730111819-978c4383ac68

--- a/go.sum
+++ b/go.sum
@@ -911,8 +911,8 @@ github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUB
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
-github.com/jpower432/operator-registry v1.19.6-0.20220115001925-b3985d21a611 h1:6LDxL9QJaNJ/nhQwfXd9xnsIbIK9JOCQnhxRw3lpLsE=
-github.com/jpower432/operator-registry v1.19.6-0.20220115001925-b3985d21a611/go.mod h1:zErrUvHdA8Ou1un5tULohVTlNB/TL+f2oB6Xa9TfIDE=
+github.com/jpower432/operator-registry v1.19.6-0.20220120155051-56dc37d68c9e h1:oa0y3O3Mq7NhKAljo0q0o3s/zJY9/rBUfKZNfenRpmo=
+github.com/jpower432/operator-registry v1.19.6-0.20220120155051-56dc37d68c9e/go.mod h1:zErrUvHdA8Ou1un5tULohVTlNB/TL+f2oB6Xa9TfIDE=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/pkg/bundle/image.go
+++ b/pkg/bundle/image.go
@@ -27,15 +27,13 @@ func IsBlocked(cfg v1alpha1.ImageSetConfiguration, imgRef reference.DockerImageR
 	return false
 }
 
-func PinImages(ctx context.Context, ref, resolverConfigPath string, insecure bool) (string, error) {
-	resolver, err := containerdregistry.NewResolver(resolverConfigPath, insecure, nil)
+func PinImages(ctx context.Context, ref, resolverConfigPath string, skipTLSVerify, plainHTTP bool) (string, error) {
+	resolver, err := containerdregistry.NewResolver(resolverConfigPath, skipTLSVerify, plainHTTP, nil)
 	if err != nil {
 		return "", fmt.Errorf("error creating image resolver: %v", err)
 	}
-
 	if !image.IsImagePinned(ref) {
 		return image.ResolveToPin(ctx, resolver, ref)
 	}
-
 	return ref, nil
 }

--- a/pkg/cli/mirror/additional_test.go
+++ b/pkg/cli/mirror/additional_test.go
@@ -89,7 +89,9 @@ func TestGetAdditional(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			assocs, err := opts.GetAdditional(test.cfg, test.cfg.Mirror.AdditionalImages)
+			ctx := context.Background()
+
+			assocs, err := opts.GetAdditional(ctx, test.cfg, test.cfg.Mirror.AdditionalImages)
 			if test.wantErr {
 				testErr := test.want
 				require.ErrorAs(t, err, &testErr)
@@ -98,7 +100,7 @@ func TestGetAdditional(t *testing.T) {
 			}
 
 			if test.imgPin {
-				testerImg, err := bundle.PinImages(context.TODO(), test.cfg.Mirror.AdditionalImages[0].Name, "", false)
+				testerImg, err := bundle.PinImages(ctx, test.cfg.Mirror.AdditionalImages[0].Name, "", false, false)
 				require.NoError(t, err)
 				if assert.Len(t, assocs, 1) {
 					require.Contains(t, assocs, testerImg)

--- a/pkg/cli/mirror/catalog_images.go
+++ b/pkg/cli/mirror/catalog_images.go
@@ -91,12 +91,13 @@ func (o *MirrorOptions) rebuildCatalogs(ctx context.Context, dstDir string, file
 		return nil, err
 	}
 
-	resolver, err := containerdregistry.NewResolver("", o.DestSkipTLS, nil)
+	resolver, err := containerdregistry.NewResolver("", o.DestSkipTLS, o.DestPlainHTTP, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating image resolver: %v", err)
 	}
 	reg, err := containerdregistry.NewRegistry(
-		containerdregistry.SkipTLS(o.DestSkipTLS),
+		containerdregistry.SkipTLSVerify(o.DestSkipTLS),
+		containerdregistry.WithPlainHTTP(o.DestPlainHTTP),
 		containerdregistry.WithCacheDir(filepath.Join(dstDir, "cache")),
 	)
 	if err != nil {

--- a/pkg/cli/mirror/catalog_images_test.go
+++ b/pkg/cli/mirror/catalog_images_test.go
@@ -41,7 +41,7 @@ func TestBuildCatalogLayer(t *testing.T) {
 	require.NoError(t, err)
 
 	o := &MirrorOptions{
-		DestSkipTLS:   true,
+		DestPlainHTTP: true,
 		UserNamespace: "custom",
 	}
 	require.NoError(t, o.buildCatalogLayer(context.Background(), targetRef, targetRef, t.TempDir(), []v1.Layer{add, delete}...))

--- a/pkg/cli/mirror/create.go
+++ b/pkg/cli/mirror/create.go
@@ -84,7 +84,7 @@ func (o *MirrorOptions) Create(ctx context.Context) error {
 	var backupMeta v1alpha1.Metadata
 	rollbackMeta := func() error {
 		logrus.Error("operation cancelled, initiating metadata rollback")
-		return metadata.UpdateMetadata(ctx, backend, &backupMeta, o.SourceSkipTLS)
+		return metadata.UpdateMetadata(ctx, backend, &backupMeta, o.SourceSkipTLS, o.SourcePlainHTTP)
 	}
 
 	var assocs image.AssociationSet
@@ -134,7 +134,7 @@ func (o *MirrorOptions) Create(ctx context.Context) error {
 	meta.PastBlobs = append(meta.PastBlobs, blobs...)
 
 	// Update the metadata.
-	if err = metadata.UpdateMetadata(ctx, backend, &meta, o.SourceSkipTLS); err != nil {
+	if err = metadata.UpdateMetadata(ctx, backend, &meta, o.SourceSkipTLS, o.SourcePlainHTTP); err != nil {
 		return err
 	}
 
@@ -196,7 +196,7 @@ func (o *MirrorOptions) createFull(ctx context.Context, cfg *v1alpha1.ImageSetCo
 
 	if len(cfg.Mirror.AdditionalImages) != 0 {
 		opts := NewAdditionalOptions(o)
-		assocs, err := opts.GetAdditional(*cfg, cfg.Mirror.AdditionalImages)
+		assocs, err := opts.GetAdditional(ctx, *cfg, cfg.Mirror.AdditionalImages)
 		if err != nil {
 			return allAssocs, err
 		}
@@ -205,7 +205,7 @@ func (o *MirrorOptions) createFull(ctx context.Context, cfg *v1alpha1.ImageSetCo
 
 	if len(cfg.Mirror.Helm.Local) != 0 || len(cfg.Mirror.Helm.Repos) != 0 {
 		opts := NewHelmOptions(o)
-		assocs, err := opts.PullCharts(*cfg)
+		assocs, err := opts.PullCharts(ctx, *cfg)
 		if err != nil {
 			return allAssocs, err
 		}
@@ -245,7 +245,7 @@ func (o *MirrorOptions) createDiff(ctx context.Context, cfg *v1alpha1.ImageSetCo
 
 	if len(cfg.Mirror.AdditionalImages) != 0 {
 		opts := NewAdditionalOptions(o)
-		assocs, err := opts.GetAdditional(*cfg, cfg.Mirror.AdditionalImages)
+		assocs, err := opts.GetAdditional(ctx, *cfg, cfg.Mirror.AdditionalImages)
 		if err != nil {
 			return allAssocs, err
 		}
@@ -254,7 +254,7 @@ func (o *MirrorOptions) createDiff(ctx context.Context, cfg *v1alpha1.ImageSetCo
 
 	if len(cfg.Mirror.Helm.Local) != 0 || len(cfg.Mirror.Helm.Repos) != 0 {
 		opts := NewHelmOptions(o)
-		assocs, err := opts.PullCharts(*cfg)
+		assocs, err := opts.PullCharts(ctx, *cfg)
 		if err != nil {
 			return allAssocs, err
 		}

--- a/pkg/cli/mirror/list/updates.go
+++ b/pkg/cli/mirror/list/updates.go
@@ -167,9 +167,8 @@ func (o UpdatesOptions) operatorUpdates(ctx context.Context, cfg v1alpha1.ImageS
 		}
 	}
 
-	// QUESTION(jpower): TLS must be configurable?
 	reg, err := containerdregistry.NewRegistry(
-		containerdregistry.SkipTLS(false),
+		containerdregistry.SkipTLSVerify(false),
 		containerdregistry.WithCacheDir(filepath.Join(dstDir, "cache")),
 	)
 	defer reg.Destroy()

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -229,13 +229,17 @@ func (o *MirrorOptions) getRemoteOpts(ctx context.Context) []remote.Option {
 }
 
 func (o *MirrorOptions) getNameOpts() (options []name.Option) {
-	if o.DestSkipTLS {
+	if o.DestSkipTLS || o.DestPlainHTTP {
 		options = append(options, name.Insecure)
 	}
 	return options
 }
 
 func (o *MirrorOptions) createRT() http.RoundTripper {
+	var insecure bool
+	if o.DestPlainHTTP || o.DestSkipTLS {
+		insecure = true
+	}
 	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
@@ -251,7 +255,7 @@ func (o *MirrorOptions) createRT() http.RoundTripper {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: o.DestSkipTLS,
+			InsecureSkipVerify: insecure,
 		},
 	}
 }

--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -156,7 +156,8 @@ func (o *OperatorOptions) createRegistry() (*containerdregistry.Registry, error)
 
 	return containerdregistry.NewRegistry(
 		containerdregistry.WithCacheDir(cacheDir),
-		containerdregistry.SkipTLS(o.SourceSkipTLS),
+		containerdregistry.SkipTLSVerify(o.SourceSkipTLS),
+		containerdregistry.WithPlainHTTP(o.SourcePlainHTTP),
 		// The containerd registry impl is somewhat verbose, even on the happy path,
 		// so discard all logger logs. Any important failures will be returned from
 		// registry methods and eventually logged as fatal errors.
@@ -251,7 +252,7 @@ func (o *OperatorOptions) mirror(ctx context.Context, dc *declcfg.DeclarativeCon
 	}
 
 	if !o.SkipImagePin {
-		resolver, err := containerdregistry.NewResolver("", o.SourceSkipTLS, nil)
+		resolver, err := containerdregistry.NewResolver("", o.SourceSkipTLS, o.SourcePlainHTTP, nil)
 		if err != nil {
 			return nil, fmt.Errorf("error creating image resolver: %v", err)
 		}

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -24,6 +24,8 @@ type MirrorOptions struct {
 	DryRun           bool
 	SourceSkipTLS    bool
 	DestSkipTLS      bool
+	SourcePlainHTTP  bool
+	DestPlainHTTP    bool
 	SkipVerification bool
 	SkipCleanup      bool
 	SkipMissing      bool
@@ -42,8 +44,10 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.ManifestsOnly, "manifests-only", o.ManifestsOnly, "Generate manifests and do not mirror")
 	fs.BoolVar(&o.DryRun, "dry-run", o.DryRun, "Print actions without mirroring images "+
 		"(experimental: only works for mirror to disk)")
-	fs.BoolVar(&o.SourceSkipTLS, "source-skip-tls", o.SourceSkipTLS, "Use plain HTTP for source registry")
-	fs.BoolVar(&o.DestSkipTLS, "dest-skip-tls", o.DestSkipTLS, "Use plain HTTP for destination registry")
+	fs.BoolVar(&o.SourceSkipTLS, "source-skip-tls", o.SourceSkipTLS, "Disable TLS validation for source registry")
+	fs.BoolVar(&o.DestSkipTLS, "dest-skip-tls", o.DestSkipTLS, "Disable TLS validation for destination registry")
+	fs.BoolVar(&o.SourcePlainHTTP, "source-use-http", o.SourcePlainHTTP, "Use plain HTTP for source registry")
+	fs.BoolVar(&o.DestPlainHTTP, "dest-use-http", o.DestPlainHTTP, "Use plain HTTP for destination registry")
 	fs.BoolVar(&o.SkipVerification, "skip-verification", o.SkipVerification, "Skip digest verification")
 	fs.BoolVar(&o.SkipCleanup, "skip-cleanup", o.SkipCleanup, "Skip removal of artifact directories")
 	fs.StringSliceVar(&o.FilterOptions, "filter-by-os", o.FilterOptions, "A regular expression to control which release image is picked when multiple variants are available")

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -15,12 +15,12 @@ import (
 
 // UpdateMetadata runs some reconciliation functions on Metadata to ensure its state is consistent
 // then uses the Backend to update the metadata storage medium.
-func UpdateMetadata(ctx context.Context, backend storage.Backend, meta *v1alpha1.Metadata, insecure bool) error {
+func UpdateMetadata(ctx context.Context, backend storage.Backend, meta *v1alpha1.Metadata, skipTLSVerify, plainHTTP bool) error {
 
 	var operatorErrs []error
 	for mi, mirror := range meta.PastMirrors {
 		for _, operator := range mirror.Mirror.Operators {
-			operatorMeta, err := resolveOperatorMetadata(ctx, operator, backend, insecure)
+			operatorMeta, err := resolveOperatorMetadata(ctx, operator, backend, skipTLSVerify, plainHTTP)
 			if err != nil {
 				operatorErrs = append(operatorErrs, err)
 				continue
@@ -41,10 +41,10 @@ func UpdateMetadata(ctx context.Context, backend storage.Backend, meta *v1alpha1
 	return nil
 }
 
-func resolveOperatorMetadata(ctx context.Context, operator v1alpha1.Operator, backend storage.Backend, insecure bool) (operatorMeta v1alpha1.OperatorMetadata, err error) {
+func resolveOperatorMetadata(ctx context.Context, operator v1alpha1.Operator, backend storage.Backend, skipTLSVerify, plainHTTP bool) (operatorMeta v1alpha1.OperatorMetadata, err error) {
 	operatorMeta.Catalog = operator.Catalog
 
-	resolver, err := containerdregistry.NewResolver("", insecure, nil)
+	resolver, err := containerdregistry.NewResolver("", skipTLSVerify, plainHTTP, nil)
 	if err != nil {
 		return v1alpha1.OperatorMetadata{}, fmt.Errorf("error creating image resolver: %v", err)
 	}

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -4,7 +4,7 @@
 # needed to run against a local test registry and provide informative
 # debug data in case of test errors.
 function run_cmd() {
-  local test_flags="--log-level debug --dest-skip-tls --skip-cleanup"
+  local test_flags="--log-level debug --dest-use-http --skip-cleanup"
 
   echo "$CMD" $@ $test_flags
   echo
@@ -150,7 +150,7 @@ function run_full() {
   # Copy the catalog to the connected registry so they can have the same tag
   "${DIR}/operator/setup-testdata.sh" "${DATA_TMP}" "$CREATE_FULL_DIR" "latest/$config" false
    prep_registry false
-  run_cmd --config "${CREATE_FULL_DIR}/$config" "file://${CREATE_FULL_DIR}" --source-skip-tls 
+  run_cmd --config "${CREATE_FULL_DIR}/$config" "file://${CREATE_FULL_DIR}" --source-use-http 
   pushd $PUBLISH_FULL_DIR
   if [[ -n $ns ]]; then
     NS="/$ns"
@@ -170,7 +170,7 @@ function run_diff() {
   # Copy the catalog to the connected registry so they can have the same tag
   "${DIR}/operator/setup-testdata.sh" "${DATA_TMP}" "$CREATE_DIFF_DIR" "latest/$config" true
   prep_registry true
-  run_cmd --config "${CREATE_DIFF_DIR}/$config" "file://${CREATE_DIFF_DIR}" --source-skip-tls 
+  run_cmd --config "${CREATE_DIFF_DIR}/$config" "file://${CREATE_DIFF_DIR}" --source-use-http 
   pushd ${PUBLISH_DIFF_DIR}
   if [[ -n $ns ]]; then
     NS="/$ns"
@@ -195,7 +195,7 @@ function mirror2mirror() {
   else
    NS=""
   fi
-  run_cmd --config "${CREATE_FULL_DIR}/$config" "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}${NS}" --source-skip-tls 
+  run_cmd --config "${CREATE_FULL_DIR}/$config" "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}${NS}" --source-use-http 
   popd
 }
 


### PR DESCRIPTION
This update incorporates changes from the operator-registry
upstream that allows the use of untrusted HTTPS. It also adds a
fix for empty packages from that repo.

Fixes #209
Fixes #272

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

The PR updates the `operator-registry` dependency to include the TLS disable support and empty package pruning. Update to `oc-mirror` flags include `dest-use-http` and `source-use-http`

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] E2E update and unit tests updated
- [ ] Disable TLS validated manually tested with quay mirror registry

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules