### PR TITLE
fix(manifest): changes source name in ICSP to include registry during…

### DIFF
--- a/pkg/cli/mirror/publish.go
+++ b/pkg/cli/mirror/publish.go
@@ -277,7 +277,12 @@ func (o *MirrorOptions) Publish(ctx context.Context) (image.TypedImageMapping, e
 
 			// Add top level assocation to the ICSP mapping
 			if assoc.Name == imageName {
-				allMappings.Add(m.Source, m.Destination, assoc.Type)
+				source, err := imagesource.ParseReference(imageName)
+				if err != nil {
+					errs = append(errs, err)
+					continue
+				}
+				allMappings.Add(source, m.Destination, assoc.Type)
 			}
 
 			if len(missingLayers) != 0 {


### PR DESCRIPTION
… disk to mirror workflow

Closes #322

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

This PR changes the ICSP format in disk to mirror workflow to include the correct source. Currently the source include is the source from disk, not the original registry source.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Manually tested ICSP output

Note: Automated integration testing in CI will be added to catch this type of issue before merges

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules