### PR TITLE
Added HOME for CI

### DIFF
--- a/test/integration/scripts/common.sh
+++ b/test/integration/scripts/common.sh
@@ -12,6 +12,10 @@ fi
 # Source the virtual environment for all actions inside the integration area
 source .venv/bin/activate
 
+# Home is not being set for random UID in CI
+HOME="${HOME:-/tmp}"
+export HOME
+
 # The version of OpenShift to run with through the test suite with this version
 #   of oc-mirror (noting that it can be different than the target release for this
 #   version of oc-mirror)


### PR DESCRIPTION
# Description

Simple fix for [permissions errors in CI](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/27189/rehearse-27189-pull-ci-openshift-oc-mirror-main-integration/1508459466041856000#1:build-log.txt%3A41) which is in line with what [some other projects do](https://github.com/openshift/release/blob/4b2ccd70ff5b1e7f689996d05d49339a7fc9253a/ci-operator/config/netobserv/network-observability-console-plugin/netobserv-network-observability-console-plugin-main.yaml#L29)