### PR TITLE
Bug 2053154: fix(associations): modifies association return values to allows image…

### DIFF
--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -461,11 +461,12 @@ func (o *OperatorOptions) associateDeclarativeConfigImageLayers(ctlgRef imagesou
 	assocs, err := image.AssociateImageLayers(srcDir, mappings, images, image.TypeOperatorBundle)
 	if err != nil {
 		merr := &image.ErrNoMapping{}
-		cerr := &image.ErrInvalidComponent{}
+		ierr := &image.ErrInvalidImage{}
 		for _, err := range err.Errors() {
-			if !errors.As(err, &merr) && !errors.As(err, &cerr) {
-				return nil, err
+			if (errors.As(err, &merr) || errors.As(err, &ierr)) && o.ContinueOnError {
+				continue
 			}
+			return nil, err
 		}
 		o.Logger.Warn(err)
 	}

--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -461,9 +461,10 @@ func (o *OperatorOptions) associateDeclarativeConfigImageLayers(ctlgRef imagesou
 	assocs, err := image.AssociateImageLayers(srcDir, mappings, images, image.TypeOperatorBundle)
 	if err != nil {
 		merr := &image.ErrNoMapping{}
+		cerr := &image.ErrInvalidComponent{}
 		ierr := &image.ErrInvalidImage{}
 		for _, err := range err.Errors() {
-			if (errors.As(err, &merr) || errors.As(err, &ierr)) && o.ContinueOnError {
+			if (errors.As(err, &merr) || errors.As(err, &ierr) || errors.As(err, &cerr)) && o.ContinueOnError {
 				continue
 			}
 			return nil, err

--- a/pkg/image/association.go
+++ b/pkg/image/association.go
@@ -26,6 +26,15 @@ func (e *ErrNoMapping) Error() string {
 	return fmt.Sprintf("image %q has no mirror mapping", e.image)
 }
 
+type ErrInvalidComponent struct {
+	image string
+	tag   string
+}
+
+func (e *ErrInvalidComponent) Error() string {
+	return fmt.Sprintf("image %q has invalid component %q", e.image, e.tag)
+}
+
 type ErrInvalidImage struct {
 	image string
 }
@@ -345,7 +354,7 @@ func associateImageLayers(image, localRoot, dirRef, tagOrID, defaultTag string, 
 
 	info, err := os.Lstat(manifestPath)
 	if errors.Is(err, os.ErrNotExist) {
-		return nil, &ErrInvalidImage{image}
+		return nil, &ErrInvalidComponent{image, tagOrID}
 	} else if err != nil {
 		return nil, err
 	}

--- a/pkg/image/association.go
+++ b/pkg/image/association.go
@@ -26,13 +26,12 @@ func (e *ErrNoMapping) Error() string {
 	return fmt.Sprintf("image %q has no mirror mapping", e.image)
 }
 
-type ErrInvalidComponent struct {
+type ErrInvalidImage struct {
 	image string
-	tag   string
 }
 
-func (e *ErrInvalidComponent) Error() string {
-	return fmt.Sprintf("image %q has invalid component %q", e.image, e.tag)
+func (e *ErrInvalidImage) Error() string {
+	return fmt.Sprintf("image %q is invalid or does not exist", e.image)
 }
 
 // Associations is a map for Association
@@ -316,7 +315,7 @@ func AssociateImageLayers(rootDir string, imgMappings map[string]string, images 
 
 		// Verify that the dirRef exists before proceeding
 		if _, err := os.Stat(imagePath); err != nil {
-			errs = append(errs, fmt.Errorf("image %q mapping %q: %v", image, dirRef, err))
+			errs = append(errs, &ErrInvalidImage{image})
 			continue
 		}
 
@@ -346,7 +345,7 @@ func associateImageLayers(image, localRoot, dirRef, tagOrID, defaultTag string, 
 
 	info, err := os.Lstat(manifestPath)
 	if errors.Is(err, os.ErrNotExist) {
-		return nil, &ErrInvalidComponent{image, tagOrID}
+		return nil, &ErrInvalidImage{image}
 	} else if err != nil {
 		return nil, err
 	}

--- a/pkg/image/association_test.go
+++ b/pkg/image/association_test.go
@@ -183,7 +183,7 @@ func TestAssociateImageLayers(t *testing.T) {
 			imgMapping: map[string]string{"imgname:latest": "single_manifest"},
 			imgs:       []string{"imgname:latest"},
 			wantErr:    true,
-			expError:   &ErrInvalidImage{},
+			expError:   &ErrInvalidComponent{},
 		},
 		{
 			name:       "Invalid/InvalidImage",

--- a/pkg/image/association_test.go
+++ b/pkg/image/association_test.go
@@ -183,7 +183,15 @@ func TestAssociateImageLayers(t *testing.T) {
 			imgMapping: map[string]string{"imgname:latest": "single_manifest"},
 			imgs:       []string{"imgname:latest"},
 			wantErr:    true,
-			expError:   &ErrInvalidComponent{},
+			expError:   &ErrInvalidImage{},
+		},
+		{
+			name:       "Invalid/InvalidImage",
+			imgTyp:     TypeGeneric,
+			imgMapping: map[string]string{"imgname:latest": "fake_manifest:latest"},
+			imgs:       []string{"imgname:latest"},
+			wantErr:    true,
+			expError:   &ErrInvalidImage{},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
… skipping

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

This PR fixes a bug with the `continue-on-error` flag. This will allow for missing images provided in the mapping when associating catalog image layers. With `--continue-on-error` specified, a warning will be logged for notification.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] Unit test added
- [X] Manual testing


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules