### PR TITLE
Bug 2058267: Add clarifying information to oc-mirror version command and remove alpha.3 from semver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,51 @@
 GO := go
-GO_BUILD_FLAGS := -tags=json1 -mod=vendor
 
-.PHONY: all
+ifdef OS_GIT_VERSION
+SOURCE_GIT_TAG := ${OS_GIT_VERSION}
+endif
+
+SOURCE_GIT_COMMIT := $(shell git rev-parse HEAD)
+
+GO_LD_EXTRAFLAGS :=-X k8s.io/component-base/version.gitMajor="0" \
+                   -X k8s.io/component-base/version.gitMinor="1" \
+                   -X k8s.io/component-base/version.gitVersion="v0.1.0" \
+                   -X k8s.io/component-base/version.gitCommit="$(SOURCE_GIT_COMMIT)" \
+                   -X k8s.io/component-base/version.buildDate="$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+                   -X k8s.io/component-base/version.gitTreeState="clean" \
+                   -X k8s.io/client-go/pkg/version.gitVersion="$(SOURCE_GIT_TAG)" \
+                   -X k8s.io/client-go/pkg/version.gitCommit="$(SOURCE_GIT_COMMIT)" \
+                   -X k8s.io/client-go/pkg/version.buildDate="$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+                   -X k8s.io/client-go/pkg/version.gitTreeState="$(SOURCE_GIT_TREE_STATE)"
+
+
+
+GO_BUILD_FLAGS :=-tags 'json1 -mod=vendor'
+
 all: clean tidy test-unit build
+.PHONY: all
 
-.PHONY: build
 build: clean
-	$(GO) build $(GO_BUILD_FLAGS) -o bin/oc-mirror ./cmd/oc-mirror
+	$(GO) build $(GO_BUILD_FLAGS) -ldflags="$(GO_LD_EXTRAFLAGS)" -o bin/oc-mirror ./cmd/oc-mirror
+.PHONY: build
 
-.PHONY: tidy
 tidy:
 	$(GO) mod tidy
 	$(GO) mod verify
 	$(GO) mod vendor
+.PHONY: vendor
 
-.PHONY: clean
 clean:
 	@rm -rf ./bin/*
+.PHONY: clean
 
 .PHONY: test-unit
 test-unit: tidy
 	$(GO) test $(GO_BUILD_FLAGS) -coverprofile=coverage.out -race -count=1 ./pkg/...
+.PHONY: test-unit
 
-.PHONY: test-e2e
 test-e2e: build
 	./test/e2e-simple.sh ./bin/oc-mirror
+.PHONY: test-e2e
 
 .PHONY: test-prow
 test-prow: build

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	k8s.io/apimachinery v0.22.1
 	k8s.io/cli-runtime v0.22.1
 	k8s.io/client-go v0.22.1
+	k8s.io/component-base v0.22.1
 	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.9.0
 	k8s.io/kubectl v0.22.1

--- a/pkg/cli/mirror/version/version.go
+++ b/pkg/cli/mirror/version/version.go
@@ -1,41 +1,97 @@
 package version
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 
-	"github.com/openshift/oc-mirror/pkg/cli"
 	"github.com/spf13/cobra"
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+	"k8s.io/component-base/version"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/templates"
+	"sigs.k8s.io/yaml"
+
+	"github.com/openshift/oc-mirror/pkg/cli"
 )
 
 type VersionOptions struct {
 	*cli.RootOptions
+	Output string
+	Short  bool
+}
+
+// Version is a struct for version information
+type Version struct {
+	ClientVersion *apimachineryversion.Info `json:"clientVersion,omitempty" yaml:"clientVersion,omitempty"`
 }
 
 func NewVersionCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command {
 	o := VersionOptions{
-		ro,
+		RootOptions: ro,
 	}
 
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Output version",
+		Example: templates.Examples(`
+			# Get oc-mirror version
+			oc-mirror version
+		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Validate())
 			kcmdutil.CheckErr(o.Run())
 		},
 	}
 
+	fs := cmd.Flags()
+	fs.BoolVar(&o.Short, "short", o.Short, "If true, print just the version number")
+	fs.StringVar(&o.Output, "output", o.Output, "One of 'yaml' or 'json'.")
 	o.BindFlags(cmd.PersistentFlags())
 
 	return cmd
 }
 
+// Validate validates the provided options
 func (o *VersionOptions) Validate() error {
+	if o.Output != "" && o.Output != "yaml" && o.Output != "json" {
+		return errors.New(`--output must be 'yaml' or 'json'`)
+	}
+
 	return nil
 }
 
+// Run executes version command
 func (o *VersionOptions) Run() error {
-	fmt.Println("v0.1.0-alpha.3")
+	var versionInfo Version
+
+	clientVersion := version.Get()
+	versionInfo.ClientVersion = &clientVersion
+
+	switch o.Output {
+	case "":
+		if o.Short {
+			fmt.Fprintf(o.Out, "Client Version: %s\n", clientVersion.GitVersion)
+		} else {
+			fmt.Fprintf(o.Out, "Client Version: %#v\n", clientVersion)
+		}
+	case "yaml":
+		marshalled, err := yaml.Marshal(&versionInfo)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(o.Out, string(marshalled))
+	case "json":
+		marshalled, err := json.MarshalIndent(&versionInfo, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(o.Out, string(marshalled))
+	default:
+		// There is a bug in the program if we hit this case.
+		// However, we follow a policy of never panicking.
+		return fmt.Errorf("VersionOptions were not validated: --output=%q should have been rejected", o.Output)
+	}
+
 	return nil
 }

--- a/pkg/cli/mirror/version/version_test.go
+++ b/pkg/cli/mirror/version/version_test.go
@@ -1,0 +1,51 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionValidate(t *testing.T) {
+
+	type spec struct {
+		name     string
+		opts     *VersionOptions
+		expError string
+	}
+
+	cases := []spec{
+		{
+			name: "Invalid/InvalidOutput",
+			opts: &VersionOptions{
+				Output: "invalid",
+			},
+			expError: "--output must be 'yaml' or 'json'",
+		},
+		{
+			name: "Valid/YAMLOutput",
+			opts: &VersionOptions{
+				Output: "yaml",
+			},
+			expError: "",
+		},
+		{
+			name: "Valid/JSONOutput",
+			opts: &VersionOptions{
+				Output: "json",
+			},
+			expError: "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.opts.Validate()
+			if c.expError != "" {
+				require.EqualError(t, err, c.expError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1192,6 +1192,7 @@ k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue
 # k8s.io/component-base v0.22.1
+## explicit
 k8s.io/component-base/featuregate
 k8s.io/component-base/metrics
 k8s.io/component-base/metrics/legacyregistry


### PR DESCRIPTION

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

This PR backports changes to the `oc-mirror` version command to the `release 4.10` branch to fix the Bugzilla issue below.

Related to #328 
Fixes Bugzilla issue 2056752

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] Unit tests added
- [X] Manual testing

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules