### PR TITLE
feat: remove disk space requirement for mirror to mirror transfer

### DIFF
--- a/pkg/bundle/image.go
+++ b/pkg/bundle/image.go
@@ -12,6 +12,14 @@ import (
 	"github.com/openshift/oc-mirror/pkg/image"
 )
 
+type ErrBlocked struct {
+	image string
+}
+
+func (e ErrBlocked) Error() string {
+	return fmt.Sprintf("image %s blocked", e.image)
+}
+
 // IsBlocked will return a boolean value on whether an image
 // is specified as blocked in the BundleSpec
 func IsBlocked(cfg v1alpha1.ImageSetConfiguration, imgRef reference.DockerImageReference) bool {

--- a/pkg/cli/mirror/additional.go
+++ b/pkg/cli/mirror/additional.go
@@ -1,66 +1,22 @@
 package mirror
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 
-	"github.com/openshift/oc/pkg/cli/image/imagesource"
-	imagemanifest "github.com/openshift/oc/pkg/cli/image/manifest"
-	"github.com/openshift/oc/pkg/cli/image/mirror"
-	"github.com/sirupsen/logrus"
-
-	"github.com/openshift/oc-mirror/pkg/bundle"
-	"github.com/openshift/oc-mirror/pkg/config"
 	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
 	"github.com/openshift/oc-mirror/pkg/image"
+	"github.com/openshift/oc/pkg/cli/image/imagesource"
 )
 
-type AdditionalOptions struct {
-	*MirrorOptions
-	// insecure indicates whether the source
-	// registry is insecure
-	insecure bool
-}
+// TODO(jpower432): determine whether this can be
+// deleted or whether it will implement an interface
 
-func NewAdditionalOptions(mo *MirrorOptions) *AdditionalOptions {
-	opts := &AdditionalOptions{MirrorOptions: mo}
-	if mo.SourcePlainHTTP || mo.SourceSkipTLS {
-		opts.insecure = true
-	}
-	return opts
-}
+type AdditionalOptions struct{}
 
-type ErrBlocked struct {
-	image string
-}
+func (o *AdditionalOptions) Plan(imageList []v1alpha1.AdditionalImages) (image.TypedImageMapping, error) {
+	mmappings := make(image.TypedImageMapping, len(imageList))
+	for _, img := range imageList {
 
-func (e ErrBlocked) Error() string {
-	return fmt.Sprintf("additional image %s also specified as blocked, remove the image one config field or the other", e.image)
-}
-
-// GetAdditional downloads specified images in the imageset-config.yaml under mirror.additonalImages
-func (o *AdditionalOptions) GetAdditional(ctx context.Context, cfg v1alpha1.ImageSetConfiguration, imageList []v1alpha1.AdditionalImages) (assocs image.AssociationSet, err error) {
-
-	opts := mirror.NewMirrorImageOptions(o.IOStreams)
-	opts.DryRun = o.DryRun
-	opts.SecurityOptions.Insecure = o.insecure
-	opts.SecurityOptions.SkipVerification = o.SkipVerification
-	opts.FileDir = filepath.Join(o.Dir, config.SourceDir)
-	opts.FilterOptions = imagemanifest.FilterOptions{FilterByOS: ".*"}
-
-	logrus.Infof("Downloading %d image(s) to %s", len(imageList), opts.FileDir)
-
-	var mappings []mirror.Mapping
-	images := make([]string, len(imageList))
-	assocMappings := make(map[string]string, len(imageList))
-	for i, img := range imageList {
-
-		regctx, err := config.CreateDefaultContext(o.insecure)
-		if err != nil {
-			return nil, fmt.Errorf("error creating registry context: %v", err)
-		}
-		opts.SecurityOptions.CachedContext = regctx
 		// Get source image information
 		srcRef, err := imagesource.ParseReference(img.Name)
 		if err != nil {
@@ -71,49 +27,16 @@ func (o *AdditionalOptions) GetAdditional(ctx context.Context, cfg v1alpha1.Imag
 			srcRef.Ref.Tag = "latest"
 		}
 
-		// Set destination image information
+		// Set destination image information as file by default
 		dstRef := srcRef
 		dstRef.Type = imagesource.DestinationFile
 		dstRef.Ref = dstRef.Ref.DockerClientDefaults()
-
-		// Check if image is specified as a blocked image
-		if bundle.IsBlocked(cfg, srcRef.Ref) {
-			return nil, ErrBlocked{img.Name}
-		}
-		// Create mapping from source and destination images
-		mappings = append(mappings, mirror.Mapping{
-			Source:      srcRef,
-			Destination: dstRef,
-			Name:        srcRef.Ref.Name,
-		})
-
-		// Add mapping and image for image association.
-		// The registry component is not included in the final path.
-		srcImage, err := bundle.PinImages(ctx, srcRef.Ref.Exact(), "", o.SourceSkipTLS, o.SourcePlainHTTP)
-		if err != nil {
-			return nil, err
-		}
-
 		dstRef.Ref.Registry = ""
-		assocMappings[srcImage] = dstRef.String()
-		images[i] = srcImage
+
+		mmappings.Add(srcRef, dstRef, image.TypeGeneric)
 	}
 
-	opts.Mappings = mappings
-
-	if err := opts.Run(); err != nil {
-		return nil, err
-	}
-
-	// Do not build associations on dry runs because there are no manifests
-	if !o.DryRun {
-		assocs, err = image.AssociateImageLayers(opts.FileDir, assocMappings, images, image.TypeGeneric)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return assocs, nil
+	return mmappings, nil
 }
 
 func setLatest(img imagesource.TypedImageReference) bool {

--- a/pkg/cli/mirror/additional_test.go
+++ b/pkg/cli/mirror/additional_test.go
@@ -1,34 +1,16 @@
 package mirror
 
 import (
-	"context"
-	"os"
 	"testing"
 
+	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
+	"github.com/openshift/oc-mirror/pkg/image"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-
-	"github.com/openshift/oc-mirror/pkg/bundle"
-	"github.com/openshift/oc-mirror/pkg/cli"
-	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
 )
 
-// TODO: use some oc lib to mock image mirroring, or mirror from files.
-
-func TestGetAdditional(t *testing.T) {
-	tmpdir := t.TempDir()
-	mo := MirrorOptions{
-		RootOptions: &cli.RootOptions{
-			Dir: tmpdir,
-			IOStreams: genericclioptions.IOStreams{
-				In:     os.Stdin,
-				Out:    os.Stdout,
-				ErrOut: os.Stderr,
-			},
-		},
-	}
-	opts := NewAdditionalOptions(&mo)
+func TestPlan_Additional(t *testing.T) {
+	opts := &AdditionalOptions{}
 
 	tests := []struct {
 		name    string
@@ -38,7 +20,7 @@ func TestGetAdditional(t *testing.T) {
 		imgPin  bool
 	}{
 		{
-			name: "testing with no block",
+			name: "Valid/WithTag",
 			cfg: v1alpha1.ImageSetConfiguration{
 				ImageSetConfigurationSpec: v1alpha1.ImageSetConfigurationSpec{
 					Mirror: v1alpha1.Mirror{
@@ -54,7 +36,7 @@ func TestGetAdditional(t *testing.T) {
 			imgPin: true,
 		},
 		{
-			name: "testing with no tag",
+			name: "Valid/NoTag",
 			cfg: v1alpha1.ImageSetConfiguration{
 				ImageSetConfigurationSpec: v1alpha1.ImageSetConfigurationSpec{
 					Mirror: v1alpha1.Mirror{
@@ -68,30 +50,11 @@ func TestGetAdditional(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "testing with block",
-			cfg: v1alpha1.ImageSetConfiguration{
-				ImageSetConfigurationSpec: v1alpha1.ImageSetConfigurationSpec{
-					Mirror: v1alpha1.Mirror{
-						BlockedImages: []v1alpha1.BlockedImages{
-							{Image: v1alpha1.Image{Name: "pull-tester-blocked"}},
-						},
-						AdditionalImages: []v1alpha1.AdditionalImages{
-							{Image: v1alpha1.Image{Name: "quay.io/estroz/pull-tester-blocked"}},
-						},
-					},
-				},
-			},
-			want:    ErrBlocked{},
-			wantErr: true,
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			ctx := context.Background()
-
-			assocs, err := opts.GetAdditional(ctx, test.cfg, test.cfg.Mirror.AdditionalImages)
+			mappings, err := opts.Plan(test.cfg.Mirror.AdditionalImages)
 			if test.wantErr {
 				testErr := test.want
 				require.ErrorAs(t, err, &testErr)
@@ -99,12 +62,13 @@ func TestGetAdditional(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			if test.imgPin {
-				testerImg, err := bundle.PinImages(ctx, test.cfg.Mirror.AdditionalImages[0].Name, "", false, false)
-				require.NoError(t, err)
-				if assert.Len(t, assocs, 1) {
-					require.Contains(t, assocs, testerImg)
-				}
+			testerRef, err := image.ParseTypedImage(test.cfg.Mirror.AdditionalImages[0].Name, image.TypeGeneric)
+			require.NoError(t, err)
+			if testerRef.Ref.Tag == "" {
+				testerRef.Ref.Tag = "latest"
+			}
+			if assert.Len(t, mappings, 1) {
+				require.Contains(t, mappings, testerRef)
 			}
 		})
 	}

--- a/pkg/cli/mirror/additional_test.go
+++ b/pkg/cli/mirror/additional_test.go
@@ -1,23 +1,32 @@
 package mirror
 
 import (
+	"context"
+	"os"
 	"testing"
 
-	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
-	"github.com/openshift/oc-mirror/pkg/image"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/openshift/library-go/pkg/image/reference"
+	"github.com/openshift/oc/pkg/cli/image/imagesource"
+
+	"github.com/openshift/oc-mirror/pkg/cli"
+	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
+	"github.com/openshift/oc-mirror/pkg/image"
 )
 
+// TODO(jpower432): replace images being used under estroz org
 func TestPlan_Additional(t *testing.T) {
-	opts := &AdditionalOptions{}
+	tmpdir := t.TempDir()
 
 	tests := []struct {
-		name    string
-		cfg     v1alpha1.ImageSetConfiguration
-		want    error
-		wantErr bool
-		imgPin  bool
+		name      string
+		cfg       v1alpha1.ImageSetConfiguration
+		want      error
+		wantImage image.TypedImage
+		wantErr   bool
 	}{
 		{
 			name: "Valid/WithTag",
@@ -33,7 +42,19 @@ func TestPlan_Additional(t *testing.T) {
 					},
 				},
 			},
-			imgPin: true,
+			wantImage: image.TypedImage{
+				TypedImageReference: imagesource.TypedImageReference{
+					Ref: reference.DockerImageReference{
+						Name:      "pull-tester-additional",
+						ID:        "sha256:5e642429d9e8d03267879160121f3001a300cc31cd93455bc27edea309ea9a88",
+						Tag:       "latest",
+						Namespace: "estroz",
+						Registry:  "quay.io",
+					},
+					Type: imagesource.DestinationRegistry,
+				},
+				Category: image.TypeGeneric,
+			},
 		},
 		{
 			name: "Valid/NoTag",
@@ -41,7 +62,7 @@ func TestPlan_Additional(t *testing.T) {
 				ImageSetConfigurationSpec: v1alpha1.ImageSetConfigurationSpec{
 					Mirror: v1alpha1.Mirror{
 						BlockedImages: []v1alpha1.BlockedImages{
-							{Image: v1alpha1.Image{Name: "pull-tester-blocked"}},
+							{Image: v1alpha1.Image{Name: "pull-tester-blocked:test"}},
 						},
 						AdditionalImages: []v1alpha1.AdditionalImages{
 							{Image: v1alpha1.Image{Name: "quay.io/estroz/pull-tester-additional"}},
@@ -49,12 +70,36 @@ func TestPlan_Additional(t *testing.T) {
 					},
 				},
 			},
+			wantImage: image.TypedImage{
+				TypedImageReference: imagesource.TypedImageReference{
+					Ref: reference.DockerImageReference{
+						Registry:  "quay.io",
+						Name:      "pull-tester-additional",
+						ID:        "sha256:5e642429d9e8d03267879160121f3001a300cc31cd93455bc27edea309ea9a88",
+						Tag:       "latest",
+						Namespace: "estroz",
+					},
+					Type: imagesource.DestinationRegistry,
+				},
+				Category: image.TypeGeneric,
+			},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			mo := MirrorOptions{
+				RootOptions: &cli.RootOptions{
+					Dir: tmpdir,
+					IOStreams: genericclioptions.IOStreams{
+						In:     os.Stdin,
+						Out:    os.Stdout,
+						ErrOut: os.Stderr,
+					},
+				},
+			}
+			opts := NewAdditionalOptions(&mo)
 
-			mappings, err := opts.Plan(test.cfg.Mirror.AdditionalImages)
+			mappings, err := opts.Plan(context.TODO(), test.cfg.Mirror.AdditionalImages)
 			if test.wantErr {
 				testErr := test.want
 				require.ErrorAs(t, err, &testErr)
@@ -62,13 +107,8 @@ func TestPlan_Additional(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			testerRef, err := image.ParseTypedImage(test.cfg.Mirror.AdditionalImages[0].Name, image.TypeGeneric)
-			require.NoError(t, err)
-			if testerRef.Ref.Tag == "" {
-				testerRef.Ref.Tag = "latest"
-			}
 			if assert.Len(t, mappings, 1) {
-				require.Contains(t, mappings, testerRef)
+				require.Contains(t, mappings, test.wantImage)
 			}
 		})
 	}

--- a/pkg/cli/mirror/catalog_images.go
+++ b/pkg/cli/mirror/catalog_images.go
@@ -25,14 +25,15 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/openshift/library-go/pkg/image/reference"
-	"github.com/openshift/oc-mirror/pkg/image"
-	"github.com/openshift/oc-mirror/pkg/operator"
-	"github.com/openshift/oc/pkg/cli/image/imagesource"
 	"github.com/operator-framework/operator-registry/alpha/action"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/pkg/containertools"
 	"github.com/operator-framework/operator-registry/pkg/image/containerdregistry"
 	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/oc-mirror/pkg/image"
+	"github.com/openshift/oc-mirror/pkg/operator"
+	"github.com/openshift/oc/pkg/cli/image/imagesource"
 )
 
 // unpackCatalog will unpack file-based catalogs if they exists

--- a/pkg/cli/mirror/create.go
+++ b/pkg/cli/mirror/create.go
@@ -4,48 +4,33 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
-
-	"github.com/openshift/oc-mirror/pkg/archive"
-	"github.com/openshift/oc-mirror/pkg/bundle"
 	"github.com/openshift/oc-mirror/pkg/config"
 	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
 	"github.com/openshift/oc-mirror/pkg/image"
-	"github.com/openshift/oc-mirror/pkg/metadata"
 	"github.com/openshift/oc-mirror/pkg/metadata/storage"
+	"github.com/sirupsen/logrus"
 )
 
-var (
-	// NoUpdatesExist should be returned by Create() when no updates are found
-	NoUpdatesExist = errors.New("no updates detected, process stopping")
-)
-
-func (o *MirrorOptions) Create(ctx context.Context) error {
-
-	// Read the imageset-config.yaml
-	cfg, err := config.LoadConfig(o.ConfigPath)
-	if err != nil {
-		return err
-	}
-
+// Create will plan a mirroring operation based on provided configuration
+func (o *MirrorOptions) Create(ctx context.Context, cfg v1alpha1.ImageSetConfiguration) (v1alpha1.Metadata, image.TypedImageMapping, error) {
 	// Determine stateless or stateful mode.
 	// Empty storage configuration will trigger a metadata cleanup
 	// action and labels metadata as single use
+	path := filepath.Join(o.Dir, config.SourceDir)
 	var backend storage.Backend
 	var meta v1alpha1.Metadata
-	path := filepath.Join(o.Dir, config.SourceDir)
+	var err error
 	if (v1alpha1.StorageConfig{} == cfg.StorageConfig) {
 		meta.SingleUse = true
 		logrus.Warnf("backend is not configured in %s, using stateless mode", o.ConfigPath)
 		cfg.StorageConfig.Local = &v1alpha1.LocalConfig{Path: path}
 		backend, err = storage.ByConfig(path, cfg.StorageConfig)
 		if err != nil {
-			return fmt.Errorf("error opening backend: %v", err)
+			return meta, image.TypedImageMapping{}, fmt.Errorf("error opening backend: %v", err)
 		}
 		defer func() {
 			if err := backend.Cleanup(ctx, config.MetadataBasePath); err != nil {
@@ -56,283 +41,99 @@ func (o *MirrorOptions) Create(ctx context.Context) error {
 		meta.SingleUse = false
 		backend, err = storage.ByConfig(path, cfg.StorageConfig)
 		if err != nil {
-			return fmt.Errorf("error opening backend: %v", err)
+			return meta, image.TypedImageMapping{}, fmt.Errorf("error opening backend: %v", err)
 		}
 	}
-
-	// Run full or diff mirror.
-	merr := backend.ReadMetadata(ctx, &meta, config.MetadataBasePath)
-	if merr != nil && !errors.Is(merr, storage.ErrMetadataNotExist) {
-		return merr
-	}
-
-	if err := bundle.MakeCreateDirs(o.Dir); err != nil {
-		return err
-	}
-	if !o.SkipCleanup {
-		defer func() {
-			if err := os.RemoveAll(filepath.Join(o.Dir, config.SourceDir)); err != nil {
-				logrus.Error(err)
-			}
-		}()
-	}
-
-	// Ensure meta has the latest OPM image, and if not add it to cfg for mirroring.
-	addOPMImage(&cfg, meta)
-
 	thisRun := v1alpha1.PastMirror{
 		Timestamp: int(time.Now().Unix()),
 	}
+	// Run full or diff mirror.
+	merr := backend.ReadMetadata(ctx, &meta, config.MetadataBasePath)
+	if merr != nil && !errors.Is(merr, storage.ErrMetadataNotExist) {
+		return meta, image.TypedImageMapping{}, merr
+	}
 	// New metadata files get a full mirror, with complete/heads-only catalogs, release images,
 	// and a new UUID. Otherwise, use data from the last mirror to mirror just the layer diff.
-
-	var backupMeta v1alpha1.Metadata
-	rollbackMeta := func() error {
-		logrus.Error("operation cancelled, initiating metadata rollback")
-		return metadata.UpdateMetadata(ctx, backend, &backupMeta, o.SourceSkipTLS, o.SourcePlainHTTP)
-	}
-
-	var assocs image.AssociationSet
 	switch {
 	case merr != nil || len(meta.PastMirrors) == 0:
 		meta.Uid = uuid.New()
 		thisRun.Sequence = 1
-
-		assocs, err = o.createFull(ctx, &cfg, meta)
-		if err != nil {
-			return err
+		thisRun.Mirror = cfg.Mirror
+		meta.PastMirrors = append(meta.PastMirrors, thisRun)
+		f := func(ctx context.Context, cfg v1alpha1.ImageSetConfiguration) (image.TypedImageMapping, error) {
+			if len(cfg.Mirror.Operators) != 0 {
+				operator := NewOperatorOptions(o)
+				operator.SkipImagePin = o.SkipImagePin
+				return operator.PlanFull(ctx, cfg)
+			}
+			return image.TypedImageMapping{}, nil
 		}
-
+		mmapping, err := o.run(ctx, &cfg, meta, f)
+		return meta, mmapping, err
 	default:
-		backupMeta = meta
 		lastRun := meta.PastMirrors[len(meta.PastMirrors)-1]
 		thisRun.Sequence = lastRun.Sequence + 1
-
-		assocs, err = o.createDiff(ctx, &cfg, lastRun, meta)
-		if err != nil {
-			return err
+		thisRun.Mirror = cfg.Mirror
+		meta.PastMirrors = append(meta.PastMirrors, thisRun)
+		f := func(ctx context.Context, cfg v1alpha1.ImageSetConfiguration) (image.TypedImageMapping, error) {
+			if len(cfg.Mirror.Operators) != 0 {
+				operator := NewOperatorOptions(o)
+				operator.SkipImagePin = o.SkipImagePin
+				return operator.PlanDiff(ctx, cfg, lastRun)
+			}
+			return image.TypedImageMapping{}, nil
 		}
+		mmapping, err := o.run(ctx, &cfg, meta, f)
+		return meta, mmapping, err
 	}
-
-	// Stop the process if DryRun
-	if o.DryRun {
-		return nil
-	}
-
-	if err := o.writeAssociations(assocs); err != nil {
-		return fmt.Errorf("error writing association file: %v", err)
-	}
-
-	// Store mirror in the run
-	thisRun.Mirror = cfg.Mirror
-
-	// Update metadata files and get newly created filepaths.
-	manifests, blobs, err := o.getFiles(meta)
-	if err != nil {
-		return err
-	}
-
-	// Stop the process if no new blobs
-	if len(blobs) == 0 {
-		logrus.Infof("no updates detected, process stopping")
-		return NoUpdatesExist
-	}
-
-	// Add only the new manifests and blobs created to the current run.
-	thisRun.Manifests = append(thisRun.Manifests, manifests...)
-	thisRun.Blobs = append(thisRun.Blobs, blobs...)
-	// Add this run and metadata to top level metadata.
-	meta.PastMirrors = append(meta.PastMirrors, thisRun)
-	meta.PastBlobs = append(meta.PastBlobs, blobs...)
-
-	// Update the metadata.
-	if err = metadata.UpdateMetadata(ctx, backend, &meta, o.SourceSkipTLS, o.SourcePlainHTTP); err != nil {
-		return err
-	}
-
-	// Allow for user interrupts
-	ctx, done := o.CancelContext(ctx)
-	defer done()
-
-	// If any errors occur after the metadata is written
-	// initiate metadata rollback
-	if err := o.prepareArchive(ctx, cfg, backend, thisRun.Sequence, manifests, blobs); err != nil {
-		if err := rollbackMeta(); err != nil {
-			return fmt.Errorf("error occurred during metadata rollback: %v", err)
-		}
-		return err
-	}
-
-	if ctx.Err() == context.Canceled {
-		o.interrupted = true
-		return rollbackMeta()
-	}
-
-	/* Commenting out temporarily because no concrete types implement this
-	if committer, isCommitter := backend.(storage.Committer); isCommitter {
-		if err := committer.Commit(ctx); err != nil {
-			return err
-		}
-	}*/
-
-	return nil
 }
 
-// createFull performs all tasks in creating full imagesets
-func (o *MirrorOptions) createFull(ctx context.Context, cfg *v1alpha1.ImageSetConfiguration, meta v1alpha1.Metadata) (image.AssociationSet, error) {
+func (o *MirrorOptions) run(ctx context.Context, cfg *v1alpha1.ImageSetConfiguration, meta v1alpha1.Metadata, operatorPlan operatorFunc) (image.TypedImageMapping, error) {
 
-	allAssocs := image.AssociationSet{}
+	// Ensure meta has the latest OPM image, and if not add it to cfg for mirroring.
+	addOPMImage(cfg, meta)
+	mmappings := image.TypedImageMapping{}
 
 	if len(cfg.Mirror.OCP.Channels) != 0 {
-		opts := NewReleaseOptions(o)
-		assocs, err := opts.GetReleases(ctx, meta, cfg)
+		release := NewReleaseOptions(o)
+		mappings, err := release.Plan(ctx, meta, cfg)
 		if err != nil {
-			return allAssocs, err
+			return mmappings, err
 		}
-		allAssocs.Merge(assocs)
+		mmappings.Merge(mappings)
 	}
 
-	if len(cfg.Mirror.Operators) != 0 {
-		opts := NewOperatorOptions(o)
-		opts.SkipImagePin = o.SkipImagePin
-		assocs, err := opts.Full(ctx, *cfg)
+	mappings, err := operatorPlan(ctx, *cfg)
+	if err != nil {
+		return mmappings, err
+	}
+	mmappings.Merge(mappings)
+
+	if len(cfg.Mirror.AdditionalImages) != 0 {
+		additional := &AdditionalOptions{}
+		mappings, err := additional.Plan(cfg.Mirror.AdditionalImages)
 		if err != nil {
-			return allAssocs, err
+			return mmappings, err
 		}
-		allAssocs.Merge(assocs)
+		mmappings.Merge(mappings)
+	}
+
+	if len(cfg.Mirror.Helm.Local) != 0 || len(cfg.Mirror.Helm.Repos) != 0 {
+		helm := NewHelmOptions(o)
+		mappings, err := helm.PullCharts(ctx, *cfg)
+		if err != nil {
+			return mmappings, err
+		}
+		mmappings.Merge(mappings)
 	}
 
 	if len(cfg.Mirror.Samples) != 0 {
 		logrus.Debugf("sample images full not implemented")
 	}
-
-	if len(cfg.Mirror.AdditionalImages) != 0 {
-		opts := NewAdditionalOptions(o)
-		assocs, err := opts.GetAdditional(ctx, *cfg, cfg.Mirror.AdditionalImages)
-		if err != nil {
-			return allAssocs, err
-		}
-		allAssocs.Merge(assocs)
-	}
-
-	if len(cfg.Mirror.Helm.Local) != 0 || len(cfg.Mirror.Helm.Repos) != 0 {
-		opts := NewHelmOptions(o)
-		assocs, err := opts.PullCharts(ctx, *cfg)
-		if err != nil {
-			return allAssocs, err
-		}
-		allAssocs.Merge(assocs)
-	}
-
-	return allAssocs, nil
+	return mmappings, nil
 }
 
-// createDiff performs all tasks in creating differential imagesets
-func (o *MirrorOptions) createDiff(ctx context.Context, cfg *v1alpha1.ImageSetConfiguration, lastRun v1alpha1.PastMirror, meta v1alpha1.Metadata) (image.AssociationSet, error) {
-
-	allAssocs := image.AssociationSet{}
-
-	if len(cfg.Mirror.OCP.Channels) != 0 {
-		opts := NewReleaseOptions(o)
-		assocs, err := opts.GetReleases(ctx, meta, cfg)
-		if err != nil {
-			return allAssocs, err
-		}
-		allAssocs.Merge(assocs)
-	}
-
-	if len(cfg.Mirror.Operators) != 0 {
-		opts := NewOperatorOptions(o)
-		opts.SkipImagePin = o.SkipImagePin
-		assocs, err := opts.Diff(ctx, *cfg, lastRun)
-		if err != nil {
-			return allAssocs, err
-		}
-		allAssocs.Merge(assocs)
-	}
-
-	if len(cfg.Mirror.Samples) != 0 {
-		logrus.Debugf("sample images diff not implemented")
-	}
-
-	if len(cfg.Mirror.AdditionalImages) != 0 {
-		opts := NewAdditionalOptions(o)
-		assocs, err := opts.GetAdditional(ctx, *cfg, cfg.Mirror.AdditionalImages)
-		if err != nil {
-			return allAssocs, err
-		}
-		allAssocs.Merge(assocs)
-	}
-
-	if len(cfg.Mirror.Helm.Local) != 0 || len(cfg.Mirror.Helm.Repos) != 0 {
-		opts := NewHelmOptions(o)
-		assocs, err := opts.PullCharts(ctx, *cfg)
-		if err != nil {
-			return allAssocs, err
-		}
-		allAssocs.Merge(assocs)
-	}
-
-	return allAssocs, nil
-}
-
-func (o *MirrorOptions) prepareArchive(ctx context.Context, cfg v1alpha1.ImageSetConfiguration, backend storage.Backend, seq int, manifests []v1alpha1.Manifest, blobs []v1alpha1.Blob) error {
-
-	// Default to a 500GiB archive size.
-	var segSize int64 = 500
-	if cfg.ImageSetConfigurationSpec.ArchiveSize != 0 {
-		segSize = cfg.ImageSetConfigurationSpec.ArchiveSize
-		logrus.Debugf("Using user provider archive size %d GiB", segSize)
-	}
-	segSize *= 1024 * 1024 * 1024
-
-	// Set get absolute path to output dir
-	// to avoid issue with directory change
-	output, err := filepath.Abs(o.OutputDir)
-	if err != nil {
-		return err
-	}
-
-	// Change directory before archiving to
-	// avoid broken symlink paths
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	if err := os.Chdir(filepath.Join(o.Dir, config.SourceDir)); err != nil {
-		return err
-	}
-	defer os.Chdir(cwd)
-
-	packager := archive.NewPackager(manifests, blobs)
-	prefix := fmt.Sprintf("mirror_seq%d", seq)
-	if err := packager.CreateSplitArchive(ctx, backend, segSize, output, ".", prefix, o.SkipCleanup); err != nil {
-		return fmt.Errorf("failed to create archive: %v", err)
-	}
-
-	return nil
-}
-
-func (o *MirrorOptions) getFiles(meta v1alpha1.Metadata) ([]v1alpha1.Manifest, []v1alpha1.Blob, error) {
-	diskPath := filepath.Join(o.Dir, config.SourceDir, "v2")
-	// Define a map that associates locations
-	// on disk to location in archive
-	paths := map[string]string{diskPath: "v2"}
-	return bundle.ReconcileV2Dir(meta, paths)
-}
-
-func (o *MirrorOptions) writeAssociations(assocs image.AssociationSet) error {
-	assocPath := filepath.Join(o.Dir, config.SourceDir, config.AssociationsBasePath)
-	if err := os.MkdirAll(filepath.Dir(assocPath), 0755); err != nil {
-		return fmt.Errorf("mkdir image associations file: %v", err)
-	}
-	f, err := os.OpenFile(assocPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0640)
-	if err != nil {
-		return fmt.Errorf("open image associations file: %v", err)
-	}
-	defer f.Close()
-	return assocs.Encode(f)
-}
+type operatorFunc func(ctx context.Context, cfg v1alpha1.ImageSetConfiguration) (image.TypedImageMapping, error)
 
 // Make sure the latest `opm` image exists during the publishing step
 // in case it does not exist in a past mirror.

--- a/pkg/cli/mirror/create.go
+++ b/pkg/cli/mirror/create.go
@@ -8,11 +8,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/oc-mirror/pkg/config"
 	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
 	"github.com/openshift/oc-mirror/pkg/image"
 	"github.com/openshift/oc-mirror/pkg/metadata/storage"
-	"github.com/sirupsen/logrus"
 )
 
 // Create will plan a mirroring operation based on provided configuration
@@ -110,8 +111,8 @@ func (o *MirrorOptions) run(ctx context.Context, cfg *v1alpha1.ImageSetConfigura
 	mmappings.Merge(mappings)
 
 	if len(cfg.Mirror.AdditionalImages) != 0 {
-		additional := &AdditionalOptions{}
-		mappings, err := additional.Plan(cfg.Mirror.AdditionalImages)
+		additional := NewAdditionalOptions(o)
+		mappings, err := additional.Plan(ctx, cfg.Mirror.AdditionalImages)
 		if err != nil {
 			return mmappings, err
 		}
@@ -130,6 +131,7 @@ func (o *MirrorOptions) run(ctx context.Context, cfg *v1alpha1.ImageSetConfigura
 	if len(cfg.Mirror.Samples) != 0 {
 		logrus.Debugf("sample images full not implemented")
 	}
+
 	return mmappings, nil
 }
 

--- a/pkg/cli/mirror/create_test.go
+++ b/pkg/cli/mirror/create_test.go
@@ -7,12 +7,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openshift/oc-mirror/pkg/cli"
-	"github.com/openshift/oc-mirror/pkg/config"
-	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/openshift/oc-mirror/pkg/cli"
+	"github.com/openshift/oc-mirror/pkg/config"
+	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
 )
 
 func TestAddOPMImage(t *testing.T) {

--- a/pkg/cli/mirror/helm.go
+++ b/pkg/cli/mirror/helm.go
@@ -110,8 +110,8 @@ func (h *HelmOptions) PullCharts(ctx context.Context, cfg v1alpha1.ImageSetConfi
 	}
 
 	// Image download planning
-	additional := &AdditionalOptions{}
-	return additional.Plan(images)
+	additional := NewAdditionalOptions(h.MirrorOptions)
+	return additional.Plan(ctx, images)
 }
 
 // FindImages will download images found in a Helm chart on disk

--- a/pkg/cli/mirror/helm_test.go
+++ b/pkg/cli/mirror/helm_test.go
@@ -5,11 +5,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"k8s.io/client-go/util/jsonpath"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
+
+	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
 )
 
 func TestGetCustomPaths(t *testing.T) {

--- a/pkg/cli/mirror/manifests.go
+++ b/pkg/cli/mirror/manifests.go
@@ -71,16 +71,6 @@ func (g *icspGenerator) Run(icspName, icspScope string, byteLimit int) (icsps []
 				Mirrors: []string{registryMapping[key]},
 			})
 
-			// FIXME(jpower432): add this as a workaround until
-			// mirroring individual images for release is implemented
-			// add OCP component image location to all release ICSPs
-			if g.icspType == typeOCPRelease {
-				icsp.Spec.RepositoryDigestMirrors = append(icsp.Spec.RepositoryDigestMirrors, operatorv1alpha1.RepositoryDigestMirrors{
-					Source:  "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
-					Mirrors: []string{registryMapping[key]},
-				})
-			}
-
 			y, err := yaml.Marshal(icsp)
 			if err != nil {
 				return nil, fmt.Errorf("unable to marshal ImageContentSourcePolicy yaml: %v", err)

--- a/pkg/cli/mirror/manifests.go
+++ b/pkg/cli/mirror/manifests.go
@@ -12,11 +12,12 @@ import (
 
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"github.com/openshift/library-go/pkg/image/reference"
-	"github.com/openshift/oc-mirror/pkg/image"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openshift/oc-mirror/pkg/image"
 )
 
 const (
@@ -24,7 +25,13 @@ const (
 	registryICSPScope   = "registry"
 	repositoryICSPScope = "repository"
 	namespaceICSPScope  = "namespace"
+	icspKind            = "ImageContentSourcePolicy"
 )
+
+var icspTypeMeta = metav1.TypeMeta{
+	APIVersion: operatorv1alpha1.GroupVersion.String(),
+	Kind:       icspKind,
+}
 
 // ICSPBuilder defines methods for generating ICSPs
 type ICSPBuilder interface {
@@ -39,9 +46,7 @@ type ReleaseBuilder struct{}
 func (b *ReleaseBuilder) New(icspName string, icspCount int) operatorv1alpha1.ImageContentSourcePolicy {
 	name := strings.Join(strings.Split(icspName, "/"), "-") + "-" + strconv.Itoa(icspCount)
 	return operatorv1alpha1.ImageContentSourcePolicy{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: operatorv1alpha1.GroupVersion.String(),
-			Kind:       "ImageContentSourcePolicy"},
+		TypeMeta: icspTypeMeta,
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
@@ -65,9 +70,7 @@ type OperatorBuilder struct{}
 func (b *OperatorBuilder) New(icspName string, icspCount int) operatorv1alpha1.ImageContentSourcePolicy {
 	name := strings.Join(strings.Split(icspName, "/"), "-") + "-" + strconv.Itoa(icspCount)
 	return operatorv1alpha1.ImageContentSourcePolicy{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: operatorv1alpha1.GroupVersion.String(),
-			Kind:       "ImageContentSourcePolicy"},
+		TypeMeta: icspTypeMeta,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
 			Labels: map[string]string{"operators.openshift.org/catalog": "true"},
@@ -89,9 +92,7 @@ type GenericBuilder struct{}
 func (b *GenericBuilder) New(icspName string, icspCount int) operatorv1alpha1.ImageContentSourcePolicy {
 	name := strings.Join(strings.Split(icspName, "/"), "-") + "-" + strconv.Itoa(icspCount)
 	return operatorv1alpha1.ImageContentSourcePolicy{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: operatorv1alpha1.GroupVersion.String(),
-			Kind:       "ImageContentSourcePolicy"},
+		TypeMeta: icspTypeMeta,
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},

--- a/pkg/cli/mirror/manifests_test.go
+++ b/pkg/cli/mirror/manifests_test.go
@@ -5,10 +5,11 @@ import (
 
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"github.com/openshift/library-go/pkg/image/reference"
-	"github.com/openshift/oc-mirror/pkg/image"
 	"github.com/openshift/oc/pkg/cli/image/imagesource"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/oc-mirror/pkg/image"
 )
 
 func TestICSPGeneration(t *testing.T) {

--- a/pkg/cli/mirror/manifests_test.go
+++ b/pkg/cli/mirror/manifests_test.go
@@ -117,10 +117,6 @@ func TestICSPGeneration(t *testing.T) {
 						Source:  "some-registry/namespace/image",
 						Mirrors: []string{"disconn-registry/namespace/image"},
 					},
-					{
-						Source:  "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
-						Mirrors: []string{"disconn-registry/namespace/image"},
-					},
 				},
 			},
 		},

--- a/pkg/cli/mirror/manifests_test.go
+++ b/pkg/cli/mirror/manifests_test.go
@@ -5,6 +5,8 @@ import (
 
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"github.com/openshift/library-go/pkg/image/reference"
+	"github.com/openshift/oc-mirror/pkg/image"
+	"github.com/openshift/oc/pkg/cli/image/imagesource"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -12,36 +14,48 @@ import (
 func TestICSPGeneration(t *testing.T) {
 	tests := []struct {
 		name          string
-		sourceImage   reference.DockerImageReference
-		destImage     reference.DockerImageReference
-		typ           icspType
+		sourceImage   image.TypedImage
+		destImage     image.TypedImage
+		typ           ICSPBuilder
 		icspScope     string
 		icspSizeLimit int
 		expected      []operatorv1alpha1.ImageContentSourcePolicy
 		err           string
 	}{{
 		name: "Valid/OperatorType",
-		sourceImage: reference.DockerImageReference{
-			Registry:  "some-registry",
-			Namespace: "namespace",
-			Name:      "image",
-			ID:        "digest",
+		sourceImage: image.TypedImage{
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "some-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: image.TypeOperatorBundle,
 		},
-		destImage: reference.DockerImageReference{
-			Registry:  "disconn-registry",
-			Namespace: "namespace",
-			Name:      "image",
-			ID:        "digest",
+		destImage: image.TypedImage{
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "disconn-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: image.TypeOperatorBundle,
 		},
 		icspScope:     "repository",
 		icspSizeLimit: 250000,
-		typ:           typeOperator,
+		typ:           &OperatorBuilder{},
 		expected: []operatorv1alpha1.ImageContentSourcePolicy{{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: operatorv1alpha1.GroupVersion.String(),
 				Kind:       "ImageContentSourcePolicy"},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   "some-registry-namespace-image:digest-0",
+				Name:   "test-0",
 				Labels: map[string]string{"operators.openshift.org/catalog": "true"},
 			},
 			Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
@@ -56,26 +70,39 @@ func TestICSPGeneration(t *testing.T) {
 		},
 	}, {
 		name: "Valid/GenericType",
-		sourceImage: reference.DockerImageReference{
-			Registry:  "some-registry",
-			Namespace: "namespace",
-			Name:      "image",
-			ID:        "digest",
+		sourceImage: image.TypedImage{
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "some-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: image.TypeGeneric,
 		},
-		destImage: reference.DockerImageReference{
-			Registry:  "disconn-registry",
-			Namespace: "namespace",
-			Name:      "image",
-			ID:        "digest",
+		destImage: image.TypedImage{
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "disconn-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: image.TypeGeneric,
 		},
 		icspScope:     "repository",
 		icspSizeLimit: 250000,
+		typ:           &GenericBuilder{},
 		expected: []operatorv1alpha1.ImageContentSourcePolicy{{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: operatorv1alpha1.GroupVersion.String(),
 				Kind:       "ImageContentSourcePolicy"},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "some-registry-namespace-image:digest-0",
+				Name: "test-0",
 			},
 			Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
 				RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
@@ -89,19 +116,31 @@ func TestICSPGeneration(t *testing.T) {
 		},
 	}, {
 		name: "Valid/ReleaseType",
-		sourceImage: reference.DockerImageReference{
-			Registry:  "some-registry",
-			Namespace: "namespace",
-			Name:      "image",
-			ID:        "digest",
+		sourceImage: image.TypedImage{
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "some-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: image.TypeOCPRelease,
 		},
-		destImage: reference.DockerImageReference{
-			Registry:  "disconn-registry",
-			Namespace: "namespace",
-			Name:      "image",
-			ID:        "digest",
+		destImage: image.TypedImage{
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "disconn-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: image.TypeOCPRelease,
 		},
-		typ:           typeOCPRelease,
+		typ:           &ReleaseBuilder{},
 		icspScope:     "repository",
 		icspSizeLimit: 250000,
 		expected: []operatorv1alpha1.ImageContentSourcePolicy{{
@@ -109,7 +148,7 @@ func TestICSPGeneration(t *testing.T) {
 				APIVersion: operatorv1alpha1.GroupVersion.String(),
 				Kind:       "ImageContentSourcePolicy"},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "some-registry-namespace-image:digest-0",
+				Name: "test-0",
 			},
 			Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
 				RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
@@ -123,19 +162,31 @@ func TestICSPGeneration(t *testing.T) {
 		},
 	}, {
 		name: "Valid/NamespaceScope",
-		sourceImage: reference.DockerImageReference{
-			Registry:  "some-registry",
-			Namespace: "namespace",
-			Name:      "image",
-			ID:        "digest",
+		sourceImage: image.TypedImage{
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "some-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: image.TypeGeneric,
 		},
-		destImage: reference.DockerImageReference{
-			Registry:  "disconn-registry",
-			Namespace: "namespace",
-			Name:      "image",
-			ID:        "digest",
+		destImage: image.TypedImage{
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "disconn-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: image.TypeGeneric,
 		},
-		typ:           typeGeneric,
+		typ:           &GenericBuilder{},
 		icspScope:     "namespace",
 		icspSizeLimit: 250000,
 		expected: []operatorv1alpha1.ImageContentSourcePolicy{{
@@ -143,7 +194,7 @@ func TestICSPGeneration(t *testing.T) {
 				APIVersion: operatorv1alpha1.GroupVersion.String(),
 				Kind:       "ImageContentSourcePolicy"},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "some-registry-namespace-image:digest-0",
+				Name: "test-0",
 			},
 			Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
 				RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
@@ -157,19 +208,31 @@ func TestICSPGeneration(t *testing.T) {
 		},
 	}, {
 		name: "Valid/RegistryScope",
-		sourceImage: reference.DockerImageReference{
-			Registry:  "some-registry",
-			Namespace: "namespace",
-			Name:      "image",
-			ID:        "digest",
+		sourceImage: image.TypedImage{
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "some-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: image.TypeGeneric,
 		},
-		destImage: reference.DockerImageReference{
-			Registry:  "disconn-registry",
-			Namespace: "namespace",
-			Name:      "image",
-			ID:        "digest",
+		destImage: image.TypedImage{
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "disconn-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: image.TypeGeneric,
 		},
-		typ:           typeGeneric,
+		typ:           &GenericBuilder{},
 		icspScope:     "registry",
 		icspSizeLimit: 250000,
 		expected: []operatorv1alpha1.ImageContentSourcePolicy{{
@@ -177,7 +240,7 @@ func TestICSPGeneration(t *testing.T) {
 				APIVersion: operatorv1alpha1.GroupVersion.String(),
 				Kind:       "ImageContentSourcePolicy"},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "some-registry-namespace-image:digest-0",
+				Name: "test-0",
 			},
 			Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
 				RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
@@ -191,19 +254,31 @@ func TestICSPGeneration(t *testing.T) {
 		},
 	}, {
 		name: "Valid/NamespaceScopeNoNamespace",
-		sourceImage: reference.DockerImageReference{
-			Registry:  "some-registry",
-			Namespace: "",
-			Name:      "image",
-			ID:        "digest",
+		sourceImage: image.TypedImage{
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "some-registry",
+					Namespace: "",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: image.TypeGeneric,
 		},
-		destImage: reference.DockerImageReference{
-			Registry:  "disconn-registry",
-			Namespace: "",
-			Name:      "image",
-			ID:        "digest",
+		destImage: image.TypedImage{
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "disconn-registry",
+					Namespace: "",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: image.TypeGeneric,
 		},
-		typ:           typeGeneric,
+		typ:           &GenericBuilder{},
 		icspScope:     "namespace",
 		icspSizeLimit: 250000,
 		expected: []operatorv1alpha1.ImageContentSourcePolicy{{
@@ -211,7 +286,7 @@ func TestICSPGeneration(t *testing.T) {
 				APIVersion: operatorv1alpha1.GroupVersion.String(),
 				Kind:       "ImageContentSourcePolicy"},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "some-registry-image:digest-0",
+				Name: "test-0",
 			},
 			Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
 				RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
@@ -225,31 +300,77 @@ func TestICSPGeneration(t *testing.T) {
 		},
 	}, {
 		name: "Invalid/NoDigestMapping",
-		sourceImage: reference.DockerImageReference{
-			Registry:  "some-registry",
-			Namespace: "namespace",
-			Name:      "image",
-			Tag:       "latest",
+		sourceImage: image.TypedImage{
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "some-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: image.TypeGeneric,
 		},
-		destImage: reference.DockerImageReference{
-			Registry:  "disconnected-registry",
-			Namespace: "namespace",
-			Name:      "image",
-			Tag:       "latest",
+		icspScope:     "namespace",
+		icspSizeLimit: 250000,
+		typ:           &GenericBuilder{},
+		destImage: image.TypedImage{
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "disconn-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: image.TypeGeneric,
 		},
 		expected: nil,
+	}, {
+		name: "Invalid/InvalidICSPScope",
+		sourceImage: image.TypedImage{
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "some-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: image.TypeGeneric,
+		},
+		icspScope:     "invalid",
+		icspSizeLimit: 250000,
+		typ:           &GenericBuilder{},
+		destImage: image.TypedImage{
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "disconn-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: image.TypeGeneric,
+		},
+		expected: nil,
+		err:      "invalid ICSP scope invalid",
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			gen := icspGenerator{
-				icspMapping: map[reference.DockerImageReference]reference.DockerImageReference{
-					test.sourceImage: test.destImage,
-				},
-				icspType: test.typ,
+			mapping := image.TypedImageMapping{}
+			mapping[test.sourceImage] = test.destImage
+			icsps, err := GenerateICSP("test", test.icspScope, test.icspSizeLimit, mapping, test.typ)
+			if test.err != "" {
+				require.EqualError(t, err, test.err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.expected, icsps)
 			}
-			icsps, err := gen.Run(test.sourceImage.Exact(), test.icspScope, test.icspSizeLimit)
-			require.NoError(t, err)
-			require.Equal(t, test.expected, icsps)
 		})
 	}
 }

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -3,6 +3,7 @@ package mirror
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -236,6 +237,10 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 		// Pack the images set
 		tmpBackend, err := o.Pack(cmd.Context(), assocs, meta, cfg.ArchiveSize)
 		if err != nil {
+			if errors.Is(err, ErrNoUpdatesExist) {
+				logrus.Infof("no updates detected, process stopping")
+				return nil
+			}
 			return err
 		}
 

--- a/pkg/cli/mirror/mirror_test.go
+++ b/pkg/cli/mirror/mirror_test.go
@@ -182,15 +182,6 @@ func TestMirrorValidate(t *testing.T) {
 			expError: `must specify a configuration file with --config`,
 		},
 		{
-			name: "Invalid/DryRunWithMirror",
-			opts: &MirrorOptions{
-				ConfigPath: "foo",
-				ToMirror:   u.Host,
-				DryRun:     true,
-			},
-			expError: "--dry-run is not supported for mirror publishing operations",
-		},
-		{
 			name: "Invalid/UnsupportReleaseArch",
 			opts: &MirrorOptions{
 				ConfigPath:    "foo",

--- a/pkg/cli/mirror/mirror_test.go
+++ b/pkg/cli/mirror/mirror_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/registry"
-	"github.com/openshift/oc-mirror/pkg/cli"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openshift/oc-mirror/pkg/cli"
 )
 
 func TestMirrorComplete(t *testing.T) {

--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -296,7 +296,7 @@ func (o *OperatorOptions) mirror(ctx context.Context, dc *declcfg.DeclarativeCon
 		return nil, fmt.Errorf("error running catalog mirror: %v", err)
 	}
 
-	mappings, err := image.ReadImageMapping(filepath.Join(opts.ManifestDir, mappingFile))
+	mappings, err := image.ReadImageMapping(filepath.Join(opts.ManifestDir, mappingFile), "=")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -50,13 +50,12 @@ func NewOperatorOptions(mo *MirrorOptions) *OperatorOptions {
 	return &OperatorOptions{MirrorOptions: mo}
 }
 
-// PlanFull plans a mirror for each catalog image in its entirety to the <Dir>/src directory.
+// PlanFull plans a mirror for each catalog image in its entirety
 func (o *OperatorOptions) PlanFull(ctx context.Context, cfg v1alpha1.ImageSetConfiguration) (image.TypedImageMapping, error) {
 	return o.run(ctx, cfg, o.renderDCFull)
 }
 
 // PlanDiff plans only the diff between each old and new catalog image pair
-// to the <Dir>/src directory.
 func (o *OperatorOptions) PlanDiff(ctx context.Context, cfg v1alpha1.ImageSetConfiguration, lastRun v1alpha1.PastMirror) (image.TypedImageMapping, error) {
 	f := func(ctx context.Context, reg *containerdregistry.Registry, ctlg v1alpha1.Operator) (*declcfg.DeclarativeConfig, error) {
 		return o.renderDCDiff(ctx, reg, ctlg, lastRun)
@@ -77,8 +76,6 @@ func (o *OperatorOptions) complete() {
 
 type renderDCFunc func(context.Context, *containerdregistry.Registry, v1alpha1.Operator) (*declcfg.DeclarativeConfig, error)
 
-// Diff mirrors only the diff between each old and new catalog image pair
-// to the <Dir>/src directory.
 func (o *OperatorOptions) run(ctx context.Context, cfg v1alpha1.ImageSetConfiguration, renderDC renderDCFunc) (image.TypedImageMapping, error) {
 	o.complete()
 

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -32,9 +32,8 @@ type MirrorOptions struct {
 	ContinueOnError  bool
 	FilterOptions    []string
 	// cancelCh is a channel listening for command cancellations
-	cancelCh    <-chan struct{}
-	interrupted bool
-	once        sync.Once
+	cancelCh <-chan struct{}
+	once     sync.Once
 }
 
 func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -7,9 +7,10 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/openshift/oc-mirror/pkg/cli"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
+
+	"github.com/openshift/oc-mirror/pkg/cli"
 )
 
 type MirrorOptions struct {

--- a/pkg/cli/mirror/pack.go
+++ b/pkg/cli/mirror/pack.go
@@ -2,6 +2,7 @@ package mirror
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,6 +17,11 @@ import (
 	"github.com/openshift/oc-mirror/pkg/image"
 	"github.com/openshift/oc-mirror/pkg/metadata"
 	"github.com/openshift/oc-mirror/pkg/metadata/storage"
+)
+
+var (
+	// NoUpdatesExist should be returned by Create() when no updates are found
+	ErrNoUpdatesExist = errors.New("no updates detected, process stopping")
 )
 
 const (
@@ -51,6 +57,12 @@ func (o *MirrorOptions) Pack(ctx context.Context, assocs image.AssociationSet, m
 	if err != nil {
 		return tmpBackend, err
 	}
+
+	// Stop the process if no new blobs
+	if len(blobs) == 0 {
+		return tmpBackend, ErrNoUpdatesExist
+	}
+
 	// Add only the new manifests and blobs created to the current run.
 	currRun.Manifests = append(currRun.Manifests, manifests...)
 	currRun.Blobs = append(currRun.Blobs, blobs...)

--- a/pkg/cli/mirror/pack.go
+++ b/pkg/cli/mirror/pack.go
@@ -1,0 +1,139 @@
+package mirror
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/openshift/oc-mirror/pkg/archive"
+	"github.com/openshift/oc-mirror/pkg/bundle"
+	"github.com/openshift/oc-mirror/pkg/config"
+	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
+	"github.com/openshift/oc-mirror/pkg/image"
+	"github.com/openshift/oc-mirror/pkg/metadata"
+	"github.com/openshift/oc-mirror/pkg/metadata/storage"
+	"github.com/sirupsen/logrus"
+)
+
+// Pack will pack the imageset and return a temporary backend storing metadata for final push
+// The metadata has been updated by the plan stage at this point but not pushed to the backend
+func (o *MirrorOptions) Pack(ctx context.Context, assocs image.AssociationSet, meta v1alpha1.Metadata, archiveSize int64) (storage.Backend, error) {
+	tmpdir, _, err := o.mktempDir()
+	if err != nil {
+		return nil, err
+	}
+	cfg := v1alpha1.StorageConfig{
+		Local: &v1alpha1.LocalConfig{Path: tmpdir},
+	}
+	tmpBackend, err := storage.ByConfig(tmpdir, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := o.writeAssociations(assocs); err != nil {
+		return tmpBackend, fmt.Errorf("error writing association file: %v", err)
+	}
+
+	currRun := meta.PastMirrors[len(meta.PastMirrors)-1]
+	// Update metadata files and get newly created filepaths.
+	manifests, blobs, err := o.getFiles(meta)
+	if err != nil {
+		return tmpBackend, err
+	}
+	// Add only the new manifests and blobs created to the current run.
+	currRun.Manifests = append(currRun.Manifests, manifests...)
+	currRun.Blobs = append(currRun.Blobs, blobs...)
+	// Add this run and metadata to top level metadata.
+	meta.PastMirrors[len(meta.PastMirrors)-1] = currRun
+	meta.PastBlobs = append(meta.PastBlobs, blobs...)
+
+	// Update the metadata.
+	if err := metadata.UpdateMetadata(ctx, tmpBackend, &meta, o.SourceSkipTLS, o.SourcePlainHTTP); err != nil {
+		return tmpBackend, err
+	}
+
+	// If any errors occur after the metadata is written
+	// initiate metadata rollback
+	if err := o.prepareArchive(ctx, tmpBackend, archiveSize, currRun.Sequence, manifests, blobs); err != nil {
+		return tmpBackend, err
+	}
+
+	/* Commenting out temporarily because no concrete types implement this
+	if committer, isCommitter := backend.(storage.Committer); isCommitter {
+		if err := committer.Commit(ctx); err != nil {
+			return err
+		}
+	}*/
+
+	return tmpBackend, nil
+}
+
+func (o *MirrorOptions) prepareArchive(ctx context.Context, backend storage.Backend, archiveSize int64, seq int, manifests []v1alpha1.Manifest, blobs []v1alpha1.Blob) error {
+
+	// Default to a 500GiB archive size.
+	var segSize int64 = 500
+	if archiveSize != 0 {
+		segSize = archiveSize
+		logrus.Debugf("Using user provider archive size %d GiB", segSize)
+	}
+	segSize *= 1024 * 1024 * 1024
+
+	// Set get absolute path to output dir
+	// to avoid issue with directory change
+	output, err := filepath.Abs(o.OutputDir)
+	if err != nil {
+		return err
+	}
+
+	// Change directory before archiving to
+	// avoid broken symlink paths
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	if err := os.Chdir(filepath.Join(o.Dir, config.SourceDir)); err != nil {
+		return err
+	}
+	defer os.Chdir(cwd)
+
+	packager := archive.NewPackager(manifests, blobs)
+	prefix := fmt.Sprintf("mirror_seq%d", seq)
+	if err := packager.CreateSplitArchive(ctx, backend, segSize, output, ".", prefix, o.SkipCleanup); err != nil {
+		return fmt.Errorf("failed to create archive: %v", err)
+	}
+	return nil
+}
+
+func (o *MirrorOptions) getFiles(meta v1alpha1.Metadata) ([]v1alpha1.Manifest, []v1alpha1.Blob, error) {
+	diskPath := filepath.Join(o.Dir, config.SourceDir, "v2")
+	// Define a map that associates locations
+	// on disk to location in archive
+	paths := map[string]string{diskPath: "v2"}
+	return bundle.ReconcileV2Dir(meta, paths)
+}
+
+func (o *MirrorOptions) writeAssociations(assocs image.AssociationSet) error {
+	assocPath := filepath.Join(o.Dir, config.SourceDir, config.AssociationsBasePath)
+	if err := os.MkdirAll(filepath.Dir(assocPath), 0755); err != nil {
+		return fmt.Errorf("mkdir image associations file: %v", err)
+	}
+	f, err := os.OpenFile(assocPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0640)
+	if err != nil {
+		return fmt.Errorf("open image associations file: %v", err)
+	}
+	defer f.Close()
+	return assocs.Encode(f)
+}
+
+func (o *MirrorOptions) mktempDir() (string, func(), error) {
+	// Placing this under the source directory, so it will be cleaned up
+	// at the end of operators if cleanup func is not used
+	dir := filepath.Join(o.Dir, config.SourceDir, fmt.Sprintf("tmpbackend.%d", time.Now().Unix()))
+	return dir, func() {
+		if err := os.RemoveAll(dir); err != nil {
+			logrus.Error(err)
+		}
+	}, os.MkdirAll(dir, os.ModePerm)
+}

--- a/pkg/cli/mirror/publish.go
+++ b/pkg/cli/mirror/publish.go
@@ -10,20 +10,16 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/opencontainers/go-digest"
-	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"github.com/openshift/library-go/pkg/image/reference"
 	"github.com/openshift/library-go/pkg/image/registryclient"
 	"github.com/openshift/oc/pkg/cli/image/imagesource"
 	imagemanifest "github.com/openshift/oc/pkg/cli/image/manifest"
 	imgmirror "github.com/openshift/oc/pkg/cli/image/mirror"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/openshift/oc-mirror/pkg/archive"
 	"github.com/openshift/oc-mirror/pkg/bundle"
@@ -31,11 +27,6 @@ import (
 	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
 	"github.com/openshift/oc-mirror/pkg/image"
 	"github.com/openshift/oc-mirror/pkg/metadata/storage"
-)
-
-const (
-	icspSizeLimit = 250000
-	icspScope     = "namespace"
 )
 
 type UuidError struct {
@@ -64,13 +55,15 @@ func (e *ErrArchiveFileNotFound) Error() string {
 	return fmt.Sprintf("file %s not found in archive", e.filename)
 }
 
-func (o *MirrorOptions) Publish(ctx context.Context, cmd *cobra.Command, f kcmdutil.Factory) error {
+// Publish will plan a mirroring operation based on provided imageset on disk
+func (o *MirrorOptions) Publish(ctx context.Context) (image.TypedImageMapping, error) {
 
 	logrus.Infof("Publishing image set from archive %q to registry %q", o.From, o.ToMirror)
 
 	var currentMeta v1alpha1.Metadata
 	var incomingMeta v1alpha1.Metadata
 	a := archive.NewArchiver()
+	allMappings := image.TypedImageMapping{}
 	var insecure bool
 	if o.DestPlainHTTP || o.DestSkipTLS {
 		insecure = true
@@ -81,14 +74,14 @@ func (o *MirrorOptions) Publish(ctx context.Context, cmd *cobra.Command, f kcmdu
 		dir, err := o.createResultsDir()
 		o.OutputDir = dir
 		if err != nil {
-			return err
+			return allMappings, err
 		}
 	}
 
 	// Create workspace
 	cleanup, tmpdir, err := mktempDir(o.Dir)
 	if err != nil {
-		return err
+		return allMappings, err
 	}
 
 	// Handle cleanup of disk
@@ -101,39 +94,34 @@ func (o *MirrorOptions) Publish(ctx context.Context, cmd *cobra.Command, f kcmdu
 	// Get file information from the source archives
 	filesInArchive, err := bundle.ReadImageSet(a, o.From)
 	if err != nil {
-		return err
+		return allMappings, err
 	}
 
 	// Extract imageset
 	if err := o.unpackImageSet(a, tmpdir); err != nil {
-		return err
+		return allMappings, err
 	}
 
 	// Create a local workspace backend for incoming data
 	workspace, err := storage.NewLocalBackend(tmpdir)
 	if err != nil {
-		return fmt.Errorf("error opening local backend: %v", err)
+		return allMappings, fmt.Errorf("error opening local backend: %v", err)
 	}
 	// Load incoming metadta
 	if err := workspace.ReadMetadata(ctx, &incomingMeta, config.MetadataBasePath); err != nil {
-		return fmt.Errorf("error reading incoming metadata: %v", err)
+		return allMappings, fmt.Errorf("error reading incoming metadata: %v", err)
 	}
 
-	repo := path.Join(o.ToMirror, o.UserNamespace, "oc-mirror")
-	metaImage := fmt.Sprintf("%s:%s", repo, incomingMeta.Uid)
-
+	metaImage := o.newMetadataImage(incomingMeta.Uid.String())
 	// Determine stateless or stateful mode
 	var backend storage.Backend
 	if incomingMeta.SingleUse {
 		logrus.Warn("metadata has single-use label, using stateless mode")
 		cfg := v1alpha1.StorageConfig{
-			Local: &v1alpha1.LocalConfig{
-				Path: o.Dir,
-			},
-		}
+			Local: &v1alpha1.LocalConfig{Path: o.Dir}}
 		backend, err = storage.ByConfig(o.Dir, cfg)
 		if err != nil {
-			return err
+			return allMappings, err
 		}
 		defer func() {
 			if err := backend.Cleanup(ctx, config.MetadataBasePath); err != nil {
@@ -149,20 +137,20 @@ func (o *MirrorOptions) Publish(ctx context.Context, cmd *cobra.Command, f kcmdu
 		}
 		backend, err = storage.ByConfig(o.Dir, cfg)
 		if err != nil {
-			return err
+			return allMappings, err
 		}
 	}
 
 	// Read in current metadata, if present
 	switch err := backend.ReadMetadata(ctx, &currentMeta, config.MetadataBasePath); {
 	case err != nil && !errors.Is(err, storage.ErrMetadataNotExist):
-		return err
+		return allMappings, err
 	case err != nil:
 		logrus.Infof("No existing metadata found. Setting up new workspace")
 		// Check that this is the first imageset
 		incomingRun := incomingMeta.PastMirrors[len(incomingMeta.PastMirrors)-1]
 		if incomingRun.Sequence != 1 {
-			return &SequenceError{1, incomingRun.Sequence}
+			return allMappings, &SequenceError{1, incomingRun.Sequence}
 		}
 	default:
 		// Complete metadata checks
@@ -171,66 +159,43 @@ func (o *MirrorOptions) Publish(ctx context.Context, cmd *cobra.Command, f kcmdu
 		currRun := currentMeta.PastMirrors[len(currentMeta.PastMirrors)-1]
 		incomingRun := incomingMeta.PastMirrors[len(incomingMeta.PastMirrors)-1]
 		if incomingRun.Sequence != (currRun.Sequence + 1) {
-			return &SequenceError{currRun.Sequence + 1, incomingRun.Sequence}
+			return allMappings, &SequenceError{currRun.Sequence + 1, incomingRun.Sequence}
 		}
 	}
 
 	// Unpack chart to user destination if it exists
 	logrus.Debugf("Unpacking any provided Helm charts to %s", o.OutputDir)
 	if err := unpack(config.HelmDir, o.OutputDir, filesInArchive); err != nil {
-		return err
+		return allMappings, err
 	}
 
 	// Load image associations to find layers not present locally.
 	assocs, err := readAssociations(filepath.Join(tmpdir, config.AssociationsBasePath))
 	if err != nil {
-		return err
+		return allMappings, err
 	}
 
 	toMirrorRef, err := imagesource.ParseReference(o.ToMirror)
 	if err != nil {
-		return fmt.Errorf("error parsing mirror registry %q: %v", o.ToMirror, err)
+		return allMappings, fmt.Errorf("error parsing mirror registry %q: %v", o.ToMirror, err)
 	}
 	logrus.Debugf("mirror reference: %#v", toMirrorRef)
 	if toMirrorRef.Type != imagesource.DestinationRegistry {
-		return fmt.Errorf("destination %q must be a registry reference", o.ToMirror)
+		return allMappings, fmt.Errorf("destination %q must be a registry reference", o.ToMirror)
 	}
 
-	var (
-		errs     []error
-		allICSPs []operatorv1alpha1.ImageContentSourcePolicy
-	)
-
-	releaseICSP := &icspGenerator{
-		icspType:    typeOCPRelease,
-		icspMapping: make(map[reference.DockerImageReference]reference.DockerImageReference),
-	}
-	catalogICSP := &icspGenerator{
-		icspType:    typeOperator,
-		icspMapping: make(map[reference.DockerImageReference]reference.DockerImageReference),
-	}
-	genericICSP := &icspGenerator{
-		icspType:    typeGeneric,
-		icspMapping: make(map[reference.DockerImageReference]reference.DockerImageReference),
-	}
+	var errs []error
 
 	for _, imageName := range assocs.Keys() {
 
-		genericMappings := []imgmirror.Mapping{}
-
-		// Save original source mapping to generate ICSP for this image.
-		imageRef, err := reference.Parse(imageName)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error parsing image name %q for ICSP generation: %v", imageName, err))
-			continue
-		}
+		var mmapping []imgmirror.Mapping
 
 		values, _ := assocs.Search(imageName)
 
 		// Create temp workspace for image processing
 		cleanUnpackDir, unpackDir, err := mktempDir(tmpdir)
 		if err != nil {
-			return err
+			return allMappings, err
 		}
 
 		for _, assoc := range values {
@@ -307,47 +272,25 @@ func (o *MirrorOptions) Publish(ctx context.Context, cmd *cobra.Command, f kcmdu
 			m.Destination.Ref.ID = m.Source.Ref.ID
 			m.Destination.Ref.Namespace = path.Join(o.UserNamespace, m.Source.Ref.Namespace)
 
-			switch assoc.Type {
-			case image.TypeGeneric:
-				genericMappings = append(genericMappings, m)
-				// Add top level association to ICSP generator
-				if assoc.Name == imageRef.Exact() {
-					genericICSP.icspMapping[imageRef] = m.Destination.Ref
-				}
-			case image.TypeOCPRelease:
-				genericMappings = append(genericMappings, m)
-				if assoc.Name == imageRef.Exact() {
-					releaseICSP.icspMapping[imageRef] = m.Destination.Ref
-				}
-			case image.TypeOperatorCatalog:
-				genericMappings = append(genericMappings, m)
-				// Add top level association to ICSP generator
-				if assoc.Name == imageRef.Exact() {
-					catalogICSP.icspMapping[imageRef] = m.Destination.Ref
-				}
-			case image.TypeOperatorBundle, image.TypeOperatorRelatedImage:
-				genericMappings = append(genericMappings, m)
-				// Add top level association to ICSP generator
-				if assoc.Name == imageRef.Exact() {
-					catalogICSP.icspMapping[imageRef] = m.Destination.Ref
-				}
-			case image.TypeInvalid:
-				errs = append(errs, fmt.Errorf("image %q: image type is not set", imageName))
-			default:
-				errs = append(errs, fmt.Errorf("image %q: invalid image type %v", imageName, assoc.Type))
+			// Add references for the mirror mapping
+			mmapping = append(mmapping, m)
+
+			// Add top level assocation to the ICSP mapping
+			if assoc.Name == imageName {
+				allMappings.Add(m.Source, m.Destination, assoc.Type)
 			}
 
 			if len(missingLayers) != 0 {
 				// Fetch all layers and mount them at the specified paths.
-				if err := o.fetchBlobs(ctx, currentMeta, m, missingLayers); err != nil {
-					return err
+				if err := o.fetchBlobs(ctx, currentMeta, missingLayers); err != nil {
+					return allMappings, err
 				}
 			}
 		}
 
-		// Mirror all generic mappings for this image
-		if len(genericMappings) != 0 {
-			if err := o.mirrorImage(genericMappings, unpackDir); err != nil {
+		// Mirror all mappings for this image
+		if len(mmapping) != 0 {
+			if err := o.publishImage(mmapping, unpackDir); err != nil {
 				errs = append(errs, err)
 			}
 		}
@@ -358,58 +301,33 @@ func (o *MirrorOptions) Publish(ctx context.Context, cmd *cobra.Command, f kcmdu
 		}
 	}
 	if len(errs) != 0 {
-		return utilerrors.NewAggregate(errs)
+		return allMappings, utilerrors.NewAggregate(errs)
 	}
 
 	logrus.Debug("rebuilding catalog images")
 
-	ctlgRefs, err := o.rebuildCatalogs(ctx, tmpdir, filesInArchive)
+	found, err := o.unpackCatalog(tmpdir, filesInArchive)
 	if err != nil {
-		return fmt.Errorf("error rebuilding catalog images from file-based catalogs: %v", err)
+		return allMappings, err
 	}
-	// Create CatalogSource manifests and save ICSP data for all catalog refs.
-	// Source and dest refs are treated the same intentionally since
-	// the source image does not exist and destination image was built above.
-	for sourceRef, destRef := range ctlgRefs {
-		catalogICSP.icspMapping[sourceRef] = destRef
-		if err := WriteCatalogSource(sourceRef, destRef, o.OutputDir); err != nil {
-			return fmt.Errorf("error writing CatalogSource for catalog image %q: %v", destRef.Exact(), err)
+
+	if found {
+		ctlgRefs, err := o.rebuildCatalogs(ctx, tmpdir)
+		if err != nil {
+			return allMappings, fmt.Errorf("error rebuilding catalog images from file-based catalogs: %v", err)
 		}
+		if err := WriteCatalogSource(ctlgRefs, o.OutputDir); err != nil {
+			return allMappings, err
+		}
+		allMappings.Merge(ctlgRefs)
 	}
-
-	// Generate ICSPs for all images.
-	catalogICSPS, err := catalogICSP.Run("catalog", icspScope, icspSizeLimit)
-	if err != nil {
-		return fmt.Errorf("error generating ICSP for catalog images: %v", err)
-	}
-	allICSPs = append(allICSPs, catalogICSPS...)
-	// Set release ICSP to repository due to the image name change that
-	// occurs during mirroring
-	releaseICSPS, err := releaseICSP.Run("release", "repository", icspSizeLimit)
-	if err != nil {
-		return fmt.Errorf("error generating ICSP for release images: %v", err)
-	}
-	allICSPs = append(allICSPs, releaseICSPS...)
-	genericICSPS, err := genericICSP.Run("generic", icspScope, icspSizeLimit)
-	if err != nil {
-		return fmt.Errorf("error generating ICSP for generic images: %v", err)
-	}
-	allICSPs = append(allICSPs, genericICSPS...)
-
-	// Write an aggregation of ICSPs
-	if err := WriteICSPs(o.OutputDir, allICSPs); err != nil {
-		return fmt.Errorf("error writing ICSPs: %v", err)
-	}
-
-	// Install catalogsource and icsp
-	logrus.Info("CatalogSource and ICSP install not implemented")
 
 	// Replace old metadata with new metadata
 	if err := backend.WriteMetadata(ctx, &incomingMeta, config.MetadataBasePath); err != nil {
-		return err
+		return allMappings, err
 	}
 
-	return nil
+	return allMappings, nil
 }
 
 // readAssociations will process and return data from the image associations file
@@ -490,7 +408,7 @@ func copyBlobFile(src io.Reader, dstPath string) error {
 	return nil
 }
 
-func (o *MirrorOptions) fetchBlobs(ctx context.Context, meta v1alpha1.Metadata, mapping imgmirror.Mapping, missingLayers map[string][]string) error {
+func (o *MirrorOptions) fetchBlobs(ctx context.Context, meta v1alpha1.Metadata, missingLayers map[string][]string) error {
 	var insecure bool
 	if o.DestPlainHTTP || o.DestSkipTLS {
 		insecure = true
@@ -572,8 +490,8 @@ func mktempDir(dir string) (func(), string, error) {
 	}, dir, err
 }
 
-// mirrorImages uses the `oc mirror` library to mirror generic images
-func (o *MirrorOptions) mirrorImage(mappings []imgmirror.Mapping, fromDir string) error {
+// publishImages uses the `oc mirror` library to mirror generic images
+func (o *MirrorOptions) publishImage(mappings []imgmirror.Mapping, fromDir string) error {
 	var insecure bool
 	if o.DestPlainHTTP || o.DestSkipTLS {
 		insecure = true
@@ -611,21 +529,10 @@ func (o *MirrorOptions) mirrorImage(mappings []imgmirror.Mapping, fromDir string
 	return nil
 }
 
-func (o *MirrorOptions) createResultsDir() (resultsDir string, err error) {
-	resultsDir = filepath.Join(
-		o.Dir,
-		fmt.Sprintf("results-%v", time.Now().Unix()),
-	)
-	if err := os.MkdirAll(resultsDir, os.ModePerm); err != nil {
-		return resultsDir, err
-	}
-	return resultsDir, nil
-}
-
 func (o *MirrorOptions) findBlobRepo(meta v1alpha1.Metadata, layerDigest string) (imagesource.TypedImageReference, error) {
 	var namespacename string
 	// TODO(jpower432): implement map searching instead for efficiency
-	// would have to ensure the latest run is prefferred
+	// would have to ensure the latest run is preferred
 	for _, mirror := range meta.PastMirrors {
 		for _, blob := range mirror.Blobs {
 			if blob.ID == layerDigest {

--- a/pkg/cli/mirror/publish_test.go
+++ b/pkg/cli/mirror/publish_test.go
@@ -10,17 +10,17 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/openshift/oc-mirror/pkg/config"
-
 	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/google/uuid"
 	"github.com/openshift/library-go/pkg/image/reference"
-	"github.com/openshift/oc-mirror/pkg/cli"
-	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
-	"github.com/openshift/oc-mirror/pkg/metadata/storage"
 	"github.com/openshift/oc/pkg/cli/image/imagesource"
 	"github.com/stretchr/testify/require"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/openshift/oc-mirror/pkg/cli"
+	"github.com/openshift/oc-mirror/pkg/config"
+	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
+	"github.com/openshift/oc-mirror/pkg/metadata/storage"
 )
 
 func TestMetadataError(t *testing.T) {

--- a/pkg/cli/mirror/release.go
+++ b/pkg/cli/mirror/release.go
@@ -133,7 +133,7 @@ func (o *ReleaseOptions) getDownloads(ctx context.Context, client cincinnati.Cli
 	lastCh, lastVer, err := cincinnati.FindLastRelease(meta, channel)
 	currCh := channel
 	reverse := false
-	logrus.Infof("Downloading requested release %s", requested.String())
+	logrus.Infof("Planning download for requested release %s", requested.String())
 	switch {
 	case err != nil && errors.Is(err, cincinnati.ErrNoPreviousRelease):
 		lastVer = requested

--- a/pkg/cli/mirror/release_test.go
+++ b/pkg/cli/mirror/release_test.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/blang/semver/v4"
 	"github.com/google/uuid"
 	"github.com/openshift/oc-mirror/pkg/cincinnati"
 	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
@@ -42,14 +41,8 @@ func TestGetDownloads(t *testing.T) {
 		channel: "stable-4.1",
 		version: "4.1.0-6",
 		expected: downloads{
-			"quay.io/openshift-release-dev/ocp-release:4.0.0-6": download{
-				Update: cincinnati.Update{Version: semver.MustParse("4.0.0-6"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-6"},
-				arch:   "test-arch",
-			},
-			"quay.io/openshift-release-dev/ocp-release:4.1.0-6": download{
-				Update: cincinnati.Update{Version: semver.MustParse("4.1.0-6"), Image: "quay.io/openshift-release-dev/ocp-release:4.1.0-6"},
-				arch:   "test-arch",
-			},
+			"quay.io/openshift-release-dev/ocp-release:4.0.0-6": struct{}{},
+			"quay.io/openshift-release-dev/ocp-release:4.1.0-6": struct{}{},
 		},
 	}, {
 		name: "reverse",
@@ -63,10 +56,7 @@ func TestGetDownloads(t *testing.T) {
 		channel: "stable-4.0",
 		version: "4.0.0-6",
 		expected: downloads{
-			"quay.io/openshift-release-dev/ocp-release:4.0.0-6": download{
-				Update: cincinnati.Update{Version: semver.MustParse("4.0.0-6"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-6"},
-				arch:   "test-arch",
-			},
+			"quay.io/openshift-release-dev/ocp-release:4.0.0-6": struct{}{},
 		},
 	}, {
 		name: "multi-arch",
@@ -80,14 +70,8 @@ func TestGetDownloads(t *testing.T) {
 		channel: "stable-4.0",
 		version: "4.0.0-6",
 		expected: downloads{
-			"quay.io/openshift-release-dev/ocp-release:4.0.0-6": download{
-				Update: cincinnati.Update{Version: semver.MustParse("4.0.0-6"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-6"},
-				arch:   "test-arch",
-			},
-			"quay.io/openshift-release-dev/ocp-release:4.0.0-6-another": download{
-				Update: cincinnati.Update{Version: semver.MustParse("4.0.0-6"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-6-another"},
-				arch:   "another-arch",
-			},
+			"quay.io/openshift-release-dev/ocp-release:4.0.0-6":         struct{}{},
+			"quay.io/openshift-release-dev/ocp-release:4.0.0-6-another": struct{}{},
 		},
 	}}
 	for _, test := range tests {

--- a/pkg/cli/mirror/release_test.go
+++ b/pkg/cli/mirror/release_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
 	"github.com/openshift/oc-mirror/pkg/cincinnati"
 	"github.com/openshift/oc-mirror/pkg/config/v1alpha1"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGetDownloads(t *testing.T) {

--- a/pkg/cli/mirror/testdata/configs/test.yaml
+++ b/pkg/cli/mirror/testdata/configs/test.yaml
@@ -1,9 +1,6 @@
 ---
 apiVersion: mirror.openshift.io/v1alpha1
 kind: ImageSetConfiguration
-storageConfig:
-  local:
-    path: testdata
 mirror:
   additionalimages:
     - name: quay.io/estroz/pull-tester-additional:latest

--- a/pkg/config/v1alpha1/storage_config_types.go
+++ b/pkg/config/v1alpha1/storage_config_types.go
@@ -17,3 +17,10 @@ type RegistryConfig struct {
 type LocalConfig struct {
 	Path string `json:"path"`
 }
+
+func (s StorageConfig) IsSet() bool {
+	if s.Registry != nil || s.Local != nil {
+		return true
+	}
+	return false
+}

--- a/pkg/config/v1alpha1/storage_config_types.go
+++ b/pkg/config/v1alpha1/storage_config_types.go
@@ -18,6 +18,8 @@ type LocalConfig struct {
 	Path string `json:"path"`
 }
 
+// IsSet will determine whether StorageConfig
+// is empty or has backends set
 func (s StorageConfig) IsSet() bool {
 	if s.Registry != nil || s.Local != nil {
 		return true

--- a/pkg/image/association.go
+++ b/pkg/image/association.go
@@ -253,7 +253,7 @@ func (as AssociationSet) validate() error {
 }
 
 // ReadImageMapping reads a mapping.txt file and parses each line into a map k/v.
-func ReadImageMapping(mappingsPath string) (map[string]string, error) {
+func ReadImageMapping(mappingsPath, seperator string) (map[string]string, error) {
 	f, err := os.Open(mappingsPath)
 	if err != nil {
 		return nil, err
@@ -264,7 +264,7 @@ func ReadImageMapping(mappingsPath string) (map[string]string, error) {
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		text := scanner.Text()
-		split := strings.Split(text, "=")
+		split := strings.Split(text, seperator)
 		if len(split) != 2 {
 			return nil, fmt.Errorf("mapping %q expected to have exactly one \"=\"", text)
 		}

--- a/pkg/image/association.go
+++ b/pkg/image/association.go
@@ -231,7 +231,8 @@ func AssociateImageLayers(rootDir string, imgMappings TypedImageMapping) (Associ
 	localRoot := filepath.Join(rootDir, "v2")
 	for image, diskLoc := range imgMappings {
 		if diskLoc.Type != imagesource.DestinationFile {
-			errs = append(errs, fmt.Errorf("image destination for %q is not type file", image.Ref.String()))
+			errs = append(errs, fmt.Errorf("image destination for %q is not type file", image.Ref.Exact()))
+			continue
 		}
 		dirRef := diskLoc.Ref.AsRepository().String()
 		imagePath := filepath.Join(localRoot, dirRef)
@@ -243,10 +244,15 @@ func AssociateImageLayers(rootDir string, imgMappings TypedImageMapping) (Associ
 		}
 
 		var tagOrID string
-		if image.Ref.Tag != "" {
-			tagOrID = image.Ref.Tag
+		if diskLoc.Ref.Tag != "" {
+			tagOrID = diskLoc.Ref.Tag
 		} else {
-			tagOrID = image.Ref.ID
+			tagOrID = diskLoc.Ref.ID
+		}
+
+		if tagOrID == "" {
+			errs = append(errs, &ErrInvalidComponent{image.String(), tagOrID})
+			continue
 		}
 
 		// TODO(estroz): parallelize

--- a/pkg/image/association_test.go
+++ b/pkg/image/association_test.go
@@ -1,8 +1,15 @@
 package image
 
 import (
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/openshift/library-go/pkg/image/reference"
+	"github.com/openshift/oc/pkg/cli/image/imagesource"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,20 +21,30 @@ const (
 func TestAssociateImageLayers(t *testing.T) {
 	tests := []struct {
 		name       string
-		tag        string
 		imgTyp     ImageType
-		imgs       []string
-		imgMapping map[string]string
+		imgMapping TypedImageMapping
 		expResult  AssociationSet
 		expError   error
 		wantErr    bool
 	}{
 		{
-			name:       "Valid/ManifestWithTag",
-			imgTyp:     TypeGeneric,
-			tag:        "oc-mirror",
-			imgMapping: map[string]string{"imgname:latest": "single_manifest:latest"},
-			imgs:       []string{"imgname:latest"},
+			name:   "Valid/ManifestWithTag",
+			imgTyp: TypeGeneric,
+			imgMapping: map[TypedImage]TypedImage{
+				{
+					TypedImageReference: imagesource.TypedImageReference{
+						Ref: reference.DockerImageReference{
+							Name: "imgname",
+							Tag:  "latest",
+						}},
+					Category: TypeGeneric}: {
+					TypedImageReference: imagesource.TypedImageReference{
+						Ref: reference.DockerImageReference{
+							Name: "single_manifest",
+						},
+						Type: imagesource.DestinationFile,
+					},
+					Category: TypeGeneric}},
 			expResult: AssociationSet{"imgname:latest": map[string]Association{
 				"imgname:latest": {
 					Name:            "imgname:latest",
@@ -49,18 +66,27 @@ func TestAssociateImageLayers(t *testing.T) {
 		},
 		{
 			name:   "Valid/ManifestWithDigest",
-			tag:    "oc-mirror",
 			imgTyp: TypeGeneric,
-			imgMapping: map[string]string{
-				"imgname@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19": "single_manifest@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19"},
-			imgs: []string{
-				"imgname@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
-			},
+			imgMapping: map[TypedImage]TypedImage{
+				{
+					TypedImageReference: imagesource.TypedImageReference{
+						Ref: reference.DockerImageReference{
+							Name: "imgname",
+							ID:   "sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
+						}},
+					Category: TypeGeneric}: {
+					TypedImageReference: imagesource.TypedImageReference{
+						Ref: reference.DockerImageReference{
+							Name: "single_manifest",
+						},
+						Type: imagesource.DestinationFile,
+					},
+					Category: TypeGeneric}},
 			expResult: AssociationSet{"imgname@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19": map[string]Association{
 				"imgname@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19": {
 					Name:            "imgname@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
 					Path:            "single_manifest",
-					TagSymlink:      "oc-mirror",
+					TagSymlink:      "oc-mirrord31c6e",
 					ID:              "sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
 					Type:            TypeGeneric,
 					ManifestDigests: nil,
@@ -77,13 +103,22 @@ func TestAssociateImageLayers(t *testing.T) {
 		},
 		{
 			name:   "Valid/IndexManifest",
-			tag:    "oc-mirror",
 			imgTyp: TypeGeneric,
-			imgMapping: map[string]string{
-				"imgname:latest": "index_manifest:latest"},
-			imgs: []string{
-				"imgname:latest",
-			},
+			imgMapping: map[TypedImage]TypedImage{
+				{
+					TypedImageReference: imagesource.TypedImageReference{
+						Ref: reference.DockerImageReference{
+							Name: "imgname",
+							Tag:  "latest",
+						}},
+					Category: TypeGeneric}: {
+					TypedImageReference: imagesource.TypedImageReference{
+						Ref: reference.DockerImageReference{
+							Name: "index_manifest",
+						},
+						Type: imagesource.DestinationFile,
+					},
+					Category: TypeGeneric}},
 			expResult: AssociationSet{"imgname:latest": map[string]Association{
 				"imgname:latest": {
 					Name:       "imgname:latest",
@@ -170,25 +205,30 @@ func TestAssociateImageLayers(t *testing.T) {
 			}},
 		},
 		{
-			name:       "Invalid/ImageWithNoMapping",
-			imgTyp:     TypeGeneric,
-			imgMapping: map[string]string{"imgname:notlatest": "single_manifest:latest"},
-			imgs:       []string{"imgname:latest"},
-			wantErr:    true,
-			expError:   &ErrNoMapping{},
-		},
-		{
-			name:       "Invalid/InvalidComponent",
-			imgTyp:     TypeGeneric,
-			imgMapping: map[string]string{"imgname:latest": "single_manifest"},
-			imgs:       []string{"imgname:latest"},
-			wantErr:    true,
-			expError:   &ErrInvalidComponent{},
+			name:   "Invalid/InvalidComponent",
+			imgTyp: TypeGeneric,
+			imgMapping: map[TypedImage]TypedImage{
+				{
+					TypedImageReference: imagesource.TypedImageReference{
+						Ref: reference.DockerImageReference{
+							Name: "imgname",
+							ID:   "d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
+						}},
+					Category: TypeGeneric}: {
+					TypedImageReference: imagesource.TypedImageReference{
+						Ref: reference.DockerImageReference{
+							Name: "single_manifest",
+						}},
+					Category: TypeGeneric}},
+			wantErr:  true,
+			expError: &ErrInvalidComponent{},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			asSet, err := AssociateImageLayers("testdata", test.imgMapping, test.imgs, test.imgTyp)
+			tmpdir := t.TempDir()
+			require.NoError(t, copyV2("testdata", tmpdir))
+			asSet, err := AssociateImageLayers(tmpdir, test.imgMapping)
 			if !test.wantErr {
 				require.NoError(t, err)
 				require.Equal(t, test.expResult, asSet)
@@ -197,7 +237,36 @@ func TestAssociateImageLayers(t *testing.T) {
 			}
 		})
 	}
+}
 
+func copyV2(source, destination string) error {
+	err := filepath.Walk(source, func(path string, info os.FileInfo, err error) error {
+		relPath := strings.Replace(path, source, "", 1)
+		if relPath == "" {
+			return nil
+		}
+		switch m := info.Mode(); {
+		case m&fs.ModeSymlink != 0: // Tag is the file name, so follow the symlink to the layer ID-named file.
+			dst, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			id := filepath.Base(dst)
+			if err := os.Symlink(id, filepath.Join(destination, relPath)); err != nil {
+				return err
+			}
+		case m.IsDir():
+			return os.Mkdir(filepath.Join(destination, relPath), 0755)
+		default:
+			data, err := ioutil.ReadFile(filepath.Join(source, relPath))
+			if err != nil {
+				return err
+			}
+			return ioutil.WriteFile(filepath.Join(destination, relPath), data, 0777)
+		}
+		return nil
+	})
+	return err
 }
 
 func TestUpdateKey(t *testing.T) {

--- a/pkg/image/association_test.go
+++ b/pkg/image/association_test.go
@@ -41,6 +41,7 @@ func TestAssociateImageLayers(t *testing.T) {
 					TypedImageReference: imagesource.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name: "single_manifest",
+							Tag:  "latest",
 						},
 						Type: imagesource.DestinationFile,
 					},
@@ -78,6 +79,7 @@ func TestAssociateImageLayers(t *testing.T) {
 					TypedImageReference: imagesource.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name: "single_manifest",
+							ID:   "sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
 						},
 						Type: imagesource.DestinationFile,
 					},
@@ -115,6 +117,7 @@ func TestAssociateImageLayers(t *testing.T) {
 					TypedImageReference: imagesource.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name: "index_manifest",
+							Tag:  "latest",
 						},
 						Type: imagesource.DestinationFile,
 					},
@@ -212,13 +215,14 @@ func TestAssociateImageLayers(t *testing.T) {
 					TypedImageReference: imagesource.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name: "imgname",
-							ID:   "d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
 						}},
 					Category: TypeGeneric}: {
 					TypedImageReference: imagesource.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name: "single_manifest",
-						}},
+						},
+						Type: imagesource.DestinationFile,
+					},
 					Category: TypeGeneric}},
 			wantErr:  true,
 			expError: &ErrInvalidComponent{},

--- a/pkg/image/image_types.go
+++ b/pkg/image/image_types.go
@@ -1,0 +1,24 @@
+package image
+
+type ImageType int
+
+const (
+	TypeInvalid ImageType = iota
+	TypeOCPRelease
+	TypeOperatorCatalog
+	TypeOperatorBundle
+	TypeOperatorRelatedImage
+	TypeGeneric
+)
+
+var imageTypeStrings = map[ImageType]string{
+	TypeOCPRelease:           "ocpRelease",
+	TypeOperatorCatalog:      "operatorCatalog",
+	TypeOperatorBundle:       "operatorBundle",
+	TypeOperatorRelatedImage: "operatorRelatedImage",
+	TypeGeneric:              "generic",
+}
+
+func (it ImageType) String() string {
+	return imageTypeStrings[it]
+}

--- a/pkg/image/mapping.go
+++ b/pkg/image/mapping.go
@@ -1,0 +1,132 @@
+package image
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/openshift/oc/pkg/cli/image/imagesource"
+)
+
+type TypedImage struct {
+	imagesource.TypedImageReference
+	// Category adds image category type to TypedImageReference
+	Category ImageType
+}
+
+// ParseTypeImage will create a TypedImage from a string and type
+func ParseTypedImage(image string, typ ImageType) (TypedImage, error) {
+	ref, err := imagesource.ParseReference(image)
+	if err != nil {
+		return TypedImage{}, err
+	}
+	return TypedImage{ref, typ}, nil
+}
+
+type TypedImageMapping map[TypedImage]TypedImage
+
+// ReadImageMapping reads a mapping.txt file and parses each line into a map k/v.
+func ReadImageMapping(mappingsPath, separator string, typ ImageType) (TypedImageMapping, error) {
+	f, err := os.Open(mappingsPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	mappings := TypedImageMapping{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		text := scanner.Text()
+		split := strings.Split(text, separator)
+		if len(split) != 2 {
+			return nil, fmt.Errorf("mapping %q expected to have exactly one \"=\"", text)
+		}
+		srcTypedRef, err := ParseTypedImage(strings.TrimSpace(split[0]), typ)
+		if err != nil {
+			return nil, err
+		}
+		dstTypedRef, err := ParseTypedImage(strings.TrimSpace(split[1]), typ)
+		if err != nil {
+			return nil, err
+		}
+		mappings[srcTypedRef] = dstTypedRef
+	}
+
+	return mappings, scanner.Err()
+}
+
+// WriteImageMapping reads a mapping.txt file and parses each line into a map k/v.
+func (m TypedImageMapping) WriteImageMapping(mappingsPath string) error {
+	f, err := os.Create(mappingsPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	for fromStr, toStr := range m {
+		_, err := f.WriteString(fmt.Sprintf("%s=%s\n", fromStr.Ref.Exact(), toStr.Ref.Exact()))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ToRegistry will convet a mapping to disk to a registry to registry mapping
+func (m TypedImageMapping) ToRegistry(registry, namespace string) {
+	for src, dest := range m {
+		dest.Type = imagesource.DestinationRegistry
+		dest.Ref.Registry = registry
+		dest.Ref.Namespace = path.Join(namespace, dest.Ref.Namespace)
+		dest.Ref.ID = src.Ref.ID
+		dest.Ref.Tag = src.Ref.Tag
+		m[src] = dest
+	}
+}
+
+// Merge will add new image maps to current map
+func (m TypedImageMapping) Merge(in TypedImageMapping) {
+	for k, v := range in {
+		m[k] = v
+	}
+}
+
+// Add stores a key-value pair into image map
+func (m TypedImageMapping) Add(srcRef, dstRef imagesource.TypedImageReference, typ ImageType) {
+	srcTypedRef := TypedImage{
+		TypedImageReference: srcRef,
+		Category:            typ,
+	}
+	dstTypedRef := TypedImage{
+		TypedImageReference: dstRef,
+		Category:            TypeGeneric,
+	}
+	m[srcTypedRef] = dstTypedRef
+}
+
+// Remove will remove an image from the map given the TypeImageReference and type
+func (m TypedImageMapping) Remove(ref imagesource.TypedImageReference, typ ImageType) {
+	typedRef := TypedImage{
+		TypedImageReference: ref,
+		Category:            typ,
+	}
+	delete(m, typedRef)
+}
+
+// ByCategory will return a pruned mapping by containing provided types
+func ByCategory(m TypedImageMapping, types ...ImageType) TypedImageMapping {
+	foundTypes := map[ImageType]struct{}{}
+	for _, typ := range types {
+		foundTypes[typ] = struct{}{}
+	}
+	// return a new map with the pruned mapping
+	prunedMap := TypedImageMapping{}
+	for key, val := range m {
+		_, ok := foundTypes[key.Category]
+		if ok {
+			prunedMap[key] = val
+		}
+	}
+	return prunedMap
+}

--- a/pkg/image/mapping.go
+++ b/pkg/image/mapping.go
@@ -81,7 +81,6 @@ func (m TypedImageMapping) ToRegistry(registry, namespace string) {
 		dest.Ref.Registry = registry
 		dest.Ref.Namespace = path.Join(namespace, dest.Ref.Namespace)
 		dest.Ref.ID = src.Ref.ID
-		dest.Ref.Tag = src.Ref.Tag
 		m[src] = dest
 	}
 }

--- a/pkg/image/mapping.go
+++ b/pkg/image/mapping.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/openshift/oc/pkg/cli/image/imagesource"
+	"github.com/sirupsen/logrus"
 )
 
 type TypedImage struct {
@@ -88,6 +89,11 @@ func (m TypedImageMapping) ToRegistry(registry, namespace string) {
 // Merge will add new image maps to current map
 func (m TypedImageMapping) Merge(in TypedImageMapping) {
 	for k, v := range in {
+		_, found := m[k]
+		if found {
+			logrus.Debugf("source image %s already exists in mapping", k.String())
+			continue
+		}
 		m[k] = v
 	}
 }

--- a/pkg/image/mapping_test.go
+++ b/pkg/image/mapping_test.go
@@ -1,0 +1,225 @@
+package image
+
+import (
+	"testing"
+
+	"github.com/openshift/library-go/pkg/image/reference"
+	"github.com/openshift/oc/pkg/cli/image/imagesource"
+	"github.com/stretchr/testify/require"
+)
+
+func TestByCategory(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    TypedImageMapping
+		typ      []ImageType
+		expected TypedImageMapping
+		err      string
+	}{{
+		name: "Valid/OneType",
+		input: TypedImageMapping{
+			{TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "some-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+				Category: TypeOperatorBundle}: {
+				TypedImageReference: imagesource.TypedImageReference{
+					Ref: reference.DockerImageReference{
+						Registry:  "disconn-registry",
+						Namespace: "namespace",
+						Name:      "image",
+						ID:        "digest",
+					},
+					Type: imagesource.DestinationRegistry,
+				},
+				Category: TypeOperatorBundle},
+			{TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "some-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+				Category: TypeOCPRelease}: {
+				TypedImageReference: imagesource.TypedImageReference{
+					Ref: reference.DockerImageReference{
+						Registry:  "disconn-registry",
+						Namespace: "namespace",
+						Name:      "image",
+						ID:        "digest",
+					},
+					Type: imagesource.DestinationRegistry,
+				},
+				Category: TypeOCPRelease},
+		},
+		typ: []ImageType{TypeOperatorBundle},
+		expected: TypedImageMapping{{
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "some-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: TypeOperatorBundle}: {
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "disconn-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: TypeOperatorBundle},
+		},
+	}, {
+		name: "Valid/PruneAllTypes",
+		input: TypedImageMapping{{
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "some-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: TypeOperatorBundle}: {
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "disconn-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: TypeOperatorBundle},
+		},
+		typ:      []ImageType{TypeGeneric},
+		expected: TypedImageMapping{},
+	}, {
+		name: "Valid/MultipleTypes",
+		input: TypedImageMapping{
+			{TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "some-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+				Category: TypeOperatorBundle}: {
+				TypedImageReference: imagesource.TypedImageReference{
+					Ref: reference.DockerImageReference{
+						Registry:  "disconn-registry",
+						Namespace: "namespace",
+						Name:      "image",
+						ID:        "digest",
+					},
+					Type: imagesource.DestinationRegistry,
+				},
+				Category: TypeOperatorBundle},
+			{TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "some-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+				Category: TypeOperatorCatalog}: {
+				TypedImageReference: imagesource.TypedImageReference{
+					Ref: reference.DockerImageReference{
+						Registry:  "disconn-registry",
+						Namespace: "namespace",
+						Name:      "image",
+						ID:        "digest",
+					},
+					Type: imagesource.DestinationRegistry,
+				},
+				Category: TypeOperatorCatalog},
+			{TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "some-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+				Category: TypeGeneric}: {
+				TypedImageReference: imagesource.TypedImageReference{
+					Ref: reference.DockerImageReference{
+						Registry:  "disconn-registry",
+						Namespace: "namespace",
+						Name:      "image",
+						ID:        "digest",
+					},
+					Type: imagesource.DestinationRegistry,
+				},
+				Category: TypeGeneric},
+		},
+		typ: []ImageType{TypeOperatorBundle, TypeOperatorCatalog},
+		expected: TypedImageMapping{
+			{TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "some-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+				Category: TypeOperatorBundle}: {
+				TypedImageReference: imagesource.TypedImageReference{
+					Ref: reference.DockerImageReference{
+						Registry:  "disconn-registry",
+						Namespace: "namespace",
+						Name:      "image",
+						ID:        "digest",
+					},
+					Type: imagesource.DestinationRegistry,
+				},
+				Category: TypeOperatorBundle},
+			{TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "some-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "digest",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+				Category: TypeOperatorCatalog}: {
+				TypedImageReference: imagesource.TypedImageReference{
+					Ref: reference.DockerImageReference{
+						Registry:  "disconn-registry",
+						Namespace: "namespace",
+						Name:      "image",
+						ID:        "digest",
+					},
+					Type: imagesource.DestinationRegistry,
+				},
+				Category: TypeOperatorCatalog},
+		},
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mapping := ByCategory(test.input, test.typ...)
+			require.Equal(t, test.expected, mapping)
+		})
+	}
+}

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -13,11 +13,11 @@ import (
 	"github.com/openshift/oc-mirror/pkg/metadata/storage"
 )
 
-// SyncMetadata syncs metadata from one backend to another
+// SyncMetadata copies Metadata from one Backend to another
 func SyncMetadata(ctx context.Context, first storage.Backend, second storage.Backend) error {
 	var meta v1alpha1.Metadata
 	if err := first.ReadMetadata(ctx, &meta, config.MetadataBasePath); err != nil {
-		return err
+		return fmt.Errorf("error reading metadata: %v", err)
 	}
 	// Add mirror as a new PastMirror
 	if err := second.WriteMetadata(ctx, &meta, config.MetadataBasePath); err != nil {


### PR DESCRIPTION
# Description

This PR adds a TypedImageMapping type that is used to decouple the Associations type from Imageset creation operators and ICSP creation from Imageset publishing operations to make it possible to use existing Imageset creation functionality without the requirement of storing images on disk.

Fixes #285 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Updated unit tests where required
- [x] Added unit tests for TypedImageType
- [x] E2E test has been unedited and is passing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules