### PR TITLE
refactor: heads only workflow to remove the requirement to merge FBCs

### DIFF
--- a/pkg/api/v1alpha2/types_include_config.go
+++ b/pkg/api/v1alpha2/types_include_config.go
@@ -62,7 +62,6 @@ func (ic *IncludeConfig) ConvertToDiffIncludeConfig() (dic action.DiffIncludeCon
 		case pkg.StartingBundle != "":
 			dpkg.Bundles = []string{pkg.StartingBundle}
 		}
-		dic.Packages = append(dic.Packages, dpkg)
 
 		for chIdx, ch := range pkg.Channels {
 			if ch.Name == "" {
@@ -81,6 +80,7 @@ func (ic *IncludeConfig) ConvertToDiffIncludeConfig() (dic action.DiffIncludeCon
 			}
 			dpkg.Channels = append(dpkg.Channels, dch)
 		}
+		dic.Packages = append(dic.Packages, dpkg)
 	}
 
 	return dic, nil

--- a/pkg/api/v1alpha2/types_include_config_test.go
+++ b/pkg/api/v1alpha2/types_include_config_test.go
@@ -1,0 +1,118 @@
+package v1alpha2
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/operator-framework/operator-registry/alpha/action"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertToDiffIncludeConfig(t *testing.T) {
+	type spec struct {
+		name string
+		cfg  IncludeConfig
+		exp  action.DiffIncludeConfig
+	}
+
+	specs := []spec{
+		{
+			name: "Valid/WithChannels",
+			cfg: IncludeConfig{
+				Packages: []IncludePackage{
+					{
+						Name: "bar",
+						Channels: []IncludeChannel{
+							{
+								Name: "stable",
+								IncludeBundle: IncludeBundle{
+									StartingVersion: semver.MustParse("0.1.0"),
+								},
+							},
+						},
+					},
+					{
+						Name: "foo",
+						Channels: []IncludeChannel{
+							{
+								Name: "stable",
+								IncludeBundle: IncludeBundle{
+									StartingVersion: semver.MustParse("0.1.0"),
+								},
+							},
+						},
+					},
+				},
+			},
+			exp: action.DiffIncludeConfig{
+				Packages: []action.DiffIncludePackage{
+					{
+						Name: "bar",
+						Channels: []action.DiffIncludeChannel{
+							{
+								Name: "stable",
+								Versions: []semver.Version{
+									semver.MustParse("0.1.0"),
+								},
+							},
+						},
+					},
+					{
+						Name: "foo",
+						Channels: []action.DiffIncludeChannel{
+							{
+								Name: "stable",
+								Versions: []semver.Version{
+									semver.MustParse("0.1.0"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Valid/NoChannels",
+			cfg: IncludeConfig{
+				Packages: []IncludePackage{
+					{
+						Name: "bar",
+						IncludeBundle: IncludeBundle{
+							StartingVersion: semver.MustParse("0.1.0"),
+						},
+					},
+					{
+						Name: "foo",
+						IncludeBundle: IncludeBundle{
+							StartingVersion: semver.MustParse("0.1.0"),
+						},
+					},
+				},
+			},
+			exp: action.DiffIncludeConfig{
+				Packages: []action.DiffIncludePackage{
+					{
+						Name: "bar",
+						Versions: []semver.Version{
+							semver.MustParse("0.1.0"),
+						},
+					},
+					{
+						Name: "foo",
+						Versions: []semver.Version{
+							semver.MustParse("0.1.0"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, s := range specs {
+		t.Run(s.name, func(t *testing.T) {
+			dic, err := s.cfg.ConvertToDiffIncludeConfig()
+			require.NoError(t, err)
+			require.Equal(t, s.exp, dic)
+		})
+	}
+}

--- a/pkg/api/v1alpha2/types_metadata.go
+++ b/pkg/api/v1alpha2/types_metadata.go
@@ -46,6 +46,8 @@ type PastMirror struct {
 	Mirror Mirror `json:"mirror"`
 	// Operators are metadata about the set of mirrored operators in a mirror operation.
 	Operators []OperatorMetadata `json:"operators,omitempty"`
+	// Platforms are metadata about the set of mirrored platform release channels in a mirror operation.
+	Platforms []PlatformMetadata `json:"platforms,omitempty"`
 	// Associations are metadata about the set of mirrored images including
 	// child manifest and layer digest information
 	Associations []Association `json:"associations,omitempty"`
@@ -59,6 +61,22 @@ type OperatorMetadata struct {
 	// This image will be pulled using the pull secret
 	// in the metadata's Mirror config for this catalog.
 	ImagePin string `json:"imagePin"`
+	// IncludeConfig in OperatorMetadata holds the starting
+	// versions of all newly mirrored catalogs. This will
+	// be populated the first time a catalog is mirrored
+	// and copied the remaining runs.
+	IncludeConfig `json:",inline"`
+}
+
+// ReleaseMetadata holds an Release's post-mirror metadata.
+type PlatformMetadata struct {
+	// Release references a channel name from the mirror spec.
+	ReleaseChannel string `json:"channel"`
+	// MinVersion in ReleaseMetadata holds the starting
+	// versions of all newly mirrored channels. This will
+	// be populated the first time a channel is mirrored
+	// and copied the remaining runs.
+	MinVersion string `json:"minVersion"`
 }
 
 var _ io.Writer = &InlinedIndex{}

--- a/pkg/api/v1alpha2/types_metadata.go
+++ b/pkg/api/v1alpha2/types_metadata.go
@@ -10,17 +10,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Metadata object kind.
+// MetadataKind object kind.
 const MetadataKind = "Metadata"
 
 // Metadata configures image set creation.
 type Metadata struct {
 	metav1.TypeMeta `json:",inline"`
-	// MetadataSpec defines the global specificed for Metadata types.
+	// MetadataSpec defines the global specified for Metadata types.
 	MetadataSpec `json:",inline"`
 }
 
-// MetadataSpec defines the global configuration specificed for Metadata types.
+// MetadataSpec defines the global configuration specified for Metadata types.
 type MetadataSpec struct {
 	// Uid uniquely identifies this metadata object.
 	Uid uuid.UUID `json:"uid"`
@@ -35,7 +35,7 @@ type MetadataSpec struct {
 
 // PastMirror defines the specification for previously mirrored content.
 type PastMirror struct {
-	// TimeStamp defines when the mirrored was proccessed.
+	// TimeStamp defines when the mirrored was processed.
 	Timestamp int `json:"timestamp"`
 	// Sequence defines the serial number
 	// assigned to the processed mirror.
@@ -62,17 +62,17 @@ type OperatorMetadata struct {
 	// in the metadata's Mirror config for this catalog.
 	ImagePin string `json:"imagePin"`
 	// IncludeConfig in OperatorMetadata holds the starting
-	// versions of all newly mirrored catalogs. This will
-	// be populated the first time a catalog is mirrored
-	// and copied the remaining runs.
+	// versions of all heads-only mirrored catalogs. It will
+	// be validated against the current catalog during each run
+	// and updated.
 	IncludeConfig `json:",inline"`
 }
 
-// ReleaseMetadata holds an Release's post-mirror metadata.
+// PlatformMetadata holds an Release's post-mirror metadata.
 type PlatformMetadata struct {
 	// Release references a channel name from the mirror spec.
 	ReleaseChannel string `json:"channel"`
-	// MinVersion in ReleaseMetadata holds the starting
+	// MinVersion in OCPMetadata holds the starting
 	// versions of all newly mirrored channels. This will
 	// be populated the first time a channel is mirrored
 	// and copied the remaining runs.

--- a/pkg/cli/mirror/catalog_images.go
+++ b/pkg/cli/mirror/catalog_images.go
@@ -65,7 +65,7 @@ func (o *MirrorOptions) rebuildCatalogs(ctx context.Context, dstDir string) (ima
 		}
 
 		// From the index path determine the artifacts (index and layout) directory.
-		// Using that path determine the corresponding catalog image for processing.
+		// Using that path to determine the corresponding catalog image for processing.
 		slashPath := filepath.ToSlash(fpath)
 		if base := path.Base(slashPath); base == "index.json" {
 			slashPath = path.Dir(slashPath)
@@ -126,10 +126,8 @@ func (o *MirrorOptions) rebuildCatalogs(ctx context.Context, dstDir string) (ima
 
 func (o *MirrorOptions) processCatalogRefs(ctx context.Context, catalogsByImage map[imagesource.TypedImageReference]string) error {
 	for ctlgRef, artifactDir := range catalogsByImage {
-		// An image for a particular catalog may not exist in the mirror registry yet,
-		// ex. when publish is run for the first time for a catalog (full/headsonly).
-		// If that is the case, then simply build the catalog image with the new
-		// declarative config catalog; otherwise render the existing and new catalogs together.
+		// Always build the catalog image with the new declarative config catalog
+		// using the original catalog as the base image
 		var layers []v1.Layer
 		var layoutPath layout.Path
 		refExact := ctlgRef.Ref.Exact()

--- a/pkg/cli/mirror/catalog_images.go
+++ b/pkg/cli/mirror/catalog_images.go
@@ -10,19 +10,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/remotes"
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
-	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/openshift/library-go/pkg/image/reference"
-	"github.com/operator-framework/operator-registry/alpha/action"
-	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/pkg/containertools"
-	operatorimage "github.com/operator-framework/operator-registry/pkg/image"
 	"github.com/operator-framework/operator-registry/pkg/image/containerdregistry"
 	"github.com/sirupsen/logrus"
 
@@ -30,7 +22,6 @@ import (
 	"github.com/openshift/oc-mirror/pkg/config"
 	"github.com/openshift/oc-mirror/pkg/image"
 	"github.com/openshift/oc-mirror/pkg/image/builder"
-	"github.com/openshift/oc-mirror/pkg/operator"
 	"github.com/openshift/oc/pkg/cli/image/imagesource"
 )
 
@@ -65,7 +56,7 @@ func (o *MirrorOptions) rebuildCatalogs(ctx context.Context, dstDir string) (ima
 
 		// Skip the layouts dir because we only need
 		// to process the parent directory one time
-		if filepath.Base(fpath) == LayoutsDir {
+		if filepath.Base(fpath) == config.LayoutsDir {
 			return filepath.SkipDir
 		}
 
@@ -78,7 +69,7 @@ func (o *MirrorOptions) rebuildCatalogs(ctx context.Context, dstDir string) (ima
 		slashPath := filepath.ToSlash(fpath)
 		if base := path.Base(slashPath); base == "index.json" {
 			slashPath = path.Dir(slashPath)
-			slashPath = strings.TrimSuffix(slashPath, IndexDir)
+			slashPath = strings.TrimSuffix(slashPath, config.IndexDir)
 
 			repoPath := strings.TrimPrefix(slashPath, fmt.Sprintf("%s/%s/", dstDir, config.CatalogsDir))
 			regRepoNs, id := path.Split(path.Dir(repoPath))
@@ -111,22 +102,13 @@ func (o *MirrorOptions) rebuildCatalogs(ctx context.Context, dstDir string) (ima
 		return nil, err
 	}
 
+	if err := o.processCatalogRefs(ctx, catalogsByImage); err != nil {
+		return nil, err
+	}
+
 	resolver, err := containerdregistry.NewResolver("", o.DestSkipTLS, o.DestPlainHTTP, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating image resolver: %v", err)
-	}
-	reg, err := containerdregistry.NewRegistry(
-		containerdregistry.SkipTLSVerify(o.DestSkipTLS),
-		containerdregistry.WithPlainHTTP(o.DestPlainHTTP),
-		containerdregistry.WithCacheDir(filepath.Join(dstDir, "cache")),
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer reg.Destroy()
-
-	if err := o.processCatalogRefs(ctx, catalogsByImage, reg, resolver); err != nil {
-		return nil, err
 	}
 
 	// Resolve the image's digest for ICSP creation.
@@ -142,7 +124,7 @@ func (o *MirrorOptions) rebuildCatalogs(ctx context.Context, dstDir string) (ima
 	return refs, nil
 }
 
-func (o *MirrorOptions) processCatalogRefs(ctx context.Context, catalogsByImage map[imagesource.TypedImageReference]string, reg operatorimage.Registry, resolver remotes.Resolver) error {
+func (o *MirrorOptions) processCatalogRefs(ctx context.Context, catalogsByImage map[imagesource.TypedImageReference]string) error {
 	for ctlgRef, artifactDir := range catalogsByImage {
 		// An image for a particular catalog may not exist in the mirror registry yet,
 		// ex. when publish is run for the first time for a catalog (full/headsonly).
@@ -160,87 +142,30 @@ func (o *MirrorOptions) processCatalogRefs(ctx context.Context, catalogsByImage 
 		// Check push permissions before trying to resolve for Quay compatibility
 		nameOpts := getNameOpts(destInsecure)
 		remoteOpts := getRemoteOpts(ctx, destInsecure)
-		ref, err := name.ParseReference(refExact, nameOpts...)
-		if err != nil {
-			return err
-		}
-		err = remote.CheckPushPermission(ref, authn.DefaultKeychain, createRT(destInsecure))
-		if err != nil {
-			return err
-		}
 		imgBuilder := &builder.ImageBuilder{
 			NameOpts:   nameOpts,
 			RemoteOpts: remoteOpts,
 		}
 
-		switch _, _, rerr := resolver.Resolve(ctx, refExact); {
-		case errors.Is(rerr, errdefs.ErrNotFound):
-			logrus.Infof("Catalog image %q found, building from file with file-based catalog ", refExact)
+		logrus.Infof("Rendering catalog image %q with file-based catalog ", refExact)
 
-			add, err := builder.LayerFromPath("/configs", filepath.Join(artifactDir, IndexDir, "index.json"))
-			if err != nil {
-				return fmt.Errorf("error creating add layer: %v", err)
-			}
+		add, err := builder.LayerFromPath("/configs", filepath.Join(artifactDir, config.IndexDir, "index.json"))
+		if err != nil {
+			return fmt.Errorf("error creating add layer: %v", err)
+		}
 
-			// Since we are defining the FBC as index.json, remove
-			// any .yaml files from the initial image to ensure they are not processed instead
-			deleted, err := deleteLayer("/configs/.wh.index.yaml")
-			if err != nil {
-				return fmt.Errorf("error creating deleted layer: %v", err)
-			}
-			layers = append(layers, add, deleted)
+		// Since we are defining the FBC as index.json, remove
+		// any .yaml files from the initial image to ensure they are not processed instead
+		deleted, err := deleteLayer("/configs/.wh.index.yaml")
+		if err != nil {
+			return fmt.Errorf("error creating deleted layer: %v", err)
+		}
+		layers = append(layers, add, deleted)
 
-			layoutDir := filepath.Join(artifactDir, LayoutsDir)
-			layoutPath, err = imgBuilder.CreateLayout("", layoutDir)
-			if err != nil {
-				return fmt.Errorf("error creating OCI layout: %v", err)
-			}
-		case rerr == nil:
-			logrus.Infof("Catalog image %q found, rendering with file-based catalog", refExact)
-
-			dcDir := filepath.Join(artifactDir, IndexDir)
-			dc, err := action.Render{
-				// Order the old ctlgRef before dcDir so new packages/channels/bundles overwrite
-				// existing counterparts.
-				Refs:           []string{refExact, dcDir},
-				AllowedRefMask: action.RefAll,
-				Registry:       reg,
-			}.Run(ctx)
-			if err != nil {
-				return err
-			}
-			// Remove any duplicate objects
-			merger := &operator.TwoWayStrategy{}
-			if err := merger.Merge(dc); err != nil {
-				return err
-			}
-			dcDirToBuild := filepath.Join(dcDir, "rendered")
-			if err := os.MkdirAll(dcDirToBuild, os.ModePerm); err != nil {
-				return err
-			}
-			renderedPath := filepath.Join(dcDirToBuild, "index.json")
-			f, err := os.Create(renderedPath)
-			if err != nil {
-				return err
-			}
-			defer f.Close()
-			if err := declcfg.WriteJSON(*dc, f); err != nil {
-				return err
-			}
-
-			add, err := builder.LayerFromPath("/configs", renderedPath)
-			if err != nil {
-				return fmt.Errorf("error creating add layer: %v", err)
-			}
-			layers = append(layers, add)
-
-			layoutDir := filepath.Join(dcDir, "layout")
-			layoutPath, err = imgBuilder.CreateLayout(refExact, layoutDir)
-			if err != nil {
-				return fmt.Errorf("error creating OCI layout: %v", err)
-			}
-		default:
-			return fmt.Errorf("error resolving existing catalog image %q: %v", refExact, rerr)
+		layoutDir := filepath.Join(artifactDir, config.LayoutsDir)
+		layoutPath, err = imgBuilder.CreateLayout("", layoutDir)
+		if err != nil {
+			return fmt.Errorf("error creating OCI layout: %v", err)
 		}
 
 		update := func(cfg *v1.ConfigFile) {

--- a/pkg/cli/mirror/create_test.go
+++ b/pkg/cli/mirror/create_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
@@ -37,41 +36,4 @@ func TestCreate(t *testing.T) {
 	_, mappings, err := opts.Create(ctx, cfg)
 	require.NoError(t, err)
 	require.Len(t, mappings, 1)
-}
-
-func TestAddGraphImage(t *testing.T) {
-
-	var cfg v1alpha2.ImageSetConfiguration
-	var meta v1alpha2.Metadata
-
-	// No past GraphImage.
-	cfg = v1alpha2.ImageSetConfiguration{}
-	meta = v1alpha2.Metadata{}
-	meta.MetadataSpec.PastMirror = v1alpha2.PastMirror{
-		Mirror: v1alpha2.Mirror{
-			AdditionalImages: []v1alpha2.Image{
-				{Name: "reg.com/ns/other:latest"},
-			},
-		},
-	}
-
-	addGraphImage(&cfg, meta)
-	if assert.Len(t, cfg.Mirror.AdditionalImages, 1) {
-		require.Equal(t, cfg.Mirror.AdditionalImages[0].Name, graphBaseImage)
-	}
-
-	// Has past OPMImage.
-	cfg = v1alpha2.ImageSetConfiguration{}
-	meta = v1alpha2.Metadata{}
-	meta.MetadataSpec.PastMirror = v1alpha2.PastMirror{
-		Mirror: v1alpha2.Mirror{
-			AdditionalImages: []v1alpha2.Image{
-				{Name: graphBaseImage},
-				{Name: "reg.com/ns/other:latest"},
-			},
-		},
-	}
-
-	addGraphImage(&cfg, meta)
-	require.Len(t, cfg.Mirror.AdditionalImages, 0)
 }

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -229,8 +229,6 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 		}
 		if !o.IgnoreHistory {
 			// Prune out old associations if applicable
-			// Ignore history while transitioning to range could result
-			// in unexpected behavior
 			prevAssociations = removePreviouslyMirrored(mapping, prevAssociations)
 			if len(mapping) == 0 {
 				logrus.Infof("no new images detected, process stopping")
@@ -336,8 +334,6 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 		}
 		if !o.IgnoreHistory {
 			// Prune out old associations if applicable
-			// Ignore history while transitioning to range could result
-			// in unexpected behavior
 			prevAssociations = removePreviouslyMirrored(mapping, prevAssociations)
 			if len(mapping) == 0 {
 				logrus.Infof("no new images detected, process stopping")
@@ -471,8 +467,12 @@ func removePreviouslyMirrored(images image.TypedImageMapping, prevDownloads imag
 	newPrevious := image.AssociationSet{}
 
 	for srcRef := range images {
-		// The skip-image-pin flag could create some unexpected behavior.
 		// All keys need to specify image with digest.
+		// Tagged images will need to be redownloaded to
+		// ensure their digests have not be updated.
+		if srcRef.Ref.ID == "" {
+			continue
+		}
 		if found := prevDownloads.SetContainsKey(srcRef.Ref.String()); found {
 			logrus.Debugf("skipping previously mirrored image %s", srcRef.Ref.String())
 			images.Remove(srcRef)

--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -33,11 +33,7 @@ import (
 	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
 	"github.com/openshift/oc-mirror/pkg/config"
 	"github.com/openshift/oc-mirror/pkg/image"
-)
-
-const (
-	LayoutsDir = "layout"
-	IndexDir   = "index"
+	"github.com/openshift/oc-mirror/pkg/operator"
 )
 
 // OperatorOptions configures either a Full or Diff mirror operation
@@ -201,21 +197,26 @@ func (o *OperatorOptions) renderDCFull(ctx context.Context, reg *containerdregis
 	return dc, nil
 }
 
-// renderDCDiff renders data in ctlg into a declarative config for o.Diff().
+// renderDCDiff renders data in ctlg into a declarative config for o.PlanDiff().
+// This produces the declarative config that will be used to determine
+// differential images
 func (o *OperatorOptions) renderDCDiff(ctx context.Context, reg *containerdregistry.Registry, ctlg v1alpha2.Operator, lastRun v1alpha2.PastMirror) (dc *declcfg.DeclarativeConfig, err error) {
+	prevCatalog := make(map[string]v1alpha2.OperatorMetadata, len(lastRun.Operators))
+	for _, ctlg := range lastRun.Operators {
+		prevCatalog[ctlg.Catalog] = ctlg
+	}
+
 	hasInclude := len(ctlg.IncludeConfig.Packages) != 0
+	// Render the full catalog if neither HeadsOnly or IncludeConfig are specified.
+	full := !ctlg.IsHeadsOnly() && !hasInclude
+
 	// Generate and mirror a heads-only diff using the catalog as a new ref,
 	// and an old ref found for this catalog in lastRun.
 	catLogger := o.Logger.WithField("catalog", ctlg.Catalog)
-	dic, err := ctlg.IncludeConfig.ConvertToDiffIncludeConfig()
-	if err != nil {
-		return nil, err
-	}
 	a := action.Diff{
-		Registry:      reg,
-		NewRefs:       []string{ctlg.Catalog},
-		Logger:        catLogger,
-		IncludeConfig: dic,
+		Registry: reg,
+		NewRefs:  []string{ctlg.Catalog},
+		Logger:   catLogger,
 		// This is hard-coded to false because a diff post-metadata creation must always include
 		// newly published catalog data to join graphs. Any included objects previously included
 		// will be added as a diff as part of the latest diff mode.
@@ -223,31 +224,46 @@ func (o *OperatorOptions) renderDCDiff(ctx context.Context, reg *containerdregis
 		SkipDependencies:  ctlg.SkipDependencies,
 	}
 
-	// An old ref is always required to generate a latest diff.
-	// To make sure we always download the full include config
-	// don't set the old ref when that is specified
-	if !hasInclude {
-		for _, operator := range lastRun.Operators {
-			if operator.Catalog != ctlg.Catalog {
-				continue
-			}
-
-			if operator.ImagePin == "" {
-				return nil, fmt.Errorf("metadata sequence %d catalog %q: ImagePin must be set", lastRun.Sequence, ctlg.Catalog)
-			}
-			a.OldRefs = []string{operator.ImagePin}
-			break
-		}
-	}
-
-	resultdc, err := a.Run(ctx)
+	// Instead of creating a partial FBC with diff
+	// generate the current FBC according to the previous
+	// include config or just render the full catalog again
+	dic, err := ctlg.IncludeConfig.ConvertToDiffIncludeConfig()
 	if err != nil {
 		return nil, err
 	}
+	switch {
+	case full:
+		// Mirror the entire catalog.
+		dc, err = action.Render{
+			Registry: reg,
+			Refs:     []string{ctlg.Catalog},
+		}.Run(ctx)
+		if err != nil {
+			return nil, err
+		}
+	case !hasInclude:
+		// If a previous specified starting version can be found on
+		// the mirror run. Populate the IncludeConfig else, keep the
+		// IncludeConfig get a new catalog at heads only.
+		prev, found := prevCatalog[ctlg.Catalog]
+		if found {
+			dic, err = prev.IncludeConfig.ConvertToDiffIncludeConfig()
+			if err != nil {
+				return nil, err
+			}
+		}
+		fallthrough
+	default:
+		a.IncludeConfig = dic
+		dc, err = a.Run(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
 
-	verifyOperatorPkgFound(dic, resultdc)
+	verifyOperatorPkgFound(dic, dc)
 
-	return resultdc, nil
+	return dc, nil
 }
 
 // verifyOperatorPkgFound will verify that each of the requested operator packages were
@@ -334,8 +350,12 @@ func (o *OperatorOptions) plan(ctx context.Context, dc *declcfg.DeclarativeConfi
 	}
 
 	// Remove the catalog image from mappings we are going to transfer this
-	// using an OCI layout
-	mappings.Remove(ctlgRef, v1alpha2.TypeOperatorBundle)
+	// using an OCI layout.
+	ctlgImg := image.TypedImage{
+		TypedImageReference: ctlgRef,
+		Category:            v1alpha2.TypeOperatorBundle,
+	}
+	mappings.Remove(ctlgImg)
 	if err := o.writeLayout(ctx, ctlgRef.Ref); err != nil {
 		return nil, err
 	}
@@ -444,11 +464,11 @@ func (o *OperatorOptions) writeLayout(ctx context.Context, ctlgRef imgreference.
 
 	// Write catalog OCI layout file to src so it is included in the archive
 	// at a path unique to the image.
-	ctlgDir, err := getCatalogDir(ctlgRef)
+	ctlgDir, err := operator.GenerateCatalogDir(ctlgRef)
 	if err != nil {
 		return err
 	}
-	layoutDir := filepath.Join(o.Dir, config.SourceDir, config.CatalogsDir, ctlgDir, LayoutsDir)
+	layoutDir := filepath.Join(o.Dir, config.SourceDir, config.CatalogsDir, ctlgDir, config.LayoutsDir)
 	if err := os.MkdirAll(layoutDir, os.ModePerm); err != nil {
 		return fmt.Errorf("error catalog layout dir: %v", err)
 	}
@@ -495,11 +515,11 @@ func (o *OperatorOptions) writeDC(dc *declcfg.DeclarativeConfig, ctlgRef imgrefe
 
 	// Write catalog declarative config file to src so it is included in the archive
 	// at a path unique to the image.
-	ctlgDir, err := getCatalogDir(ctlgRef)
+	ctlgDir, err := operator.GenerateCatalogDir(ctlgRef)
 	if err != nil {
 		return "", err
 	}
-	indexDir := filepath.Join(o.Dir, config.SourceDir, config.CatalogsDir, ctlgDir, IndexDir)
+	indexDir := filepath.Join(o.Dir, config.SourceDir, config.CatalogsDir, ctlgDir, config.IndexDir)
 	if err := os.MkdirAll(indexDir, os.ModePerm); err != nil {
 		return "", fmt.Errorf("error creating diff index dir: %v", err)
 	}
@@ -521,17 +541,6 @@ func (o *OperatorOptions) writeDC(dc *declcfg.DeclarativeConfig, ctlgRef imgrefe
 	}
 
 	return indexDir, nil
-}
-
-func getCatalogDir(ctlgRef imgreference.DockerImageReference) (string, error) {
-	leafDir := ctlgRef.Tag
-	if leafDir == "" {
-		leafDir = ctlgRef.ID
-	}
-	if leafDir == "" {
-		return "", fmt.Errorf("catalog %q must have either a tag or digest", ctlgRef.Exact())
-	}
-	return filepath.Join(ctlgRef.Registry, ctlgRef.Namespace, ctlgRef.Name, leafDir), nil
 }
 
 func (o *OperatorOptions) newMirrorCatalogOptions(ctlgRef imgreference.DockerImageReference, fileDir string) (*catalog.MirrorCatalogOptions, error) {

--- a/pkg/cli/mirror/pack.go
+++ b/pkg/cli/mirror/pack.go
@@ -34,7 +34,7 @@ const (
 
 // Pack will pack the imageset and return a temporary backend storing metadata for final push
 // The metadata has been updated by the plan stage at this point but not pushed to the backend
-func (o *MirrorOptions) Pack(ctx context.Context, assocs image.AssociationSet, meta *v1alpha2.Metadata, archiveSize int64) (storage.Backend, error) {
+func (o *MirrorOptions) Pack(ctx context.Context, prevAssocs, currAssocs image.AssociationSet, meta *v1alpha2.Metadata, archiveSize int64) (storage.Backend, error) {
 	tmpdir, _, err := o.mktempDir()
 	if err != nil {
 		return nil, err
@@ -52,14 +52,11 @@ func (o *MirrorOptions) Pack(ctx context.Context, assocs image.AssociationSet, m
 	// Define a map that associates locations
 	// on disk to location in archive
 	paths := map[string]string{diskPath: config.V2Dir}
-	associations := image.AssociationSet{}
+	reconcileAssociation := image.AssociationSet{}
 	if !o.IgnoreHistory {
-		associations, err = image.ConvertToAssociationSet(meta.PastAssociations)
-		if err != nil {
-			return tmpBackend, err
-		}
+		reconcileAssociation = prevAssocs
 	}
-	manifests, blobs, err := bundle.ReconcileV2Dir(associations, paths)
+	manifests, blobs, err := bundle.ReconcileV2Dir(reconcileAssociation, paths)
 	if err != nil {
 		return tmpBackend, fmt.Errorf("error reconciling v2 files: %v", err)
 	}
@@ -69,12 +66,16 @@ func (o *MirrorOptions) Pack(ctx context.Context, assocs image.AssociationSet, m
 		return tmpBackend, ErrNoUpdatesExist
 	}
 
-	// Update Association in PastMirror to the current value and update
-	meta.PastMirror.Associations, err = image.ConvertFromAssociationSet(assocs)
+	meta.PastMirror.Associations, err = image.ConvertFromAssociationSet(currAssocs)
 	if err != nil {
 		return tmpBackend, err
 	}
-	if err := metadata.UpdateMetadata(ctx, tmpBackend, meta, o.SourceSkipTLS, o.SourcePlainHTTP); err != nil {
+	prevAssocs.Merge(currAssocs)
+	meta.PastAssociations, err = image.ConvertFromAssociationSet(prevAssocs)
+	if err != nil {
+		return tmpBackend, err
+	}
+	if err := metadata.UpdateMetadata(ctx, tmpBackend, meta, filepath.Join(o.Dir, config.SourceDir), o.SourceSkipTLS, o.SourcePlainHTTP); err != nil {
 		return tmpBackend, err
 	}
 

--- a/pkg/cli/mirror/pack.go
+++ b/pkg/cli/mirror/pack.go
@@ -66,6 +66,7 @@ func (o *MirrorOptions) Pack(ctx context.Context, prevAssocs, currAssocs image.A
 		return tmpBackend, ErrNoUpdatesExist
 	}
 
+	// Update Association in PastMirror to the current value and update
 	meta.PastMirror.Associations, err = image.ConvertFromAssociationSet(currAssocs)
 	if err != nil {
 		return tmpBackend, err

--- a/pkg/cli/mirror/pack_test.go
+++ b/pkg/cli/mirror/pack_test.go
@@ -173,9 +173,10 @@ func TestPack(t *testing.T) {
 			require.NoError(t, copyV2(filepath.Join("testdata", config.V2Dir), path))
 			ctx := context.Background()
 
+			prevAssocs, err := image.ConvertToAssociationSet(c.meta.PastAssociations)
+			require.NoError(t, err)
 			// First run will create mirror_seq1_0000.tar
-			_, err = c.opts.Pack(ctx, c.assocs, &c.meta, 0)
-			t.Log(err)
+			_, err = c.opts.Pack(ctx, prevAssocs, c.assocs, &c.meta, 0)
 
 			if c.updates {
 				require.NoError(t, err)

--- a/pkg/cli/mirror/release.go
+++ b/pkg/cli/mirror/release.go
@@ -139,7 +139,7 @@ func (o *ReleaseOptions) Plan(ctx context.Context, lastRun v1alpha2.PastMirror, 
 			} else {
 				// Range is set. Ensure full is true so this
 				// is skipped when processing release metadata.
-				// QUESTION(jpower432): This enforced during config validation
+				// QUESTION(jpower432): This is enforced during config validation
 				// for catalogs. Should we do the same here?
 				logrus.Debugf("Processing minimum version %s and maximum version %s", ch.MinVersion, ch.MaxVersion)
 				ch.Full = true

--- a/pkg/cli/mirror/release.go
+++ b/pkg/cli/mirror/release.go
@@ -73,6 +73,11 @@ func (o *ReleaseOptions) Plan(ctx context.Context, lastRun v1alpha2.PastMirror, 
 		errs             = []error{}
 	)
 
+	prevChannels := make(map[string]string, len(lastRun.Platforms))
+	for _, ch := range lastRun.Platforms {
+		prevChannels[ch.ReleaseChannel] = ch.MinVersion
+	}
+
 	for _, arch := range o.arch {
 
 		versionsByChannel := make(map[string]v1alpha2.ReleaseChannel, len(cfg.Mirror.Platform.Channels))
@@ -107,12 +112,19 @@ func (o *ReleaseOptions) Plan(ctx context.Context, lastRun v1alpha2.PastMirror, 
 
 					// Update version to release channel
 					ch.MaxVersion = latest.String()
+					logrus.Debugf("Detected minimum version as %s", ch.MaxVersion)
 					if len(ch.MinVersion) == 0 && ch.IsHeadsOnly() {
-						ch.MinVersion = latest.String()
+						min, found := prevChannels[ch.Name]
+						if !found {
+							// Starting at a new headsOnly channels
+							min = latest.String()
+						}
+						ch.MinVersion = min
+						logrus.Debugf("Detected minimum version as %s", ch.MinVersion)
 					}
 				}
 
-				// Find channel minimum if heads-only is false or just the minimum is not set
+				// Find channel minimum if full is true or just the minimum is not set
 				// in the config
 				if len(ch.MinVersion) == 0 {
 					first, err := cincinnati.GetChannelMinOrMax(ctx, client, arch, ch.Name, true)
@@ -121,7 +133,16 @@ func (o *ReleaseOptions) Plan(ctx context.Context, lastRun v1alpha2.PastMirror, 
 						continue
 					}
 					ch.MinVersion = first.String()
+					logrus.Debugf("Detected minimum version as %s", ch.MinVersion)
 				}
+				versionsByChannel[ch.Name] = ch
+			} else {
+				// Range is set. Ensure full is true so this
+				// is skipped when processing release metadata.
+				// QUESTION(jpower432): This enforced during config validation
+				// for catalogs. Should we do the same here?
+				logrus.Debugf("Processing minimum version %s and maximum version %s", ch.MinVersion, ch.MaxVersion)
+				ch.Full = true
 				versionsByChannel[ch.Name] = ch
 			}
 
@@ -135,7 +156,12 @@ func (o *ReleaseOptions) Plan(ctx context.Context, lastRun v1alpha2.PastMirror, 
 
 		// Update cfg release channels with maximum and minimum versions
 		// if applicable
-		cfg.Mirror.Platform.Channels = updateReleaseChannel(cfg.Mirror.Platform.Channels, versionsByChannel)
+		for i, ch := range cfg.Mirror.Platform.Channels {
+			ch, found := versionsByChannel[ch.Name]
+			if found {
+				cfg.Mirror.Platform.Channels[i] = ch
+			}
+		}
 
 		if len(cfg.Mirror.Platform.Channels) > 1 {
 			newDownloads, err := o.getCrossChannelDownloads(ctx, arch, cfg.Mirror.Platform.Channels)
@@ -299,6 +325,7 @@ func (o *ReleaseOptions) getCrossChannelDownloads(ctx context.Context, arch stri
 func gatherUpdates(current, newest cincinnati.Update, updates []cincinnati.Update) downloads {
 	releaseDownloads := downloads{}
 	for _, update := range updates {
+		logrus.Debugf("Found update %s", update.Version)
 		releaseDownloads[update.Image] = struct{}{}
 	}
 
@@ -368,18 +395,6 @@ func (o *ReleaseOptions) getMapping(opts *release.MirrorOptions) (image.TypedIma
 	mappings[releaseImageRef] = dstReleaseRef
 
 	return mappings, nil
-}
-
-// updateReleaseChannel will add a version to the ReleaseChannel to record
-// for metadata
-func updateReleaseChannel(releaseChannels []v1alpha2.ReleaseChannel, versionsByKey map[string]v1alpha2.ReleaseChannel) []v1alpha2.ReleaseChannel {
-	for i, ch := range releaseChannels {
-		ch, found := versionsByKey[ch.Name]
-		if found {
-			releaseChannels[i] = ch
-		}
-	}
-	return releaseChannels
 }
 
 // Define download types

--- a/pkg/config/metadata.go
+++ b/pkg/config/metadata.go
@@ -16,6 +16,8 @@ const (
 	ReleaseSignatureDir = "release-signatures"
 	GraphDataDir        = "cincinnati"
 	CatalogsDir         = "catalogs"
+	LayoutsDir          = "layout"
+	IndexDir            = "index"
 )
 
 var (

--- a/pkg/image/association_set.go
+++ b/pkg/image/association_set.go
@@ -116,7 +116,7 @@ func (as AssociationSet) Merge(in AssociationSet) {
 
 // Encode Associations in an efficient, opaque format.
 func (as AssociationSet) Encode(w io.Writer) error {
-	if err := as.validate(); err != nil {
+	if err := as.Validate(); err != nil {
 		return fmt.Errorf("invalid image associations: %v", err)
 	}
 	enc := gob.NewEncoder(w)
@@ -160,6 +160,27 @@ func (as *AssociationSet) UpdatePath() error {
 	return nil
 }
 
+// Validate AssociationSet and all contained Associations
+func (as AssociationSet) Validate() error {
+	var errs []error
+	for imageName, assocs := range as {
+		for _, assoc := range assocs {
+			if len(assoc.ManifestDigests) != 0 {
+				for _, digest := range assoc.ManifestDigests {
+					if _, found := assocs[digest]; !found {
+						errs = append(errs, fmt.Errorf("image %q: digest %s not found", imageName, digest))
+						continue
+					}
+				}
+			}
+			if err := assoc.Validate(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
 // GetDigests will return all layer and manifest digests in the AssociationSet
 func (as *AssociationSet) GetDigests() []string {
 	var digests []string
@@ -189,19 +210,16 @@ func GetImageFromBlob(as AssociationSet, digest string) string {
 	return ""
 }
 
-func (as AssociationSet) validate() error {
-	var errs []error
-	for _, imageName := range as.Keys() {
-		assocs, found := as.Search(imageName)
-		if !found {
-			return fmt.Errorf("image %q does not exist in association set", imageName)
+// Prune will return a pruned AssociationSet containing provided keys
+func Prune(in AssociationSet, keepKey []string) (AssociationSet, error) {
+	// return a new map with the pruned mapping
+	pruned := AssociationSet{}
+	for _, key := range keepKey {
+		assocs, ok := in[key]
+		if !ok {
+			return pruned, fmt.Errorf("key %s does not exist in provided associations", key)
 		}
-		for _, a := range assocs {
-
-			if err := a.Validate(); err != nil {
-				errs = append(errs, err)
-			}
-		}
+		pruned[key] = assocs
 	}
-	return utilerrors.NewAggregate(errs)
+	return pruned, nil
 }

--- a/pkg/image/association_set.go
+++ b/pkg/image/association_set.go
@@ -65,14 +65,16 @@ func (as AssociationSet) UpdateValue(key string, value v1alpha2.Association) err
 }
 
 // Add stores a key-value pair in this multimap.
-func (as AssociationSet) Add(key string, value v1alpha2.Association) {
+func (as AssociationSet) Add(key string, values ...v1alpha2.Association) {
 	assocs, found := as[key]
-	if found {
-		assocs[value.Name] = value
-	} else {
-		assocs = make(Associations)
-		assocs[value.Name] = value
-		as[key] = assocs
+	for _, value := range values {
+		if found {
+			assocs[value.Name] = value
+		} else {
+			assocs = make(Associations)
+			assocs[value.Name] = value
+			as[key] = assocs
+		}
 	}
 }
 

--- a/pkg/image/mapping.go
+++ b/pkg/image/mapping.go
@@ -66,13 +66,11 @@ func (m TypedImageMapping) Add(srcRef, dstRef imagesource.TypedImageReference, t
 	m[srcTypedRef] = dstTypedRef
 }
 
-// Remove will remove an image from the map given the TypeImageReference and type
-func (m TypedImageMapping) Remove(ref imagesource.TypedImageReference, typ v1alpha2.ImageType) {
-	typedRef := TypedImage{
-		TypedImageReference: ref,
-		Category:            typ,
+// Remove will remove a TypedImage from the mapping
+func (m TypedImageMapping) Remove(images ...TypedImage) {
+	for _, img := range images {
+		delete(m, img)
 	}
-	delete(m, typedRef)
 }
 
 // ByCategory will return a pruned mapping containing provided types

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -71,12 +71,16 @@ func UpdateMetadata(ctx context.Context, backend storage.Backend, meta *v1alpha2
 		containerdregistry.WithCacheDir(cacheDir),
 		containerdregistry.SkipTLSVerify(skipTLSVerify),
 		containerdregistry.WithPlainHTTP(plainHTTP),
+		// The containerd registry impl is somewhat verbose, even on the happy path,
+		// so discard all logger logs. Any important failures will be returned from
+		// registry methods and eventually logged as fatal errors.
 		containerdregistry.WithLog(nullLogger),
 	)
 	if err != nil {
 		return err
 	}
 	defer reg.Destroy()
+
 	for _, operator := range mirror.Mirror.Operators {
 		operatorMeta, err := resolveOperatorMetadata(ctx, operator, reg, resolver, workspace)
 		if err != nil {

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -2,15 +2,24 @@ package metadata
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 
+	"github.com/containerd/containerd/remotes"
+	imgreference "github.com/openshift/library-go/pkg/image/reference"
+	"github.com/operator-framework/operator-registry/alpha/action"
 	"github.com/operator-framework/operator-registry/pkg/image/containerdregistry"
+	"github.com/sirupsen/logrus"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
 	"github.com/openshift/oc-mirror/pkg/config"
 	"github.com/openshift/oc-mirror/pkg/image"
 	"github.com/openshift/oc-mirror/pkg/metadata/storage"
+	"github.com/openshift/oc-mirror/pkg/operator"
 )
 
 // SyncMetadata copies Metadata from one Backend to another
@@ -28,22 +37,59 @@ func SyncMetadata(ctx context.Context, first storage.Backend, second storage.Bac
 
 // UpdateMetadata runs some reconciliation functions on Metadata to ensure its state is consistent
 // then uses the Backend to update the metadata storage medium.
-func UpdateMetadata(ctx context.Context, backend storage.Backend, meta *v1alpha2.Metadata, skipTLSVerify, plainHTTP bool) error {
-
-	// If using heads only setting, aggregate all of the associations.
-	// Replace if using ranges to prune any old image information
-	// to support pruning.
-	if keepPastAssociations(meta.PastMirror.Mirror) {
-		meta.PastAssociations = append(meta.PastAssociations, meta.PastMirror.Associations...)
-	} else {
-		meta.PastAssociations = meta.PastMirror.Associations
+func UpdateMetadata(ctx context.Context, backend storage.Backend, meta *v1alpha2.Metadata, workspace string, skipTLSVerify, plainHTTP bool) error {
+	pastMeta := v1alpha2.NewMetadata()
+	pastOperators := map[string]v1alpha2.IncludeConfig{}
+	pastReleases := map[string]string{}
+	merr := backend.ReadMetadata(ctx, &pastMeta, config.MetadataBasePath)
+	if merr != nil && !errors.Is(merr, storage.ErrMetadataNotExist) {
+		return merr
+	} else if merr == nil {
+		for _, ctlg := range pastMeta.PastMirror.Operators {
+			pastOperators[ctlg.Catalog] = ctlg.IncludeConfig
+		}
+		for _, ch := range pastMeta.PastMirror.Platforms {
+			pastReleases[ch.ReleaseChannel] = ch.MinVersion
+		}
 	}
 
+	// TODO(jpower432): Add a warning or return an error when the starting
+	// version recorded here no longer exists.
+	mirror := meta.PastMirror
+	// Store starting versions for new catalogs
+	logrus.Debugf("Resolving operator metadata")
 	var operatorErrs []error
 
-	mirror := meta.PastMirror
+	resolver, err := containerdregistry.NewResolver("", skipTLSVerify, plainHTTP, nil)
+	if err != nil {
+		return fmt.Errorf("error creating image resolver: %v", err)
+	}
+	cacheDir, err := os.MkdirTemp("", "imageset-catalog-registry-")
+	if err != nil {
+		return err
+	}
+
+	logger := logrus.New()
+	logger.SetOutput(ioutil.Discard)
+	nullLogger := logrus.NewEntry(logger)
+
+	reg, err := containerdregistry.NewRegistry(
+		containerdregistry.WithCacheDir(cacheDir),
+		containerdregistry.SkipTLSVerify(skipTLSVerify),
+		containerdregistry.WithPlainHTTP(plainHTTP),
+		containerdregistry.WithLog(nullLogger),
+	)
+	if err != nil {
+		return err
+	}
+	defer reg.Destroy()
 	for _, operator := range mirror.Mirror.Operators {
-		operatorMeta, err := resolveOperatorMetadata(ctx, operator, skipTLSVerify, plainHTTP)
+
+		ic, ok := pastOperators[operator.Catalog]
+		if !ok {
+			ic = v1alpha2.IncludeConfig{}
+		}
+		operatorMeta, err := resolveOperatorMetadata(ctx, operator, ic, reg, resolver, workspace)
 		if err != nil {
 			operatorErrs = append(operatorErrs, err)
 			continue
@@ -55,6 +101,28 @@ func UpdateMetadata(ctx context.Context, backend storage.Backend, meta *v1alpha2
 		return utilerrors.NewAggregate(operatorErrs)
 	}
 
+	// Store starting versions for new release channels
+	logrus.Debugf("Resolving OCP release metadata")
+	for _, channel := range mirror.Mirror.Platform.Channels {
+
+		// Only collect the information
+		// for heads only work flow for conversions
+		// from ranges to heads only.
+		if !channel.IsHeadsOnly() {
+			continue
+		}
+		min, ok := pastReleases[channel.Name]
+		if !ok {
+			logrus.Debugf("channel %q not found, setting new min to %q", channel.Name, channel.MinVersion)
+			min = channel.MinVersion
+		}
+
+		releaseMeta := v1alpha2.PlatformMetadata{}
+		releaseMeta.ReleaseChannel = channel.Name
+		releaseMeta.MinVersion = min
+		meta.PastMirror.Platforms = append(meta.PastMirror.Platforms, releaseMeta)
+	}
+
 	// Add mirror as a new PastMirror
 	if err := backend.WriteMetadata(ctx, meta, config.MetadataBasePath); err != nil {
 		return fmt.Errorf("error writing metadata: %v", err)
@@ -63,36 +131,46 @@ func UpdateMetadata(ctx context.Context, backend storage.Backend, meta *v1alpha2
 	return nil
 }
 
-// TODO:(jpower432): Remove and use a
-// configuration key to determine whether pruning
-// is enabled
-func keepPastAssociations(mirror v1alpha2.Mirror) bool {
-	for _, release := range mirror.Platform.Channels {
-		if release.IsHeadsOnly() {
-			return true
+func resolveOperatorMetadata(ctx context.Context, ctlg v1alpha2.Operator, ic v1alpha2.IncludeConfig, reg *containerdregistry.Registry, resolver remotes.Resolver, workspace string) (operatorMeta v1alpha2.OperatorMetadata, err error) {
+	operatorMeta.Catalog = ctlg.Catalog
+	ctlgPin := ctlg.Catalog
+	if !image.IsImagePinned(ctlg.Catalog) {
+		ctlgPin, err = image.ResolveToPin(ctx, resolver, ctlg.Catalog)
+		if err != nil {
+			return v1alpha2.OperatorMetadata{}, fmt.Errorf("error resolving catalog image %q: %v", ctlg.Catalog, err)
 		}
 	}
-	for _, ctlg := range mirror.Operators {
-		// Keep for heads only and full catalog workflows
-		if ctlg.IsHeadsOnly() || len(ctlg.Packages) == 0 {
-			return true
+	operatorMeta.ImagePin = ctlgPin
+
+	// Only collect the information
+	// for heads only work flows for conversions from ranges
+	// or full catalogs to heads only.
+	if len(ic.Packages) == 0 && ctlg.IsHeadsOnly() {
+		// Determine the location of the created FBC
+		ctlgRef, err := imgreference.Parse(ctlg.Catalog)
+		if err != nil {
+			return v1alpha2.OperatorMetadata{}, err
+		}
+		dcLoc, err := operator.GenerateCatalogDir(ctlgRef)
+		if err != nil {
+			return v1alpha2.OperatorMetadata{}, err
+		}
+		dcLoc = filepath.Join(workspace, config.CatalogsDir, dcLoc, config.IndexDir)
+		dc, err := action.Render{
+			Registry:       reg,
+			Refs:           []string{dcLoc},
+			AllowedRefMask: action.RefAll,
+		}.Run(ctx)
+		if err != nil {
+			return v1alpha2.OperatorMetadata{}, err
+		}
+		ic, err = operator.ConvertDCToIncludeConfig(*dc)
+		if err != nil {
+			return v1alpha2.OperatorMetadata{}, err
 		}
 	}
 
-	return false
-}
-
-func resolveOperatorMetadata(ctx context.Context, operator v1alpha2.Operator, skipTLSVerify, plainHTTP bool) (operatorMeta v1alpha2.OperatorMetadata, err error) {
-	operatorMeta.Catalog = operator.Catalog
-
-	resolver, err := containerdregistry.NewResolver("", skipTLSVerify, plainHTTP, nil)
-	if err != nil {
-		return v1alpha2.OperatorMetadata{}, fmt.Errorf("error creating image resolver: %v", err)
-	}
-	operatorMeta.ImagePin, err = image.ResolveToPin(ctx, resolver, operator.Catalog)
-	if err != nil {
-		return v1alpha2.OperatorMetadata{}, fmt.Errorf("error resolving catalog image %q: %v", operator.Catalog, err)
-	}
+	operatorMeta.IncludeConfig = ic
 
 	return operatorMeta, nil
 }

--- a/pkg/metadata/store_test.go
+++ b/pkg/metadata/store_test.go
@@ -1,0 +1,203 @@
+package metadata
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
+	"github.com/openshift/oc-mirror/pkg/metadata/storage"
+)
+
+func TestUpdateMetadata_Catalogs(t *testing.T) {
+	type spec struct {
+		name     string
+		config   v1alpha2.ImageSetConfiguration
+		expIC    v1alpha2.IncludeConfig
+		expError string
+	}
+
+	cases := []spec{
+		{
+			name: "Valid/HeadsOnlyFalse",
+			config: v1alpha2.ImageSetConfiguration{
+				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+					Mirror: v1alpha2.Mirror{
+						Operators: []v1alpha2.Operator{
+							{
+								Catalog: "test.registry/catalog@sha256:30c794a11b4c340c77238c5b7ca845752904bd8b74b73a9b16d31253234da031",
+								IncludeConfig: v1alpha2.IncludeConfig{
+									Packages: []v1alpha2.IncludePackage{{Name: "foo"}},
+								},
+								Full: true,
+							},
+						},
+					},
+				},
+			},
+			expIC: v1alpha2.IncludeConfig{},
+		},
+		{
+			name: "Valid/HeadsOnlyTrue",
+			config: v1alpha2.ImageSetConfiguration{
+				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+					Mirror: v1alpha2.Mirror{
+						Operators: []v1alpha2.Operator{
+							{
+								Catalog: "test.registry/catalog@sha256:30c794a11b4c340c77238c5b7ca845752904bd8b74b73a9b16d31253234da031",
+								Full:    false,
+							},
+						},
+					},
+				},
+			},
+			expIC: v1alpha2.IncludeConfig{
+				Packages: []v1alpha2.IncludePackage{
+					{
+						Name: "bar",
+						Channels: []v1alpha2.IncludeChannel{
+							{
+								Name: "alpha",
+								IncludeBundle: v1alpha2.IncludeBundle{
+									StartingVersion: semver.MustParse("0.1.0"),
+								},
+							},
+							{
+								Name: "stable",
+								IncludeBundle: v1alpha2.IncludeBundle{
+									StartingVersion: semver.MustParse("1.0.0"),
+								},
+							},
+						},
+					},
+					{
+						Name: "baz",
+						Channels: []v1alpha2.IncludeChannel{
+							{
+								Name: "stable",
+								IncludeBundle: v1alpha2.IncludeBundle{
+									StartingVersion: semver.MustParse("1.0.0"),
+								},
+							},
+						},
+					},
+					{
+						Name: "foo",
+						Channels: []v1alpha2.IncludeChannel{
+							{
+								Name: "beta",
+								IncludeBundle: v1alpha2.IncludeBundle{
+									StartingVersion: semver.MustParse("0.1.0"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			inputMeta := v1alpha2.NewMetadata()
+			inputMeta.PastMirror.Mirror = c.config.Mirror
+			cfg := v1alpha2.StorageConfig{
+				Local: &v1alpha2.LocalConfig{
+					Path: t.TempDir(),
+				},
+			}
+			backend, err := storage.ByConfig("", cfg)
+			require.NoError(t, err)
+			err = UpdateMetadata(context.TODO(), backend, &inputMeta, "testdata", true, true)
+			if c.expError != "" {
+				require.EqualError(t, err, c.expError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, c.expIC, inputMeta.PastMirror.Operators[len(inputMeta.PastMirror.Operators)-1].IncludeConfig)
+			}
+		})
+	}
+}
+
+func TestUpdateMetadata_OCPReleases(t *testing.T) {
+
+	type spec struct {
+		name     string
+		config   v1alpha2.ImageSetConfiguration
+		expMeta  v1alpha2.PlatformMetadata
+		expError string
+	}
+
+	cases := []spec{
+		{
+			name: "Valid/HeadsOnlyFalse",
+			config: v1alpha2.ImageSetConfiguration{
+				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+					Mirror: v1alpha2.Mirror{
+						Platform: v1alpha2.Platform{
+							Channels: []v1alpha2.ReleaseChannel{
+								{
+									Name:       "stable-4.9",
+									MinVersion: "4.9.0",
+									MaxVersion: "4.9.5",
+									Full:       true,
+								},
+							},
+						},
+					},
+				},
+			},
+			expMeta: v1alpha2.PlatformMetadata{},
+		},
+		{
+			name: "Valid/HeadsOnlyTrue",
+			config: v1alpha2.ImageSetConfiguration{
+				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+					Mirror: v1alpha2.Mirror{
+						Platform: v1alpha2.Platform{
+							Channels: []v1alpha2.ReleaseChannel{
+								{
+									Name:       "stable-4.9",
+									MinVersion: "4.9.5",
+									MaxVersion: "4.9.5",
+									Full:       false,
+								},
+							},
+						},
+					},
+				},
+			},
+			expMeta: v1alpha2.PlatformMetadata{
+				ReleaseChannel: "stable-4.9",
+				MinVersion:     "4.9.5",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			inputMeta := v1alpha2.NewMetadata()
+			inputMeta.PastMirror.Mirror = c.config.Mirror
+			cfg := v1alpha2.StorageConfig{
+				Local: &v1alpha2.LocalConfig{
+					Path: t.TempDir(),
+				},
+			}
+			backend, err := storage.ByConfig("", cfg)
+			require.NoError(t, err)
+			err = UpdateMetadata(context.TODO(), backend, &inputMeta, "testdata", true, true)
+			if c.expError != "" {
+				require.EqualError(t, err, c.expError)
+			} else {
+				require.NoError(t, err)
+				actual := v1alpha2.PlatformMetadata{}
+				if len(inputMeta.PastMirror.Platforms) != 0 {
+					actual = inputMeta.PastMirror.Platforms[len(inputMeta.PastMirror.Platforms)-1]
+				}
+				require.Equal(t, c.expMeta, actual)
+			}
+		})
+	}
+}

--- a/pkg/metadata/testdata/catalogs/test.registry/catalog/sha256:30c794a11b4c340c77238c5b7ca845752904bd8b74b73a9b16d31253234da031/index/index.yaml
+++ b/pkg/metadata/testdata/catalogs/test.registry/catalog/sha256:30c794a11b4c340c77238c5b7ca845752904bd8b74b73a9b16d31253234da031/index/index.yaml
@@ -1,0 +1,357 @@
+---
+defaultChannel: stable
+name: bar
+schema: olm.package
+---
+name: alpha
+package: bar
+schema: olm.channel
+entries:
+  - name: bar.v0.1.0
+  - name: bar.v0.2.0
+    replaces: bar.v0.1.0
+    skipRange: <0.2.0
+    skips:
+      - bar.v0.1.0
+  - name: bar.v1.0.0
+    replaces: bar.v0.2.0
+---
+name: stable
+package: bar
+schema: olm.channel
+entries:
+  - name: bar.v1.0.0
+---
+image: test.registry/bar-operator/bar-bundle:v0.1.0
+name: bar.v0.1.0
+package: bar
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhcnMudGVzdC5iYXIifSwic3BlYyI6eyJncm91cCI6InRlc3QuYmFyIiwibmFtZXMiOnsia2luZCI6IkJhciIsInBsdXJhbCI6ImJhcnMifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MWFscGhhMSJ9XX19
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhci52MC4xLjAifSwic3BlYyI6eyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjp7Im93bmVkIjpbeyJncm91cCI6InRlc3QuYmFyIiwia2luZCI6IkJhciIsIm5hbWUiOiJiYXJzLnRlc3QuYmFyIiwidmVyc2lvbiI6InYxYWxwaGExIn1dfSwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJ0ZXN0LnJlZ2lzdHJ5L2Jhci1vcGVyYXRvci9iYXI6djAuMS4wIiwibmFtZSI6Im9wZXJhdG9yIn1dLCJ2ZXJzaW9uIjoiMC4xLjAifX0=
+- type: olm.gvk
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: bar
+    version: 0.1.0
+relatedImages:
+- image: test.registry/bar-operator/bar:v0.1.0
+  name: operator
+schema: olm.bundle
+---
+image: test.registry/bar-operator/bar-bundle:v0.2.0
+name: bar.v0.2.0
+package: bar
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhcnMudGVzdC5iYXIifSwic3BlYyI6eyJncm91cCI6InRlc3QuYmFyIiwibmFtZXMiOnsia2luZCI6IkJhciIsInBsdXJhbCI6ImJhcnMifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MWFscGhhMSJ9XX19
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsib2xtLnNraXBSYW5nZSI6Ilx1MDAzYzAuMi4wIn0sIm5hbWUiOiJiYXIudjAuMi4wIn0sInNwZWMiOnsiY3VzdG9tcmVzb3VyY2VkZWZpbml0aW9ucyI6eyJvd25lZCI6W3siZ3JvdXAiOiJ0ZXN0LmJhciIsImtpbmQiOiJCYXIiLCJuYW1lIjoiYmFycy50ZXN0LmJhciIsInZlcnNpb24iOiJ2MWFscGhhMSJ9XX0sInJlbGF0ZWRJbWFnZXMiOlt7ImltYWdlIjoidGVzdC5yZWdpc3RyeS9iYXItb3BlcmF0b3IvYmFyOnYwLjIuMCIsIm5hbWUiOiJvcGVyYXRvciJ9XSwic2tpcHMiOlsiYmFyLnYwLjEuMCJdLCJ2ZXJzaW9uIjoiMC4yLjAifX0=
+- type: olm.gvk
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: bar
+    version: 0.2.0
+relatedImages:
+- image: test.registry/bar-operator/bar:v0.2.0
+  name: operator
+schema: olm.bundle
+---
+image: test.registry/bar-operator/bar-bundle:v1.0.0
+name: bar.v1.0.0
+package: bar
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhcnMudGVzdC5iYXIifSwic3BlYyI6eyJncm91cCI6InRlc3QuYmFyIiwibmFtZXMiOnsia2luZCI6IkJhciIsInBsdXJhbCI6ImJhcnMifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MWFscGhhMSIsInNlcnZlZCI6dHJ1ZSwic3RvcmFnZSI6ZmFsc2V9LHsibmFtZSI6InYxIiwic2VydmVkIjp0cnVlLCJzdG9yYWdlIjp0cnVlfV19fQ==
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhci52MS4wLjAifSwic3BlYyI6eyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjp7Im93bmVkIjpbeyJncm91cCI6InRlc3QuYmFyIiwia2luZCI6IkJhciIsIm5hbWUiOiJiYXJzLnRlc3QuYmFyIiwidmVyc2lvbiI6InYxYWxwaGExIn0seyJncm91cCI6InRlc3QuYmFyIiwia2luZCI6IkJhciIsIm5hbWUiOiJiYXJzLnRlc3QuYmFyIiwidmVyc2lvbiI6InYxIn1dfSwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJ0ZXN0LnJlZ2lzdHJ5L2Jhci1vcGVyYXRvci9iYXI6djEuMC4wIiwibmFtZSI6Im9wZXJhdG9yIn1dLCJyZXBsYWNlcyI6ImJhci52MC4yLjAiLCJ2ZXJzaW9uIjoiMS4wLjAifX0=
+- type: olm.gvk
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1
+- type: olm.gvk
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: bar
+    version: 1.0.0
+relatedImages:
+- image: test.registry/bar-operator/bar:v1.0.0
+  name: operator
+schema: olm.bundle
+---
+defaultChannel: stable
+name: baz
+schema: olm.package
+---
+schema: olm.channel
+package: baz
+name: stable
+entries:
+  - name: baz.v1.0.0
+    skipRange: <1.0.0
+  - name: baz.v1.0.1
+    replaces: baz.v1.0.0
+    skipRange: <1.0.0
+    skips:
+      - baz.v1.0.0
+  - name: baz.v1.1.0
+    replaces: baz.v1.0.0
+    skips:
+      - baz.v1.0.1
+---
+image: test.registry/baz-operator/baz-bundle:v1.0.0
+name: baz.v1.0.0
+package: baz
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhenMudGVzdC5iYXoifSwic3BlYyI6eyJncm91cCI6InRlc3QuYmF6IiwibmFtZXMiOnsia2luZCI6IkJheiIsInBsdXJhbCI6ImJhenMifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MSJ9XX19
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhei52MS4wLjAifSwic3BlYyI6eyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjp7Im93bmVkIjpbeyJncm91cCI6InRlc3QuYmF6Iiwia2luZCI6IkJheiIsIm5hbWUiOiJiYXpzLnRlc3QuYmF6IiwidmVyc2lvbiI6InYxIn1dfSwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJ0ZXN0LnJlZ2lzdHJ5L2Jhei1vcGVyYXRvci9iYXo6djEuMC4wIiwibmFtZSI6Im9wZXJhdG9yIn1dLCJ2ZXJzaW9uIjoiMS4wLjAifX0=
+- type: olm.gvk
+  value:
+    group: test.baz
+    kind: Baz
+    version: v1
+- type: olm.package
+  value:
+    packageName: baz
+    version: 1.0.0
+relatedImages:
+- image: test.registry/baz-operator/baz:v1.0.0
+  name: operator
+schema: olm.bundle
+---
+image: test.registry/baz-operator/baz-bundle:v1.0.1
+name: baz.v1.0.1
+package: baz
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhenMudGVzdC5iYXoifSwic3BlYyI6eyJncm91cCI6InRlc3QuYmF6IiwibmFtZXMiOnsia2luZCI6IkJheiIsInBsdXJhbCI6ImJhenMifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MSJ9XX19
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsib2xtLnNraXBSYW5nZSI6Ilx1MDAzYzEuMC4xIn0sIm5hbWUiOiJiYXoudjEuMC4xIn0sInNwZWMiOnsiY3VzdG9tcmVzb3VyY2VkZWZpbml0aW9ucyI6eyJvd25lZCI6W3siZ3JvdXAiOiJ0ZXN0LmJheiIsImtpbmQiOiJCYXoiLCJuYW1lIjoiYmF6cy50ZXN0LmJheiIsInZlcnNpb24iOiJ2MSJ9XX0sInJlbGF0ZWRJbWFnZXMiOlt7ImltYWdlIjoidGVzdC5yZWdpc3RyeS9iYXotb3BlcmF0b3IvYmF6OnYxLjAuMSIsIm5hbWUiOiJvcGVyYXRvciJ9XSwic2tpcHMiOlsiYmF6LnYxLjAuMCJdLCJ2ZXJzaW9uIjoiMS4wLjEifX0=
+- type: olm.gvk
+  value:
+    group: test.baz
+    kind: Baz
+    version: v1
+- type: olm.package
+  value:
+    packageName: baz
+    version: 1.0.1
+relatedImages:
+- image: test.registry/baz-operator/baz:v1.0.1
+  name: operator
+schema: olm.bundle
+---
+image: test.registry/baz-operator/baz-bundle:v1.1.0
+name: baz.v1.1.0
+package: baz
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhenMudGVzdC5iYXoifSwic3BlYyI6eyJncm91cCI6InRlc3QuYmF6IiwibmFtZXMiOnsia2luZCI6IkJheiIsInBsdXJhbCI6ImJhenMifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MSJ9XX19
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhei52MS4xLjAifSwic3BlYyI6eyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjp7Im93bmVkIjpbeyJncm91cCI6InRlc3QuYmF6Iiwia2luZCI6IkJheiIsIm5hbWUiOiJiYXpzLnRlc3QuYmF6IiwidmVyc2lvbiI6InYxIn1dfSwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJ0ZXN0LnJlZ2lzdHJ5L2Jhei1vcGVyYXRvci9iYXo6djEuMS4wIiwibmFtZSI6Im9wZXJhdG9yIn1dLCJyZXBsYWNlcyI6ImJhei52MS4wLjAiLCJ2ZXJzaW9uIjoiMS4xLjAifX0=
+- type: olm.gvk
+  value:
+    group: test.baz
+    kind: Baz
+    version: v1
+- type: olm.package
+  value:
+    packageName: baz
+    version: 1.1.0
+relatedImages:
+- image: test.registry/baz-operator/baz:v1.1.0
+  name: operator
+schema: olm.bundle
+---
+defaultChannel: beta
+name: foo
+schema: olm.package
+---
+schema: olm.channel
+package: foo
+name: beta
+entries:
+  - name: foo.v0.1.0
+    skipRange: <0.1.0
+  - name: foo.v0.2.0
+    replaces: foo.v0.1.0
+    skipRange: <0.2.0
+    skips:
+      - foo.v0.1.1
+      - foo.v0.1.2
+  - name: foo.v0.3.0
+    replaces: foo.v0.2.0
+  - name: foo.v0.3.1
+    replaces: foo.v0.2.0
+    skips:
+      - foo.v0.3.0
+---
+image: test.registry/foo-operator/foo-bundle:v0.1.0
+name: foo.v0.1.0
+package: foo
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImZvb3MudGVzdC5mb28ifSwic3BlYyI6eyJncm91cCI6InRlc3QuZm9vIiwibmFtZXMiOnsia2luZCI6IkZvbyIsInBsdXJhbCI6ImZvb3MifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MSJ9XX19
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsib2xtLnNraXBSYW5nZSI6Ilx1MDAzYzAuMS4wIn0sIm5hbWUiOiJmb28udjAuMS4wIn0sInNwZWMiOnsiY3VzdG9tcmVzb3VyY2VkZWZpbml0aW9ucyI6eyJvd25lZCI6W3siZ3JvdXAiOiJ0ZXN0LmZvbyIsImtpbmQiOiJGb28iLCJuYW1lIjoiZm9vcy50ZXN0LmZvbyIsInZlcnNpb24iOiJ2MSJ9XX0sInJlbGF0ZWRJbWFnZXMiOlt7ImltYWdlIjoidGVzdC5yZWdpc3RyeS9mb28tb3BlcmF0b3IvZm9vOnYwLjEuMCIsIm5hbWUiOiJvcGVyYXRvciJ9XSwidmVyc2lvbiI6IjAuMS4wIn19
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v1
+- type: olm.gvk.required
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: foo
+    version: 0.1.0
+- type: olm.package.required
+  value:
+    packageName: bar
+    versionRange: <0.1.0
+relatedImages:
+- image: test.registry/foo-operator/foo:v0.1.0
+  name: operator
+schema: olm.bundle
+---
+image: test.registry/foo-operator/foo-bundle:v0.2.0
+name: foo.v0.2.0
+package: foo
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImZvb3MudGVzdC5mb28ifSwic3BlYyI6eyJncm91cCI6InRlc3QuZm9vIiwibmFtZXMiOnsia2luZCI6IkZvbyIsInBsdXJhbCI6ImZvb3MifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MSJ9XX19
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsib2xtLnNraXBSYW5nZSI6Ilx1MDAzYzAuMi4wIn0sIm5hbWUiOiJmb28udjAuMi4wIn0sInNwZWMiOnsiY3VzdG9tcmVzb3VyY2VkZWZpbml0aW9ucyI6eyJvd25lZCI6W3siZ3JvdXAiOiJ0ZXN0LmZvbyIsImtpbmQiOiJGb28iLCJuYW1lIjoiZm9vcy50ZXN0LmZvbyIsInZlcnNpb24iOiJ2MSJ9XX0sInJlbGF0ZWRJbWFnZXMiOlt7ImltYWdlIjoidGVzdC5yZWdpc3RyeS9mb28tb3BlcmF0b3IvZm9vOnYwLjIuMCIsIm5hbWUiOiJvcGVyYXRvciJ9XSwicmVwbGFjZXMiOiJmb28udjAuMS4wIiwic2tpcHMiOlsiZm9vLnYwLjEuMSIsImZvby52MC4xLjIiXSwidmVyc2lvbiI6IjAuMi4wIn19
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v1
+- type: olm.gvk.required
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: foo
+    version: 0.2.0
+- type: olm.package.required
+  value:
+    packageName: bar
+    versionRange: <0.1.0
+relatedImages:
+- image: test.registry/foo-operator/foo:v0.2.0
+  name: operator
+schema: olm.bundle
+---
+image: test.registry/foo-operator/foo-bundle:v0.3.0
+name: foo.v0.3.0
+package: foo
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImZvb3MudGVzdC5mb28ifSwic3BlYyI6eyJncm91cCI6InRlc3QuZm9vIiwibmFtZXMiOnsia2luZCI6IkZvbyIsInBsdXJhbCI6ImZvb3MifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MSIsInNlcnZlZCI6dHJ1ZSwic3RvcmFnZSI6ZmFsc2V9LHsibmFtZSI6InYyIiwic2VydmVkIjp0cnVlLCJzdG9yYWdlIjp0cnVlfV19fQ==
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImZvby52MC4zLjAifSwic3BlYyI6eyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjp7Im93bmVkIjpbeyJncm91cCI6InRlc3QuZm9vIiwia2luZCI6IkZvbyIsIm5hbWUiOiJmb29zLnRlc3QuZm9vIiwidmVyc2lvbiI6InYxIn0seyJncm91cCI6InRlc3QuZm9vIiwia2luZCI6IkZvbyIsIm5hbWUiOiJmb29zLnRlc3QuZm9vIiwidmVyc2lvbiI6InYyIn1dfSwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJ0ZXN0LnJlZ2lzdHJ5L2Zvby1vcGVyYXRvci9mb286djAuMy4wIiwibmFtZSI6Im9wZXJhdG9yIn1dLCJyZXBsYWNlcyI6ImZvby52MC4yLjAiLCJ2ZXJzaW9uIjoiMC4zLjAifX0=
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v1
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v2
+- type: olm.gvk.required
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: foo
+    version: 0.3.0
+- type: olm.package.required
+  value:
+    packageName: bar
+    versionRange: <0.2.0
+relatedImages:
+- image: test.registry/foo-operator/foo:v0.3.0
+  name: operator
+schema: olm.bundle
+---
+image: test.registry/foo-operator/foo-bundle:v0.3.1
+name: foo.v0.3.1
+package: foo
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImZvb3MudGVzdC5mb28ifSwic3BlYyI6eyJncm91cCI6InRlc3QuZm9vIiwibmFtZXMiOnsia2luZCI6IkZvbyIsInBsdXJhbCI6ImZvb3MifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MSIsInNlcnZlZCI6dHJ1ZSwic3RvcmFnZSI6ZmFsc2V9LHsibmFtZSI6InYyIiwic2VydmVkIjp0cnVlLCJzdG9yYWdlIjp0cnVlfV19fQ==
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImZvby52MC4zLjEifSwic3BlYyI6eyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjp7Im93bmVkIjpbeyJncm91cCI6InRlc3QuZm9vIiwia2luZCI6IkZvbyIsIm5hbWUiOiJmb29zLnRlc3QuZm9vIiwidmVyc2lvbiI6InYxIn0seyJncm91cCI6InRlc3QuZm9vIiwia2luZCI6IkZvbyIsIm5hbWUiOiJmb29zLnRlc3QuZm9vIiwidmVyc2lvbiI6InYyIn1dfSwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJ0ZXN0LnJlZ2lzdHJ5L2Zvby1vcGVyYXRvci9mb286djAuMy4xIiwibmFtZSI6Im9wZXJhdG9yIn1dLCJyZXBsYWNlcyI6ImZvby52MC4yLjAiLCJza2lwcyI6WyJmb28udjAuMy4wIl0sInZlcnNpb24iOiIwLjMuMSJ9fQ==
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v1
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v2
+- type: olm.gvk.required
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: foo
+    version: 0.3.1
+- type: olm.package.required
+  value:
+    packageName: bar
+    versionRange: <0.2.0
+relatedImages:
+- image: test.registry/foo-operator/foo:v0.3.1
+  name: operator
+schema: olm.bundle

--- a/pkg/operator/catalog_dir.go
+++ b/pkg/operator/catalog_dir.go
@@ -1,0 +1,20 @@
+package operator
+
+import (
+	"fmt"
+	"path/filepath"
+
+	imgreference "github.com/openshift/library-go/pkg/image/reference"
+)
+
+// GenerateCatalogDir will generate a directory location for a catalog from a reference
+func GenerateCatalogDir(ctlgRef imgreference.DockerImageReference) (string, error) {
+	leafDir := ctlgRef.Tag
+	if leafDir == "" {
+		leafDir = ctlgRef.ID
+	}
+	if leafDir == "" {
+		return "", fmt.Errorf("catalog %q must have either a tag or digest", ctlgRef.Exact())
+	}
+	return filepath.Join(ctlgRef.Registry, ctlgRef.Namespace, ctlgRef.Name, leafDir), nil
+}

--- a/pkg/operator/catalog_dir_test.go
+++ b/pkg/operator/catalog_dir_test.go
@@ -1,0 +1,21 @@
+package operator
+
+import (
+	"testing"
+
+	imgreference "github.com/openshift/library-go/pkg/image/reference"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateCatalogDir(t *testing.T) {
+
+	exp := "registry.com/catalog/latest"
+	ctlg := "registry.com/catalog:latest"
+	ctlgRef, err := imgreference.Parse(ctlg)
+	require.NoError(t, err)
+
+	actual, err := GenerateCatalogDir(ctlgRef)
+	require.NoError(t, err)
+
+	require.Equal(t, exp, actual)
+}

--- a/pkg/operator/declcfg_to_includecfg.go
+++ b/pkg/operator/declcfg_to_includecfg.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"sort"
 
+	"github.com/blang/semver/v4"
 	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/model"
@@ -11,14 +12,14 @@ import (
 // ConvertDCToIncludeConfig converts a heads-only rendered declarative config to an IncludeConfig
 // with all of the package channels with the lowest bundle version.
 func ConvertDCToIncludeConfig(dc declcfg.DeclarativeConfig) (ic v1alpha2.IncludeConfig, err error) {
-	model, err := declcfg.ConvertToModel(dc)
+	inputModel, err := declcfg.ConvertToModel(dc)
 	if err != nil {
 		return ic, err
 	}
-	for _, mpkg := range model {
+	for _, mpkg := range inputModel {
 		icPkg := v1alpha2.IncludePackage{
 			Name:     mpkg.Name,
-			Channels: traverseModelChannels(*mpkg),
+			Channels: getFirstBundle(*mpkg),
 		}
 		sort.Slice(icPkg.Channels, func(i, j int) bool {
 			return icPkg.Channels[i].Name < icPkg.Channels[j].Name
@@ -31,7 +32,7 @@ func ConvertDCToIncludeConfig(dc declcfg.DeclarativeConfig) (ic v1alpha2.Include
 	return ic, nil
 }
 
-func traverseModelChannels(mpkg model.Package) []v1alpha2.IncludeChannel {
+func getFirstBundle(mpkg model.Package) []v1alpha2.IncludeChannel {
 	channels := []v1alpha2.IncludeChannel{}
 
 	for _, ch := range mpkg.Channels {
@@ -56,4 +57,158 @@ func traverseModelChannels(mpkg model.Package) []v1alpha2.IncludeChannel {
 	}
 
 	return channels
+}
+
+// UpdateIncludeConfig will process the current IncludeConfig to add any new packages or channels. Starting versions are
+// also validated and incremented if the version no longer exists in the catalog.
+func UpdateIncludeConfig(dc declcfg.DeclarativeConfig, curr v1alpha2.IncludeConfig) (ic v1alpha2.IncludeConfig, err error) {
+	inputModel, err := declcfg.ConvertToModel(dc)
+	if err != nil {
+		return ic, err
+	}
+	currPackages := make(map[string]v1alpha2.IncludePackage, len(curr.Packages))
+	for _, pkg := range curr.Packages {
+		currPackages[pkg.Name] = pkg
+	}
+
+	// If there is a new package get the channel head.
+	// If existing validate the starting bundle is
+	// still in the catalog and iterate, if needed.
+	for _, mpkg := range inputModel {
+		icPkg := v1alpha2.IncludePackage{
+			Name: mpkg.Name,
+		}
+		currPkg, found := currPackages[mpkg.Name]
+		if !found {
+			chWithHeads, err := getChannelHeads(*mpkg)
+			icPkg.Channels = chWithHeads
+			if err != nil {
+				return ic, err
+			}
+		} else {
+			ch, err := getCurrBundle(*mpkg, currPkg)
+			if err != nil {
+				return ic, err
+			}
+			icPkg.Channels = ch
+		}
+
+		sort.Slice(icPkg.Channels, func(i, j int) bool {
+			return icPkg.Channels[i].Name < icPkg.Channels[j].Name
+		})
+		ic.Packages = append(ic.Packages, icPkg)
+	}
+	sort.Slice(ic.Packages, func(i, j int) bool {
+		return ic.Packages[i].Name < ic.Packages[j].Name
+	})
+	return ic, nil
+}
+
+func getCurrBundle(mpkg model.Package, icPkg v1alpha2.IncludePackage) ([]v1alpha2.IncludeChannel, error) {
+
+	// Add every bundle with a specified bundle name or \
+	// directly satisfying a bundle version to bundles.
+	includeChannels := make(map[string]v1alpha2.IncludeBundle, len(icPkg.Channels))
+	for _, ch := range icPkg.Channels {
+		includeChannels[ch.Name] = ch.IncludeBundle
+	}
+	channels := []v1alpha2.IncludeChannel{}
+
+	for _, ch := range mpkg.Channels {
+		// initialize channel
+		c := v1alpha2.IncludeChannel{
+			Name: ch.Name,
+		}
+
+		bundleSet := make(map[string]struct{}, len(ch.Bundles))
+		versionsToInclude := []semver.Version{}
+		for _, b := range ch.Bundles {
+			bundleSet[b.Version.String()] = struct{}{}
+			versionsToInclude = append(versionsToInclude, b.Version)
+		}
+
+		var startingBundle v1alpha2.IncludeBundle
+		var err error
+		icBundle, found := includeChannels[ch.Name]
+
+		// If the channel is new, return the channel head
+		// if the channel is found and the bundle is found
+		// keep the current include bundle. If the target version
+		// does not exist in the bundle set, sort by version and
+		// find the next version using binary search
+		if !found {
+			startingBundle, err = getHeadBundle(*ch)
+			if err != nil {
+				return nil, err
+			}
+			c.IncludeBundle = startingBundle
+			channels = append(channels, c)
+			continue
+		} else if _, found = bundleSet[icBundle.StartingVersion.String()]; found {
+			startingBundle = icBundle
+		} else {
+			versionsToInclude = append(versionsToInclude, icBundle.StartingVersion)
+			startingBundle, err = findNextBundle(versionsToInclude, icBundle.StartingVersion)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		c.IncludeBundle = startingBundle
+		channels = append(channels, c)
+	}
+	return channels, nil
+}
+
+func findNextBundle(versions []semver.Version, target semver.Version) (v1alpha2.IncludeBundle, error) {
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i].LT(versions[j])
+	})
+	nextVerision := search(versions, target, 0, len(versions)-1)
+	return v1alpha2.IncludeBundle{StartingVersion: nextVerision}, nil
+}
+
+func search(versions []semver.Version, target semver.Version, low, high int) semver.Version {
+	if high < low {
+		return semver.Version{}
+	}
+
+	mid := low + (high+low)/2
+	if versions[mid].EQ(target) {
+		return versions[mid+1]
+	}
+
+	if target.GT(versions[mid]) {
+		return search(versions, target, mid+1, high)
+	}
+
+	return search(versions, target, low, high)
+}
+
+func getChannelHeads(mpkg model.Package) ([]v1alpha2.IncludeChannel, error) {
+	channels := []v1alpha2.IncludeChannel{}
+
+	for _, ch := range mpkg.Channels {
+		// initialize channel
+		c := v1alpha2.IncludeChannel{
+			Name: ch.Name,
+		}
+
+		b, err := getHeadBundle(*ch)
+		if err != nil {
+			return nil, err
+		}
+		c.IncludeBundle = b
+		channels = append(channels, c)
+	}
+	return channels, nil
+}
+
+func getHeadBundle(mch model.Channel) (v1alpha2.IncludeBundle, error) {
+	bundle, err := mch.Head()
+	if err != nil {
+		return v1alpha2.IncludeBundle{}, err
+	}
+
+	return v1alpha2.IncludeBundle{StartingVersion: bundle.Version}, nil
 }

--- a/pkg/operator/declcfg_to_includecfg.go
+++ b/pkg/operator/declcfg_to_includecfg.go
@@ -1,0 +1,59 @@
+package operator
+
+import (
+	"sort"
+
+	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+	"github.com/operator-framework/operator-registry/alpha/model"
+)
+
+// ConvertDCToIncludeConfig converts a heads-only rendered declarative config to an IncludeConfig
+// with all of the package channels with the lowest bundle version.
+func ConvertDCToIncludeConfig(dc declcfg.DeclarativeConfig) (ic v1alpha2.IncludeConfig, err error) {
+	model, err := declcfg.ConvertToModel(dc)
+	if err != nil {
+		return ic, err
+	}
+	for _, mpkg := range model {
+		icPkg := v1alpha2.IncludePackage{
+			Name:     mpkg.Name,
+			Channels: traverseModelChannels(*mpkg),
+		}
+		sort.Slice(icPkg.Channels, func(i, j int) bool {
+			return icPkg.Channels[i].Name < icPkg.Channels[j].Name
+		})
+		ic.Packages = append(ic.Packages, icPkg)
+	}
+	sort.Slice(ic.Packages, func(i, j int) bool {
+		return ic.Packages[i].Name < ic.Packages[j].Name
+	})
+	return ic, nil
+}
+
+func traverseModelChannels(mpkg model.Package) []v1alpha2.IncludeChannel {
+	channels := []v1alpha2.IncludeChannel{}
+
+	for _, ch := range mpkg.Channels {
+		// initialize channel
+		c := v1alpha2.IncludeChannel{
+			Name: ch.Name,
+		}
+
+		keys := make([]string, 0, len(ch.Bundles))
+		for k := range ch.Bundles {
+			keys = append(keys, k)
+		}
+		sort.Slice(keys, func(i, j int) bool {
+			return ch.Bundles[keys[i]].Version.GT(ch.Bundles[keys[j]].Version)
+		})
+
+		b := v1alpha2.IncludeBundle{
+			StartingVersion: ch.Bundles[keys[len(keys)-1]].Version,
+		}
+		c.IncludeBundle = b
+		channels = append(channels, c)
+	}
+
+	return channels
+}

--- a/pkg/operator/declfg_to_includecfg_test.go
+++ b/pkg/operator/declfg_to_includecfg_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConvertDcToIncludeConfig(t *testing.T) {
+func TestConvertDCToIncludeConfig(t *testing.T) {
 	type spec struct {
 		name string
 		cfg  declcfg.DeclarativeConfig
@@ -19,7 +19,7 @@ func TestConvertDcToIncludeConfig(t *testing.T) {
 
 	specs := []spec{
 		{
-			name: "Valid/HeadsOnly",
+			name: "Success/HeadsOnly",
 			cfg: declcfg.DeclarativeConfig{
 				Packages: []declcfg.Package{
 					{Schema: "olm.package", Name: "bar", DefaultChannel: "stable"},
@@ -89,6 +89,311 @@ func TestConvertDcToIncludeConfig(t *testing.T) {
 			ic, err := ConvertDCToIncludeConfig(s.cfg)
 			require.NoError(t, err)
 			require.Equal(t, s.exp, ic)
+		})
+	}
+}
+
+func TestUpdateIncludeConfig(t *testing.T) {
+
+	type spec struct {
+		name   string
+		cfg    declcfg.DeclarativeConfig
+		in     v1alpha2.IncludeConfig
+		exp    v1alpha2.IncludeConfig
+		expErr string
+	}
+
+	specs := []spec{
+		{
+			name: "Success/NewPackages",
+			cfg: declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{Schema: "olm.package", Name: "bar", DefaultChannel: "stable"},
+					{Schema: "olm.package", Name: "foo", DefaultChannel: "stable"},
+				},
+				Channels: []declcfg.Channel{
+					{Schema: "olm.channel", Name: "stable", Package: "bar", Entries: []declcfg.ChannelEntry{
+						{Name: "bar.v0.1.0"},
+					}},
+					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.1.0"},
+					}},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "bar.v0.1.0",
+						Package: "bar",
+						Image:   "reg/bar:latest",
+						Properties: []property.Property{
+							property.MustBuildGVKRequired("etcd.database.coreos.com", "v1", "EtcdBackup"),
+							property.MustBuildPackage("bar", "0.1.0"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.0",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.1.0"),
+						},
+					},
+				},
+			},
+			in: v1alpha2.IncludeConfig{
+				Packages: []v1alpha2.IncludePackage{
+					{
+						Name: "bar",
+						Channels: []v1alpha2.IncludeChannel{
+							{
+								Name: "stable",
+								IncludeBundle: v1alpha2.IncludeBundle{
+									StartingVersion: semver.MustParse("0.1.0"),
+								},
+							},
+						},
+					},
+				},
+			},
+			exp: v1alpha2.IncludeConfig{
+				Packages: []v1alpha2.IncludePackage{
+					{
+						Name: "bar",
+						Channels: []v1alpha2.IncludeChannel{
+							{
+								Name: "stable",
+								IncludeBundle: v1alpha2.IncludeBundle{
+									StartingVersion: semver.MustParse("0.1.0"),
+								},
+							},
+						},
+					},
+					{
+						Name: "foo",
+						Channels: []v1alpha2.IncludeChannel{
+							{
+								Name: "stable",
+								IncludeBundle: v1alpha2.IncludeBundle{
+									StartingVersion: semver.MustParse("0.1.0"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Success/NewChannels",
+			cfg: declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{Schema: "olm.package", Name: "bar", DefaultChannel: "stable"},
+					{Schema: "olm.package", Name: "foo", DefaultChannel: "stable"},
+				},
+				Channels: []declcfg.Channel{
+					{Schema: "olm.channel", Name: "stable", Package: "bar", Entries: []declcfg.ChannelEntry{
+						{Name: "bar.v0.1.0"},
+						{Name: "bar.v0.1.1", Replaces: "bar.v0.1.0"},
+					}},
+					{Schema: "olm.channel", Name: "alpha", Package: "bar", Entries: []declcfg.ChannelEntry{
+						{Name: "bar.v0.1.0"},
+					}},
+					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.1.0"},
+					}},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "bar.v0.1.1",
+						Package: "bar",
+						Image:   "reg/bar:latest",
+						Properties: []property.Property{
+							property.MustBuildGVKRequired("etcd.database.coreos.com", "v1", "EtcdBackup"),
+							property.MustBuildPackage("bar", "0.1.1"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "bar.v0.1.0",
+						Package: "bar",
+						Image:   "reg/bar:latest",
+						Properties: []property.Property{
+							property.MustBuildGVKRequired("etcd.database.coreos.com", "v1", "EtcdBackup"),
+							property.MustBuildPackage("bar", "0.1.0"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.0",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.1.0"),
+						},
+					},
+				},
+			},
+			in: v1alpha2.IncludeConfig{
+				Packages: []v1alpha2.IncludePackage{
+					{
+						Name: "bar",
+						Channels: []v1alpha2.IncludeChannel{
+							{
+								Name: "stable",
+								IncludeBundle: v1alpha2.IncludeBundle{
+									StartingVersion: semver.MustParse("0.1.0"),
+								},
+							},
+						},
+					},
+					{
+						Name: "foo",
+						Channels: []v1alpha2.IncludeChannel{
+							{
+								Name: "stable",
+								IncludeBundle: v1alpha2.IncludeBundle{
+									StartingVersion: semver.MustParse("0.1.0"),
+								},
+							},
+						},
+					},
+				},
+			},
+			exp: v1alpha2.IncludeConfig{
+				Packages: []v1alpha2.IncludePackage{
+					{
+						Name: "bar",
+						Channels: []v1alpha2.IncludeChannel{
+							{
+								Name: "alpha",
+								IncludeBundle: v1alpha2.IncludeBundle{
+									StartingVersion: semver.MustParse("0.1.0"),
+								},
+							},
+							{
+								Name: "stable",
+								IncludeBundle: v1alpha2.IncludeBundle{
+									StartingVersion: semver.MustParse("0.1.0"),
+								},
+							},
+						},
+					},
+					{
+						Name: "foo",
+						Channels: []v1alpha2.IncludeChannel{
+							{
+								Name: "stable",
+								IncludeBundle: v1alpha2.IncludeBundle{
+									StartingVersion: semver.MustParse("0.1.0"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Success/PruneChannelHead",
+			cfg: declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{Schema: "olm.package", Name: "bar", DefaultChannel: "stable"},
+					{Schema: "olm.package", Name: "foo", DefaultChannel: "stable"},
+				},
+				Channels: []declcfg.Channel{
+					{Schema: "olm.channel", Name: "stable", Package: "bar", Entries: []declcfg.ChannelEntry{
+						{Name: "bar.v0.1.1", Skips: []string{"bar.v0.1.0"}},
+					}},
+					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.1.0"},
+					}},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "bar.v0.1.1",
+						Package: "bar",
+						Image:   "reg/bar:latest",
+						Properties: []property.Property{
+							property.MustBuildGVKRequired("etcd.database.coreos.com", "v1", "EtcdBackup"),
+							property.MustBuildPackage("bar", "0.1.1"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.0",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.1.0"),
+						},
+					},
+				},
+			},
+			in: v1alpha2.IncludeConfig{
+				Packages: []v1alpha2.IncludePackage{
+					{
+						Name: "bar",
+						Channels: []v1alpha2.IncludeChannel{
+							{
+								Name: "stable",
+								IncludeBundle: v1alpha2.IncludeBundle{
+									StartingVersion: semver.MustParse("0.1.0"),
+								},
+							},
+						},
+					},
+					{
+						Name: "foo",
+						Channels: []v1alpha2.IncludeChannel{
+							{
+								Name: "stable",
+								IncludeBundle: v1alpha2.IncludeBundle{
+									StartingVersion: semver.MustParse("0.1.0"),
+								},
+							},
+						},
+					},
+				},
+			},
+			exp: v1alpha2.IncludeConfig{
+				Packages: []v1alpha2.IncludePackage{
+					{
+						Name: "bar",
+						Channels: []v1alpha2.IncludeChannel{
+							{
+								Name: "stable",
+								IncludeBundle: v1alpha2.IncludeBundle{
+									StartingVersion: semver.MustParse("0.1.1"),
+								},
+							},
+						},
+					},
+					{
+						Name: "foo",
+						Channels: []v1alpha2.IncludeChannel{
+							{
+								Name: "stable",
+								IncludeBundle: v1alpha2.IncludeBundle{
+									StartingVersion: semver.MustParse("0.1.0"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, s := range specs {
+		t.Run(s.name, func(t *testing.T) {
+			ic, err := UpdateIncludeConfig(s.cfg, s.in)
+			if s.expErr != "" {
+				require.EqualError(t, err, s.expErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, s.exp, ic)
+			}
 		})
 	}
 }

--- a/pkg/operator/declfg_to_includecfg_test.go
+++ b/pkg/operator/declfg_to_includecfg_test.go
@@ -1,0 +1,94 @@
+package operator
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+	"github.com/operator-framework/operator-registry/alpha/property"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertDcToIncludeConfig(t *testing.T) {
+	type spec struct {
+		name string
+		cfg  declcfg.DeclarativeConfig
+		exp  v1alpha2.IncludeConfig
+	}
+
+	specs := []spec{
+		{
+			name: "Valid/HeadsOnly",
+			cfg: declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{Schema: "olm.package", Name: "bar", DefaultChannel: "stable"},
+					{Schema: "olm.package", Name: "foo", DefaultChannel: "stable"},
+				},
+				Channels: []declcfg.Channel{
+					{Schema: "olm.channel", Name: "stable", Package: "bar", Entries: []declcfg.ChannelEntry{
+						{Name: "bar.v0.1.0"},
+					}},
+					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.1.0"},
+					}},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "bar.v0.1.0",
+						Package: "bar",
+						Image:   "reg/bar:latest",
+						Properties: []property.Property{
+							property.MustBuildGVKRequired("etcd.database.coreos.com", "v1", "EtcdBackup"),
+							property.MustBuildPackage("bar", "0.1.0"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.0",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.1.0"),
+						},
+					},
+				},
+			},
+			exp: v1alpha2.IncludeConfig{
+				Packages: []v1alpha2.IncludePackage{
+					{
+						Name: "bar",
+						Channels: []v1alpha2.IncludeChannel{
+							{
+								Name: "stable",
+								IncludeBundle: v1alpha2.IncludeBundle{
+									StartingVersion: semver.MustParse("0.1.0"),
+								},
+							},
+						},
+					},
+					{
+						Name: "foo",
+						Channels: []v1alpha2.IncludeChannel{
+							{
+								Name: "stable",
+								IncludeBundle: v1alpha2.IncludeBundle{
+									StartingVersion: semver.MustParse("0.1.0"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, s := range specs {
+		t.Run(s.name, func(t *testing.T) {
+			ic, err := ConvertDCToIncludeConfig(s.cfg)
+			require.NoError(t, err)
+			require.Equal(t, s.exp, ic)
+		})
+	}
+}

--- a/test/testcases.sh
+++ b/test/testcases.sh
@@ -27,7 +27,7 @@ function headsonly_diff () {
 
     run_diff imageset-config-headsonly.yaml
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
-    "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1 foo.v0.3.2" \
+    "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
 }
 
@@ -40,7 +40,7 @@ function registry_backend () {
 
     run_diff imageset-config-headsonly-backend-registry.yaml
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
-    "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1 foo.v0.3.2" \
+    "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
 }
 
@@ -69,7 +69,7 @@ function custom_namespace {
 
     run_diff imageset-config-headsonly-backend-registry.yaml "custom"
     check_bundles "localhost.localdomain:${REGISTRY_DISCONN_PORT}/custom/${CATALOGNAMESPACE}:test-catalog-latest" \
-    "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1 foo.v0.3.2" \
+    "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT} "custom"
 }
 


### PR DESCRIPTION
# Description

When merging the catalog, unintentional changes to the upgrade and pruned bundles can be created in the target FBC generated by oc-mirror.
    
To remove the requirement to merge FBCs, package ranges are being used in metadata for heads-only workflows to generate FBCs that are scoped per the configuration instead of generating differential FBCs and merging with previous FBCs. The OCP releases heads only workflow has been updated work in the same way. To achieve the same optimization in regards to downloaded images, all images in the image mapping during each run are validated against the metadata to make sure they do not exist in PastAssociations.

### Workflows Conversion Behavior (Catalogs and Operators):

**Heads Only to Range**: Just the specified range will be downloaded the previous starting version between be erased.
**Range to Heads Only**: Previous range versions will not be recorded and the new Heads only starting version will be the current head.

Closes #377

Blocked by #364 

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [X] Unit tests for added methods
- [X] Manual testing of specified scenarios below

# Testing Scenarios
Pruned catalog test cases are being added to the E2E testing with PR #400.
1. Testing differential behavior when mirroring catalogs (new packages, new channels, pruned bundles)
2. Testing differential behavior when mirroring the latest releases ( a bit harder to validate due to the use of the Cincinnati API, can possibly replicate in a unit testing with a mock API)
3. Testing `IgnoreHistory` when using with image redownloads. Previously downloaded images in ranges are no longer redownloaded by default`. Implemented to replace previous heads only catalog behavior.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Notes to Reviewer
Changes to E2E bundles were made due to old refs no longer being passed during the differential operations. The older dependency bundles are no longer pruned out resulting in an additional bundle.