### PR TITLE
chore: add required operator label to Dockerfile

### DIFF
--- a/images/cli/Dockerfile.ci
+++ b/images/cli/Dockerfile.ci
@@ -6,7 +6,10 @@ RUN make build
 
 FROM registry.ci.openshift.org/ocp/4.10:base
 COPY --from=builder /go/src/github.com/openshift/oc-mirror/bin/oc-mirror /usr/bin/
+
 LABEL io.k8s.display-name="oc-mirror" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
-      io.openshift.tags="openshift,cli,mirror"
+      io.openshift.tags="openshift,cli,mirror" \
+      # We're not really an operator, we're just getting some data into the release image.
+      io.openshift.release.operator=true
 ENTRYPOINT ["/usr/bin/oc-mirror"]


### PR DESCRIPTION
Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

This PR adds label  `LABEL io.openshift.release.operator=true` to Dockerfile to get into OCP release payload

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules