### PR TITLE
feat(releases): adds ShortestPath key to ReleaseChannel spec to toggl…

### DIFF
--- a/docs/examples/imageset-config-release-full-channel.yaml
+++ b/docs/examples/imageset-config-release-full-channel.yaml
@@ -1,6 +1,5 @@
 # This config demonstrates how to mirror the minimum and maximum
-# versions in the specified channel for an OpenShift release and the shortest
-# upgrade path in between
+# versions in the specified channel for an OpenShift release
 ---
 apiVersion: mirror.openshift.io/v1alpha2
 kind: ImageSetConfiguration

--- a/docs/examples/imageset-config-release.yaml
+++ b/docs/examples/imageset-config-release.yaml
@@ -10,3 +10,4 @@ mirror:
       - name: stable-4.9
         minVersion: 4.9.13
         maxVersion: 4.9.26
+        shortestPath: true

--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -121,9 +121,9 @@ func GetUpdates(ctx context.Context, c Client, arch string, channel string, vers
 
 	shortestPath := func(g map[int][]int, start, end int) []int {
 		prev := map[int]int{}
-		visited := map[int]bool{}
+		visited := map[int]struct{}{}
 		queue := []int{start}
-		visited[start] = true
+		visited[start] = struct{}{}
 		prev[start] = -1
 
 		for len(queue) > 0 {
@@ -134,17 +134,16 @@ func GetUpdates(ctx context.Context, c Client, arch string, channel string, vers
 			}
 
 			for _, neighbor := range g[node] {
-				if !visited[neighbor] {
+				if _, ok := visited[neighbor]; !ok {
 					prev[neighbor] = node
 					queue = append(queue, neighbor)
-					visited[neighbor] = true
+					visited[neighbor] = struct{}{}
 				}
 			}
-
 		}
 
 		// No path to end
-		if !visited[end] {
+		if _, ok := visited[end]; !ok {
 			return []int{}
 		}
 

--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -222,6 +222,64 @@ func TestGetVersions(t *testing.T) {
 	}
 }
 
+func TestGetUpdatesInRange(t *testing.T) {
+	arch := "test-arch"
+	channelName := "test-channel"
+	tests := []struct {
+		name string
+
+		expectedQuery string
+		versions      []Update
+		releaseRange  semver.Range
+		err           string
+	}{{
+		name:          "Valid/OneChannel",
+		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab",
+		versions: []Update{
+			{Version: semver.MustParse("4.0.0-5"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-5"},
+			{Version: semver.MustParse("4.0.0-6"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-6"},
+			{Version: semver.MustParse("4.0.0-6+2"), Image: "quay.io/openshift-release-dev/ocp-release:4.0.0-6+2"},
+		},
+		releaseRange: semver.MustParseRange(">=4.0.0-5"),
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requestQuery := make(chan string, 1)
+			defer close(requestQuery)
+
+			handler := getHandler(t, requestQuery)
+
+			ts := httptest.NewServer(http.HandlerFunc(handler))
+			t.Cleanup(ts.Close)
+
+			endpoint, err := url.Parse(ts.URL)
+			require.NoError(t, err)
+			c := &mockClient{url: endpoint}
+
+			versions, err := GetUpdatesInRange(context.TODO(), c, channelName, arch, test.releaseRange)
+			if test.err == "" {
+				require.NoError(t, err)
+				require.Equal(t, test.versions, versions)
+
+			} else {
+				require.EqualError(t, err, test.err)
+			}
+
+			actualQuery := ""
+			select {
+			case actualQuery = <-requestQuery:
+			default:
+				t.Fatal("no request received at upstream URL")
+			}
+			expectedQueryValues, err := url.ParseQuery(test.expectedQuery)
+			require.NoError(t, err)
+			actualQueryValues, err := url.ParseQuery(actualQuery)
+			require.NoError(t, err)
+			require.Equal(t, expectedQueryValues, actualQueryValues)
+		})
+	}
+}
+
 func TestCalculateUpgrades(t *testing.T) {
 	arch := "test-arch"
 

--- a/pkg/cli/mirror/release.go
+++ b/pkg/cli/mirror/release.go
@@ -239,11 +239,10 @@ func (o *ReleaseOptions) getChannelDownloads(ctx context.Context, c cincinnati.C
 // getCrossChannelDownloads will determine required downloads between channel versions (for OCP only)
 func (o *ReleaseOptions) getCrossChannelDownloads(ctx context.Context, arch string, channels []v1alpha2.ReleaseChannel) (downloads, error) {
 	// Strip any OKD channels from the list
-	ocpChannels := make([]v1alpha2.ReleaseChannel, len(channels))
-	copy(ocpChannels, channels)
-	for i, ch := range ocpChannels {
-		if ch.Name == cincinnati.OkdChannel {
-			ocpChannels = append(ocpChannels[:i], ocpChannels[i+1:]...)
+	var ocpChannels []v1alpha2.ReleaseChannel
+	for _, ch := range channels {
+		if ch.Name != cincinnati.OkdChannel {
+			ocpChannels = append(ocpChannels, ch)
 		}
 	}
 	// If no other channels exist, return no downloads

--- a/pkg/cli/mirror/release_test.go
+++ b/pkg/cli/mirror/release_test.go
@@ -30,18 +30,30 @@ func TestGetDownloads(t *testing.T) {
 		arch: []string{"test-arch"},
 		channels: []v1alpha2.ReleaseChannel{
 			{
-				Name:       "stable-4.0",
-				MinVersion: "4.0.0-5",
-				MaxVersion: "4.0.0-6",
-			},
-			{
 				Name:       "stable-4.1",
-				MinVersion: "4.1.0-6",
+				MinVersion: "4.0.0-4",
 				MaxVersion: "4.1.0-6",
 			},
 		},
 		expected: downloads{
+			"quay.io/openshift-release-dev/ocp-release:4.0.0-4": struct{}{},
 			"quay.io/openshift-release-dev/ocp-release:4.0.0-5": struct{}{},
+			"quay.io/openshift-release-dev/ocp-release:4.0.0-6": struct{}{},
+			"quay.io/openshift-release-dev/ocp-release:4.1.0-6": struct{}{},
+		},
+	}, {
+		name: "Success/OneChannelShortestPath",
+		channels: []v1alpha2.ReleaseChannel{
+			{
+				Name:         "stable-4.1",
+				MinVersion:   "4.0.0-4",
+				MaxVersion:   "4.1.0-6",
+				ShortestPath: true,
+			},
+		},
+		arch: []string{"test-arch"},
+		expected: downloads{
+			"quay.io/openshift-release-dev/ocp-release:4.0.0-4": struct{}{},
 			"quay.io/openshift-release-dev/ocp-release:4.0.0-6": struct{}{},
 			"quay.io/openshift-release-dev/ocp-release:4.1.0-6": struct{}{},
 		},
@@ -205,7 +217,7 @@ func getHandlerMulti(t *testing.T, requestQuery chan<- string) http.HandlerFunc 
 					"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.3"
 				  }
 				],
-				"edges": [[0,1],[1,2],[4,5]]
+				"edges": [[0,1],[1,2],[2,4],[4,5]]
 			  }`))
 			if err != nil {
 				t.Fatal(err)
@@ -279,7 +291,7 @@ func getHandlerMulti(t *testing.T, requestQuery chan<- string) http.HandlerFunc 
 					"payload": "quay.io/openshift-release-dev/ocp-release:4.1.0-6"
 				  }
 				],
-				"edges": [[0,1],[1,2],[2,6],[4,5]]
+				"edges": [[0,1],[0,2],[1,2],[2,6],[4,5]]
 			  }`))
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/config/v1alpha2/config_types.go
+++ b/pkg/config/v1alpha2/config_types.go
@@ -52,6 +52,9 @@ type ReleaseChannel struct {
 	// HeadsOnly mode mirrors only the channel head.
 	// The default is true.
 	HeadsOnly *bool `json:"headsOnly,omitempty"`
+	// ShortestPath mode calculates the shortest path
+	// between the min and mav version
+	ShortestPath bool `json:"shortestPath,omitempty"`
 }
 
 func (r ReleaseChannel) IsHeadsOnly() bool {

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/openshift/oc-mirror/pkg/config/v1alpha2"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -9,7 +10,7 @@ import (
 
 type validationFunc func(cfg *v1alpha2.ImageSetConfiguration) error
 
-var validationChecks = []validationFunc{validateOperatorOptions}
+var validationChecks = []validationFunc{validateOperatorOptions, validateReleaseChannels}
 
 func Validate(cfg *v1alpha2.ImageSetConfiguration) error {
 	var errs []error
@@ -28,6 +29,19 @@ func validateOperatorOptions(cfg *v1alpha2.ImageSetConfiguration) error {
 				"invalid configuration option: catalog cannot define packages with headsOnly set to true",
 			)
 		}
+	}
+	return nil
+}
+
+func validateReleaseChannels(cfg *v1alpha2.ImageSetConfiguration) error {
+	seen := map[string]bool{}
+	for _, channel := range cfg.Mirror.OCP.Channels {
+		if seen[channel.Name] {
+			return fmt.Errorf(
+				"invalid configuration option: duplicate release channel %s found in configuration", channel.Name,
+			)
+		}
+		seen[channel.Name] = true
 	}
 	return nil
 }

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -70,6 +70,25 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
+			name: "Valid/UniqueReleaseChannels",
+			config: &v1alpha2.ImageSetConfiguration{
+				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+					Mirror: v1alpha2.Mirror{
+						OCP: v1alpha2.OCP{
+							Channels: []v1alpha2.ReleaseChannel{
+								{
+									Name: "channel1",
+								},
+								{
+									Name: "channel2",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "Invalid/HeadsOnlyTrue",
 			config: &v1alpha2.ImageSetConfiguration{
 				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
@@ -86,6 +105,26 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			expError: "invalid configuration option: catalog cannot define packages with headsOnly set to true",
+		},
+		{
+			name: "Invalid/DuplicateChannels",
+			config: &v1alpha2.ImageSetConfiguration{
+				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+					Mirror: v1alpha2.Mirror{
+						OCP: v1alpha2.OCP{
+							Channels: []v1alpha2.ReleaseChannel{
+								{
+									Name: "channel",
+								},
+								{
+									Name: "channel",
+								},
+							},
+						},
+					},
+				},
+			},
+			expError: "invalid configuration option: duplicate release channel channel found in configuration",
 		},
 	}
 


### PR DESCRIPTION
…e path calculations

This change will allow the ImagesetConfiguration to control whether all versions in
range are returned or just the shortest path of updates

BREAKING CHANGE: changes ImagesetConfigurationSpec API

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description
^^

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Unit tests added to `release_test.go` and `cincinnati_test.go`


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules