### PR TITLE
feat(releases): adds headsOnly flag to release to toggle full channel…

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Example configurations can be found in the docs [here](docs/examples)
 #### Backends
 > **IMPORTANT**: Backends must be configured to utilize the lifecycle management features of `oc-mirror`. Examples are below.
 ```sh
-apiVersion: mirror.openshift.io/v1alpha1
+apiVersion: mirror.openshift.io/v1alpha2
 kind: ImageSetConfiguration
 archiveSize: 1
 storageConfig:
@@ -46,7 +46,7 @@ storageConfig:
     path: /home/user/workspace
 ```
 ```sh
-apiVersion: mirror.openshift.io/v1alpha1
+apiVersion: mirror.openshift.io/v1alpha2
 kind: ImageSetConfiguration
 storageConfig:
   registry:

--- a/docs/examples/imageset-config-release-full-channel.yaml
+++ b/docs/examples/imageset-config-release-full-channel.yaml
@@ -1,0 +1,11 @@
+# This config demonstrates how to mirror a specified
+# version(s) of openshift. Optionally, omit the version to mirror
+# the latest release.
+---
+apiVersion: mirror.openshift.io/v1alpha2
+kind: ImageSetConfiguration
+mirror:
+  ocp:
+    channels:
+      - name: stable-4.9
+        headsOnly: false

--- a/docs/examples/imageset-config-release-full-channel.yaml
+++ b/docs/examples/imageset-config-release-full-channel.yaml
@@ -1,6 +1,6 @@
-# This config demonstrates how to mirror a specified
-# version(s) of openshift. Optionally, omit the version to mirror
-# the latest release.
+# This config demonstrates how to mirror the minimum and maximum
+# versions in the specified channel for an OpenShift release and the shortest
+# upgrade path in between
 ---
 apiVersion: mirror.openshift.io/v1alpha2
 kind: ImageSetConfiguration

--- a/docs/examples/imageset-config-release-latest.yaml
+++ b/docs/examples/imageset-config-release-latest.yaml
@@ -1,0 +1,10 @@
+# This config demonstrates how to mirror a specified
+# version(s) of openshift. Optionally, omit the version to mirror
+# the latest release.
+---
+apiVersion: mirror.openshift.io/v1alpha2
+kind: ImageSetConfiguration
+mirror:
+  ocp:
+    channels:
+      - name: stable-4.9

--- a/docs/examples/imageset-config-release-latest.yaml
+++ b/docs/examples/imageset-config-release-latest.yaml
@@ -1,6 +1,5 @@
-# This config demonstrates how to mirror a specified
-# version(s) of openshift. Optionally, omit the version to mirror
-# the latest release.
+# This config demonstrates how to mirror the latest
+# version in the specified channel for an OpenShift release
 ---
 apiVersion: mirror.openshift.io/v1alpha2
 kind: ImageSetConfiguration

--- a/docs/examples/imageset-config-release.yaml
+++ b/docs/examples/imageset-config-release.yaml
@@ -1,6 +1,6 @@
-# This config demonstrates how to mirror a specified
-# version(s) of openshift. Optionally, omit the version to mirror
-# the latest release.
+# This config demonstrates how to mirror a version range
+# in the specified channel for an OpenShift release and the shortest
+# upgrade path in between
 ---
 apiVersion: mirror.openshift.io/v1alpha2
 kind: ImageSetConfiguration

--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -165,7 +165,7 @@ func CalculateUpgrades(ctx context.Context, c Client, arch, sourceChannel, targe
 	// Perform initial calculation for the source channel and
 	// recurse through the rest until the target or a blocked
 	// edge is hit
-	latest, err := GetChannelMinorMax(ctx, c, arch, sourceChannel, false)
+	latest, err := GetChannelMinOrMax(ctx, c, arch, sourceChannel, false)
 	if err != nil {
 		return Update{}, Update{}, nil, fmt.Errorf("cannot get latest: %v", err)
 	}
@@ -260,7 +260,7 @@ func calculate(ctx context.Context, c Client, arch, sourceChannel, targetChannel
 
 // GetChannelLatest fetches the latest version from the specified
 // upstream Cincinnati stack given architecture and channel
-func GetChannelMinOrMax(ctx context.Context, c client, arch string, channel string, min bool) (semver.Version, error) {
+func GetChannelMinOrMax(ctx context.Context, c Client, arch string, channel string, min bool) (semver.Version, error) {
 	// Prepare parametrized cincinnati query.
 	c.SetQueryParams(arch, channel, "")
 

--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -105,13 +106,46 @@ func GetUpdates(ctx context.Context, c Client, arch string, channel string, vers
 		}
 	}
 
-	// Find the children of the current version.
-	var nextIdxs []int
+	edgesByOrigin := make(map[int][]int, len(graph.Nodes))
 	for _, edge := range graph.Edges {
-		if edge.Origin == currentIdx && edge.Destination == destinationIdx {
-			nextIdxs = append(nextIdxs, edge.Destination)
-		}
+		edgesByOrigin[edge.Origin] = append(edgesByOrigin[edge.Origin], edge.Destination)
 	}
+
+	// Sort destination by semver to ensure deterministic result
+	for origin, destinations := range edgesByOrigin {
+		sort.Slice(destinations, func(i, j int) bool {
+			return graph.Nodes[destinations[i]].Version.GT(graph.Nodes[destinations[j]].Version)
+		})
+		edgesByOrigin[origin] = destinations
+	}
+
+	var shortestPath func(map[int][]int, int, int, path) []int
+	shortestPath = func(g map[int][]int, start, end int, path path) []int {
+		path = append(path, start)
+		if start == end {
+			return path
+		}
+		adj := g[start]
+		// If we get through the map and the start never
+		// reaches the end, return nothing
+		if len(adj) == 0 {
+			return []int{}
+		}
+		shortest := make([]int, 0)
+		for _, node := range adj {
+			if !path.has(node) {
+				currPath := shortestPath(g, node, end, path)
+				if len(currPath) > 0 {
+					if len(shortest) == 0 || len(currPath) < len(shortest) {
+						shortest = currPath
+					}
+				}
+			}
+		}
+		return shortest
+	}
+
+	nextIdxs := shortestPath(edgesByOrigin, currentIdx, destinationIdx, path{})
 
 	var updates []Update
 	for _, i := range nextIdxs {
@@ -131,7 +165,7 @@ func CalculateUpgrades(ctx context.Context, c Client, arch, sourceChannel, targe
 	// Perform initial calculation for the source channel and
 	// recurse through the rest until the target or a blocked
 	// edge is hit
-	latest, err := GetChannelLatest(ctx, c, arch, sourceChannel)
+	latest, err := GetChannelMinorMax(ctx, c, arch, sourceChannel, false)
 	if err != nil {
 		return Update{}, Update{}, nil, fmt.Errorf("cannot get latest: %v", err)
 	}
@@ -143,7 +177,16 @@ func CalculateUpgrades(ctx context.Context, c Client, arch, sourceChannel, targe
 	requested, newUpgrades, err := calculate(ctx, c, arch, sourceChannel, targetChannel, latest, reqVer)
 	upgrades = append(upgrades, newUpgrades...)
 
-	return current, requested, upgrades, err
+	var finalUpgrades []Update
+	seen := make(map[string]struct{}, len(upgrades))
+	for _, upgrade := range upgrades {
+		if _, ok := seen[upgrade.Image]; !ok {
+			finalUpgrades = append(finalUpgrades, upgrade)
+			seen[upgrade.Image] = struct{}{}
+		}
+	}
+
+	return current, requested, finalUpgrades, err
 }
 
 func calculate(ctx context.Context, c Client, arch, sourceChannel, targetChannel string, startVer, reqVer semver.Version) (requested Update, upgrades []Update, err error) {
@@ -169,8 +212,9 @@ func calculate(ctx context.Context, c Client, arch, sourceChannel, targetChannel
 		// If this is the target channel get
 		// requested version so we don't exceed the maximun version
 		targetVer = reqVer
+		logrus.Info(targetVer)
 	} else {
-		targetVer, err = GetChannelLatest(ctx, c, arch, currChannel)
+		targetVer, err = GetChannelMinOrMax(ctx, c, arch, currChannel, false)
 		if err != nil {
 			return requested, upgrades, nil
 		}
@@ -216,7 +260,7 @@ func calculate(ctx context.Context, c Client, arch, sourceChannel, targetChannel
 
 // GetChannelLatest fetches the latest version from the specified
 // upstream Cincinnati stack given architecture and channel
-func GetChannelLatest(ctx context.Context, c Client, arch string, channel string) (semver.Version, error) {
+func GetChannelMinOrMax(ctx context.Context, c client, arch string, channel string, min bool) (semver.Version, error) {
 	// Prepare parametrized cincinnati query.
 	c.SetQueryParams(arch, channel, "")
 
@@ -240,6 +284,10 @@ func GetChannelLatest(ctx context.Context, c Client, arch string, channel string
 			Reason:  "NoVersionsFound",
 			Message: fmt.Sprintf("no cluster versions found for %q in the %q channel", arch, channel),
 		}
+	}
+
+	if min {
+		return Vers[0], nil
 	}
 
 	return Vers[len(Vers)-1], nil
@@ -386,4 +434,15 @@ func (e *edge) UnmarshalJSON(data []byte) error {
 	e.Destination = fields[1]
 
 	return nil
+}
+
+type path []int
+
+func (p path) has(num int) bool {
+	for _, v := range p {
+		if num == v {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"testing"
 
 	"github.com/blang/semver/v4"
@@ -30,40 +29,46 @@ func TestGetUpdates(t *testing.T) {
 		available     []Update
 		err           string
 	}{{
-		name:          "one update available",
+		name:          "Valid/DirectUpdate",
 		version:       "4.0.0-4",
 		reqVer:        "4.0.0-5",
 		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-4",
 		current:       Update{Version: semver.MustParse("4.0.0-4"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-4"},
 		requested:     Update{Version: semver.MustParse("4.0.0-5"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-5"},
 		available: []Update{
+			{Version: semver.MustParse("4.0.0-4"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-4"},
 			{Version: semver.MustParse("4.0.0-5"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-5"},
 		},
 	}, {
-		name:          "two updates available",
-		version:       "4.0.0-5",
-		reqVer:        "4.0.0-6",
-		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-5",
-		current:       Update{Version: semver.MustParse("4.0.0-5"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-5"},
-		requested:     Update{Version: semver.MustParse("4.0.0-6"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-6"},
+		name:          "Valid/FullChannel",
+		version:       "4.0.0-4",
+		reqVer:        "4.0.0-0.3",
+		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-4",
+		current:       Update{Version: semver.MustParse("4.0.0-4"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-4"},
+		requested:     Update{Version: semver.MustParse("4.0.0-0.3"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-0.3"},
 		available: []Update{
-			{Version: semver.MustParse("4.0.0-6"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-6"},
+			{Version: semver.MustParse("4.0.0-4"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-4"},
+			{Version: semver.MustParse("4.0.0-5"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-5"},
+			{Version: semver.MustParse("4.0.0-6+2"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-6+2"},
+			{Version: semver.MustParse("4.0.0-0.2"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-0.2"},
+			{Version: semver.MustParse("4.0.0-0.3"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-0.3"},
 		},
 	}, {
-		name:          "no updates available",
-		version:       "4.0.0-0.okd-0",
+		name:          "Valid/NoUpdates",
+		version:       "4.0.0-4",
 		reqVer:        "4.0.0-0.okd-0",
-		current:       Update{Version: semver.MustParse("4.0.0-0.okd-0"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-0.okd-0"},
+		current:       Update{Version: semver.MustParse("4.0.0-4"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-4"},
 		requested:     Update{Version: semver.MustParse("4.0.0-0.okd-0"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-0.okd-0"},
-		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-0.okd-0",
+		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-4",
+		available:     nil,
 	}, {
-		name:          "unknown version current",
+		name:          "Invalid/UnknownCurrentVersion",
 		version:       "4.0.0-3",
 		reqVer:        "0.0.0",
 		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-3",
 		err:           "VersionNotFound: current version 4.0.0-3 not found in the \"test-channel\" channel",
 	}, {
-		name:          "unknown version requested",
+		name:          "Invalid/UnknownRequestedVersion",
 		version:       "4.0.0-5",
 		reqVer:        "4.0.0-7",
 		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-5",
@@ -85,22 +90,12 @@ func TestGetUpdates(t *testing.T) {
 
 			current, requested, updates, err := GetUpdates(context.Background(), c, arch, channelName, semver.MustParse(test.version), semver.MustParse(test.reqVer))
 			if test.err == "" {
-				if err != nil {
-					t.Fatalf("expected nil error, got: %v", err)
-				}
-				if !reflect.DeepEqual(current, test.current) {
-					t.Fatalf("expected current %v, got: %v", test.current, current)
-				}
-				if !reflect.DeepEqual(requested, test.requested) {
-					t.Fatalf("expected current %v, got: %v", test.requested, requested)
-				}
-				if !reflect.DeepEqual(updates, test.available) {
-					t.Fatalf("expected updates %v, got: %v", test.available, updates)
-				}
+				require.NoError(t, err)
+				require.Equal(t, test.current, current)
+				require.Equal(t, test.requested, requested)
+				require.Equal(t, test.available, updates)
 			} else {
-				if err == nil || err.Error() != test.err {
-					t.Fatalf("expected err to be %s, got: %v", test.err, err)
-				}
+				require.EqualError(t, err, test.err)
 			}
 
 			actualQuery := ""
@@ -110,33 +105,33 @@ func TestGetUpdates(t *testing.T) {
 				t.Fatal("no request received at upstream URL")
 			}
 			expectedQueryValues, err := url.ParseQuery(test.expectedQuery)
-			if err != nil {
-				t.Fatalf("could not parse expected query: %v", err)
-			}
+			require.NoError(t, err)
 			actualQueryValues, err := url.ParseQuery(actualQuery)
-			if err != nil {
-				t.Fatalf("could not parse acutal query: %v", err)
-			}
-			if e, a := expectedQueryValues, actualQueryValues; !reflect.DeepEqual(e, a) {
-				t.Errorf("expected query to be %q, got: %q", e, a)
-			}
+			require.NoError(t, err)
+			require.Equal(t, expectedQueryValues, actualQueryValues)
 		})
 	}
 }
 
-func TestGetLatest(t *testing.T) {
+func TestGetMinorMax(t *testing.T) {
 	arch := "test-arch"
 	channelName := "test-channel"
 	tests := []struct {
 		name string
 
 		expectedQuery string
-		latest        semver.Version
+		version       semver.Version
+		min           bool
 		err           string
 	}{{
-		name:          "one update available",
+		name:          "Valid/MaxChannel",
 		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab",
-		latest:        semver.MustParse("4.0.0-6+2"),
+		version:       semver.MustParse("4.0.0-6+2"),
+	}, {
+		name:          "Valid/MinChannel",
+		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab",
+		version:       semver.MustParse("4.0.0-0.2"),
+		min:           true,
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -152,18 +147,13 @@ func TestGetLatest(t *testing.T) {
 			require.NoError(t, err)
 			c := &mockClient{url: endpoint}
 
-			latest, err := GetChannelLatest(context.Background(), c, arch, channelName)
+			latest, err := GetChannelMinOrMax(context.Background(), c, arch, channelName, test.min)
 			if test.err == "" {
-				if err != nil {
-					t.Fatalf("expected nil error, got: %v", err)
-				}
-				if !reflect.DeepEqual(latest, test.latest) {
-					t.Fatalf("expected version %v, got: %v", test.latest, latest)
-				}
+				require.NoError(t, err)
+				require.Equal(t, test.version, version)
+
 			} else {
-				if err == nil || err.Error() != test.err {
-					t.Fatalf("expected err to be %s, got: %v", test.err, err)
-				}
+				require.EqualError(t, err, test.err)
 			}
 
 			actualQuery := ""
@@ -173,16 +163,10 @@ func TestGetLatest(t *testing.T) {
 				t.Fatal("no request received at upstream URL")
 			}
 			expectedQueryValues, err := url.ParseQuery(test.expectedQuery)
-			if err != nil {
-				t.Fatalf("could not parse expected query: %v", err)
-			}
+			require.NoError(t, err)
 			actualQueryValues, err := url.ParseQuery(actualQuery)
-			if err != nil {
-				t.Fatalf("could not parse acutal query: %v", err)
-			}
-			if e, a := expectedQueryValues, actualQueryValues; !reflect.DeepEqual(e, a) {
-				t.Errorf("expected query to be %q, got: %q", e, a)
-			}
+			require.NoError(t, err)
+			require.Equal(t, expectedQueryValues, actualQueryValues)
 		})
 	}
 }
@@ -196,7 +180,7 @@ func TestGetVersions(t *testing.T) {
 		versions      []semver.Version
 		err           string
 	}{{
-		name:          "one update available",
+		name:          "Valid/OneChannel",
 		expectedQuery: "channel=test-channel&id=01234567-0123-0123-0123-0123456789ab",
 		versions:      getSemVers([]string{"4.0.0-0.2", "4.0.0-0.3", "4.0.0-0.okd-0", "4.0.0-4", "4.0.0-5", "4.0.0-6", "4.0.0-6+2"}),
 	}}
@@ -216,16 +200,11 @@ func TestGetVersions(t *testing.T) {
 
 			versions, err := GetVersions(context.Background(), c, channelName)
 			if test.err == "" {
-				if err != nil {
-					t.Fatalf("expected nil error, got: %v", err)
-				}
-				if !reflect.DeepEqual(versions, test.versions) {
-					t.Fatalf("expected version %v, got: %v", test.versions, versions)
-				}
+				require.NoError(t, err)
+				require.Equal(t, test.versions, versions)
+
 			} else {
-				if err == nil || err.Error() != test.err {
-					t.Fatalf("expected err to be %s, got: %v", test.err, err)
-				}
+				require.EqualError(t, err, test.err)
 			}
 
 			actualQuery := ""
@@ -235,16 +214,10 @@ func TestGetVersions(t *testing.T) {
 				t.Fatal("no request received at upstream URL")
 			}
 			expectedQueryValues, err := url.ParseQuery(test.expectedQuery)
-			if err != nil {
-				t.Fatalf("could not parse expected query: %v", err)
-			}
+			require.NoError(t, err)
 			actualQueryValues, err := url.ParseQuery(actualQuery)
-			if err != nil {
-				t.Fatalf("could not parse acutal query: %v", err)
-			}
-			if e, a := expectedQueryValues, actualQueryValues; !reflect.DeepEqual(e, a) {
-				t.Errorf("expected query to be %q, got: %q", e, a)
-			}
+			require.NoError(t, err)
+			require.Equal(t, expectedQueryValues, actualQueryValues)
 		})
 	}
 }
@@ -271,6 +244,7 @@ func TestCalculateUpgrades(t *testing.T) {
 		current:       Update{Version: semver.MustParse("4.0.0-5"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-5"},
 		requested:     Update{Version: semver.MustParse("4.1.0-6"), Image: "quay.io/openshift-release-dev/ocp-release:4.1.0-6"},
 		needed: []Update{
+			{Version: semver.MustParse("4.0.0-5"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-5"},
 			{Version: semver.MustParse("4.0.0-6"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-6"},
 			{Version: semver.MustParse("4.1.0-6"), Image: "quay.io/openshift-release-dev/ocp-release:4.1.0-6"},
 		},
@@ -283,6 +257,7 @@ func TestCalculateUpgrades(t *testing.T) {
 		current:       Update{Version: semver.MustParse("4.0.0-5"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-5"},
 		requested:     Update{Version: semver.MustParse("4.2.0-3"), Image: "quay.io/openshift-release-dev/ocp-release:4.2.0-3"},
 		needed: []Update{
+			{Version: semver.MustParse("4.0.0-5"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-5"},
 			{Version: semver.MustParse("4.0.0-6"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-6"},
 			{Version: semver.MustParse("4.1.0-6"), Image: "quay.io/openshift-release-dev/ocp-release:4.1.0-6"},
 			{Version: semver.MustParse("4.2.0-3"), Image: "quay.io/openshift-release-dev/ocp-release:4.2.0-3"},
@@ -295,7 +270,9 @@ func TestCalculateUpgrades(t *testing.T) {
 		req:           semver.MustParse("4.2.0-2"),
 		current:       Update{Version: semver.MustParse("4.1.0-6"), Image: "quay.io/openshift-release-dev/ocp-release:4.1.0-6"},
 		requested:     Update{Version: semver.MustParse("4.2.0-2"), Image: "quay.io/openshift-release-dev/ocp-release:4.2.0-2"},
-		needed:        nil,
+		needed: []Update{
+			{Version: semver.MustParse("4.1.0-6"), Image: "quay.io/openshift-release-dev/ocp-release:4.1.0-6"},
+		},
 	}, {
 		name:          "SuccessWithWarning/BlockedEdge",
 		sourceChannel: "stable-4.2",
@@ -305,6 +282,7 @@ func TestCalculateUpgrades(t *testing.T) {
 		current:       Update{Version: semver.MustParse("4.2.0-3"), Image: "quay.io/openshift-release-dev/ocp-release:4.2.0-3"},
 		requested:     Update{Version: semver.MustParse("4.3.0"), Image: "quay.io/openshift-release-dev/ocp-release:4.3.0"},
 		needed: []Update{
+			{Version: semver.MustParse("4.2.0-3"), Image: "quay.io/openshift-release-dev/ocp-release:4.2.0-3"},
 			{Version: semver.MustParse("4.2.0-5"), Image: "quay.io/openshift-release-dev/ocp-release:4.2.0-5"},
 		},
 	}, {
@@ -434,16 +412,11 @@ func TestNodeUnmarshalJSON(t *testing.T) {
 			var n node
 			err := json.Unmarshal(test.raw, &n)
 			if test.err == "" {
-				if err != nil {
-					t.Fatalf("expecting nil error, got: %v", err)
-				}
-				if !reflect.DeepEqual(n, test.exp) {
-					t.Fatalf("expecting %v got %v", test.exp, n)
-				}
+				require.NoError(t, err)
+				require.Equal(t, test.exp, n)
+
 			} else {
-				if err.Error() != test.err {
-					t.Fatalf("expecting %s error, got: %v", test.err, err)
-				}
+				require.EqualError(t, err, test.err)
 			}
 		})
 	}
@@ -506,11 +479,11 @@ func getHandler(t *testing.T, requestQuery chan<- string) http.HandlerFunc {
 				"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.3"
 			  }
 			],
-			"edges": [[0,1],[1,2],[1,3],[5,6]]
+			"edges": [[0,1],[1,2],[2,3],[1,3],[3,5],[5,6]]
 		  }`))
 		if err != nil {
-			t.Fatal(err)
 			w.WriteHeader(http.StatusInternalServerError)
+			t.Fatal(err)
 			return
 		}
 	}
@@ -640,8 +613,8 @@ func getHandlerMulti(t *testing.T, requestQuery chan<- string) http.HandlerFunc 
 				"edges": [[0,2],[1,2],[2,3]]
 			}`))
 			if err != nil {
-				t.Fatal(err)
 				w.WriteHeader(http.StatusInternalServerError)
+				t.Fatal(err)
 				return
 			}
 		case ch == "stable-4.3":
@@ -659,8 +632,8 @@ func getHandlerMulti(t *testing.T, requestQuery chan<- string) http.HandlerFunc 
 				"edges": [[0,1]]
 			}`))
 			if err != nil {
-				t.Fatal(err)
 				w.WriteHeader(http.StatusInternalServerError)
+				t.Fatal(err)
 				return
 			}
 		default:

--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -147,7 +147,7 @@ func TestGetMinorMax(t *testing.T) {
 			require.NoError(t, err)
 			c := &mockClient{url: endpoint}
 
-			latest, err := GetChannelMinOrMax(context.Background(), c, arch, channelName, test.min)
+			version, err := GetChannelMinOrMax(context.Background(), c, arch, channelName, test.min)
 			if test.err == "" {
 				require.NoError(t, err)
 				require.Equal(t, test.version, version)

--- a/pkg/cli/mirror/list/updates.go
+++ b/pkg/cli/mirror/list/updates.go
@@ -127,7 +127,7 @@ func (o UpdatesOptions) releaseUpdates(ctx context.Context, arch string, cfg v1a
 		if err != nil {
 			return err
 		}
-		latest, err := cincinnati.GetChannelLatest(ctx, c, arch, ch.Name)
+		latest, err := cincinnati.GetChannelMinOrMax(ctx, c, arch, ch.Name, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/mirror/release.go
+++ b/pkg/cli/mirror/release.go
@@ -56,7 +56,7 @@ func (o *ReleaseOptions) Plan(ctx context.Context, lastRun v1alpha2.PastMirror, 
 
 	for _, arch := range o.arch {
 
-		channelVersion := make(map[string]string, len(cfg.Mirror.OCP.Channels))
+		versionsByChannel := make(map[string]v1alpha2.ReleaseChannel, len(cfg.Mirror.OCP.Channels))
 
 		for _, ch := range cfg.Mirror.OCP.Channels {
 
@@ -74,15 +74,25 @@ func (o *ReleaseOptions) Plan(ctx context.Context, lastRun v1alpha2.PastMirror, 
 
 			if len(ch.MaxVersion) == 0 && len(ch.MinVersion) == 0 {
 				// If no version was specified from the channel, then get the latest release
-				latest, err := cincinnati.GetChannelLatest(ctx, client, arch, ch.Name)
+				latest, err := cincinnati.GetChannelMinOrMax(ctx, client, arch, ch.Name, false)
 				if err != nil {
 					errs = append(errs, err)
 					continue
 				}
+
 				// Update version to release channel
 				ch.MaxVersion = latest.String()
 				ch.MinVersion = latest.String()
-				channelVersion[ch.Name] = latest.String()
+
+				if !*ch.HeadsOnly {
+					first, err := cincinnati.GetChannelMinOrMax(ctx, client, arch, ch.Name, true)
+					if err != nil {
+						errs = append(errs, err)
+						continue
+					}
+					ch.MinVersion = first.String()
+				}
+				versionsByChannel[ch.Name] = ch
 			}
 
 			downloads, err := o.getChannelDownloads(ctx, client, lastRun.Mirror.OCP.Channels, ch, arch)
@@ -95,13 +105,16 @@ func (o *ReleaseOptions) Plan(ctx context.Context, lastRun v1alpha2.PastMirror, 
 
 		// Update cfg release channels with maximum and minimum versions
 		// if applicable
-		cfg.Mirror.OCP.Channels = updateReleaseChannel(cfg.Mirror.OCP.Channels, channelVersion)
-		newDownloads, err := o.getCrossChannelDownloads(ctx, arch, cfg.Mirror.OCP.Channels)
-		if err != nil {
-			errs = append(errs, err)
-			continue
+		cfg.Mirror.OCP.Channels = updateReleaseChannel(cfg.Mirror.OCP.Channels, versionsByChannel)
+
+		if len(cfg.Mirror.OCP.Channels) > 1 {
+			newDownloads, err := o.getCrossChannelDownloads(ctx, arch, cfg.Mirror.OCP.Channels)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			releaseDownloads.Merge(newDownloads)
 		}
-		releaseDownloads.Merge(newDownloads)
 	}
 	if len(errs) != 0 {
 		return mmapping, utilerrors.NewAggregate(errs)
@@ -287,12 +300,11 @@ func (o *ReleaseOptions) getMapping(opts *release.MirrorOptions) (image.TypedIma
 
 // updateReleaseChannel will add a version to the ReleaseChannel to record
 // for metadata
-func updateReleaseChannel(releaseChannels []v1alpha2.ReleaseChannel, channelVersions map[string]string) []v1alpha2.ReleaseChannel {
+func updateReleaseChannel(releaseChannels []v1alpha2.ReleaseChannel, versionsByKey map[string]v1alpha2.ReleaseChannel) []v1alpha2.ReleaseChannel {
 	for i, ch := range releaseChannels {
-		v, found := channelVersions[ch.Name]
+		ch, found := versionsByKey[ch.Name]
 		if found {
-			releaseChannels[i].MaxVersion = v
-			releaseChannels[i].MinVersion = v
+			releaseChannels[i] = ch
 		}
 	}
 	return releaseChannels

--- a/pkg/config/v1alpha2/config_types.go
+++ b/pkg/config/v1alpha2/config_types.go
@@ -49,6 +49,16 @@ type ReleaseChannel struct {
 	// MaxVersion is maximum version in the
 	// release channel to mirror
 	MaxVersion string `json:"maxVersion"`
+	// HeadsOnly mode mirrors only the channel head.
+	// The default is true.
+	HeadsOnly *bool `json:"headsOnly,omitempty"`
+}
+
+func (r ReleaseChannel) IsHeadsOnly() bool {
+	if r.HeadsOnly == nil {
+		return true
+	}
+	return *r.HeadsOnly
 }
 
 // Operator configures operator catalog mirroring.

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -9,7 +9,7 @@ import (
 
 type validationFunc func(cfg *v1alpha2.ImageSetConfiguration) error
 
-var validationChecks = []validationFunc{validateOperatorOptions, validateReleaseOptions}
+var validationChecks = []validationFunc{validateOperatorOptions}
 
 func Validate(cfg *v1alpha2.ImageSetConfiguration) error {
 	var errs []error
@@ -26,22 +26,6 @@ func validateOperatorOptions(cfg *v1alpha2.ImageSetConfiguration) error {
 		if len(ctlg.IncludeConfig.Packages) != 0 && ctlg.IsHeadsOnly() {
 			return errors.New(
 				"invalid configuration option: catalog cannot define packages with headsOnly set to true",
-			)
-		}
-	}
-	return nil
-}
-
-func validateReleaseOptions(cfg *v1alpha2.ImageSetConfiguration) error {
-	for _, ch := range cfg.Mirror.OCP.Channels {
-		if len(ch.MaxVersion) == 0 && len(ch.MinVersion) > 0 {
-			return errors.New(
-				"invalid configuration option: release channel must have a maximum version specified",
-			)
-		}
-		if len(ch.MinVersion) == 0 && len(ch.MaxVersion) > 0 {
-			return errors.New(
-				"invalid configuration option: release channel must have a minimum version specified",
 			)
 		}
 	}

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -70,39 +70,6 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
-			name: "Valid/MinandMaxReleaseVersionSet",
-			config: &v1alpha2.ImageSetConfiguration{
-				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
-					Mirror: v1alpha2.Mirror{
-						OCP: v1alpha2.OCP{
-							Channels: []v1alpha2.ReleaseChannel{
-								{
-									MinVersion: "1.2.3",
-									MaxVersion: "1.2.3",
-								},
-							},
-						},
-					},
-				},
-			},
-			expError: "",
-		},
-		{
-			name: "Valid/MinandMaxReleaseVersionNotSet",
-			config: &v1alpha2.ImageSetConfiguration{
-				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
-					Mirror: v1alpha2.Mirror{
-						OCP: v1alpha2.OCP{
-							Channels: []v1alpha2.ReleaseChannel{
-								{},
-							},
-						},
-					},
-				},
-			},
-			expError: "",
-		},
-		{
 			name: "Invalid/HeadsOnlyTrue",
 			config: &v1alpha2.ImageSetConfiguration{
 				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
@@ -119,40 +86,6 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			expError: "invalid configuration option: catalog cannot define packages with headsOnly set to true",
-		},
-		{
-			name: "Invalid/NoMinimumReleaseVersion",
-			config: &v1alpha2.ImageSetConfiguration{
-				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
-					Mirror: v1alpha2.Mirror{
-						OCP: v1alpha2.OCP{
-							Channels: []v1alpha2.ReleaseChannel{
-								{
-									MaxVersion: "1.2.3",
-								},
-							},
-						},
-					},
-				},
-			},
-			expError: "invalid configuration option: release channel must have a minimum version specified",
-		},
-		{
-			name: "Invalid/NoMaximunReleaseVersion",
-			config: &v1alpha2.ImageSetConfiguration{
-				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
-					Mirror: v1alpha2.Mirror{
-						OCP: v1alpha2.OCP{
-							Channels: []v1alpha2.ReleaseChannel{
-								{
-									MinVersion: "1.2.3",
-								},
-							},
-						},
-					},
-				},
-			},
-			expError: "invalid configuration option: release channel must have a maximum version specified",
 		},
 	}
 


### PR DESCRIPTION
… pulls

The `headsOnly` configuration, in terms of releases, is meant to enable only the latest
OCP versions from channels to be mirrored. It defaults to true. When set to false, the min
and the max OCP versions in the channel will be chosen and the shortest upgrade path between the two
will be calculated and mirrored.

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

^^ 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules