### PR TITLE
fix(publish): implements ICSPTypes for processing and grouping per type

### DIFF
--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/openshift/oc-mirror/pkg/metadata/storage"
 )
 
-/* FIXME(jpower): known issue with many small files
+/* FIXME(jpower432): known issue with many small files
 the tar size will end up larger than specified by the
  user because of the tar header being written*/
 

--- a/pkg/cli/mirror/manifests.go
+++ b/pkg/cli/mirror/manifests.go
@@ -73,6 +73,7 @@ func (g *ICSPGenerator) Run(icspScope string, byteLimit int) (icsps []operatorv1
 
 			// FIXME(jpower432): add this as a workaround until
 			// mirroring individual images for release is implemented
+			// add OCP component image location to all release ICSPs
 			if g.ICSPType == TypeOCPRelease {
 				icsp.Spec.RepositoryDigestMirrors = append(icsp.Spec.RepositoryDigestMirrors, operatorv1alpha1.RepositoryDigestMirrors{
 					Source:  "quay.io/openshift-release-dev/ocp-v4.0-art-dev",

--- a/pkg/cli/mirror/manifests_test.go
+++ b/pkg/cli/mirror/manifests_test.go
@@ -11,12 +11,14 @@ import (
 
 func TestICSPGeneration(t *testing.T) {
 	tests := []struct {
-		name        string
-		sourceImage reference.DockerImageReference
-		destImage   reference.DockerImageReference
-		typ         icspType
-		expected    []operatorv1alpha1.ImageContentSourcePolicy
-		err         string
+		name          string
+		sourceImage   reference.DockerImageReference
+		destImage     reference.DockerImageReference
+		typ           icspType
+		icspScope     string
+		icspSizeLimit int
+		expected      []operatorv1alpha1.ImageContentSourcePolicy
+		err           string
 	}{{
 		name: "Valid/OperatorType",
 		sourceImage: reference.DockerImageReference{
@@ -31,7 +33,9 @@ func TestICSPGeneration(t *testing.T) {
 			Name:      "image",
 			ID:        "digest",
 		},
-		typ: typeOperator,
+		icspScope:     "repository",
+		icspSizeLimit: 250000,
+		typ:           typeOperator,
 		expected: []operatorv1alpha1.ImageContentSourcePolicy{{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: operatorv1alpha1.GroupVersion.String(),
@@ -64,6 +68,8 @@ func TestICSPGeneration(t *testing.T) {
 			Name:      "image",
 			ID:        "digest",
 		},
+		icspScope:     "repository",
+		icspSizeLimit: 250000,
 		expected: []operatorv1alpha1.ImageContentSourcePolicy{{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: operatorv1alpha1.GroupVersion.String(),
@@ -95,7 +101,9 @@ func TestICSPGeneration(t *testing.T) {
 			Name:      "image",
 			ID:        "digest",
 		},
-		typ: typeOCPRelease,
+		typ:           typeOCPRelease,
+		icspScope:     "repository",
+		icspSizeLimit: 250000,
 		expected: []operatorv1alpha1.ImageContentSourcePolicy{{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: operatorv1alpha1.GroupVersion.String(),
@@ -112,6 +120,108 @@ func TestICSPGeneration(t *testing.T) {
 					{
 						Source:  "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
 						Mirrors: []string{"disconn-registry/namespace/image"},
+					},
+				},
+			},
+		},
+		},
+	}, {
+		name: "Valid/NamespaceScope",
+		sourceImage: reference.DockerImageReference{
+			Registry:  "some-registry",
+			Namespace: "namespace",
+			Name:      "image",
+			ID:        "digest",
+		},
+		destImage: reference.DockerImageReference{
+			Registry:  "disconn-registry",
+			Namespace: "namespace",
+			Name:      "image",
+			ID:        "digest",
+		},
+		typ:           typeGeneric,
+		icspScope:     "namespace",
+		icspSizeLimit: 250000,
+		expected: []operatorv1alpha1.ImageContentSourcePolicy{{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: operatorv1alpha1.GroupVersion.String(),
+				Kind:       "ImageContentSourcePolicy"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "some-registry-namespace-image:digest-0",
+			},
+			Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
+				RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
+					{
+						Source:  "some-registry/namespace",
+						Mirrors: []string{"disconn-registry/namespace"},
+					},
+				},
+			},
+		},
+		},
+	}, {
+		name: "Valid/RegistryScope",
+		sourceImage: reference.DockerImageReference{
+			Registry:  "some-registry",
+			Namespace: "namespace",
+			Name:      "image",
+			ID:        "digest",
+		},
+		destImage: reference.DockerImageReference{
+			Registry:  "disconn-registry",
+			Namespace: "namespace",
+			Name:      "image",
+			ID:        "digest",
+		},
+		typ:           typeGeneric,
+		icspScope:     "registry",
+		icspSizeLimit: 250000,
+		expected: []operatorv1alpha1.ImageContentSourcePolicy{{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: operatorv1alpha1.GroupVersion.String(),
+				Kind:       "ImageContentSourcePolicy"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "some-registry-namespace-image:digest-0",
+			},
+			Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
+				RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
+					{
+						Source:  "some-registry",
+						Mirrors: []string{"disconn-registry"},
+					},
+				},
+			},
+		},
+		},
+	}, {
+		name: "Valid/NamespaceScopeNoNamespace",
+		sourceImage: reference.DockerImageReference{
+			Registry:  "some-registry",
+			Namespace: "",
+			Name:      "image",
+			ID:        "digest",
+		},
+		destImage: reference.DockerImageReference{
+			Registry:  "disconn-registry",
+			Namespace: "",
+			Name:      "image",
+			ID:        "digest",
+		},
+		typ:           typeGeneric,
+		icspScope:     "namespace",
+		icspSizeLimit: 250000,
+		expected: []operatorv1alpha1.ImageContentSourcePolicy{{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: operatorv1alpha1.GroupVersion.String(),
+				Kind:       "ImageContentSourcePolicy"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "some-registry-image:digest-0",
+			},
+			Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
+				RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
+					{
+						Source:  "some-registry/image",
+						Mirrors: []string{"disconn-registry/image"},
 					},
 				},
 			},
@@ -136,13 +246,12 @@ func TestICSPGeneration(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			gen := icspGenerator{
-				imageName: test.sourceImage.Exact(),
 				icspMapping: map[reference.DockerImageReference]reference.DockerImageReference{
 					test.sourceImage: test.destImage,
 				},
 				icspType: test.typ,
 			}
-			icsps, err := gen.Run(icspScope, icspSizeLimit)
+			icsps, err := gen.Run(test.sourceImage.Exact(), test.icspScope, test.icspSizeLimit)
 			require.NoError(t, err)
 			require.Equal(t, test.expected, icsps)
 		})

--- a/pkg/cli/mirror/manifests_test.go
+++ b/pkg/cli/mirror/manifests_test.go
@@ -14,7 +14,7 @@ func TestICSPGeneration(t *testing.T) {
 		name        string
 		sourceImage reference.DockerImageReference
 		destImage   reference.DockerImageReference
-		typ         ICSPType
+		typ         icspType
 		expected    []operatorv1alpha1.ImageContentSourcePolicy
 		err         string
 	}{{
@@ -31,7 +31,7 @@ func TestICSPGeneration(t *testing.T) {
 			Name:      "image",
 			ID:        "digest",
 		},
-		typ: TypeOperator,
+		typ: typeOperator,
 		expected: []operatorv1alpha1.ImageContentSourcePolicy{{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: operatorv1alpha1.GroupVersion.String(),
@@ -95,7 +95,7 @@ func TestICSPGeneration(t *testing.T) {
 			Name:      "image",
 			ID:        "digest",
 		},
-		typ: TypeOCPRelease,
+		typ: typeOCPRelease,
 		expected: []operatorv1alpha1.ImageContentSourcePolicy{{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: operatorv1alpha1.GroupVersion.String(),
@@ -135,12 +135,12 @@ func TestICSPGeneration(t *testing.T) {
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			gen := ICSPGenerator{
-				ImageName: test.sourceImage.Exact(),
-				ICSPMapping: map[reference.DockerImageReference]reference.DockerImageReference{
+			gen := icspGenerator{
+				imageName: test.sourceImage.Exact(),
+				icspMapping: map[reference.DockerImageReference]reference.DockerImageReference{
 					test.sourceImage: test.destImage,
 				},
-				ICSPType: test.typ,
+				icspType: test.typ,
 			}
 			icsps, err := gen.Run(icspScope, icspSizeLimit)
 			require.NoError(t, err)

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -139,7 +139,7 @@ func (o *MirrorOptions) Validate() error {
 	}
 
 	// Attempt to login to registry
-	// FIXME(jpower): CheckPushPermissions is slated for deprecation
+	// FIXME(jpower432): CheckPushPermissions is slated for deprecation
 	// must replace with its replacement
 	if len(o.ToMirror) > 0 {
 		logrus.Infof("Checking push permissions for %s", o.ToMirror)

--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -341,6 +341,7 @@ func (o *OperatorOptions) pinImages(ctx context.Context, dc *declcfg.Declarative
 	for i, b := range dc.Bundles {
 
 		if !image.IsImagePinned(b.Image) {
+			logrus.Warnf("bundle %s: pinning bundle image %s to digest", b.Name, b.Image)
 
 			if !image.IsImageTagged(b.Image) {
 				logrus.Warnf("bundle %s: bundle image tag not set", b.Name)
@@ -356,6 +357,7 @@ func (o *OperatorOptions) pinImages(ctx context.Context, dc *declcfg.Declarative
 		}
 		for j, ri := range b.RelatedImages {
 			if !image.IsImagePinned(ri.Image) {
+				logrus.Warnf("bundle %s: pinning related image %s to digest", ri.Name, ri.Image)
 
 				if !image.IsImageTagged(ri.Image) {
 					logrus.Warnf("bundle %s: related image tag not set", b.Name)
@@ -456,7 +458,7 @@ func (o *OperatorOptions) associateDeclarativeConfigImageLayers(ctlgRef imagesou
 	}
 
 	srcDir := filepath.Join(o.Dir, config.SourceDir)
-	assocs, err := image.AssociateImageLayers(srcDir, mappings, images, image.TypeGeneric)
+	assocs, err := image.AssociateImageLayers(srcDir, mappings, images, image.TypeOperatorBundle)
 	if err != nil {
 		merr := &image.ErrNoMapping{}
 		cerr := &image.ErrInvalidComponent{}

--- a/pkg/cli/mirror/publish.go
+++ b/pkg/cli/mirror/publish.go
@@ -202,7 +202,7 @@ func (o *MirrorOptions) Publish(ctx context.Context, cmd *cobra.Command, f kcmdu
 		allICSPs []operatorv1alpha1.ImageContentSourcePolicy
 	)
 
-	namedICSPData := map[string]ICSPGenerator{}
+	namedICSPData := map[string]icspGenerator{}
 	for _, imageName := range assocs.Keys() {
 
 		genericMappings := []imgmirror.Mapping{}
@@ -218,11 +218,11 @@ func (o *MirrorOptions) Publish(ctx context.Context, cmd *cobra.Command, f kcmdu
 		dstRef.Registry = toMirrorRef.Ref.Registry
 		dstRef.Namespace = path.Join(o.UserNamespace, dstRef.Namespace)
 
-		icspData := ICSPGenerator{
-			ICSPMapping: map[reference.DockerImageReference]reference.DockerImageReference{
+		icspData := icspGenerator{
+			icspMapping: map[reference.DockerImageReference]reference.DockerImageReference{
 				imageRef: dstRef,
 			},
-			ImageName: imageRef.Name,
+			imageName: imageRef.Name,
 		}
 
 		values, _ := assocs.Search(imageName)
@@ -312,7 +312,7 @@ func (o *MirrorOptions) Publish(ctx context.Context, cmd *cobra.Command, f kcmdu
 			switch assoc.Type {
 			case image.TypeGeneric:
 				genericMappings = append(genericMappings, m)
-				icspData.ICSPType = TypeGeneric
+				icspData.icspType = typeGeneric
 			case image.TypeOCPRelease:
 				// Remove component info in mapping for
 				// release mirroring step
@@ -323,15 +323,15 @@ func (o *MirrorOptions) Publish(ctx context.Context, cmd *cobra.Command, f kcmdu
 					// Update destination ref ICSP to match the
 					// default mirror location of releases (openshift/release)
 					m.Destination.Ref.ID = assoc.ID
-					icspData.ICSPMapping[imageRef] = m.Destination.Ref
-					icspData.ICSPType = TypeOCPRelease
+					icspData.icspMapping[imageRef] = m.Destination.Ref
+					icspData.icspType = typeOCPRelease
 				}
 			case image.TypeOperatorCatalog:
 				genericMappings = append(genericMappings, m)
-				icspData.ICSPType = TypeOperator
+				icspData.icspType = typeOperator
 			case image.TypeOperatorBundle, image.TypeOperatorRelatedImage:
 				genericMappings = append(genericMappings, m)
-				icspData.ICSPType = TypeOperator
+				icspData.icspType = typeOperator
 			case image.TypeInvalid:
 				errs = append(errs, fmt.Errorf("image %q: image type is not set", imageName))
 			default:
@@ -382,10 +382,10 @@ func (o *MirrorOptions) Publish(ctx context.Context, cmd *cobra.Command, f kcmdu
 	// Source and dest refs are treated the same intentionally since
 	// the source image does not exist and destination image was built above.
 	for sourceRef, destRef := range ctlgRefs {
-		icspData := ICSPGenerator{
-			ICSPMapping: map[reference.DockerImageReference]reference.DockerImageReference{sourceRef: destRef},
-			ImageName:   sourceRef.Name,
-			ICSPType:    TypeOperator,
+		icspData := icspGenerator{
+			icspMapping: map[reference.DockerImageReference]reference.DockerImageReference{sourceRef: destRef},
+			imageName:   sourceRef.Name,
+			icspType:    typeOperator,
 		}
 		namedICSPData[sourceRef.Name] = icspData
 

--- a/pkg/cli/mirror/publish.go
+++ b/pkg/cli/mirror/publish.go
@@ -166,11 +166,8 @@ func (o *MirrorOptions) Publish(ctx context.Context, cmd *cobra.Command, f kcmdu
 			return &SequenceError{1, incomingRun.Sequence}
 		}
 	default:
-		// UUID check removed because the image is stored as
-		// UUID name. A mismatch will now be seen as a new workspace.
-		// TODO: Add a way show the user what UUID images existing in the registry?
-
 		// Complete metadata checks
+		// UUID mismatch will now be seen as a new workspace.
 		logrus.Debug("Check metadata sequence number")
 		currRun := currentMeta.PastMirrors[len(currentMeta.PastMirrors)-1]
 		incomingRun := incomingMeta.PastMirrors[len(incomingMeta.PastMirrors)-1]
@@ -584,8 +581,7 @@ func mktempDir(dir string) (func(), string, error) {
 }
 
 // mirrorRelease uses the `oc release mirror` library to mirror OCP release
-// QUESTION(jpower): should we just mirror release one by one
-// The namespace is not the same as the image name
+// TODO(jpower432): refactor to mirror release images as individual images
 func (o *MirrorOptions) mirrorRelease(mapping imgmirror.Mapping, cmd *cobra.Command, f kcmdutil.Factory, fromDir string) error {
 	var insecure bool
 	if o.DestPlainHTTP || o.DestSkipTLS {

--- a/pkg/cli/mirror/release.go
+++ b/pkg/cli/mirror/release.go
@@ -199,6 +199,9 @@ func (o *ReleaseOptions) mirror(ctx context.Context, toDir string, downloads map
 		opts.SecurityOptions.SkipVerification = o.SkipVerification
 		opts.DryRun = o.DryRun
 		opts.From = img
+		if err := opts.Validate(); err != nil {
+			return nil, err
+		}
 		if err := opts.Run(); err != nil {
 			return nil, err
 		}
@@ -255,6 +258,9 @@ func (o *ReleaseOptions) getMapping(ctx context.Context, opts release.MirrorOpti
 	opts.IOStreams.Out = &buffer
 	opts.ToMirror = true
 
+	if err := opts.Validate(); err != nil {
+		return mappings, images, err
+	}
 	if err := opts.Run(); err != nil {
 		return mappings, images, err
 	}

--- a/pkg/config/credentials.go
+++ b/pkg/config/credentials.go
@@ -10,10 +10,11 @@ import (
 	imagemanifest "github.com/openshift/oc/pkg/cli/image/manifest"
 )
 
+// TODO: create a context based on user provided
+// pull secret
+
 // CreateDefault a default context for the registryClient of `oc mirror`
 func CreateDefaultContext(skipTLS bool) (*registryclient.Context, error) {
-	// TODO: create a context based on user provided
-	// pull secret
 	opts := &imagemanifest.SecurityOptions{}
 	opts.Insecure = skipTLS
 

--- a/pkg/config/v1alpha1/register.go
+++ b/pkg/config/v1alpha1/register.go
@@ -4,8 +4,7 @@ import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
 	version = "v1alpha1"
-	// TODO: what should this be?
-	group = "mirror.openshift.io"
+	group   = "mirror.openshift.io"
 )
 
 var (

--- a/pkg/image/association.go
+++ b/pkg/image/association.go
@@ -344,9 +344,6 @@ func associateImageLayers(image, localRoot, dirRef, tagOrID, defaultTag string, 
 	// for the first recursion leaf since image manifest layers always contain id's,
 	// so unroll this component into AssociateImageLayers.
 
-	// FIXME(jpower): some of the mappings are passing a tag that are
-	// not actually a symlinks on disk. Need to investigate why we
-	// receiving invalid mapping and their meaning.
 	info, err := os.Lstat(manifestPath)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil, &ErrInvalidComponent{image, tagOrID}


### PR DESCRIPTION
Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

This PR adds ICSPTypes to implement specific processing steps per type and to group ICSP objects by type. This fixes issues seen with incorrect OCP release ICSP.

To test:
```
apiVersion: mirror.openshift.io/v1alpha1
kind: ImageSetConfiguration
mirror:
  ocp:
    channels:
      - name: stable-4.9
        versions:
          - 4.8.26
    graph: true
```
The ICSP for the release will require the following source and mirror (example):
```
- mirrors: [example.com/openshift/release]
  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
- mirrors: [example.com/openshift/release]
  source: quay.io/openshift-release-dev/ocp-release
```

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Unit tests changes to test ICSPTypes

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules