### PR TITLE
Bug 2069307: bump operator-registry dep v1.21.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/openshift/api v0.0.0-20210831091943-07e756545ac1
 	github.com/openshift/library-go v0.0.0-20210831102543-1a08f0c3bd9a
 	github.com/openshift/oc v0.0.0-alpha.0.0.20210721184532-4df50be4d929
-	github.com/operator-framework/operator-registry v1.19.6-0.20220120140729-354cd3851678
+	github.com/operator-framework/operator-registry v1.21.1-0.20220324153146-de3610408773
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.7.1
 	github.com/spf13/cobra v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -433,7 +433,6 @@ github.com/dhui/dktest v0.3.0/go.mod h1:cyzIUfGsBEbZ6BT7tnXqAShHSXCZhSNmFl70sZ7c
 github.com/distribution/distribution/v3 v3.0.0-20210804104954-38ab4c606ee3 h1:rEK0juuU5idazw//KzUcL3yYwUU3DIe2OnfJwjDBqno=
 github.com/distribution/distribution/v3 v3.0.0-20210804104954-38ab4c606ee3/go.mod h1:gt38b7cvVKazi5XkHvINNytZXgTEntyhtyM3HQz46Nk=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
-github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v20.10.7+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v20.10.12+incompatible h1:lZlz0uzG+GH+c0plStMUdF/qk3ppmgnswpR5EbqzVGA=
 github.com/docker/cli v20.10.12+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
@@ -1231,10 +1230,10 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
-github.com/operator-framework/api v0.11.0 h1:W9V1NNwl3LWPQL9S1pDaFONCarJLl8Xu6gdF9w54hTE=
-github.com/operator-framework/api v0.11.0/go.mod h1:FTiYGm11fZQ3cSX+EQHc/UWoGZAwkGfyeHU+wMJ8jmA=
-github.com/operator-framework/operator-registry v1.19.6-0.20220120140729-354cd3851678 h1:XAi8mGCev5HZHjCvOnweWrpMLkxExcPKZsD9L871rvA=
-github.com/operator-framework/operator-registry v1.19.6-0.20220120140729-354cd3851678/go.mod h1:XT2ihzyUMOB9K0dI9wxoY+6DDE0NVOrqtnQvnElEyXs=
+github.com/operator-framework/api v0.12.0 h1:aHxHk50/Y1J4Ogdk2J6tYofgX+GEqyBPCMyun+JFqV4=
+github.com/operator-framework/api v0.12.0/go.mod h1:FTiYGm11fZQ3cSX+EQHc/UWoGZAwkGfyeHU+wMJ8jmA=
+github.com/operator-framework/operator-registry v1.21.1-0.20220324153146-de3610408773 h1:OEUAU/Fw7sPm+KU/mREYL7FnlZRAswaRqx2DM8wGM/Q=
+github.com/operator-framework/operator-registry v1.21.1-0.20220324153146-de3610408773/go.mod h1:qDxBCYPeOMlOXd95Zi1q4GpiKwK9i9Mag1AkrMOoFNU=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=

--- a/vendor/github.com/operator-framework/api/pkg/constraints/constraint.go
+++ b/vendor/github.com/operator-framework/api/pkg/constraints/constraint.go
@@ -12,9 +12,9 @@ const OLMConstraintType = "olm.constraint"
 
 // Constraint holds parsed, potentially nested dependency constraints.
 type Constraint struct {
-	// Constraint message that surfaces in resolution
+	// Constraint failure message that surfaces in resolution
 	// This field is optional
-	Message string `json:"message,omitempty" yaml:"message,omitempty"`
+	FailureMessage string `json:"failureMessage,omitempty" yaml:"failureMessage,omitempty"`
 
 	// The cel struct that contraints CEL expression
 	Cel *Cel `json:"cel,omitempty" yaml:"cel,omitempty"`
@@ -25,14 +25,15 @@ type Constraint struct {
 	// GVK defines a constraint for a GVK.
 	GVK *GVKConstraint `json:"gvk,omitempty" yaml:"gvk,omitempty"`
 
-	// All, Any, and None are compound constraints. See this enhancement for details:
+	// All, Any, and Not are compound constraints. See this enhancement for details:
 	// https://github.com/operator-framework/enhancements/blob/master/enhancements/compound-bundle-constraints.md
 	All *CompoundConstraint `json:"all,omitempty" yaml:"all,omitempty"`
 	Any *CompoundConstraint `json:"any,omitempty" yaml:"any,omitempty"`
-	// A note on None: this constraint is not particularly useful by itself.
+	// A note on Not: this constraint isn't particularly useful by itself.
 	// It should be used within an All constraint alongside some other constraint type
-	// since saying "none of these GVKs/packages/etc." without an alternative doesn't make sense.
-	None *CompoundConstraint `json:"none,omitempty" yaml:"none,omitempty"`
+	// since saying "do not use any of these GVKs/packages/etc." without an alternative
+	// doesn't make sense.
+	Not *CompoundConstraint `json:"not,omitempty" yaml:"not,omitempty"`
 }
 
 // CompoundConstraint holds a list of potentially nested constraints

--- a/vendor/github.com/operator-framework/api/pkg/validation/internal/good_practices.go
+++ b/vendor/github.com/operator-framework/api/pkg/validation/internal/good_practices.go
@@ -65,10 +65,10 @@ func validateResourceRequests(csv *operatorsv1alpha1.ClusterServiceVersion) (err
 	for _, dSpec := range deploymentSpec {
 		for _, c := range dSpec.Spec.Template.Spec.Containers {
 			if c.Resources.Requests == nil || !(len(c.Resources.Requests.Cpu().String()) != 0 && len(c.Resources.Requests.Memory().String()) != 0) {
-				msg := fmt.Errorf("unable to find the resource requests for the container %s. It is recommended "+
+				msg := fmt.Errorf("unable to find the resource requests for the container: (%s). It is recommended "+
 					"to ensure the resource request for CPU and Memory. Be aware that for some clusters configurations "+
 					"it is required to specify requests or limits for those values. Otherwise, the system or quota may "+
-					"reject Pod creation. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/", c.Name)
+					"reject Pod creation. More info: https://master.sdk.operatorframework.io/docs/best-practices/managing-resources/", c.Name)
 				warns = append(warns, msg)
 			}
 		}

--- a/vendor/github.com/operator-framework/operator-registry/alpha/action/diff.go
+++ b/vendor/github.com/operator-framework/operator-registry/alpha/action/diff.go
@@ -32,8 +32,8 @@ type Diff struct {
 	Logger *logrus.Entry
 }
 
-func (a Diff) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
-	if err := a.validate(); err != nil {
+func (diff Diff) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
+	if err := diff.validate(); err != nil {
 		return nil, err
 	}
 
@@ -42,8 +42,8 @@ func (a Diff) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
 
 	// Heads-only mode does not require an old ref, so there may be nothing to render.
 	var oldModel model.Model
-	if len(a.OldRefs) != 0 {
-		oldRender := Render{Refs: a.OldRefs, Registry: a.Registry, AllowedRefMask: mask}
+	if len(diff.OldRefs) != 0 {
+		oldRender := Render{Refs: diff.OldRefs, Registry: diff.Registry, AllowedRefMask: mask}
 		oldCfg, err := oldRender.Run(ctx)
 		if err != nil {
 			if errors.Is(err, ErrNotAllowed) {
@@ -57,7 +57,7 @@ func (a Diff) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
 		}
 	}
 
-	newRender := Render{Refs: a.NewRefs, Registry: a.Registry, AllowedRefMask: mask}
+	newRender := Render{Refs: diff.NewRefs, Registry: diff.Registry, AllowedRefMask: mask}
 	newCfg, err := newRender.Run(ctx)
 	if err != nil {
 		if errors.Is(err, ErrNotAllowed) {
@@ -71,10 +71,10 @@ func (a Diff) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
 	}
 
 	g := &declcfg.DiffGenerator{
-		Logger:            a.Logger,
-		SkipDependencies:  a.SkipDependencies,
-		Includer:          convertIncludeConfigToIncluder(a.IncludeConfig),
-		IncludeAdditively: a.IncludeAdditively,
+		Logger:            diff.Logger,
+		SkipDependencies:  diff.SkipDependencies,
+		Includer:          convertIncludeConfigToIncluder(diff.IncludeConfig),
+		IncludeAdditively: diff.IncludeAdditively,
 	}
 	diffModel, err := g.Run(oldModel, newModel)
 	if err != nil {

--- a/vendor/github.com/operator-framework/operator-registry/alpha/action/testdata/foo-index-v0.2.0-declcfg/foo/index.yaml
+++ b/vendor/github.com/operator-framework/operator-registry/alpha/action/testdata/foo-index-v0.2.0-declcfg/foo/index.yaml
@@ -2,6 +2,11 @@
 schema: olm.package
 name: foo
 defaultChannel: beta
+properties:
+  - type: owner
+    value:
+      group: abc.com
+      name: admin
 ---
 schema: olm.channel
 package: foo
@@ -15,6 +20,11 @@ entries:
     skips:
       - foo.v0.1.1
       - foo.v0.1.2
+properties:
+  - type: user
+    value:
+      group: xyz.com
+      name: account
 ---
 schema: olm.channel
 package: foo

--- a/vendor/github.com/operator-framework/operator-registry/alpha/declcfg/declcfg.go
+++ b/vendor/github.com/operator-framework/operator-registry/alpha/declcfg/declcfg.go
@@ -20,11 +20,12 @@ type DeclarativeConfig struct {
 }
 
 type Package struct {
-	Schema         string `json:"schema"`
-	Name           string `json:"name"`
-	DefaultChannel string `json:"defaultChannel"`
-	Icon           *Icon  `json:"icon,omitempty"`
-	Description    string `json:"description,omitempty"`
+	Schema         string              `json:"schema"`
+	Name           string              `json:"name"`
+	DefaultChannel string              `json:"defaultChannel"`
+	Icon           *Icon               `json:"icon,omitempty"`
+	Description    string              `json:"description,omitempty"`
+	Properties     []property.Property `json:"properties,omitempty" hash:"set"`
 }
 
 type Icon struct {
@@ -33,10 +34,11 @@ type Icon struct {
 }
 
 type Channel struct {
-	Schema  string         `json:"schema"`
-	Name    string         `json:"name"`
-	Package string         `json:"package"`
-	Entries []ChannelEntry `json:"entries"`
+	Schema     string              `json:"schema"`
+	Name       string              `json:"name"`
+	Package    string              `json:"package"`
+	Entries    []ChannelEntry      `json:"entries"`
+	Properties []property.Property `json:"properties,omitempty" hash:"set"`
 }
 
 type ChannelEntry struct {

--- a/vendor/github.com/operator-framework/operator-registry/pkg/containertools/runner.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/containertools/runner.go
@@ -130,10 +130,13 @@ func (r *ContainerCommandRunner) Unpack(image, src, dst string) error {
 	r.logger.Infof("running %s create", r.containerTool)
 	r.logger.Debugf("%s", command.Args)
 
-	out, err := command.CombinedOutput()
+	out, err := command.Output()
 	if err != nil {
-		r.logger.Errorf(string(out))
-		return fmt.Errorf("error creating container %s: %v", string(out), err)
+		msg := err.Error()
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			msg = fmt.Sprintf("%s: %s", err, exitErr.Stderr)
+		}
+		return fmt.Errorf("error creating container %s: %s", string(out), msg)
 	}
 
 	id := strings.TrimSuffix(string(out), "\n")

--- a/vendor/github.com/operator-framework/operator-registry/pkg/image/containerdregistry/resolver.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/image/containerdregistry/resolver.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/adrg/xdg"
@@ -88,7 +89,15 @@ func credential(cfg *configfile.ConfigFile) func(string) (string, string, error)
 	}
 }
 
+// protects against a data race inside the docker CLI
+// TODO: upstream issue for 20.10.x is tracked here https://github.com/docker/cli/pull/3410
+// newer versions already contain the fix
+var configMutex sync.Mutex
+
 func loadConfig(dir string) (*configfile.ConfigFile, error) {
+	configMutex.Lock()
+	defer configMutex.Unlock()
+
 	if dir == "" {
 		dir = config.Dir()
 	}

--- a/vendor/github.com/operator-framework/operator-registry/pkg/registry/registry_to_model.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/registry/registry_to_model.go
@@ -55,6 +55,11 @@ func ObjectsAndPropertiesFromBundle(b *Bundle) ([]string, []property.Property, e
 				return nil, nil, property.ParseError{Idx: i, Typ: p.Type, Err: err}
 			}
 			packageRequiredProps = append(packageRequiredProps, property.MustBuildPackageRequired(v.PackageName, v.Version))
+		default:
+			otherProps = append(otherProps, property.Property{
+				Type:  p.Type,
+				Value: p.Value,
+			})
 		}
 	}
 

--- a/vendor/github.com/operator-framework/operator-registry/pkg/registry/types.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/registry/types.go
@@ -223,9 +223,9 @@ type LabelDependency struct {
 }
 
 type CelConstraint struct {
-	// Constraint message that surfaces in resolution
+	// Constraint failure message that surfaces in resolution
 	// This field is optional
-	Message string `json:"message" yaml:"message"`
+	FailureMessage string `json:"failureMessage" yaml:"failureMessage"`
 
 	// The cel struct that contraints CEL expression
 	// This field is required

--- a/vendor/github.com/operator-framework/operator-registry/pkg/sqlite/load.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/sqlite/load.go
@@ -957,6 +957,9 @@ func (s *sqlLoader) RemovePackage(packageName string) error {
 		if err != nil {
 			return err
 		}
+		if len(csvNames) == 0 {
+			return fmt.Errorf("no package found for packagename %s", packageName)
+		}
 		for _, csvName := range csvNames {
 			if err := s.rmBundle(tx, csvName); err != nil {
 				return err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -547,7 +547,7 @@ github.com/openshift/oc/pkg/cli/image/workqueue
 github.com/openshift/oc/pkg/helpers/image/credentialprovider
 github.com/openshift/oc/pkg/helpers/image/dockerlayer
 github.com/openshift/oc/pkg/helpers/image/dockerlayer/add
-# github.com/operator-framework/api v0.11.0
+# github.com/operator-framework/api v0.12.0
 github.com/operator-framework/api/pkg/constraints
 github.com/operator-framework/api/pkg/lib/version
 github.com/operator-framework/api/pkg/manifests
@@ -559,7 +559,7 @@ github.com/operator-framework/api/pkg/validation
 github.com/operator-framework/api/pkg/validation/errors
 github.com/operator-framework/api/pkg/validation/interfaces
 github.com/operator-framework/api/pkg/validation/internal
-# github.com/operator-framework/operator-registry v1.19.6-0.20220120140729-354cd3851678
+# github.com/operator-framework/operator-registry v1.21.1-0.20220324153146-de3610408773
 ## explicit
 github.com/operator-framework/operator-registry/alpha/action
 github.com/operator-framework/operator-registry/alpha/declcfg


### PR DESCRIPTION
# Description

This change updates the operator-registry dependency to
commit de36104087733013025629d80bf8445045a8a6e7 to resolve
a bug when processing cyclic dependencies in operator bundles.

Fixes BZ 2065832

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] Manually verified that the Red Hat 4.10 catalog processing successfully

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules