### PR TITLE
Stopping the process when no changes are found between runs. [190]

### DIFF
--- a/pkg/cli/mirror/create.go
+++ b/pkg/cli/mirror/create.go
@@ -20,6 +20,11 @@ import (
 	"github.com/openshift/oc-mirror/pkg/metadata/storage"
 )
 
+var (
+	// NoUpdatesExist should be returned by Create() when no updates are found
+	NoUpdatesExist = errors.New("no updates detected, process stopping")
+)
+
 func (o *MirrorOptions) Create(ctx context.Context) error {
 
 	// Read the imageset-config.yaml
@@ -126,6 +131,13 @@ func (o *MirrorOptions) Create(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Stop the process if no new blobs
+	if len(blobs) == 0 {
+		logrus.Infof("no updates detected, process stopping")
+		return NoUpdatesExist
+	}
+
 	// Add only the new manifests and blobs created to the current run.
 	thisRun.Manifests = append(thisRun.Manifests, manifests...)
 	thisRun.Blobs = append(thisRun.Blobs, blobs...)

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -181,7 +181,11 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 	case o.ManifestsOnly:
 		logrus.Info("Not implemented yet")
 	case len(o.OutputDir) > 0 && o.From == "":
-		return o.Create(cmd.Context())
+		err := o.Create(cmd.Context())
+		if err != nil && err != NoUpdatesExist {
+			return err
+		}
+		return nil
 	case len(o.ToMirror) > 0 && len(o.From) > 0:
 		return o.Publish(cmd.Context(), cmd, f)
 	case len(o.ToMirror) > 0 && len(o.ConfigPath) > 0:
@@ -197,17 +201,21 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 		fmt.Fprintf(o.IOStreams.Out, "workspace: %s\n", dir)
 
 		o.OutputDir = dir
-		if err := o.Create(cmd.Context()); err != nil {
+
+		err := o.Create(cmd.Context());
+		if err != nil && err != NoUpdatesExist {
 			return err
 		}
 
-		// run publish
-		o.From = dir
-		o.OutputDir = ""
+		if err != NoUpdatesExist {
+			// run publish
+			o.From = dir
+			o.OutputDir = ""
 
-		if err := o.Publish(cmd.Context(), cmd, f); err != nil {
-			fmt.Fprintf(o.IOStreams.ErrOut, "Image Publish:\nERROR: publishing operation failed: %v\nTo retry this operation run \"oc-mirror --from %s docker://%s\"\n", err, o.From, o.ToMirror)
-			return kcmdutil.ErrExit
+			if err := o.Publish(cmd.Context(), cmd, f); err != nil {
+				fmt.Fprintf(o.IOStreams.ErrOut, "Image Publish:\nERROR: publishing operation failed: %v\nTo retry this operation run \"oc-mirror --from %s docker://%s\"\n", err, o.From, o.ToMirror)
+				return kcmdutil.ErrExit
+			}
 		}
 
 		// Remove tmp directory

--- a/test/testcases.sh
+++ b/test/testcases.sh
@@ -8,6 +8,7 @@ TESTCASES[6]="custom_namespace"
 TESTCASES[7]="package_filtering"
 TESTCASES[8]="skip_deps"
 TESTCASES[9]="helm_local"
+TESTCASES[10]="no_updates_exist"
 
 # Test full catalog mode.
 function full_catalog () {
@@ -28,6 +29,8 @@ function headsonly_diff () {
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
+
+    check_sequence_number 2
 }
 
 # Test registry backend
@@ -99,4 +102,18 @@ function skip_deps {
 function helm_local {
     run_helm imageset-config-helm.yaml podinfo-6.0.0.tgz
     check_helm "localhost.localdomain:${REGISTRY_DISCONN_PORT}/stefanprodan/podinfo:6.0.0"
+}
+
+function no_updates_exist {
+    run_no_updates imageset-config-headsonly.yaml true
+    check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
+    "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
+    localhost.localdomain:${REGISTRY_DISCONN_PORT}
+
+    if [ -f ${CREATE_FULL_DIR}/mirror_seq2_000000.tar ]; then
+        echo "no updates should not have a second sequence"
+        exit 1
+    fi
+
+    check_sequence_number 1
 }


### PR DESCRIPTION
# Description

Checks if there are any blob differences during the process. If there are no changes stop the process to avoid unnecessary sequence update / tar files with only the manifests in. 

Fixes #190

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests updated
- [x] Run yourself via two runs of oc-mirror --config imageset-config.yaml file://archives and oc-mirror --config imageset-config.yaml file://archives2. Note that in archives2 there are no tar files. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules