### PR TITLE
chore(catalog): add merge functionality for file-based catalogs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/go-git/go-git/v5 v5.4.2 // indirect
 	github.com/google/go-containerregistry v0.8.0
 	github.com/google/uuid v1.2.0
+	github.com/imdario/mergo v0.3.12
 	github.com/joelanford/ignore v0.0.0-20210610194209-63d4919d8fb2
 	github.com/mholt/archiver/v3 v3.5.0
 	github.com/opencontainers/go-digest v1.0.0
@@ -18,7 +19,7 @@ require (
 	github.com/openshift/api v0.0.0-20210831091943-07e756545ac1
 	github.com/openshift/library-go v0.0.0-20210831102543-1a08f0c3bd9a
 	github.com/openshift/oc v0.0.0-alpha.0.0.20210721184532-4df50be4d929
-	github.com/operator-framework/operator-registry v1.19.6-0.20211214163458-6b066493052b
+	github.com/operator-framework/operator-registry v1.19.6-0.20220120140729-354cd3851678
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.3.0
@@ -40,7 +41,6 @@ require (
 replace (
 	//github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.7
 	github.com/apcera/gssapi => github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b
-	github.com/operator-framework/operator-registry => github.com/jpower432/operator-registry v1.19.6-0.20220120155051-56dc37d68c9e
 	k8s.io/apimachinery => github.com/openshift/kubernetes-apimachinery v0.0.0-20210730111815-c26349f8e2c9
 	k8s.io/cli-runtime => github.com/openshift/kubernetes-cli-runtime v0.0.0-20210730111823-1570202448c3
 	k8s.io/client-go => github.com/openshift/kubernetes-client-go v0.0.0-20210730111819-978c4383ac68

--- a/go.sum
+++ b/go.sum
@@ -626,6 +626,7 @@ github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gobuffalo/flect v0.2.0/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
 github.com/gobuffalo/flect v0.2.3/go.mod h1:vmkQwuZYhN5Pc4ljYQZzP+1sq+NEkK+lh20jmEmX3jc=
@@ -818,6 +819,7 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/grpc-ecosystem/grpc-health-probe v0.3.2 h1:daShAySXI1DnGc8U9B1E4Qm6o7qzmFR4aRIJ4vY/TUo=
 github.com/grpc-ecosystem/grpc-health-probe v0.3.2/go.mod h1:izVOQ4RWbjUR6lm4nn+VLJyQ+FyaiGmprEYgI04Gs7U=
 github.com/h2non/filetype v1.1.1 h1:xvOwnXKAckvtLWsN398qS9QhlxlnVXBjXBydK2/UFB4=
 github.com/h2non/filetype v1.1.1/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
@@ -911,8 +913,6 @@ github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUB
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
-github.com/jpower432/operator-registry v1.19.6-0.20220120155051-56dc37d68c9e h1:oa0y3O3Mq7NhKAljo0q0o3s/zJY9/rBUfKZNfenRpmo=
-github.com/jpower432/operator-registry v1.19.6-0.20220120155051-56dc37d68c9e/go.mod h1:zErrUvHdA8Ou1un5tULohVTlNB/TL+f2oB6Xa9TfIDE=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -1035,12 +1035,14 @@ github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lL
 github.com/mattn/go-shellwords v1.0.11/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRUbg=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.10 h1:MLn+5bFRlWMGoSRmJour3CL1w/qL96mvipqpwQW/Sfk=
 github.com/mattn/go-sqlite3 v1.14.10/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2 h1:g+4J5sZg6osfvEfkRZxJ1em0VT95/UOZgi/l7zi1/oE=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
 github.com/mholt/archiver/v3 v3.5.0 h1:nE8gZIrw66cu4osS/U7UW7YDuGMHssxKutU8IfWxwWE=
 github.com/mholt/archiver/v3 v3.5.0/go.mod h1:qqTTPUK/HZPFgFQ/TJ3BzvTpF/dPtFVJXdQbCmeMxwc=
@@ -1226,8 +1228,14 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
+github.com/operator-framework/api v0.10.8-0.20211210002341-1eb6c0266cce h1:+zEJrt6Kw4SnN115WzleIpmw5jAgscrWb9K0WgvjhOc=
+github.com/operator-framework/api v0.10.8-0.20211210002341-1eb6c0266cce/go.mod h1:FTiYGm11fZQ3cSX+EQHc/UWoGZAwkGfyeHU+wMJ8jmA=
 github.com/operator-framework/api v0.11.0 h1:W9V1NNwl3LWPQL9S1pDaFONCarJLl8Xu6gdF9w54hTE=
 github.com/operator-framework/api v0.11.0/go.mod h1:FTiYGm11fZQ3cSX+EQHc/UWoGZAwkGfyeHU+wMJ8jmA=
+github.com/operator-framework/operator-registry v1.19.6-0.20211214163458-6b066493052b h1:sC7/O+s5YyqSHcR8nIW+Ke3Y1cF/m9DgApFo0jVSxrc=
+github.com/operator-framework/operator-registry v1.19.6-0.20211214163458-6b066493052b/go.mod h1:T6A6+GKcD3fH+GXuCalyOOXjMKAQStTVf7izdHBpLkg=
+github.com/operator-framework/operator-registry v1.19.6-0.20220120140729-354cd3851678 h1:XAi8mGCev5HZHjCvOnweWrpMLkxExcPKZsD9L871rvA=
+github.com/operator-framework/operator-registry v1.19.6-0.20220120140729-354cd3851678/go.mod h1:XT2ihzyUMOB9K0dI9wxoY+6DDE0NVOrqtnQvnElEyXs=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
@@ -2141,6 +2149,7 @@ google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ5
 google.golang.org/grpc v1.43.0 h1:Eeu7bZtDZ2DpRCsLhUlcrLnvYaMK1Gz86a+hMVvELmM=
 google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200709232328-d8193ee9cc3e/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0 h1:M1YKkFIboKNieVO5DLUEVzQfGwJD30Nv2jfUgzb5UcE=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/pkg/cli/mirror/catalog_images.go
+++ b/pkg/cli/mirror/catalog_images.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/openshift/library-go/pkg/image/reference"
+	"github.com/openshift/oc-mirror/pkg/operator"
 	"github.com/openshift/oc/pkg/cli/image/imagesource"
 	"github.com/operator-framework/operator-registry/alpha/action"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
@@ -129,7 +130,8 @@ func (o *MirrorOptions) rebuildCatalogs(ctx context.Context, dstDir string, file
 				return nil, err
 			}
 			// Remove any duplicate objects
-			if err := action.TwoWay.MergeDC(dc); err != nil {
+			merger := &operator.TwoWayStrategy{}
+			if err := merger.Merge(dc); err != nil {
 				return nil, err
 			}
 			dcDirToBuild = filepath.Join(dcDir, "rendered")

--- a/pkg/operator/doc.go
+++ b/pkg/operator/doc.go
@@ -1,0 +1,2 @@
+// Package operator contains tools for manipulating operator catalogs.
+package operator

--- a/pkg/operator/merge.go
+++ b/pkg/operator/merge.go
@@ -1,0 +1,259 @@
+package operator
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/imdario/mergo"
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+)
+
+// Merger is an object that will complete merge actions declarative config options
+type Merger interface {
+	Merge(*declcfg.DeclarativeConfig) error
+}
+
+var _ Merger = &PreferLastStrategy{}
+
+type PreferLastStrategy struct{}
+
+func (mg *PreferLastStrategy) Merge(dc *declcfg.DeclarativeConfig) error {
+	return mergeDCPreferLast(dc)
+}
+
+// mergeDCPreferLast merges all packages, channels, and bundles with the same unique key
+// into single objects using the last element with that key.
+func mergeDCPreferLast(cfg *declcfg.DeclarativeConfig) error {
+
+	// Merge declcfg.Packages.
+	pkgsByKey := make(map[string][]declcfg.Package, len(cfg.Packages))
+	for i, pkg := range cfg.Packages {
+		key := keyForDCObj(pkg)
+		pkgsByKey[key] = append(pkgsByKey[key], cfg.Packages[i])
+	}
+	if len(pkgsByKey) != 0 {
+		outPkgs := make([]declcfg.Package, len(pkgsByKey))
+		i := 0
+		for _, pkgs := range pkgsByKey {
+			outPkgs[i] = pkgs[len(pkgs)-1]
+			i++
+		}
+		sortPackages(outPkgs)
+		cfg.Packages = outPkgs
+	}
+
+	// Merge channels.
+	chsByKey := make(map[string][]declcfg.Channel, len(cfg.Channels))
+	for i, ch := range cfg.Channels {
+		key := keyForDCObj(ch)
+		chsByKey[key] = append(chsByKey[key], cfg.Channels[i])
+	}
+	if len(chsByKey) != 0 {
+		outChs := make([]declcfg.Channel, len(chsByKey))
+		i := 0
+		for _, chs := range chsByKey {
+			outChs[i] = chs[len(chs)-1]
+			i++
+		}
+		sortChannels(outChs)
+		cfg.Channels = outChs
+	}
+
+	// Merge bundles.
+	bundlesByKey := make(map[string][]declcfg.Bundle, len(cfg.Bundles))
+	for i, b := range cfg.Bundles {
+		key := keyForDCObj(b)
+		bundlesByKey[key] = append(bundlesByKey[key], cfg.Bundles[i])
+	}
+	if len(bundlesByKey) != 0 {
+		outBundles := make([]declcfg.Bundle, len(bundlesByKey))
+		i := 0
+		for _, bundles := range bundlesByKey {
+			outBundles[i] = bundles[len(bundles)-1]
+			i++
+		}
+		sortBundles(outBundles)
+		cfg.Bundles = outBundles
+	}
+
+	// There is no way to merge "other" schema since a unique key field is unknown.
+	return nil
+}
+
+var _ Merger = &TwoWayStrategy{}
+
+type TwoWayStrategy struct{}
+
+func (mg *TwoWayStrategy) Merge(dc *declcfg.DeclarativeConfig) error {
+	return mergeDCTwoWay(dc)
+}
+
+// mergeDCTwoWay merges all declcfg.Packages, channels, and bundles with the same unique key
+// into single objects with ascending priority.
+func mergeDCTwoWay(cfg *declcfg.DeclarativeConfig) error {
+	var err error
+	if cfg.Packages, err = mergePackages(cfg.Packages); err != nil {
+		return err
+	}
+	if cfg.Channels, err = mergeChannels(cfg.Channels); err != nil {
+		return err
+	}
+	if cfg.Bundles, err = mergeBundles(cfg.Bundles); err != nil {
+		return err
+	}
+	// There is no way to merge "other" schema since a unique key field is unknown.
+	return nil
+}
+
+// mergePackage Packages merges all declcfg.Packages with the same name into one declcfg.Package object.
+// Value preference is ascending: values of declcfg.Packages later in input are preferred.
+func mergePackages(inPkgs []declcfg.Package) (outPkgs []declcfg.Package, err error) {
+	pkgsByName := make(map[string][]declcfg.Package, len(inPkgs))
+	for i, pkg := range inPkgs {
+		key := keyForDCObj(pkg)
+		pkgsByName[key] = append(pkgsByName[key], inPkgs[i])
+	}
+
+	for _, pkgs := range pkgsByName {
+		mergedPkg := pkgs[0]
+
+		if len(pkgs) > 1 {
+			for _, pkg := range pkgs[1:] {
+				if err := mergo.Merge(&mergedPkg, pkg, mergo.WithOverride); err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		outPkgs = append(outPkgs, mergedPkg)
+	}
+
+	sortPackages(outPkgs)
+
+	return outPkgs, nil
+}
+
+// mergeChannels merges all channels with the same name and declcfg.Package into one channel object.
+// Value preference is ascending: values of channels later in input are preferred.
+func mergeChannels(inChs []declcfg.Channel) (outChs []declcfg.Channel, err error) {
+	chsByKey := make(map[string][]declcfg.Channel, len(inChs))
+	entriesByKey := make(map[string]map[string][]declcfg.ChannelEntry, len(inChs))
+	for i, ch := range inChs {
+		chKey := keyForDCObj(ch)
+		chsByKey[chKey] = append(chsByKey[chKey], inChs[i])
+		entries, ok := entriesByKey[chKey]
+		if !ok {
+			entries = make(map[string][]declcfg.ChannelEntry)
+			entriesByKey[chKey] = entries
+		}
+		for j, e := range ch.Entries {
+			entries[e.Name] = append(entries[e.Name], ch.Entries[j])
+		}
+	}
+
+	for chKey, chs := range chsByKey {
+		mergedCh := chs[0]
+
+		if len(chs) > 1 {
+			for _, ch := range chs[1:] {
+				if err := mergo.Merge(&mergedCh, ch, mergo.WithOverride); err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		mergedCh.Entries = nil
+		for _, entries := range entriesByKey[chKey] {
+			mergedEntry := entries[0]
+
+			if len(entries) > 1 {
+				for _, e := range entries[1:] {
+					if err := mergo.Merge(&mergedEntry, e, mergo.WithOverride); err != nil {
+						return nil, err
+					}
+				}
+			}
+
+			mergedCh.Entries = append(mergedCh.Entries, mergedEntry)
+		}
+
+		sort.Slice(mergedCh.Entries, func(i, j int) bool {
+			return mergedCh.Entries[i].Name < mergedCh.Entries[j].Name
+		})
+
+		outChs = append(outChs, mergedCh)
+	}
+
+	sortChannels(outChs)
+
+	return outChs, nil
+}
+
+// mergeBundles merges all bundles with the same name and declcfg.Package into one bundle object.
+// Value preference is ascending: values of bundles later in input are preferred.
+func mergeBundles(inBundles []declcfg.Bundle) (outBundles []declcfg.Bundle, err error) {
+	bundlesByKey := make(map[string][]declcfg.Bundle, len(inBundles))
+	for i, bundle := range inBundles {
+		key := keyForDCObj(bundle)
+		bundlesByKey[key] = append(bundlesByKey[key], inBundles[i])
+	}
+
+	for _, bundles := range bundlesByKey {
+		mergedBundle := bundles[0]
+
+		if len(bundles) > 1 {
+			for _, bundle := range bundles[1:] {
+				if err := mergo.Merge(&mergedBundle, bundle, mergo.WithOverride); err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		outBundles = append(outBundles, mergedBundle)
+	}
+
+	sortBundles(outBundles)
+
+	return outBundles, nil
+}
+
+func sortPackages(pkgs []declcfg.Package) {
+	sort.Slice(pkgs, func(i, j int) bool {
+		return pkgs[i].Name < pkgs[j].Name
+	})
+}
+
+func sortChannels(chs []declcfg.Channel) {
+	sort.Slice(chs, func(i, j int) bool {
+		if chs[i].Package == chs[j].Package {
+			return chs[i].Name < chs[j].Name
+		}
+		return chs[i].Package < chs[j].Package
+	})
+}
+
+func sortBundles(bundles []declcfg.Bundle) {
+	sort.Slice(bundles, func(i, j int) bool {
+		if bundles[i].Package == bundles[j].Package {
+			return bundles[i].Name < bundles[j].Name
+		}
+		return bundles[i].Package < bundles[j].Package
+	})
+}
+
+func keyForDCObj(obj interface{}) string {
+	switch t := obj.(type) {
+	case declcfg.Package:
+		// declcfg.Package name is globally unique.
+		return t.Name
+	case declcfg.Channel:
+		// Channel name is unqiue per declcfg.Package.
+		return t.Package + t.Name
+	case declcfg.Bundle:
+		// Bundle name is unqiue per declcfg.Package.
+		return t.Package + t.Name
+	default:
+		// This should never happen.
+		panic(fmt.Sprintf("bug: unrecognized type %T, expected one of declcfg.Package, Channel, Bundle", t))
+	}
+}

--- a/pkg/operator/merge_test.go
+++ b/pkg/operator/merge_test.go
@@ -1,0 +1,429 @@
+package operator
+
+import (
+	"testing"
+
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+	"github.com/operator-framework/operator-registry/alpha/property"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeDC(t *testing.T) {
+	type spec struct {
+		name      string
+		mt        Merger
+		dc, expDC *declcfg.DeclarativeConfig
+		expError  string
+	}
+
+	cases := []spec{
+		{
+			name:  "TwoWay/Empty",
+			mt:    &TwoWayStrategy{},
+			dc:    &declcfg.DeclarativeConfig{},
+			expDC: &declcfg.DeclarativeConfig{},
+		},
+		{
+			name: "TwoWay/NoMergeNeeded",
+			mt:   &TwoWayStrategy{},
+			dc: &declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{Schema: "olm.package", Name: "foo", DefaultChannel: "stable"},
+					{Schema: "olm.package", Name: "bar", DefaultChannel: "stable"},
+				},
+				Channels: []declcfg.Channel{
+					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.1.0"},
+					}},
+					{Schema: "olm.channel", Name: "stable", Package: "bar", Entries: []declcfg.ChannelEntry{
+						{Name: "bar.v0.1.0"},
+					}},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.0",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.1.0"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "bar.v0.1.0",
+						Package: "bar",
+						Image:   "reg/bar:latest",
+						Properties: []property.Property{
+							property.MustBuildGVKRequired("etcd.database.coreos.com", "v1", "EtcdBackup"),
+							property.MustBuildPackage("bar", "0.1.0"),
+						},
+					},
+				},
+			},
+			expDC: &declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{Schema: "olm.package", Name: "bar", DefaultChannel: "stable"},
+					{Schema: "olm.package", Name: "foo", DefaultChannel: "stable"},
+				},
+				Channels: []declcfg.Channel{
+					{Schema: "olm.channel", Name: "stable", Package: "bar", Entries: []declcfg.ChannelEntry{
+						{Name: "bar.v0.1.0"},
+					}},
+					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.1.0"},
+					}},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "bar.v0.1.0",
+						Package: "bar",
+						Image:   "reg/bar:latest",
+						Properties: []property.Property{
+							property.MustBuildGVKRequired("etcd.database.coreos.com", "v1", "EtcdBackup"),
+							property.MustBuildPackage("bar", "0.1.0"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.0",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.1.0"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "TwoWay/MergePackagesChannelsBundles",
+			mt:   &TwoWayStrategy{},
+			dc: &declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{Schema: "olm.package", Name: "foo", DefaultChannel: "stable"},
+					{Schema: "olm.package", Name: "foo", DefaultChannel: "alpha"},
+					{Schema: "olm.package", Name: "bar", DefaultChannel: "stable"},
+				},
+				Channels: []declcfg.Channel{
+					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.1.0"},
+						{Name: "foo.v0.1.0", Replaces: "foo.v0.0.5"},
+						{Name: "foo.v0.1.0", Skips: []string{"foo.v0.0.4"}},
+					}},
+					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.1.1", Replaces: "foo.v1.0.0"},
+					}},
+					{Schema: "olm.channel", Name: "stable", Package: "bar", Entries: []declcfg.ChannelEntry{
+						{Name: "bar.v0.1.0"},
+					}},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.0.5",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.0.5"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.0",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.1.0"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.1",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.1.1"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "bar.v0.1.0",
+						Package: "bar",
+						Image:   "reg/bar:latest",
+						Properties: []property.Property{
+							property.MustBuildGVKRequired("foo.example.com", "v1", "Foo"),
+							property.MustBuildPackage("bar", "0.1.0"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "bar.v0.1.0",
+						Package: "bar",
+						Image:   "reg/bar:latest",
+						Properties: []property.Property{
+							property.MustBuildGVKRequired("etcd.database.coreos.com", "v1", "EtcdBackup"),
+							property.MustBuildPackage("bar", "0.1.0"),
+						},
+					},
+				},
+			},
+			expDC: &declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{Schema: "olm.package", Name: "bar", DefaultChannel: "stable"},
+					{Schema: "olm.package", Name: "foo", DefaultChannel: "alpha"},
+				},
+				Channels: []declcfg.Channel{
+					{Schema: "olm.channel", Name: "stable", Package: "bar", Entries: []declcfg.ChannelEntry{
+						{Name: "bar.v0.1.0"},
+					}},
+					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.1.0", Replaces: "foo.v0.0.5", Skips: []string{"foo.v0.0.4"}},
+						{Name: "foo.v0.1.1", Replaces: "foo.v1.0.0"},
+					}},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "bar.v0.1.0",
+						Package: "bar",
+						Image:   "reg/bar:latest",
+						Properties: []property.Property{
+							// Can't merge properties since their keys are unknown.
+							property.MustBuildGVKRequired("etcd.database.coreos.com", "v1", "EtcdBackup"),
+							property.MustBuildPackage("bar", "0.1.0"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.0.5",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.0.5"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.0",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.1.0"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.1",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.1.1"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "PreferLast/Empty",
+			mt:    &PreferLastStrategy{},
+			dc:    &declcfg.DeclarativeConfig{},
+			expDC: &declcfg.DeclarativeConfig{},
+		},
+		{
+			name: "PreferLast/NoMergeNeeded",
+			mt:   &PreferLastStrategy{},
+			dc: &declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{Schema: "olm.package", Name: "foo", DefaultChannel: "stable"},
+					{Schema: "olm.package", Name: "bar", DefaultChannel: "stable"},
+				},
+				Channels: []declcfg.Channel{
+					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.1.0"},
+					}},
+					{Schema: "olm.channel", Name: "stable", Package: "bar", Entries: []declcfg.ChannelEntry{
+						{Name: "bar.v0.1.0"},
+					}},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.0",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.1.0"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "bar.v0.1.0",
+						Package: "bar",
+						Image:   "reg/bar:latest",
+						Properties: []property.Property{
+							property.MustBuildGVKRequired("etcd.database.coreos.com", "v1", "EtcdBackup"),
+							property.MustBuildPackage("bar", "0.1.0"),
+						},
+					},
+				},
+			},
+			expDC: &declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{Schema: "olm.package", Name: "bar", DefaultChannel: "stable"},
+					{Schema: "olm.package", Name: "foo", DefaultChannel: "stable"},
+				},
+				Channels: []declcfg.Channel{
+					{Schema: "olm.channel", Name: "stable", Package: "bar", Entries: []declcfg.ChannelEntry{
+						{Name: "bar.v0.1.0"},
+					}},
+					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.1.0"},
+					}},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "bar.v0.1.0",
+						Package: "bar",
+						Image:   "reg/bar:latest",
+						Properties: []property.Property{
+							property.MustBuildGVKRequired("etcd.database.coreos.com", "v1", "EtcdBackup"),
+							property.MustBuildPackage("bar", "0.1.0"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.0",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.1.0"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "PreferLast/MergePackagesChannelsBundles",
+			mt:   &PreferLastStrategy{},
+			dc: &declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{Schema: "olm.package", Name: "foo", DefaultChannel: "stable"},
+					{Schema: "olm.package", Name: "foo", DefaultChannel: "alpha"},
+					{Schema: "olm.package", Name: "bar", DefaultChannel: "stable"},
+				},
+				Channels: []declcfg.Channel{
+					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.1.0"},
+					}},
+					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.5.0"},
+						{Name: "foo.v0.1.0", Replaces: "foo.v0.0.5"},
+					}},
+					{Schema: "olm.channel", Name: "stable", Package: "bar", Entries: []declcfg.ChannelEntry{
+						{Name: "bar.v0.1.0"},
+					}},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.0.5",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.0.5"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.0",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.1.0"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "bar.v0.1.0",
+						Package: "bar",
+						Image:   "reg/bar:latest",
+						Properties: []property.Property{
+							property.MustBuildGVKRequired("foo.example.com", "v1", "Foo"),
+							property.MustBuildPackage("bar", "0.1.0"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "bar.v0.1.0",
+						Package: "bar",
+						Image:   "reg/bar:latest",
+						Properties: []property.Property{
+							property.MustBuildGVKRequired("etcd.database.coreos.com", "v1", "EtcdBackup"),
+							property.MustBuildPackage("bar", "0.1.0"),
+						},
+					},
+				},
+			},
+			expDC: &declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{Schema: "olm.package", Name: "bar", DefaultChannel: "stable"},
+					{Schema: "olm.package", Name: "foo", DefaultChannel: "alpha"},
+				},
+				Channels: []declcfg.Channel{
+					{Schema: "olm.channel", Name: "stable", Package: "bar", Entries: []declcfg.ChannelEntry{
+						{Name: "bar.v0.1.0"},
+					}},
+					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.5.0"},
+						{Name: "foo.v0.1.0", Replaces: "foo.v0.0.5"},
+					}},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "bar.v0.1.0",
+						Package: "bar",
+						Image:   "reg/bar:latest",
+						Properties: []property.Property{
+							property.MustBuildGVKRequired("etcd.database.coreos.com", "v1", "EtcdBackup"),
+							property.MustBuildPackage("bar", "0.1.0"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.0.5",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.0.5"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.0",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.1.0"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.mt.Merge(c.dc)
+			if c.expError != "" {
+				require.EqualError(t, err, c.expError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, c.expDC, c.dc)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

This PR adds merge functionality to `oc-mirror` for file-based catalogs. This had been implemented in a fork of `operator-registry` and it has been moved to `oc-mirror`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

- [ ] Unit tests added

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules