### PR TITLE
Ci/add ci targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,17 @@ test-e2e: build
 	./test/e2e-simple.sh ./bin/oc-mirror
 .PHONY: test-e2e
 
-test-integration: hack-build
+_integration:
 	@mkdir -p test/integration/output/clients
 	@cp bin/oc-mirror test/integration/output/clients/
 	@cd test/integration && make
+.PHONY: _integration
+
+test-integration: hack-build _integration
 .PHONY: test-integration
+
+test-ci-integration: build _integration
+.PHONY: test-ci-integration
 
 sanity: tidy
 	git diff --exit-code

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -14,7 +14,10 @@ CONSOLE_REDHAT_COM_PULL_SECRET := ${CONSOLE_REDHAT_COM_PULL_SECRET}
 # e.g. make test ANSIBLE_PLAYBOOK_ARGS="--tags sneakernet"
 ANSIBLE_PLAYBOOK_ARGS :=
 
-all: default-scenario
+all:
+	thing=$$(cat /aws-creds/AWS_FAKE_ACCESS_KEY) && [ "$$thing" = "fannypack" ] && echo worked || echo failed
+	cat /aws-creds/AWS_FAKE_ACCESS_KEY
+	exit 1
 .PHONY: all
 
 default-scenario: create test delete


### PR DESCRIPTION
This adds the integration test target that will be consumable by OpenShift CI.

It also temporarily validates secrets and will need a manual test run once [the config and jobs](https://github.com/openshift/release/pull/26915) are merged. After that test run it  will need force pushed with some more tweaks to conform to the secrets.