### PR TITLE
Bug 2063955: fix(mirror): adds back continue-on-error use for missing images

### DIFF
--- a/pkg/cli/mirror/additional.go
+++ b/pkg/cli/mirror/additional.go
@@ -59,6 +59,7 @@ func (o *AdditionalOptions) Plan(ctx context.Context, imageList []v1alpha2.Addit
 		dstRef := srcRef
 		dstRef.Type = imagesource.DestinationFile
 		dstRef.Ref = dstRef.Ref.DockerClientDefaults()
+		// The registry component is not included in the final path.
 		dstRef.Ref.Registry = ""
 
 		mmappings.Add(srcRef, dstRef, image.TypeGeneric)

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -373,6 +373,10 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 		}
 	}
 
+	if o.continuedOnError {
+		return fmt.Errorf("one or more errors occurred")
+	}
+
 	return cleanup()
 }
 
@@ -471,6 +475,7 @@ func (o *MirrorOptions) checkErr(err error, acceptableErr func(error) bool) erro
 
 		if o.ContinueOnError && (skip || skipAllTypes) {
 			logrus.Warn(err)
+			o.continuedOnError = true
 		} else {
 			return err
 		}

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -34,8 +34,9 @@ type MirrorOptions struct {
 	FilterOptions    []string
 	MaxPerRegistry   int
 	// cancelCh is a channel listening for command cancellations
-	cancelCh <-chan struct{}
-	once     sync.Once
+	cancelCh         <-chan struct{}
+	once             sync.Once
+	continuedOnError bool
 }
 
 func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {

--- a/pkg/image/association_builder_test.go
+++ b/pkg/image/association_builder_test.go
@@ -230,6 +230,28 @@ func TestAssociateLocalImageLayers(t *testing.T) {
 			wantErr:  true,
 			expError: &ErrInvalidComponent{},
 		},
+		{
+			name:   "Invalid/MissingImage",
+			imgTyp: TypeGeneric,
+			imgMapping: map[TypedImage]TypedImage{
+				{
+					TypedImageReference: imagesource.TypedImageReference{
+						Ref: reference.DockerImageReference{
+							Name: "imgname",
+							Tag:  "latest",
+						}},
+					Category: TypeGeneric}: {
+					TypedImageReference: imagesource.TypedImageReference{
+						Ref: reference.DockerImageReference{
+							Name: "fake_manifest",
+							Tag:  "latest",
+						},
+						Type: imagesource.DestinationFile,
+					},
+					Category: TypeGeneric}},
+			wantErr:  true,
+			expError: &ErrInvalidImage{},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
# Description

This PR adds fixes for errors that occur when missing images are provided in the config (via catalog or additional/helm). This allows `continue-on-error` to log a warning about the missing images instead of throwing an error if specified.

Related to #359 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] Unit test added
- [X] Manual test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules