### PR TITLE
Add flag MaxPerRegistry to make it visible

### DIFF
--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -451,7 +451,7 @@ func (o *MirrorOptions) newMirrorImageOptions(insecure bool) (*mirror.MirrorImag
 	a.FilterOptions = imagemanifest.FilterOptions{FilterByOS: ".*"}
 	a.KeepManifestList = true
 	a.SkipMultipleScopes = true
-	a.ParallelOptions = imagemanifest.ParallelOptions{MaxPerRegistry: 2}
+	a.ParallelOptions = imagemanifest.ParallelOptions{MaxPerRegistry: o.MaxPerRegistry}
 	regctx, err := image.CreateDefaultContext(insecure)
 	if err != nil {
 		return a, fmt.Errorf("error creating registry context: %v", err)

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -32,6 +32,7 @@ type MirrorOptions struct {
 	SkipMissing      bool
 	ContinueOnError  bool
 	FilterOptions    []string
+	MaxPerRegistry   int
 	// cancelCh is a channel listening for command cancellations
 	cancelCh <-chan struct{}
 	once     sync.Once
@@ -56,6 +57,7 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.SkipMissing, "skip-missing", o.SkipMissing, "If an input image is not found, skip them. "+
 		"404/NotFound errors encountered while pulling images explicitly specified in the config "+
 		"will not be skipped")
+	fs.IntVar(&o.MaxPerRegistry, "max-per-registry", 2, "Number of concurrent requests allowed per registry")
 
 	// TODO(jpower432): Make this flag visible again once release architecture selection
 	// has been more thouroughly vetted


### PR DESCRIPTION
Signed-off-by: Alberto Morgante Medina <amorgant@redhat.com>

# Description

The idea of this PR is just to enable the flag MaxPerRegistry in the CLI options to use the ParallelsOptions in order to reduce the time to complete the mirror process.
The option is forced in code directly, and the PR enables the possibility to specify the flag to set the number or leave it blank to use the default value (2)
@flaper87 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] Test A
 Working with quay mirror, using the flag MaxPerRegistry = 100 and the next file:
```
apiVersion: mirror.openshift.io/v1alpha2
kind: ImageSetConfiguration
storageConfig:
  registry:
    imageURL: kubeframe-registry-kubeframe-registry.apps.test-ci.alklabs.com/olm4
    skipTLS: true
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.9
      headsOnly: false
      packages:
        - name: kubernetes-nmstate-operator
          channels:
          - name: 'stable'
        - name: metallb-operator
          channels:
          - name: 'stable'
        - name: ocs-operator
          channels:
          - name: 'stable-4.9'
        - name: local-storage-operator
          channels:
          - name: 'stable'
        - name: advanced-cluster-management
          channels:
          - name: 'release-2.4'
```
The Command launched (**--max-per-registry 100**): 
```
time ./oc-mirror-fork --max-per-registry 100 --config config.yaml docker://kubeframe-registry-kubeframe-registry.apps.test-ci.alklabs.com  --dest-skip-tls
```
The results (regarding the time command finishing the mirror succesfully):
```
OC_MIRROR_100
info: Mirroring completed in 12m54.78s (139.7MB/s)
INFO trying next host - response was http.StatusNotFound  host=kubeframe-registry-kubeframe-registry.apps.test-ci.alklabs.com
INFO Catalog image "kubeframe-registry-kubeframe-registry.apps.test-ci.alklabs.com/redhat/redhat-operator-index:v4.9" not found, using new file-based catalog
INFO Wrote CatalogSource manifests to oc-mirror-workspace/results-1647612376
INFO Wrote ICSP manifests to oc-mirror-workspace/results-1647612376

real    14m12.788s
user    14m33.963s
sys     5m4.882s

```
- [X] Test B
Same that the TestA without flag --max-per-registry = 100. It will use the default value 2

```
real    96m12.202s
user    12m27.231s
sys     5m44.098s
```

Both tests have been implemented in the same hardware, creating the registry, routes, pvc and so on from scratch to test both equally.

**Test Configuration**:
* Firmware version:
* Hardware:
```
$ uname -a
Linux qct-d14u03.cloud.lab.eng.bos.redhat.com 4.18.0-348.12.2.el8_5.x86_64 #1 SMP Mon Jan 17 07:06:06 EST 2022 x86_64 x86_64 x86_64 GNU/Linux

$ free -h
              total        used        free      shared  buff/cache   available
Mem:          125Gi        85Gi       535Mi        42Mi        39Gi        39Gi
Swap:         8.0Gi       2.1Gi       5.9Gi
```

* Toolchain:
* SDK:

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules