### PR TITLE
refactor(release): adds a Client interface for Cincinnati client types

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -71,7 +71,7 @@ func NewPackager(manifests []v1alpha2.Manifest, blobs []v1alpha2.Blob) *packager
 	}
 }
 
-// CreateSplitAchrive will create multiple tar archives from source directory
+// CreateSplitArchive will create multiple tar archives from source directory
 func (p *packager) CreateSplitArchive(ctx context.Context, backend storage.Backend, maxSplitSize int64, destDir, sourceDir, prefix string, skipCleanup bool) error {
 
 	// Declare split variables

--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -2,18 +2,14 @@ package cincinnati
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
 	"github.com/blang/semver/v4"
-	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"k8s.io/klog/v2"
 )
@@ -30,45 +26,11 @@ const (
 	// Update urls
 	UpdateUrl    = "https://api.openshift.com/api/upgrades_info/v1/graph"
 	OkdUpdateURL = "https://origin-release.ci.openshift.org/graph"
+	OkdChannel   = "okd"
 )
 
 // Client is a Cincinnati client which can be used to fetch update graphs from
 // an upstream Cincinnati stack.
-type Client struct {
-	id        uuid.UUID
-	transport *http.Transport
-}
-
-// NewClient creates a new Cincinnati client with the given client identifier.
-func NewClient(u string, id uuid.UUID) (Client, *url.URL, error) {
-	upstream, err := url.Parse(u)
-	if err != nil {
-		return Client{}, nil, err
-	}
-
-	tls, err := getTLSConfig()
-	if err != nil {
-		return Client{}, nil, err
-	}
-
-	transport := &http.Transport{
-		TLSClientConfig: tls,
-		Proxy:           http.ProxyFromEnvironment,
-	}
-	return Client{id: id, transport: transport}, upstream, nil
-}
-
-func getTLSConfig() (*tls.Config, error) {
-	certPool, err := x509.SystemCertPool()
-	if err != nil {
-		return nil, err
-	}
-	config := &tls.Config{
-		RootCAs:    certPool,
-		MinVersion: tls.VersionTLS12,
-	}
-	return config, nil
-}
 
 // Error is returned when are unable to get updates.
 type Error struct {
@@ -97,20 +59,13 @@ type Update node
 // finding all of the children. These children are the available updates for
 // the current version and their payloads indicate from where the actual update
 // image can be downloaded.
-func (c Client) GetUpdates(ctx context.Context, uri *url.URL, arch string, channel string, version semver.Version, reqVer semver.Version) (Update, Update, []Update, error) {
+func GetUpdates(ctx context.Context, c Client, arch string, channel string, version semver.Version, reqVer semver.Version) (Update, Update, []Update, error) {
 	var current Update
 	var requested Update
 	// Prepare parametrized cincinnati query.
-	queryParams := uri.Query()
-	if channel != "okd" {
-		queryParams.Add("arch", arch)
-		queryParams.Add("channel", channel)
-		queryParams.Add("id", c.id.String())
-		queryParams.Add("version", version.String())
-	}
-	uri.RawQuery = queryParams.Encode()
+	c.SetQueryParams(arch, channel, version.String())
 
-	graph, err := c.getGraphData(ctx, uri)
+	graph, err := getGraphData(ctx, c)
 	if err != nil {
 		return Update{}, Update{}, nil, fmt.Errorf("error getting graph data for version %s in channel %s", version.String(), channel)
 	}
@@ -168,30 +123,30 @@ func (c Client) GetUpdates(ctx context.Context, uri *url.URL, arch string, chann
 
 // CalculateUpgrades fetches and calculates all the update payloads from the specified
 // upstream Cincinnati stack given the current and target version and channel
-func (c Client) CalculateUpgrades(ctx context.Context, uri *url.URL, arch, sourceChannel, targetChannel string, startVer, reqVer semver.Version) (Update, Update, []Update, error) {
+func CalculateUpgrades(ctx context.Context, c Client, arch, sourceChannel, targetChannel string, startVer, reqVer semver.Version) (Update, Update, []Update, error) {
 	if sourceChannel == targetChannel {
-		return c.GetUpdates(ctx, uri, arch, targetChannel, startVer, reqVer)
+		return GetUpdates(ctx, c, arch, targetChannel, startVer, reqVer)
 	}
 
 	// Perform initial calculation for the source channel and
 	// recurse through the rest until the target or a blocked
 	// edge is hit
-	latest, err := c.GetChannelLatest(ctx, uri, arch, sourceChannel)
+	latest, err := GetChannelLatest(ctx, c, arch, sourceChannel)
 	if err != nil {
 		return Update{}, Update{}, nil, fmt.Errorf("cannot get latest: %v", err)
 	}
-	current, _, upgrades, err := c.GetUpdates(ctx, uri, arch, sourceChannel, startVer, latest)
+	current, _, upgrades, err := GetUpdates(ctx, c, arch, sourceChannel, startVer, latest)
 	if err != nil {
 		return Update{}, Update{}, nil, fmt.Errorf("cannot get current: %v", err)
 	}
 
-	requested, newUpgrades, err := c.calculate(ctx, uri, arch, sourceChannel, targetChannel, latest, reqVer)
+	requested, newUpgrades, err := calculate(ctx, c, arch, sourceChannel, targetChannel, latest, reqVer)
 	upgrades = append(upgrades, newUpgrades...)
 
 	return current, requested, upgrades, err
 }
 
-func (c Client) calculate(ctx context.Context, uri *url.URL, arch, sourceChannel, targetChannel string, startVer, reqVer semver.Version) (requested Update, upgrades []Update, err error) {
+func calculate(ctx context.Context, c Client, arch, sourceChannel, targetChannel string, startVer, reqVer semver.Version) (requested Update, upgrades []Update, err error) {
 	// Get semver representation of source and target channel versions
 	sourceIdx := strings.LastIndex(sourceChannel, "-")
 	if sourceIdx == -1 {
@@ -215,14 +170,14 @@ func (c Client) calculate(ctx context.Context, uri *url.URL, arch, sourceChannel
 		// requested version so we don't exceed the maximun version
 		targetVer = reqVer
 	} else {
-		targetVer, err = c.GetChannelLatest(ctx, uri, arch, currChannel)
+		targetVer, err = GetChannelLatest(ctx, c, arch, currChannel)
 		if err != nil {
 			return requested, upgrades, nil
 		}
 	}
 
 	// Handles blocked edges
-	chanVersions, err := c.GetVersions(ctx, uri, currChannel)
+	chanVersions, err := GetVersions(ctx, c, currChannel)
 	if err != nil {
 		return requested, upgrades, nil
 	}
@@ -234,13 +189,13 @@ func (c Client) calculate(ctx context.Context, uri *url.URL, arch, sourceChannel
 	if _, found := foundVersions[startVer.String()]; !found {
 		// If blocked path is found, just return the requested version and any accumulated
 		// upgrades to the caller
-		_, requested, _, err = c.GetUpdates(ctx, uri, arch, targetChannel, targetVer, targetVer)
+		_, requested, _, err = GetUpdates(ctx, c, arch, targetChannel, targetVer, targetVer)
 		logrus.Warnf("No upgrade path for %s in target channel %s", startVer.String(), targetChannel)
 		return requested, upgrades, err
 	}
 
 	logrus.Debugf("Getting updates for version %s in channel %s", startVer.String(), currChannel)
-	_, requested, upgrades, err = c.GetUpdates(ctx, uri, arch, currChannel, startVer, targetVer)
+	_, requested, upgrades, err = GetUpdates(ctx, c, arch, currChannel, startVer, targetVer)
 	if err != nil {
 		return requested, upgrades, nil
 	}
@@ -249,7 +204,7 @@ func (c Client) calculate(ctx context.Context, uri *url.URL, arch, sourceChannel
 		return requested, upgrades, nil
 	}
 
-	req, up, err := c.calculate(ctx, uri, arch, currChannel, targetChannel, targetVer, reqVer)
+	req, up, err := calculate(ctx, c, arch, currChannel, targetChannel, targetVer, reqVer)
 	if err != nil {
 		return requested, upgrades, nil
 	}
@@ -261,17 +216,11 @@ func (c Client) calculate(ctx context.Context, uri *url.URL, arch, sourceChannel
 
 // GetChannelLatest fetches the latest version from the specified
 // upstream Cincinnati stack given architecture and channel
-func (c Client) GetChannelLatest(ctx context.Context, uri *url.URL, arch string, channel string) (semver.Version, error) {
+func GetChannelLatest(ctx context.Context, c Client, arch string, channel string) (semver.Version, error) {
 	// Prepare parametrized cincinnati query.
-	queryParams := uri.Query()
-	if channel != "okd" {
-		queryParams.Add("arch", arch)
-		queryParams.Add("channel", channel)
-		queryParams.Add("id", c.id.String())
-	}
-	uri.RawQuery = queryParams.Encode()
+	c.SetQueryParams(arch, channel, "")
 
-	graph, err := c.getGraphData(ctx, uri)
+	graph, err := getGraphData(ctx, c)
 	if err != nil {
 		return semver.Version{}, fmt.Errorf("error getting graph data for channel %s", channel)
 	}
@@ -298,16 +247,11 @@ func (c Client) GetChannelLatest(ctx context.Context, uri *url.URL, arch string,
 
 // GetChannels fetches the channels containing update payloads from the specified
 // upstream Cincinnati stack
-func (c Client) GetChannels(ctx context.Context, uri *url.URL, channel string) (map[string]struct{}, error) {
+func GetChannels(ctx context.Context, c Client, channel string) (map[string]struct{}, error) {
 	// Prepare parametrized cincinnati query.
-	queryParams := uri.Query()
-	if channel != "okd" {
-		queryParams.Add("channel", channel)
-		queryParams.Add("id", c.id.String())
-	}
-	uri.RawQuery = queryParams.Encode()
+	c.SetQueryParams("", channel, "")
 
-	graph, err := c.getGraphData(ctx, uri)
+	graph, err := getGraphData(ctx, c)
 	if err != nil {
 		return nil, fmt.Errorf("error getting graph data for channel %s", channel)
 	}
@@ -327,16 +271,11 @@ func (c Client) GetChannels(ctx context.Context, uri *url.URL, channel string) (
 
 // GetVersion will return all OCP/OKD versions in a specified channel fetches the current and requested (if applicable) update payload from the specified
 // upstream Cincinnati stack given the current version and channel
-func (c Client) GetVersions(ctx context.Context, uri *url.URL, channel string) ([]semver.Version, error) {
+func GetVersions(ctx context.Context, c Client, channel string) ([]semver.Version, error) {
 	// Prepare parametrized cincinnati query.
-	queryParams := uri.Query()
-	if channel != "okd" {
-		queryParams.Add("channel", channel)
-		queryParams.Add("id", c.id.String())
-	}
-	uri.RawQuery = queryParams.Encode()
+	c.SetQueryParams("", channel, "")
 
-	graph, err := c.getGraphData(ctx, uri)
+	graph, err := getGraphData(ctx, c)
 	if err != nil {
 		return nil, fmt.Errorf("error getting graph data for channel %s", channel)
 	}
@@ -361,31 +300,33 @@ func (c Client) GetVersions(ctx context.Context, uri *url.URL, channel string) (
 }
 
 // getGraphData fetches the update graph from the upstream Cincinnati stack given the current version and channel
-func (c Client) getGraphData(ctx context.Context, uri *url.URL) (graph graph, err error) {
+func getGraphData(ctx context.Context, c Client) (graph graph, err error) {
+	transport := c.GetTransport()
+	uri := c.GetURL()
 	// Download the update graph.
 	req, err := http.NewRequest("GET", uri.String(), nil)
 	if err != nil {
 		return graph, &Error{Reason: "InvalidRequest", Message: err.Error(), cause: err}
 	}
 	req.Header.Add("Accept", GraphMediaType)
-	if c.transport != nil && c.transport.TLSClientConfig != nil {
-		if c.transport.TLSClientConfig.ClientCAs == nil {
+	if transport != nil && transport.TLSClientConfig != nil {
+		if c.GetTransport().TLSClientConfig.ClientCAs == nil {
 			klog.V(5).Infof("Using a root CA pool with 0 root CA subjects to request updates from %s", uri)
 		} else {
-			klog.V(5).Infof("Using a root CA pool with %n root CA subjects to request updates from %s", len(c.transport.TLSClientConfig.RootCAs.Subjects()), uri)
+			klog.V(5).Infof("Using a root CA pool with %n root CA subjects to request updates from %s", len(transport.TLSClientConfig.RootCAs.Subjects()), uri)
 		}
 	}
 
-	if c.transport != nil && c.transport.Proxy != nil {
-		proxy, err := c.transport.Proxy(req)
+	if transport != nil && transport.Proxy != nil {
+		proxy, err := transport.Proxy(req)
 		if err == nil && proxy != nil {
 			klog.V(5).Infof("Using proxy %s to request updates from %s", proxy.Host, uri)
 		}
 	}
 
 	client := http.Client{}
-	if c.transport != nil {
-		client.Transport = c.transport
+	if transport != nil {
+		client.Transport = transport
 	}
 	timeoutCtx, cancel := context.WithTimeout(ctx, getUpdatesTimeout)
 	defer cancel()

--- a/pkg/cincinnati/client.go
+++ b/pkg/cincinnati/client.go
@@ -1,0 +1,127 @@
+package cincinnati
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"net/url"
+
+	"github.com/google/uuid"
+)
+
+type Client interface {
+	GetURL() *url.URL
+	SetQueryParams(arch, channel, version string)
+	GetID() uuid.UUID
+	GetTransport() *http.Transport
+}
+
+var _ Client = &ocpClient{}
+
+type ocpClient struct {
+	id        uuid.UUID
+	transport *http.Transport
+	url       url.URL
+}
+
+// NewOCPClient creates a new OCP Cincinnati client with the given client identifier.
+func NewOCPClient(id uuid.UUID) (Client, error) {
+	upstream, err := url.Parse(UpdateUrl)
+	if err != nil {
+		return &ocpClient{}, err
+	}
+
+	tls, err := getTLSConfig()
+	if err != nil {
+		return &ocpClient{}, err
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: tls,
+		Proxy:           http.ProxyFromEnvironment,
+	}
+	return &ocpClient{id: id, transport: transport, url: *upstream}, nil
+}
+
+func (c *ocpClient) GetURL() *url.URL {
+	return &c.url
+}
+
+func (c *ocpClient) GetTransport() *http.Transport {
+	return c.transport
+}
+
+func (c *ocpClient) GetID() uuid.UUID {
+	return c.id
+}
+
+func (c *ocpClient) SetQueryParams(arch, channel, version string) {
+	queryParams := c.url.Query()
+	queryParams.Add("id", c.id.String())
+	params := map[string]string{
+		"arch":    arch,
+		"channel": channel,
+		"version": version,
+	}
+	for key, value := range params {
+		if value != "" {
+			queryParams.Add(key, value)
+		}
+	}
+	c.url.RawQuery = queryParams.Encode()
+}
+
+var _ Client = &okdClient{}
+
+type okdClient struct {
+	id        uuid.UUID
+	transport *http.Transport
+	url       url.URL
+}
+
+// NewOKDClient creates a new OKD Cincinnati client with the given client identifier.
+func NewOKDClient(id uuid.UUID) (Client, error) {
+	upstream, err := url.Parse(OkdUpdateURL)
+	if err != nil {
+		return &okdClient{}, err
+	}
+
+	tls, err := getTLSConfig()
+	if err != nil {
+		return &okdClient{}, err
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: tls,
+		Proxy:           http.ProxyFromEnvironment,
+	}
+	return &okdClient{id: id, transport: transport, url: *upstream}, nil
+}
+
+func (c *okdClient) GetURL() *url.URL {
+	return &c.url
+}
+
+func (c *okdClient) GetID() uuid.UUID {
+	return c.id
+}
+
+func (c *okdClient) GetTransport() *http.Transport {
+	return c.transport
+}
+
+func (c *okdClient) SetQueryParams(_, _, _ string) {
+	// Do nothing
+}
+
+func getTLSConfig() (*tls.Config, error) {
+	certPool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, err
+	}
+	config := &tls.Config{
+		RootCAs:    certPool,
+		MinVersion: tls.VersionTLS12,
+	}
+	return config, nil
+}

--- a/pkg/cincinnati/find.go
+++ b/pkg/cincinnati/find.go
@@ -11,9 +11,9 @@ import (
 
 var ErrNoPreviousRelease = errors.New("no previous release downloads detected")
 
-// FindRelease will find the minimum or maximum release recorded in a mirror
-func FindRelease(mirror v1alpha2.Mirror, min bool) (string, semver.Version, error) {
-	vers, err := findReleases(mirror, min)
+// FindRelease will find the minimum or maximum release for a set of ReleaseChannels
+func FindRelease(channels []v1alpha2.ReleaseChannel, min bool) (string, semver.Version, error) {
+	vers, err := findReleases(channels, min)
 	if err != nil {
 		return "", semver.Version{}, err
 	}
@@ -35,9 +35,9 @@ func FindRelease(mirror v1alpha2.Mirror, min bool) (string, semver.Version, erro
 	return keys[len(keys)-1], vers[keys[len(keys)-1]], nil
 }
 
-func findReleases(mirror v1alpha2.Mirror, min bool) (map[string]semver.Version, error) {
+func findReleases(channels []v1alpha2.ReleaseChannel, min bool) (map[string]semver.Version, error) {
 	vers := make(map[string]semver.Version)
-	for _, ch := range mirror.OCP.Channels {
+	for _, ch := range channels {
 
 		ver := ch.MaxVersion
 		if min {

--- a/pkg/cincinnati/find_test.go
+++ b/pkg/cincinnati/find_test.go
@@ -56,20 +56,7 @@ func TestFindLatestRelease(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			meta := v1alpha2.Metadata{
-				MetadataSpec: v1alpha2.MetadataSpec{
-					PastMirror: v1alpha2.PastMirror{
-						Mirror: v1alpha2.Mirror{
-							OCP: v1alpha2.OCP{
-								Graph:    false,
-								Channels: test.channels,
-							},
-						},
-					},
-				},
-			}
-
-			ch, ver, err := FindRelease(meta.PastMirror.Mirror, test.min)
+			ch, ver, err := FindRelease(test.channels, test.min)
 
 			if len(test.err) != 0 {
 				require.Equal(t, err.Error(), test.err)

--- a/pkg/cli/mirror/list/releases.go
+++ b/pkg/cli/mirror/list/releases.go
@@ -77,13 +77,10 @@ func (o *ReleasesOptions) Run(ctx context.Context) error {
 
 	w := o.IOStreams.Out
 
-	c, url, err := cincinnati.NewClient(cincinnati.UpdateUrl, uuid.New())
-	if err != nil {
-		return err
-	}
+	client, err := cincinnati.NewOCPClient(uuid.New())
 
 	if o.Channels {
-		channels, err := c.GetChannels(ctx, url, o.Channel)
+		channels, err := cincinnati.GetChannels(ctx, client, o.Channel)
 		if err != nil {
 			return err
 		}
@@ -112,7 +109,7 @@ func (o *ReleasesOptions) Run(ctx context.Context) error {
 		}
 	}
 
-	vers, err := c.GetVersions(ctx, url, o.Channel)
+	vers, err := cincinnati.GetVersions(ctx, client, o.Channel)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/mirror/list/updates.go
+++ b/pkg/cli/mirror/list/updates.go
@@ -86,7 +86,7 @@ func (o *UpdatesOptions) Run(ctx context.Context) error {
 		return fmt.Errorf("no metadata detected")
 	default:
 		if len(cfg.Mirror.OCP.Channels) != 0 {
-			if err := o.releaseUpdates(ctx, cfg, meta.PastMirror); err != nil {
+			if err := o.releaseUpdates(ctx, "amd64", cfg, meta.PastMirror); err != nil {
 				return err
 			}
 		}
@@ -100,57 +100,54 @@ func (o *UpdatesOptions) Run(ctx context.Context) error {
 	return nil
 }
 
-func (o UpdatesOptions) releaseUpdates(ctx context.Context, cfg v1alpha2.ImageSetConfiguration, last v1alpha2.PastMirror) error {
-	uuid := uuid.New()
-	// TODO(jpower432): handle multi-arch requests here
-	arch := "amd64"
+func (o UpdatesOptions) releaseUpdates(ctx context.Context, arch string, cfg v1alpha2.ImageSetConfiguration, last v1alpha2.PastMirror) error {
 	logrus.Info("Getting release update information")
+	lastMaxVersion := map[string]semver.Version{}
+	for _, ch := range last.Mirror.OCP.Channels {
+		version, err := semver.Parse(ch.MaxVersion)
+		if err != nil {
+			return err
+		}
+		lastMaxVersion[ch.Name] = version
+	}
+
+	// Find the latest version is each channel being requested and plot upgrade graph between the old
+	// versions if available
+	id := uuid.New()
+
 	for _, ch := range cfg.Mirror.OCP.Channels {
-		url := cincinnati.UpdateUrl
-		if ch.Name == "okd" {
-			url = cincinnati.OkdUpdateURL
-		}
 
-		client, upstream, err := cincinnati.NewClient(url, uuid)
+		var c cincinnati.Client
+		var err error
+		if ch.Name == cincinnati.OkdChannel {
+			c, err = cincinnati.NewOKDClient(id)
+		} else {
+			c, err = cincinnati.NewOCPClient(id)
+		}
+		if err != nil {
+			return err
+		}
+		latest, err := cincinnati.GetChannelLatest(ctx, c, arch, ch.Name)
+		if err != nil {
+			return err
+		}
+		ver, found := lastMaxVersion[ch.Name]
+		if !found {
+			ver = latest
+		}
+		_, _, upgrades, err := cincinnati.GetUpdates(ctx, c, arch, ch.Name, ver, latest)
 		if err != nil {
 			return err
 		}
 
-		// Find the last release downloads if no downloads
-		// have been made in the target channel list
-		// all versions
 		var vers []semver.Version
-		firstCh, first, err := cincinnati.FindRelease(last.Mirror, true)
-		if err != nil {
-			return err
-		}
-		lastCh, last, err := cincinnati.FindRelease(last.Mirror, false)
-		if err != nil {
-			return err
-		}
-		switch {
-		case err != nil && !errors.Is(err, cincinnati.ErrNoPreviousRelease):
-			return err
-		case err != nil:
-			vers, err = client.GetVersions(ctx, upstream, ch.Name)
-			if err != nil {
-				return err
-			}
-		default:
-			logrus.Debugf("Finding releases between %s and %s", first.String(), last.String())
-			_, _, upgrades, err := client.CalculateUpgrades(ctx, upstream, arch, firstCh, lastCh, first, last)
-			if err != nil {
-				return err
-			}
-			for _, upgrade := range upgrades {
-				vers = append(vers, upgrade.Version)
-			}
+		for _, upgrade := range upgrades {
+			vers = append(vers, upgrade.Version)
 		}
 
 		if err := o.writeReleaseColumns(vers, ch.Name); err != nil {
 			return err
 		}
-
 	}
 	return nil
 }

--- a/pkg/cli/mirror/pack.go
+++ b/pkg/cli/mirror/pack.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	// NoUpdatesExist should be returned by Create() when no updates are found
+	// ErrNoUpdatesExist should be returned by Create() when no updates are found
 	ErrNoUpdatesExist = errors.New("no updates detected, process stopping")
 )
 

--- a/pkg/cli/mirror/release_test.go
+++ b/pkg/cli/mirror/release_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/google/uuid"
@@ -13,12 +14,8 @@ import (
 	"github.com/openshift/oc-mirror/pkg/config/v1alpha2"
 )
 
-func TestGetChannelDownloads(t *testing.T) {
-	clientID := uuid.MustParse("01234567-0123-0123-0123-0123456789ab")
-
-	opts := ReleaseOptions{
-		uuid: clientID,
-	}
+func TestGetDownloads(t *testing.T) {
+	opts := ReleaseOptions{}
 
 	tests := []struct {
 		name string
@@ -85,16 +82,17 @@ func TestGetChannelDownloads(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(handler))
 			t.Cleanup(ts.Close)
 
-			c, uri, err := cincinnati.NewClient(ts.URL, clientID)
-			require.NoError(t, err)
-
 			allDownloads := downloads{}
 			var newDownloads downloads
+
+			endpoint, err := url.Parse(ts.URL)
+			require.NoError(t, err)
+			c := &mockClient{url: endpoint}
 
 			for _, ar := range test.arch {
 				for _, ch := range test.channels {
 
-					newDownloads, err = opts.getChannelDownloads(context.Background(), c, test.channels, ch, ar, uri)
+					newDownloads, err = opts.getChannelDownloads(context.Background(), c, test.channels, ch, ar)
 					if err != nil {
 						break
 					}
@@ -110,6 +108,38 @@ func TestGetChannelDownloads(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Create a mock client
+type mockClient struct {
+	url *url.URL
+}
+
+func (c mockClient) GetID() uuid.UUID {
+	return uuid.MustParse("01234567-0123-0123-0123-0123456789ab")
+}
+
+func (c mockClient) SetQueryParams(arch, channel, version string) {
+	queryParams := c.url.Query()
+	params := map[string]string{
+		"arch":    arch,
+		"channel": channel,
+		"version": version,
+	}
+	for key, value := range params {
+		if value != "" {
+			queryParams.Add(key, value)
+		}
+	}
+	c.url.RawQuery = queryParams.Encode()
+}
+
+func (c mockClient) GetURL() *url.URL {
+	return c.url
+}
+
+func (c mockClient) GetTransport() *http.Transport {
+	return &http.Transport{}
 }
 
 // Mock Cincinnati API

--- a/pkg/config/credentials.go
+++ b/pkg/config/credentials.go
@@ -13,7 +13,7 @@ import (
 // TODO: create a context based on user provided
 // pull secret
 
-// CreateDefault a default context for the registryClient of `oc mirror`
+// CreateDefaultContext a default context for the registryClient of `oc mirror`
 func CreateDefaultContext(skipTLS bool) (*registryclient.Context, error) {
 	opts := &imagemanifest.SecurityOptions{}
 	opts.Insecure = skipTLS

--- a/pkg/image/mapping.go
+++ b/pkg/image/mapping.go
@@ -18,7 +18,7 @@ type TypedImage struct {
 	Category ImageType
 }
 
-// ParseTypeImage will create a TypedImage from a string and type
+// ParseTypedImage will create a TypedImage from a string and type
 func ParseTypedImage(image string, typ ImageType) (TypedImage, error) {
 	ref, err := imagesource.ParseReference(image)
 	if err != nil {

--- a/pkg/image/mapping.go
+++ b/pkg/image/mapping.go
@@ -29,7 +29,7 @@ func ParseTypedImage(image string, typ ImageType) (TypedImage, error) {
 
 type TypedImageMapping map[TypedImage]TypedImage
 
-// ToRegistry will convet a mapping to disk to a registry to registry mapping
+// ToRegistry will convert all mapping values to a registry destination
 func (m TypedImageMapping) ToRegistry(registry, namespace string) {
 	for src, dest := range m {
 		dest.Type = imagesource.DestinationRegistry
@@ -74,7 +74,7 @@ func (m TypedImageMapping) Remove(ref imagesource.TypedImageReference, typ Image
 	delete(m, typedRef)
 }
 
-// ByCategory will return a pruned mapping by containing provided types
+// ByCategory will return a pruned mapping containing provided types
 func ByCategory(m TypedImageMapping, types ...ImageType) TypedImageMapping {
 	foundTypes := map[ImageType]struct{}{}
 	for _, typ := range types {

--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -33,7 +33,7 @@ func IsImagePinned(img string) bool {
 	return strings.Contains(img, "@")
 }
 
-// isImageTagged returns true if img has a tag.
+// IsImageTagged returns true if img has a tag.
 func IsImageTagged(img string) bool {
 	return strings.Contains(img, ":")
 }

--- a/pkg/metadata/storage/local.go
+++ b/pkg/metadata/storage/local.go
@@ -52,7 +52,7 @@ func (b *localDirBackend) init() error {
 	return nil
 }
 
-// WriteMetadata reads the provided metadata from disk.
+// ReadMetadata reads the provided metadata from disk.
 func (b *localDirBackend) ReadMetadata(_ context.Context, meta *v1alpha2.Metadata, path string) error {
 
 	logrus.Debugf("looking for metadata file at %q", path)


### PR DESCRIPTION
OCP and OKD releases need to be handled by the same methods but require
different concrete types due to differences in API endpoints and query
parameters.

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>
# Description

This PR refactors the Cincinnati package to add a Client interface to allow flexibility when mirroring multiple release types (e.g. OCP and OKD). The `list updates` command has been altered as well to provide an upgrade path from the last specified maximum version to the latest version in the currently requested channel.

Relates to #315 


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Mock Client interface implementation incorporated into unit tests
- [x] Manual tests with OCP, OKD, and a combination of release types.

# Test Plan

## Scenarios

- [ ] Test configuration with the OKD channel only. This should mirror the requested version(s) and skip cross-channel upgrade path calculations.
- [ ] Test configuration with OCP channels only. This should mirror the requested version(s) and complete cross-channel upgrade path calculations.
- [ ] Test configuration with OKD and OCP channels. This should mirror all requested version(s) and complete cross-channel upgrade with the OKD channel filtered out. It would be useful to test `list updates` in this scenario as well.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
