### PR TITLE
Bug 2060837: resolves multiple channel heads in merged catalogs

### DIFF
--- a/pkg/operator/merge.go
+++ b/pkg/operator/merge.go
@@ -4,8 +4,12 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/blang/semver/v4"
 	"github.com/imdario/mergo"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
+	"github.com/operator-framework/operator-registry/alpha/model"
+	"github.com/operator-framework/operator-registry/alpha/property"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // Merger is an object that will complete merge actions declarative config options
@@ -14,11 +18,9 @@ type Merger interface {
 }
 
 func validate(cfg *declcfg.DeclarativeConfig) error {
-	model, err := declcfg.ConvertToModel(*cfg)
-	if err != nil {
-		return err
-	}
-	return model.Validate()
+	// configs are validated after being converted to a model
+	_, err := declcfg.ConvertToModel(*cfg)
+	return err
 }
 
 var _ Merger = &PreferLastStrategy{}
@@ -103,12 +105,28 @@ func mergeDCTwoWay(cfg *declcfg.DeclarativeConfig) error {
 	if cfg.Packages, err = mergePackages(cfg.Packages); err != nil {
 		return err
 	}
+
 	if cfg.Channels, err = mergeChannels(cfg.Channels); err != nil {
 		return err
 	}
+
 	if cfg.Bundles, err = mergeBundles(cfg.Bundles); err != nil {
 		return err
 	}
+
+	model, err := convertToModelNoValidate(*cfg)
+	if err != nil {
+		return err
+	}
+
+	newCfg, err := resolveChannelHeads(model)
+	if err != nil {
+		return fmt.Errorf("error resolving channel heads: %v", err)
+	}
+	cfg.Bundles = newCfg.Bundles
+	cfg.Channels = newCfg.Channels
+	cfg.Others = newCfg.Others
+	cfg.Packages = newCfg.Packages
 
 	// There is no way to merge "other" schema since a unique key field is unknown.
 	return validate(cfg)
@@ -265,4 +283,226 @@ func keyForDCObj(obj interface{}) string {
 		// This should never happen.
 		panic(fmt.Sprintf("bug: unrecognized type %T, expected one of declcfg.Package, Channel, Bundle", t))
 	}
+}
+
+func resolveChannelHeads(inputModel model.Model) (declcfg.DeclarativeConfig, error) {
+	for _, mpkg := range inputModel {
+		for _, mch := range mpkg.Channels {
+			incoming := map[string]int{}
+			for _, b := range mch.Bundles {
+				if b.Replaces != "" {
+					incoming[b.Replaces]++
+				}
+				for _, skip := range b.Skips {
+					incoming[skip]++
+				}
+			}
+			heads := make(map[string]*model.Bundle)
+			for _, b := range mch.Bundles {
+				if _, ok := incoming[b.Name]; !ok {
+					heads[b.Version.String()] = b
+				}
+			}
+
+			if len(heads) > 1 {
+				keys := make([]semver.Version, 0, len(heads))
+				for k := range heads {
+					keys = append(keys, semver.MustParse(k))
+				}
+				sort.Slice(keys, func(i, j int) bool {
+					return keys[i].LT(keys[j])
+				})
+				head := heads[keys[len(keys)-1].String()]
+				oldVers := keys[:len(keys)-1]
+				for _, ver := range oldVers {
+					if head.Replaces == ver.String() {
+						continue
+					}
+					// If the old version falls within the new channel head's
+					// skip range, prune the old head
+					skipRange, err := semver.ParseRange(head.SkipRange)
+					if err != nil {
+						return declcfg.DeclarativeConfig{}, err
+					}
+					if skipRange(ver) {
+						oldHead := heads[ver.String()]
+						delete(mch.Bundles, oldHead.Name)
+					}
+				}
+
+			}
+		}
+	}
+	return declcfg.ConvertFromModel(inputModel), nil
+}
+
+// Copied from  https://github.com/operator-framework/operator-registry/blob/master/alpha/declcfg/declcfg_to_model.go
+// Temporary solution
+func convertToModelNoValidate(cfg declcfg.DeclarativeConfig) (model.Model, error) {
+	mpkgs := model.Model{}
+	defaultChannels := map[string]string{}
+	for _, p := range cfg.Packages {
+		if p.Name == "" {
+			return nil, fmt.Errorf("config contains package with no name")
+		}
+
+		if _, ok := mpkgs[p.Name]; ok {
+			return nil, fmt.Errorf("duplicate package %q", p.Name)
+		}
+
+		mpkg := &model.Package{
+			Name:        p.Name,
+			Description: p.Description,
+			Channels:    map[string]*model.Channel{},
+		}
+		if p.Icon != nil {
+			mpkg.Icon = &model.Icon{
+				Data:      p.Icon.Data,
+				MediaType: p.Icon.MediaType,
+			}
+		}
+		defaultChannels[p.Name] = p.DefaultChannel
+		mpkgs[p.Name] = mpkg
+	}
+
+	channelDefinedEntries := map[string]sets.String{}
+	for _, c := range cfg.Channels {
+		mpkg, ok := mpkgs[c.Package]
+		if !ok {
+			return nil, fmt.Errorf("unknown package %q for channel %q", c.Package, c.Name)
+		}
+
+		if c.Name == "" {
+			return nil, fmt.Errorf("package %q contains channel with no name", c.Package)
+		}
+
+		if _, ok := mpkg.Channels[c.Name]; ok {
+			return nil, fmt.Errorf("package %q has duplicate channel %q", c.Package, c.Name)
+		}
+
+		mch := &model.Channel{
+			Package: mpkg,
+			Name:    c.Name,
+			Bundles: map[string]*model.Bundle{},
+		}
+
+		cde := sets.NewString()
+		for _, entry := range c.Entries {
+			if _, ok := mch.Bundles[entry.Name]; ok {
+				return nil, fmt.Errorf("invalid package %q, channel %q: duplicate entry %q", c.Package, c.Name, entry.Name)
+			}
+			cde = cde.Insert(entry.Name)
+			mch.Bundles[entry.Name] = &model.Bundle{
+				Package:   mpkg,
+				Channel:   mch,
+				Name:      entry.Name,
+				Replaces:  entry.Replaces,
+				Skips:     entry.Skips,
+				SkipRange: entry.SkipRange,
+			}
+		}
+		channelDefinedEntries[c.Package] = cde
+
+		mpkg.Channels[c.Name] = mch
+
+		defaultChannelName := defaultChannels[c.Package]
+		if defaultChannelName == c.Name {
+			mpkg.DefaultChannel = mch
+		}
+	}
+
+	// packageBundles tracks the set of bundle names for each package
+	// and is used to detect duplicate bundles.
+	packageBundles := map[string]sets.String{}
+
+	for _, b := range cfg.Bundles {
+		if b.Package == "" {
+			return nil, fmt.Errorf("package name must be set for bundle %q", b.Name)
+		}
+		mpkg, ok := mpkgs[b.Package]
+		if !ok {
+			return nil, fmt.Errorf("unknown package %q for bundle %q", b.Package, b.Name)
+		}
+
+		bundles, ok := packageBundles[b.Package]
+		if !ok {
+			bundles = sets.NewString()
+		}
+		if bundles.Has(b.Name) {
+			return nil, fmt.Errorf("package %q has duplicate bundle %q", b.Package, b.Name)
+		}
+		bundles.Insert(b.Name)
+		packageBundles[b.Package] = bundles
+
+		props, err := property.Parse(b.Properties)
+		if err != nil {
+			return nil, fmt.Errorf("parse properties for bundle %q: %v", b.Name, err)
+		}
+
+		if len(props.Packages) != 1 {
+			return nil, fmt.Errorf("package %q bundle %q must have exactly 1 %q property, found %d", b.Package, b.Name, property.TypePackage, len(props.Packages))
+		}
+
+		if b.Package != props.Packages[0].PackageName {
+			return nil, fmt.Errorf("package %q does not match %q property %q", b.Package, property.TypePackage, props.Packages[0].PackageName)
+		}
+
+		// Parse version from the package property.
+		rawVersion := props.Packages[0].Version
+		ver, err := semver.Parse(rawVersion)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing bundle %q version %q: %v", b.Name, rawVersion, err)
+		}
+
+		channelDefinedEntries[b.Package] = channelDefinedEntries[b.Package].Delete(b.Name)
+		found := false
+		for _, mch := range mpkg.Channels {
+			if mb, ok := mch.Bundles[b.Name]; ok {
+				found = true
+				mb.Image = b.Image
+				mb.Properties = b.Properties
+				mb.RelatedImages = relatedImagesToModelRelatedImages(b.RelatedImages)
+				mb.CsvJSON = b.CsvJSON
+				mb.Objects = b.Objects
+				mb.PropertiesP = props
+				mb.Version = ver
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("package %q, bundle %q not found in any channel entries", b.Package, b.Name)
+		}
+	}
+
+	for pkg, entries := range channelDefinedEntries {
+		if entries.Len() > 0 {
+			return nil, fmt.Errorf("no olm.bundle blobs found in package %q for olm.channel entries %s", pkg, entries.List())
+		}
+	}
+
+	for _, mpkg := range mpkgs {
+		defaultChannelName := defaultChannels[mpkg.Name]
+		if defaultChannelName != "" && mpkg.DefaultChannel == nil {
+			dch := &model.Channel{
+				Package: mpkg,
+				Name:    defaultChannelName,
+				Bundles: map[string]*model.Bundle{},
+			}
+			mpkg.DefaultChannel = dch
+			mpkg.Channels[dch.Name] = dch
+		}
+	}
+
+	mpkgs.Normalize()
+	return mpkgs, nil
+}
+
+func relatedImagesToModelRelatedImages(in []declcfg.RelatedImage) []model.RelatedImage {
+	var out []model.RelatedImage
+	for _, p := range in {
+		out = append(out, model.RelatedImage{
+			Name:  p.Name,
+			Image: p.Image,
+		})
+	}
+	return out
 }

--- a/pkg/operator/merge.go
+++ b/pkg/operator/merge.go
@@ -13,6 +13,14 @@ type Merger interface {
 	Merge(*declcfg.DeclarativeConfig) error
 }
 
+func validate(cfg *declcfg.DeclarativeConfig) error {
+	model, err := declcfg.ConvertToModel(*cfg)
+	if err != nil {
+		return err
+	}
+	return model.Validate()
+}
+
 var _ Merger = &PreferLastStrategy{}
 
 type PreferLastStrategy struct{}
@@ -77,7 +85,7 @@ func mergeDCPreferLast(cfg *declcfg.DeclarativeConfig) error {
 	}
 
 	// There is no way to merge "other" schema since a unique key field is unknown.
-	return nil
+	return validate(cfg)
 }
 
 var _ Merger = &TwoWayStrategy{}
@@ -101,8 +109,9 @@ func mergeDCTwoWay(cfg *declcfg.DeclarativeConfig) error {
 	if cfg.Bundles, err = mergeBundles(cfg.Bundles); err != nil {
 		return err
 	}
+
 	// There is no way to merge "other" schema since a unique key field is unknown.
-	return nil
+	return validate(cfg)
 }
 
 // mergePackage Packages merges all declcfg.Packages with the same name into one declcfg.Package object.

--- a/pkg/operator/merge_test.go
+++ b/pkg/operator/merge_test.go
@@ -197,11 +197,15 @@ func TestMerge(t *testing.T) {
 			expDC: &declcfg.DeclarativeConfig{
 				Packages: []declcfg.Package{
 					{Schema: "olm.package", Name: "bar", DefaultChannel: "stable"},
+					{Schema: "olm.package", Name: "baz", DefaultChannel: "stable"},
 					{Schema: "olm.package", Name: "foo", DefaultChannel: "stable"},
 				},
 				Channels: []declcfg.Channel{
 					{Schema: "olm.channel", Name: "stable", Package: "bar", Entries: []declcfg.ChannelEntry{
 						{Name: "bar.v0.1.0"},
+					}},
+					{Schema: "olm.channel", Name: "stable", Package: "baz", Entries: []declcfg.ChannelEntry{
+						{Name: "baz.v3.0.0", SkipRange: ">=0.1.17 <3.0.0"},
 					}},
 					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
 						{Name: "foo.v0.0.5"},
@@ -219,6 +223,15 @@ func TestMerge(t *testing.T) {
 							// Can't merge properties since their keys are unknown.
 							property.MustBuildGVKRequired("etcd.database.coreos.com", "v1", "EtcdBackup"),
 							property.MustBuildPackage("bar", "0.1.0"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "baz.v3.0.0",
+						Package: "baz",
+						Image:   "reg/baz:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("baz", "3.0.0"),
 						},
 					},
 					{
@@ -246,24 +259,6 @@ func TestMerge(t *testing.T) {
 						Image:   "reg/foo:latest",
 						Properties: []property.Property{
 							property.MustBuildPackage("foo", "0.1.1"),
-						},
-					},
-					{
-						Schema:  "olm.bundle",
-						Name:    "baz.v3.0.0",
-						Package: "baz",
-						Image:   "reg/baz:latest",
-						Properties: []property.Property{
-							property.MustBuildPackage("baz", "3.0.0"),
-						},
-					},
-					{
-						Schema:  "olm.bundle",
-						Name:    "baz.v2.0.0",
-						Package: "baz",
-						Image:   "reg/baz:latest",
-						Properties: []property.Property{
-							property.MustBuildPackage("baz", "2.0.0"),
 						},
 					},
 				},

--- a/pkg/operator/merge_test.go
+++ b/pkg/operator/merge_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMergeDC(t *testing.T) {
+func TestMerge(t *testing.T) {
 	type spec struct {
 		name      string
 		mt        Merger
@@ -103,20 +103,27 @@ func TestMergeDC(t *testing.T) {
 			dc: &declcfg.DeclarativeConfig{
 				Packages: []declcfg.Package{
 					{Schema: "olm.package", Name: "foo", DefaultChannel: "stable"},
-					{Schema: "olm.package", Name: "foo", DefaultChannel: "alpha"},
 					{Schema: "olm.package", Name: "bar", DefaultChannel: "stable"},
+					{Schema: "olm.package", Name: "baz", DefaultChannel: "stable"},
 				},
 				Channels: []declcfg.Channel{
 					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.0.5"},
 						{Name: "foo.v0.1.0"},
 						{Name: "foo.v0.1.0", Replaces: "foo.v0.0.5"},
 						{Name: "foo.v0.1.0", Skips: []string{"foo.v0.0.4"}},
 					}},
 					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
-						{Name: "foo.v0.1.1", Replaces: "foo.v1.0.0"},
+						{Name: "foo.v0.1.1", Replaces: "foo.v0.1.0"},
 					}},
 					{Schema: "olm.channel", Name: "stable", Package: "bar", Entries: []declcfg.ChannelEntry{
 						{Name: "bar.v0.1.0"},
+					}},
+					{Schema: "olm.channel", Name: "stable", Package: "baz", Entries: []declcfg.ChannelEntry{
+						{Name: "baz.v2.0.0", SkipRange: ">=0.1.17 <2.0.0"},
+					}},
+					{Schema: "olm.channel", Name: "stable", Package: "baz", Entries: []declcfg.ChannelEntry{
+						{Name: "baz.v3.0.0", SkipRange: ">=0.1.17 <3.0.0"},
 					}},
 				},
 				Bundles: []declcfg.Bundle{
@@ -167,20 +174,39 @@ func TestMergeDC(t *testing.T) {
 							property.MustBuildPackage("bar", "0.1.0"),
 						},
 					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "baz.v3.0.0",
+						Package: "baz",
+						Image:   "reg/baz:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("baz", "3.0.0"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "baz.v2.0.0",
+						Package: "baz",
+						Image:   "reg/baz:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("baz", "2.0.0"),
+						},
+					},
 				},
 			},
 			expDC: &declcfg.DeclarativeConfig{
 				Packages: []declcfg.Package{
 					{Schema: "olm.package", Name: "bar", DefaultChannel: "stable"},
-					{Schema: "olm.package", Name: "foo", DefaultChannel: "alpha"},
+					{Schema: "olm.package", Name: "foo", DefaultChannel: "stable"},
 				},
 				Channels: []declcfg.Channel{
 					{Schema: "olm.channel", Name: "stable", Package: "bar", Entries: []declcfg.ChannelEntry{
 						{Name: "bar.v0.1.0"},
 					}},
 					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.0.5"},
 						{Name: "foo.v0.1.0", Replaces: "foo.v0.0.5", Skips: []string{"foo.v0.0.4"}},
-						{Name: "foo.v0.1.1", Replaces: "foo.v1.0.0"},
+						{Name: "foo.v0.1.1", Replaces: "foo.v0.1.0"},
 					}},
 				},
 				Bundles: []declcfg.Bundle{
@@ -220,6 +246,24 @@ func TestMergeDC(t *testing.T) {
 						Image:   "reg/foo:latest",
 						Properties: []property.Property{
 							property.MustBuildPackage("foo", "0.1.1"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "baz.v3.0.0",
+						Package: "baz",
+						Image:   "reg/baz:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("baz", "3.0.0"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "baz.v2.0.0",
+						Package: "baz",
+						Image:   "reg/baz:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("baz", "2.0.0"),
 						},
 					},
 				},
@@ -315,11 +359,13 @@ func TestMergeDC(t *testing.T) {
 					{Schema: "olm.package", Name: "bar", DefaultChannel: "stable"},
 				},
 				Channels: []declcfg.Channel{
+					{Schema: "olm.channel", Name: "alpha", Package: "foo", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.1.0"},
+					}},
 					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
 						{Name: "foo.v0.1.0"},
 					}},
 					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
-						{Name: "foo.v0.5.0"},
 						{Name: "foo.v0.1.0", Replaces: "foo.v0.0.5"},
 					}},
 					{Schema: "olm.channel", Name: "stable", Package: "bar", Entries: []declcfg.ChannelEntry{
@@ -327,15 +373,6 @@ func TestMergeDC(t *testing.T) {
 					}},
 				},
 				Bundles: []declcfg.Bundle{
-					{
-						Schema:  "olm.bundle",
-						Name:    "foo.v0.0.5",
-						Package: "foo",
-						Image:   "reg/foo:latest",
-						Properties: []property.Property{
-							property.MustBuildPackage("foo", "0.0.5"),
-						},
-					},
 					{
 						Schema:  "olm.bundle",
 						Name:    "foo.v0.1.0",
@@ -376,8 +413,10 @@ func TestMergeDC(t *testing.T) {
 					{Schema: "olm.channel", Name: "stable", Package: "bar", Entries: []declcfg.ChannelEntry{
 						{Name: "bar.v0.1.0"},
 					}},
+					{Schema: "olm.channel", Name: "alpha", Package: "foo", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.1.0"},
+					}},
 					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
-						{Name: "foo.v0.5.0"},
 						{Name: "foo.v0.1.0", Replaces: "foo.v0.0.5"},
 					}},
 				},
@@ -390,15 +429,6 @@ func TestMergeDC(t *testing.T) {
 						Properties: []property.Property{
 							property.MustBuildGVKRequired("etcd.database.coreos.com", "v1", "EtcdBackup"),
 							property.MustBuildPackage("bar", "0.1.0"),
-						},
-					},
-					{
-						Schema:  "olm.bundle",
-						Name:    "foo.v0.0.5",
-						Package: "foo",
-						Image:   "reg/foo:latest",
-						Properties: []property.Property{
-							property.MustBuildPackage("foo", "0.0.5"),
 						},
 					},
 					{


### PR DESCRIPTION
# Description

This PR fixes a bug in catalog merging which results in multiple channel heads. It also adds validation during catalog processing to verify the validity of FBCs during the mirroring process.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] Merge unit tests modified to include scenarios with overwritten channel heads
- [X] Manually tested the 4.9 catalogs with different tags

# Testing Plan

1. Spin up two registries 
2. Copy the older catalog to the connected registry
`skopeo copy docker://registry.redhat.io/redhat/redhat-operator-index:v4.9-1646041330 docker://localhost:5000/fake/redhat-operator-index:v4.9`
4. Run oc-mirror with below config
```
apiVersion: mirror.openshift.io/v1alpha2
kind: ImageSetConfiguration
storageConfig:
  local:
    path: metadata
mirror:
    operators:
    - catalog: localhost:5000/fake/redhat-operator-index:v4.9
      headsOnly: false # References latest version of each operator in catalog (true is the default value and can be omitted)
      packages:
        - name: sriov-network-operator
          channels:
            - name: '4.9'
        - name: cluster-logging
          channels:
            - name: 'stable'
```
`./bin/oc-mirror --config ~/configs/imageset-config.yaml docker://localhost:5001 --dest-use-http --log-level=debug --source-use-http`
6. Copy the newer catalog to the same image name to the connected registry
`skopeo copy docker://registry.redhat.io/redhat/redhat-operator-index:v4.9 docker://localhost:5000/fake/redhat-operator-index:v4.9`
7. Run oc-mirror again with the same config

Note: Must test with both commits
- Outcome with the first commit
```
Error: could not build index model from declarative config: invalid index:
├── invalid package "sriov-network-operator":
│   ├── invalid channel "4.9":
│   │   └── multiple channel heads found in graph: sriov-network-operator.4.9.0-202202150216, sriov-network-operator.4.9.0-202202211206
│   └── invalid channel "stable":
│       └── multiple channel heads found in graph: sriov-network-operator.4.9.0-202202150216, sriov-network-operator.4.9.0-202202211206
└── invalid package "cluster-logging":
    ├── invalid channel "stable":
    │   └── multiple channel heads found in graph: cluster-logging.5.3.4-13, cluster-logging.5.3.5-20
    ├── invalid channel "stable-5.2":
    │   └── multiple channel heads found in graph: cluster-logging.5.2.7-18, cluster-logging.5.2.8-21
    └── invalid channel "stable-5.3":
        └── multiple channel heads found in graph: cluster-logging.5.3.4-13, cluster-logging.5.3.5-20
```
- Outcome with second commit - Successfully catalog rebuild

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules