### PR TITLE
chore: adds the log file to IOStream configuration for Out and ErrOut

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -20,9 +20,9 @@ $ oc-mirror version
 # What happened?
 
 Enter text here.
-Attach the relevant portions of your `.openshift_bundle.log`.
+Attach the relevant portions of your `.oc-mirror.log`.
 
-# What you expected to happen?
+# What did you expect to happen?
 
 Enter text here.
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ oc-mirror-workspace/
 pkg/image/testdata/v2/single_manifest/manifests/oc-mirror
 
 # Logs.
-**/.openshift_bundle.log
+**/.oc-mirror.log
 
 # Local vendor. Remove when ready to vendor dependencies.
 #/vendor/

--- a/pkg/cli/log.go
+++ b/pkg/cli/log.go
@@ -70,14 +70,14 @@ func (h *fileHook) Fire(entry *logrus.Entry) error {
 	return nil
 }
 
-func setupFileHook(baseDir string) func() {
+func setupFileHook(baseDir string) (func(), *os.File) {
 	if baseDir != "" && baseDir != "." {
 		if err := os.MkdirAll(baseDir, 0755); err != nil {
 			logrus.Fatalf("failed to create base directory for logs: %v", err)
 		}
 	}
 
-	logfile, err := os.OpenFile(filepath.Join(baseDir, ".openshift_bundle.log"), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
+	logfile, err := os.OpenFile(filepath.Join(baseDir, ".oc-mirror.log"), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
 	if err != nil {
 		logrus.Fatalf("failed to open log file: %v", err)
 	}
@@ -96,5 +96,5 @@ func setupFileHook(baseDir string) func() {
 	return func() {
 		logfile.Close()
 		logrus.StandardLogger().ReplaceHooks(originalHooks)
-	}
+	}, logfile
 }

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 
@@ -49,7 +50,15 @@ func (o *RootOptions) LogfilePreRun(cmd *cobra.Command, _ []string) {
 		DisableQuote:           true,
 	}))
 
-	o.logfileCleanup = setupFileHook(".")
+	cleanup, logfile := setupFileHook(".")
+	o.logfileCleanup = cleanup
+
+	// Add to root IOStream options
+	o.IOStreams = genericclioptions.IOStreams{
+		In:     o.IOStreams.In,
+		Out:    io.MultiWriter(o.IOStreams.Out, logfile),
+		ErrOut: io.MultiWriter(o.IOStreams.ErrOut, logfile),
+	}
 }
 
 func (o *RootOptions) LogfilePostRun(*cobra.Command, []string) {


### PR DESCRIPTION
This change ensures logs from oc library calls make it
into the logfile as well as standard out.

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

This PR adds the `oc-mirror` log file as an output destination when calling `oc` libraries.

Fixes #22 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Manually tested

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules