### PR TITLE
[CI] Add integration environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ pkg/image/testdata/v2/single_manifest/manifests/oc-mirror
 
 # Local
 .idea
+tags
+*.swp
 
 # Local imageset-config.yaml
 imageset-config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,10 @@ tags
 
 # Local imageset-config.yaml
 imageset-config.yaml
+
+# Local integration test files
+test/integration/.venv
+test/integration/collections
+test/integration/bin
+test/integration/output/*
+!test/integration/output/.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ build: clean
 	$(GO) build $(GO_BUILD_FLAGS) -ldflags="$(GO_LD_EXTRAFLAGS)" -o bin/oc-mirror ./cmd/oc-mirror
 .PHONY: build
 
+hack-build: clean
+	./hack/build.sh
+.PHONY: hack-build
+
 tidy:
 	$(GO) mod tidy
 	$(GO) mod verify
@@ -36,6 +40,7 @@ tidy:
 
 clean:
 	@rm -rf ./bin/*
+	@cd test/integration && make clean
 .PHONY: clean
 
 test-unit:
@@ -45,6 +50,12 @@ test-unit:
 test-e2e: build
 	./test/e2e-simple.sh ./bin/oc-mirror
 .PHONY: test-e2e
+
+test-integration: hack-build
+	@mkdir -p test/integration/output/clients
+	@cp bin/oc-mirror test/integration/output/clients/
+	@cd test/integration && make
+.PHONY: test-integration
 
 sanity: tidy
 	git diff --exit-code

--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -7,6 +7,7 @@ Let's get started!
 1. Make sure your go is up to date!
 2. Make sure that you have `gcc` and `make` installed.
 3. To run the local end-to-end test you will need `podman` or `docker`
+4. To run the full end-to-end test in the integration environment you will need `python3`, `curl`, and `unzip`
 
 ## Building
 
@@ -21,3 +22,34 @@ We are currently running automated unit tests with CI and are working on an auto
 
 We have developed local end-to-end test scripts to verify `oc-mirror` functionality with various imageset configurations.
 When added a new feature or changing a current feature ensure the functionality is covered by the end-to-test located [here](../test/../../test/e2e-simple.sh)
+
+If you would like to conduct a more exhaustive end-to-end test in a full integration environment, including an isolated VPC and a real OpenShift installation, you will need an AWS IAM user access key and secret and a pull secret from the [OpenShift console](https://console.redhat.com/openshift/install/aws/installer-provisioned). You can then run the following:
+
+```sh
+export AWS_ACCESS_KEY_ID=<your actual AWS access key ID>
+export AWS_SECRET_ACCESS_KEY=<your actual AWS secret access key>
+export CONSOLE_REDHAT_COM_PULL_SECRET='<your actual pull secret, retrieved from the link above>'
+```
+
+To run the full E2E integration suite from the repository root, you can use the `test-integration` target, e.g.:
+
+```sh
+make test-integration
+```
+
+If your integration test fails and leaves the environment hanging half-open, you can tear it down with the following:
+
+```sh
+cd test/integration
+make delete
+```
+
+To run a specific phase of the E2E integration (for example, to provision and run the test matrix in the environment, without deleting it automatically), you can run the following from the `test/integration` folder directly:
+
+```sh
+make create test
+```
+
+Additional debugging of the disconnected integration environment (including hopping through a connected host to reach the isolated bastion) can be performed with the `test/integration/connect.sh` script, which accepts a single argument - the name of the host you want to connect to. It can be one of `registry`, `proxy`, or `bastion`.
+
+For custom test scenarios, or cases where your test may break the `oc-mirror` command line arguments or configuration API schema, the `vars.yml` file contains some variables to help you. Further documentation on the E2E integration environment is available at the [ansible collection repository](https://github.com/jharmison-redhat/oc-mirror-e2e) for it.

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -1,0 +1,82 @@
+# For virtualenv/ansible installation
+PYTHON := python3
+
+# For terraform download
+TERRAFORM_VERSION := 1.1.6
+TERRAFORM_OS := linux
+TERRAFORM_ARCH := amd64
+TERRAFORM_DOWNLOAD = terraform_$(TERRAFORM_VERSION)_$(TERRAFORM_OS)_$(TERRAFORM_ARCH).zip
+
+# For Red Hat Quay installation and OpenShift release artifact mirroring
+CONSOLE_REDHAT_COM_PULL_SECRET := ${CONSOLE_REDHAT_COM_PULL_SECRET}
+
+# Extra args to pass to a playbook call
+# e.g. make test ANSIBLE_PLAYBOOK_ARGS="--tags sneakernet"
+ANSIBLE_PLAYBOOK_ARGS :=
+
+all: default-scenario
+.PHONY: all
+
+default-scenario: create test delete
+.PHONY: default-scenario
+
+.venv/bin/pip:
+	$(PYTHON) -m venv .venv
+	.venv/bin/pip install --upgrade pip setuptools wheel
+
+.venv/bin/ansible-galaxy: .venv/bin/pip
+	.venv/bin/pip install -r requirements.txt
+
+collections/ansible_collections/jharmison_redhat/oc_mirror_e2e: .venv/bin/ansible-galaxy
+	.venv/bin/ansible-galaxy install -r requirements.yml
+
+collection: collections/ansible_collections/jharmison_redhat/oc_mirror_e2e
+.PHONY: collection
+
+bin/terraform:
+	mkdir -p bin
+	cd bin \
+	&& curl -sLO https://releases.hashicorp.com/terraform/$(TERRAFORM_VERSION)/$(TERRAFORM_DOWNLOAD) \
+	&& unzip $(TERRAFORM_DOWNLOAD)
+
+terraform: bin/terraform
+.PHONY: terraform
+
+create: terraform collection
+	@.venv/bin/ansible-playbook \
+		jharmison_redhat.oc_mirror_e2e.create \
+		-e @vars.yml \
+		-e "output_dir=${PWD}/output" \
+		-e "terraform_binary_path=${PWD}/bin/terraform" \
+		-e '{"console_redhat_com_pull_secret": $(CONSOLE_REDHAT_COM_PULL_SECRET)}' \
+		$(ANSIBLE_PLAYBOOK_ARGS)
+.PHONY: create
+
+test: collection
+	@.venv/bin/ansible-playbook \
+		jharmison_redhat.oc_mirror_e2e.test \
+		-e @vars.yml \
+		-e "output_dir=${PWD}/output" \
+		-e "terraform_binary_path=${PWD}/bin/terraform" \
+		-e '{"console_redhat_com_pull_secret": $(CONSOLE_REDHAT_COM_PULL_SECRET)}' \
+		$(ANSIBLE_PLAYBOOK_ARGS)
+.PHONY: test
+
+delete: terraform collection
+	@.venv/bin/ansible-playbook \
+		jharmison_redhat.oc_mirror_e2e.delete \
+		-e @vars.yml \
+		-e "output_dir=${PWD}/output" \
+		-e "terraform_binary_path=${PWD}/bin/terraform" \
+		$(ANSIBLE_PLAYBOOK_ARGS)
+.PHONY: delete
+
+clean:
+	rm -rf .venv
+	rm -rf bin
+	rm -rf collections
+.PHONY: clean
+
+realclean: clean
+	rm -rf output/*
+.PHONY: realclean

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -24,10 +24,10 @@ default-scenario: create test delete
 	$(PYTHON) -m venv .venv
 	.venv/bin/pip install --upgrade pip setuptools wheel
 
-.venv/bin/ansible-galaxy: .venv/bin/pip
+.venv/bin/ansible-galaxy: .venv/bin/pip requirements.txt
 	.venv/bin/pip install -r requirements.txt
 
-collections/ansible_collections/jharmison_redhat/oc_mirror_e2e: .venv/bin/ansible-galaxy
+collections/ansible_collections/jharmison_redhat/oc_mirror_e2e: .venv/bin/ansible-galaxy requirements.yml
 	.venv/bin/ansible-galaxy install -r requirements.yml
 
 collection: collections/ansible_collections/jharmison_redhat/oc_mirror_e2e

--- a/test/integration/ansible.cfg
+++ b/test/integration/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+inventory           = hosts
+interpreter_python  = auto_silent
+retry_files_enabled = False
+collections_path    = ./collections

--- a/test/integration/connect.sh
+++ b/test/integration/connect.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+valid_host_names=(registry proxy bastion)
+validate () {
+    for valid_host_name in "${valid_host_names[@]}"; do
+        if [ "$1" = "$valid_host_name" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+node="${1?' You must provide a host to connect to'}" && validate "$1" || { echo 'Please supply a valid hostname as an argument.' >&2; exit 1; }
+
+if [ -f output/cluster_name ]; then
+    cluster_name=$(tr -d '[:space:]' < output/cluster_name)
+else
+    cluster_name=disco
+fi
+
+cluster_domain=$(grep '^cluster_domain:' vars.yml | cut -d: -f2- | tr -d ' ')
+
+ssh_args=(
+    -i "output/${cluster_name}_ed25519"
+    -o IdentitiesOnly=yes
+    -o StrictHostKeyChecking=no
+    -o UserKnownHostsFile=/dev/null
+    -q
+)
+
+if [ "$node" = "bastion" ]; then
+    ssh_args+=(
+        -o ProxyCommand="ssh -W %h:%p ${ssh_args[@]} ec2-user@proxy.$cluster_name.$cluster_domain"
+    )
+fi
+
+export TERM=xterm-256color
+exec ssh "${ssh_args[@]}" "ec2-user@$node.$cluster_name.$cluster_domain"

--- a/test/integration/connect.sh
+++ b/test/integration/connect.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+cd "$(dirname "$(realpath "$0")")"
+
 valid_host_names=(registry proxy bastion)
 validate () {
     for valid_host_name in "${valid_host_names[@]}"; do
@@ -30,8 +32,9 @@ ssh_args=(
 )
 
 if [ "$node" = "bastion" ]; then
+    node=bastion.internal
     ssh_args+=(
-        -o ProxyCommand="ssh -W %h:%p ${ssh_args[@]} ec2-user@proxy.$cluster_name.$cluster_domain"
+        -o ProxyCommand="ssh -W %h:%p ${ssh_args[*]} ec2-user@proxy.$cluster_name.$cluster_domain"
     )
 fi
 

--- a/test/integration/hosts
+++ b/test/integration/hosts
@@ -1,0 +1,2 @@
+[all]
+controller ansible_connection=local ansible_python_interpreter=/usr/bin/python3

--- a/test/integration/requirements.txt
+++ b/test/integration/requirements.txt
@@ -1,0 +1,5 @@
+ansible >= 5.2.0, <6.0.0
+jmespath >=0.10.0, <0.11.0
+cryptography ~=36.0.1
+kubernetes >=21.7.0, <22.0.0
+requests-oauthlib >=1.3.0, <2.0.0

--- a/test/integration/requirements.yml
+++ b/test/integration/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+  - name: jharmison_redhat.oc_mirror_e2e
+    version: 0.4.4

--- a/test/integration/requirements.yml
+++ b/test/integration/requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
   - name: jharmison_redhat.oc_mirror_e2e
-    version: 0.4.4
+    version: 0.4.7

--- a/test/integration/vars.yml
+++ b/test/integration/vars.yml
@@ -1,0 +1,32 @@
+---
+# This generates a random name (which it saves) for your cluster and subdomain
+cluster_name: '{{ lookup("password", output_dir + "/cluster_name chars=ascii_lowercase length=6") }}'
+
+# This domain is only accessible if you're using an AWS account with access to it!
+cluster_domain: redhat4govaws.io
+
+# This is important for default generation of the ImageSetConfiguration, for OpenShift release versions as well as operator catalog versions
+openshift_version: 4.9
+
+# Basically, there are only a few good choices here (depending on your AWS account configuration). You're best off not changing it unless you know why.
+aws_region: us-west-2
+
+
+# These are selections from the scenarios available at:
+# https://github.com/jharmison-redhat/oc-mirror-e2e/tree/main/collection/playbooks/vars/scenario_stubs
+scenario_stubs:
+  metadata_backend: registry
+  mirror_method: to_registry
+  registry_type: docker_registry
+  operators_to_mirror: compliance_operator
+
+# If you want to override the ImageSetConfiguration generation with a custom change to the API, you might want to use something like this:
+#
+# imageset_config_override: |-
+#   apiVersion: mirror.openshift.io/v1alpha2
+#   kind: ImageSetConfiguration
+#   ocp:
+#     channels:
+#       - name: stable-4.9
+#         minVersion: 4.9.10
+#         maxVersion: 4.9.17


### PR DESCRIPTION
# Description

This change brings the [oc-mirror-e2e](https://github.com/jharmison-redhat/oc-mirror-e2e) Ansible collection into an easy-to-execute target in the root Makefile.

Fixes #325 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

```sh
export AWS_ACCESS_KEY_ID=<my actual AWS access key ID>
export AWS_SECRET_ACCESS_KEY=<my actual AWS secret access key>
export CONSOLE_REDHAT_COM_PULL_SECRET='<my actual pull secret, retrieved from console.redhat.com>'
make test-integration
```

**Test Configuration**:

Fedora 35 on amd64

Software relevant to test execution:
GNU Make 4.3
Python 3.10.2
curl 7.79.1
UnZip 6.0.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New and existing E2E integration tests pass locally with my changes