### PR TITLE
Creating the release signature configmap for use during upgrades #125

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -258,7 +258,7 @@ func blobInArchive(file string) string {
 
 func includeFile(fpath string) bool {
 	split := strings.Split(filepath.Clean(fpath), string(filepath.Separator))
-	return split[0] == config.InternalDir || split[0] == "catalogs" || split[0] == config.HelmDir
+	return split[0] == config.InternalDir || split[0] == "catalogs" || split[0] == config.HelmDir || split[0] == config.ReleaseSignatureDir
 }
 
 func shouldRemove(fpath string, info fs.FileInfo) bool {

--- a/pkg/bundle/init.go
+++ b/pkg/bundle/init.go
@@ -14,6 +14,7 @@ func MakeCreateDirs(rootDir string) error {
 		filepath.Join(config.SourceDir, config.PublishDir),
 		filepath.Join(config.SourceDir, "v2"),
 		filepath.Join(config.SourceDir, config.HelmDir),
+		filepath.Join(config.SourceDir, config.ReleaseSignatureDir),
 	}
 	for _, p := range paths {
 		dir := filepath.Join(rootDir, p)

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -321,6 +321,15 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 		if err := o.generateAllICSPs(mapping, dir); err != nil {
 			return err
 		}
+
+		// Move release signatures into results dir
+		srcSignaturePath := filepath.Join(o.Dir, config.SourceDir, config.ReleaseSignatureDir)
+		dstSignaturePath := filepath.Join(dir, config.ReleaseSignatureDir)
+		if err := os.Rename(srcSignaturePath, dstSignaturePath); err != nil {
+			return err
+		}
+		logrus.Debugf("Moved any release signatures to %s", dir)
+
 		// Move charts into results dir
 		srcHelmPath := filepath.Join(o.Dir, config.SourceDir, config.HelmDir)
 		dstHelmPath := filepath.Join(dir, config.HelmDir)

--- a/pkg/cli/mirror/publish.go
+++ b/pkg/cli/mirror/publish.go
@@ -309,6 +309,12 @@ func (o *MirrorOptions) Publish(ctx context.Context) (image.TypedImageMapping, e
 		return allMappings, utilerrors.NewAggregate(errs)
 	}
 
+	logrus.Debug("unpack release signatures")
+	err = o.unpackReleaseSignatures(o.OutputDir, filesInArchive)
+	if err != nil {
+		return allMappings, err
+	}
+
 	logrus.Debug("rebuilding catalog images")
 
 	found, err := o.unpackCatalog(tmpdir, filesInArchive)

--- a/pkg/cli/mirror/release-configmap.yaml
+++ b/pkg/cli/mirror/release-configmap.yaml
@@ -1,0 +1,70 @@
+# Release verification against Official Red Hat keys
+apiVersion: v1
+data:
+  store-openshift-official-release: https://storage.googleapis.com/openshift-release/official/signatures/openshift/release
+  store-openshift-official-release-mirror: https://mirror.openshift.com/pub/openshift-v4/signatures/openshift/release
+  verifier-public-key-redhat: |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Comment: Use "gpg --dearmor" for unpacking
+
+    mQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF
+    0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF
+    0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c
+    u7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh
+    XGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H
+    5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW
+    9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj
+    /DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1
+    PcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY
+    HVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF
+    buhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB
+    tDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0
+    LmNvbT6JAjYEEwECACAFAkrgSTsCGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAAK
+    CRAZni+R/UMdUWzpD/9s5SFR/ZF3yjY5VLUFLMXIKUztNN3oc45fyLdTI3+UClKC
+    2tEruzYjqNHhqAEXa2sN1fMrsuKec61Ll2NfvJjkLKDvgVIh7kM7aslNYVOP6BTf
+    C/JJ7/ufz3UZmyViH/WDl+AYdgk3JqCIO5w5ryrC9IyBzYv2m0HqYbWfphY3uHw5
+    un3ndLJcu8+BGP5F+ONQEGl+DRH58Il9Jp3HwbRa7dvkPgEhfFR+1hI+Btta2C7E
+    0/2NKzCxZw7Lx3PBRcU92YKyaEihfy/aQKZCAuyfKiMvsmzs+4poIX7I9NQCJpyE
+    IGfINoZ7VxqHwRn/d5mw2MZTJjbzSf+Um9YJyA0iEEyD6qjriWQRbuxpQXmlAJbh
+    8okZ4gbVFv1F8MzK+4R8VvWJ0XxgtikSo72fHjwha7MAjqFnOq6eo6fEC/75g3NL
+    Ght5VdpGuHk0vbdENHMC8wS99e5qXGNDued3hlTavDMlEAHl34q2H9nakTGRF5Ki
+    JUfNh3DVRGhg8cMIti21njiRh7gyFI2OccATY7bBSr79JhuNwelHuxLrCFpY7V25
+    OFktl15jZJaMxuQBqYdBgSay2G0U6D1+7VsWufpzd/Abx1/c3oi9ZaJvW22kAggq
+    dzdA27UUYjWvx42w9menJwh/0jeQcTecIUd0d0rFcw/c1pvgMMl/Q73yzKgKY5kC
+    DQRJpAMwARAAtv3O2z9ZR0N10nMWyJNC0FntWDoom0AUS8H/EouT5LYLbj4m05Cq
+    WY8PKeA/nzO4w9VlM1BNF+7V4Npf3lJTDOHcOlyQENQJhDrZcEoO66zLU7zNAARL
+    SOypunwurFOkbQTHXKg9XB/+nW7H4fJrs51QO1JV/j0QR1c3Vs4+svIfOHQY6IM3
+    G2LvR3s6oI/5S84nKrEmT8/VHV4kU0QCIafFd9AQ/LkWmmtCgw5w+iMyb9w/T8UF
+    mxTOGddhjfS8nmapg+26Ss2Zlxv93a7311YrF2l6dzNO7dzZQWtw7fDRSCmdAxUV
+    wc+W788UVZnR+g7ZA1lwzzrflnZta2awjq8khaQWUEaR8NdnqNTNZYqwDSKL+2fl
+    dUIf2gcY+RFLt9rvWaYwDzzbUBehfyo2qBxx5hEALo+Ay3seC2OuOh79a3L9okBb
+    gnbyykBkohQa32R9I/yF9/9CV0JWc29zLjBT8S1xgKAFfVD/0sP1k5gLk8xVZhtd
+    1GBXjMK06DoqnF9lXCtGgtRQnEz9s+CVtz7Fr1PK1A0VGH6F6L3O3oOFZ+cB7dDQ
+    WLDYWIgAH99tAFCB80GWIt/CYFcLiXxbuN7SWROFYoPvkUKurbBMfRbc9xMEUXyf
+    c/ZhLxIonmZvr2zrzLyLophVT0gpix/myOuPSvHmZVUVrMdxFwlW9J0AEQEAAbQw
+    UmVkIEhhdCwgSW5jLiAoYmV0YSBrZXkgMikgPHNlY3VyaXR5QHJlZGhhdC5jb20+
+    iQI2BBMBAgAgBQJKUjPnAhsDBgsJCAcDAgQVAggDBBYCAwECHgECF4AACgkQk4qA
+    yvIVQev/bRAAtPips3inHl0Pxk1KFOo8vb7ZBQha5r/nO6JeF6XU7dEIagTsMupt
+    pilsJpvCn2H8tHAA0OMvxHKF5exbRQcGJpArhEBl4Uw5/Q71Y4aKCKufSxDAUDlv
+    O/UcMM0SGfHm24zFIwzxeTHz0Kj9iwbvTeCr15WaeL6MpMLrmifnG7CmUeqWetEU
+    Cjxyj/jYFBQtH33+12PXLjmWVhQHikYSzdiu250RysafpBC1m+kfWX62MGY1nDCD
+    203dZIROdy+DU36VnwJyUbZD0gzihBlZVS7S6uBxAMULdO5G7JaiEkVslxEd7kDi
+    Y+uA9WYiDM+rermeNuFROK8vawUdCc+eXDDMeTv54vcd8cxVIB/ErtsjNK94xEX9
+    uPrWzmj3+7Xm8seDinviVveYTVbLVlA8hm7OivahnyP6SArjtZzDBU6Ohqs0Og8C
+    2byfUHV6O7oxLckmZ37uNmsnGkPWSwtgzgkAlAWN+dB8ehS1tzueOkwL6U35NAes
+    fg1e5iUB+zBpkV0LBO0ywSSo6tvAp+LVadOD5sm0Mk8WXRgP/M2OqT5esclTB1ev
+    IUgShFU/65aLjh7sX3Zmb2tQ4Vb1Aul4+/okzE1SVAKv+FMp99T9TiZgNmtD0wgK
+    lpGyUoChXHLIz6E2y8sYbjEjZBGRR75Wa0ivb5z85n4kR9Dq8d8GKTE=
+    =syRO
+    -----END PGP PUBLIC KEY BLOCK-----
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/verification-config-map: ""
+  creationTimestamp: null
+  name: release-verification
+  namespace: openshift-config-managed
+  namespace: openshift-config-managed

--- a/pkg/config/metadata.go
+++ b/pkg/config/metadata.go
@@ -5,14 +5,15 @@ import (
 )
 
 const (
-	SourceDir        = "src"
-	PublishDir       = "publish"
-	InternalDir      = "internal"
-	HelmDir          = "charts"
-	V2Dir            = "v2"
-	BlobDir          = "blobs"
-	MetadataFile     = ".metadata.json"
-	AssociationsFile = "image-associations.gob"
+	SourceDir        	= "src"
+	PublishDir       	= "publish"
+	InternalDir      	= "internal"
+	HelmDir          	= "charts"
+	V2Dir            	= "v2"
+	BlobDir          	= "blobs"
+	MetadataFile     	= ".metadata.json"
+	AssociationsFile 	= "image-associations.gob"
+	ReleaseSignatureDir = "release-signatures"
 )
 
 var (


### PR DESCRIPTION
# Description

Fixes #125 

Each release now downloads its signature and creates a configmap from the signature. This is used during platform upgrades.

Still to do: 
- How should this be packaged for offline usage. I think it needs to go into the tar structure when using file:// or into the results directory if using publish. Similarily if you go from file to registry it should use the results directory. @jpower432 thoughts? 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Not yet done

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules