### PR TITLE
[CI] Correct CI Integration target

### DIFF
--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -16,14 +16,20 @@ Please run `hack/build.sh` to build the `oc-mirror` executable for local testing
 ## CI
 
 Our CI is automated using Prow. The configuration is located in the `openshift/release` project.
-We are currently running automated unit tests with CI and are working on an automated end-to-end solution.
+We are currently running automated unit and end-to-end tests with CI on all pull requets.
+
+### Integration environment tests
+
+When a PR has been approved to test (a step required for anyone not on the appropriate GitHub team), a smoke test in an integration environment may be requested. This environment includes an isolated VPC and a real OpenShift installation with release bits. To have Prow run this test on the PR, an approved person should comment `/test integration` on the PR to mark this optional test for inclusion.
+
+**NOTE:** This test takes around two hours to complete. While it is designed to recover as gracefully as possible from cancellation or failure, there are cases in which it may not properly tear down an environment and leave infrastructure hanging. A team member with access to the infrastructure provider may have to manually tear down your environment. This will include [generating a new metadata.json file](https://access.redhat.com/solutions/3826921), uninstalling OpenShift, and then manually tearing down the Integration environment components with the [integration environment manual teardown script](https://github.com/jharmison-redhat/oc-mirror-e2e/blob/main/example/teardown.sh). The subdomain on which the environment is placed is required for both of those steps and can be recovered from the build log of a given PR test step run. For an example, you can see [this build log](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_oc-mirror/393/pull-ci-openshift-oc-mirror-main-integration/1520567128246194176/artifacts/integration/test-integration/build-log.txt) and Ctrl+F for `redhat4govaws`. Every run generates a random 6-character subdomain, and this is used as `CLUSTER_NAME` variable in the metadata.json file generation as well as the `TEARDOWN_CLUSTER` variable in the environment teardown script.
 
 ## Local Testing
 
 We have developed local end-to-end test scripts to verify `oc-mirror` functionality with various imageset configurations.
 When added a new feature or changing a current feature ensure the functionality is covered by the end-to-test located [here](../test/../../test/e2e-simple.sh)
 
-If you would like to conduct a more exhaustive end-to-end test in a full integration environment, including an isolated VPC and a real OpenShift installation, you will need an AWS IAM user access key and secret and a pull secret from the [OpenShift console](https://console.redhat.com/openshift/install/aws/installer-provisioned). You can then run the following:
+If you would like to locally execute the smoke test in the full integration environment, you will need an AWS IAM user access key and secret and a pull secret from the [OpenShift console](https://console.redhat.com/openshift/install/aws/installer-provisioned). You can then run the following:
 
 ```sh
 export AWS_ACCESS_KEY_ID=<your actual AWS access key ID>
@@ -31,7 +37,7 @@ export AWS_SECRET_ACCESS_KEY=<your actual AWS secret access key>
 export CONSOLE_REDHAT_COM_PULL_SECRET='<your actual pull secret, retrieved from the link above>'
 ```
 
-To run the full E2E integration suite from the repository root, you can use the `test-integration` target, e.g.:
+To run the full integration suite from the repository root, you can use the `test-integration` target, e.g.:
 
 ```sh
 make test-integration
@@ -44,7 +50,7 @@ cd test/integration
 make delete
 ```
 
-To run a specific phase of the E2E integration (for example, to provision and run the test matrix in the environment, without deleting it automatically), you can run the following from the `test/integration` folder directly:
+To run a specific phase of the integration test (for example, to provision and run the test matrix in the environment, without deleting it automatically), you can run the following from the `test/integration` folder directly:
 
 ```sh
 make create test
@@ -52,4 +58,4 @@ make create test
 
 Additional debugging of the disconnected integration environment (including hopping through a connected host to reach the isolated bastion) can be performed with the `test/integration/connect.sh` script, which accepts a single argument - the name of the host you want to connect to. It can be one of `registry`, `proxy`, or `bastion`.
 
-For custom test scenarios, or cases where your test may break the `oc-mirror` command line arguments or configuration API schema, the `vars.yml` file contains some variables to help you. Further documentation on the E2E integration environment is available at the [ansible collection repository](https://github.com/jharmison-redhat/oc-mirror-e2e) for it.
+For custom test scenarios, or cases where your test may break the `oc-mirror` command line arguments or configuration API schema, the `vars.yml` file contains some variables to help you. Further documentation on the integration environment is available at the [ansible collection repository](https://github.com/jharmison-redhat/oc-mirror-e2e) for it.

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -7,7 +7,7 @@ export SHELLOPTS:=$(if $(SHELLOPTS),$(SHELLOPTS):)pipefail:errexit
 PYTHON := python3
 
 # For terraform download
-TERRAFORM_VERSION := 1.1.6
+TERRAFORM_VERSION := 1.1.9
 TERRAFORM_OS := linux
 TERRAFORM_ARCH := amd64
 TERRAFORM_DOWNLOAD = terraform_$(TERRAFORM_VERSION)_$(TERRAFORM_OS)_$(TERRAFORM_ARCH).zip
@@ -102,10 +102,22 @@ realclean: clean
 ###############################################################################
 # The following targets are only intended for use in OpenShift CI systems.    #
 ###############################################################################
-ci:
-	scripts/run.sh
+_ci_setup:
+	@export HOME="$${HOME:-/alabama}"
+	@cp -r . "$${HOME}/test"
+	@cd "$${HOME}/test"
+	@echo "      ansible_remote_tmp: '$${HOME}'" >> hosts.yml
+	@make terraform collection PYTHON=python3.9
+.PHONY: _ci_setup
+
+ci: _ci_setup
+	@export HOME="$${HOME:-/alabama}"
+	@cd "$${HOME}/test"
+	@scripts/run.sh
 .PHONY: ci
 
-ci-delete:
-	scripts/run.sh delete
+ci-delete: _ci_setup
+	@export HOME="$${HOME:-/alabama}"
+	@cd "$${HOME}/test"
+	@scripts/run.sh delete
 .PHONY: ci-delete

--- a/test/integration/ansible.cfg
+++ b/test/integration/ansible.cfg
@@ -1,6 +1,9 @@
 [defaults]
-inventory           = hosts
+inventory           = hosts.yml
 interpreter_python  = auto_silent
 retry_files_enabled = False
 collections_path    = ./collections
-callback_whitelist  = ansible.posix.profile_tasks
+callbacks_enabled   = ansible.posix.profile_tasks
+
+[ssh_connection]
+pipelining = True

--- a/test/integration/hosts
+++ b/test/integration/hosts
@@ -1,2 +1,0 @@
-[all]
-controller ansible_connection=local ansible_python_interpreter=python3

--- a/test/integration/hosts.yml
+++ b/test/integration/hosts.yml
@@ -1,0 +1,5 @@
+all:
+  hosts:
+    controller:
+      ansible_connection: local
+      ansible_python_interpreter: "{{ hostvars.localhost.ansible_env.PYTHON|default('python3') }}"

--- a/test/integration/requirements.yml
+++ b/test/integration/requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
   - name: jharmison_redhat.oc_mirror_e2e
-    version: 0.5.0
+    version: 0.6.3

--- a/test/integration/scripts/build-image.sh
+++ b/test/integration/scripts/build-image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -eo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 # The runtime used to build the image

--- a/test/integration/scripts/ci-prereqs.sh
+++ b/test/integration/scripts/ci-prereqs.sh
@@ -45,19 +45,5 @@ done
 chmod +x openshift-install oc kubectl
 popd
 
-# Install Terraform and the e2e collection
-make terraform collection PYTHON=python3.9
-
-# Configure the terraform modules and providers
-source .venv/bin/activate
-ansible-playbook \
-    jharmison_redhat.oc_mirror_e2e.terraform_setup \
-    -e "output_dir=${PWD}/output" \
-    -e "terraform_binary_path=${PWD}/bin/terraform"
-
-# Pull oc-mirror from builder image stage location
-mkdir -p output/clients
-cp ../../bin/oc-mirror output/clients
-
 # Cleanup
 dnf clean all -y

--- a/test/integration/scripts/common.sh
+++ b/test/integration/scripts/common.sh
@@ -1,19 +1,17 @@
 #!/bin/bash
 
 # This common file is intended for scripts run inside the integration environment
-
-cd "$(dirname "$SCRIPT_DIR")" || exit 1
-
-if [ -z "${OPENSHIFT_CI}" ]; then
-    echo "Not running in CI environment!" >&2
+if ! cd "$(dirname "$SCRIPT_DIR")"; then
+    echo "Unable to change into the integration test directory" >&2
     exit 1
 fi
 
-# Source the virtual environment for all actions inside the integration area
-source .venv/bin/activate
+if [[ -z "${OPENSHIFT_CI}" ]]; then
+    echo "Not running in CI environment! Things may break!" >&2
+fi
 
 # Home is not being set for random UID in CI
-HOME="${HOME:-/tmp}"
+HOME="${HOME:-/alabama}"
 export HOME
 
 # The version of OpenShift to run with through the test suite with this version
@@ -22,13 +20,19 @@ export HOME
 TESTED_OPENSHIFT_VERSION="${CI_OPENSHIFT_VERSION:-4.9}"
 export TESTED_OPENSHIFT_VERSION
 
-# Secrets, as made available by CI
-CONSOLE_REDHAT_COM_PULL_SECRET="$(cat /etc/ci/pull-secret/CONSOLE_REDHAT_COM_PULL_SECRET)"
-export CONSOLE_REDHAT_COM_PULL_SECRET
-AWS_ACCESS_KEY_ID="$(cat /etc/ci/aws-creds/AWS_ACCESS_KEY_ID)"
-export AWS_ACCESS_KEY_ID
-AWS_SECRET_ACCESS_KEY="$(cat /etc/ci/aws-creds/AWS_SECRET_ACCESS_KEY)"
-export AWS_SECRET_ACCESS_KEY
+if [[ -n "$OPENSHIFT_CI" ]]; then
+    # Secrets, as made available by CI
+    CONSOLE_REDHAT_COM_PULL_SECRET="$(cat /etc/ci/pull-secret/CONSOLE_REDHAT_COM_PULL_SECRET)"
+    export CONSOLE_REDHAT_COM_PULL_SECRET
+    AWS_ACCESS_KEY_ID="$(cat /etc/ci/aws-creds/AWS_ACCESS_KEY_ID)"
+    export AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY="$(cat /etc/ci/aws-creds/AWS_SECRET_ACCESS_KEY)"
+    export AWS_SECRET_ACCESS_KEY
+else
+    mkdir -p output/{shared,artifacts}
+    export SHARED_DIR="$PWD/output/shared"
+    export ARTIFACT_DIR="$PWD/output/artifacts"
+fi
 
 # The list of files needed to be saved and their locations
 declare -A save_files
@@ -41,22 +45,27 @@ save_files=(
 )
 export save_files
 
-declare -A artifact_files
+declare -a artifact_files
 artifact_files=(
-    [oc-mirror.log]=output/.oc-mirror.log
-    [openshift_install.log]=output/install/.openshift_install.log
+    output/oc-mirror-*.log
+    output/install/.openshift_install.log
 )
 export artifact_files
 
+function sanitize_kubeadmin () {
+    sed 's/Login to the console with user: .*$/Login to the console with user: <REDACTED>/'
+}
+
 function maybe_cp () {
-    echo -n " - checking for $1"
-    if [ -f "$1" ]; then
-        echo " (found -> $2)"
-        mkdir -p "$(dirname "$2")"
-        cp "$1" "$2"
+    src="$1"
+    dest="$(dirname "$2")/$(basename "$2" | sed 's/^\.//')"
+    echo -n " - checking for $src"
+    if [[ -f "$src" ]]; then
+        echo " (found -> $dest)"
+        mkdir -p "$(dirname "$dest")"
+        sanitize_kubeadmin < "$src" > "$dest"
     else
         echo " (not found)"
         return 1
     fi
 }
-

--- a/test/integration/scripts/connect.sh
+++ b/test/integration/scripts/connect.sh
@@ -2,7 +2,7 @@
 
 # This only works for local runs of the integration test, not in CI or mock CI environments
 
-set -euo pipefail
+set -eo pipefail
 
 cd "$(dirname "$(realpath "$0")")"
 

--- a/test/integration/scripts/post-run.sh
+++ b/test/integration/scripts/post-run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -eo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 source "$SCRIPT_DIR/common.sh"
@@ -12,7 +12,7 @@ for file in "${!save_files[@]}"; do
 done
 
 echo "Saving run artifacts"
-for file in "${!artifact_files[@]}"; do
-    path="${artifact_files[$file]}"
-    maybe_cp "$path" "${ARTIFACT_DIR}/$file" ||:
+for file in "${artifact_files[@]}"; do
+    basename="$(basename "$file")"
+    maybe_cp "$file" "${ARTIFACT_DIR}/$basename" ||:
 done

--- a/test/integration/scripts/pre-run.sh
+++ b/test/integration/scripts/pre-run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -eo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 source "$SCRIPT_DIR/common.sh"

--- a/test/integration/scripts/run.sh
+++ b/test/integration/scripts/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -eo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 source "$SCRIPT_DIR/common.sh"
@@ -11,11 +11,15 @@ if [ "${#targets[@]}" -eq 0 ]; then
     targets=(create test)
 fi
 
-# Always run the post-run script
-trap scripts/post-run.sh EXIT
+# Recover binary from bin image
+mkdir -p output/clients
+cp /go/src/github.com/openshift/oc-mirror/bin/oc-mirror output/clients/
 
 # Start by looking for anything to recover from a previous step's shared_dir publish
 scripts/pre-run.sh
 
-# call your makefile target
+# Always run the post-run script
+trap scripts/post-run.sh EXIT
+
+# Call your makefile target(s)
 make "${targets[@]}" PYTHON=python3.9 ANSIBLE_PLAYBOOK_ARGS="-e oc_bin=/usr/local/bin/oc -e openshift_install_bin=/usr/local/bin/openshift-install"

--- a/test/integration/vars.yml
+++ b/test/integration/vars.yml
@@ -6,27 +6,20 @@ cluster_name: '{{ lookup("password", output_dir + "/cluster_name chars=ascii_low
 cluster_domain: redhat4govaws.io
 
 # This is important for default generation of the ImageSetConfiguration, for OpenShift release versions as well as operator catalog versions
-openshift_version: 4.9
+openshift_version: "4.10"
 
 # Basically, there are only a few good choices here (depending on your AWS account configuration). You're best off not changing it unless you know why.
 aws_region: us-west-2
 
+# Mirror metadata directly to the registry (choose from registry or local)
+storage_config_backend: registry
 
-# These are selections from the scenarios available at:
-# https://github.com/jharmison-redhat/oc-mirror-e2e/tree/main/collection/playbooks/vars/scenario_stubs
-scenario_stubs:
-  metadata_backend: registry
-  mirror_method: to_registry
-  registry_type: docker_registry
-  # operators_to_mirror: compliance_operator # Disabled temporarily due to issue with live channels
+# The type of registry to use in the integration test (choose from docker_registry or redhat_quay)
+registry_type: docker_registry
 
-# If you want to override the ImageSetConfiguration generation with a custom change to the API, you might want to use something like this:
-#
-# imageset_config_override: |-
-#   apiVersion: mirror.openshift.io/v1alpha2
-#   kind: ImageSetConfiguration
-#   ocp:
-#     channels:
-#       - name: stable-4.9
-#         minVersion: 4.9.10
-#         maxVersion: 4.9.17
+# The operators to mirror, install, and test
+# Choose any of the following (or none):
+# - foo
+# - compliance_operator
+operators_to_mirror:
+- foo


### PR DESCRIPTION
# Description

- Align mock environment permissions with CI environment permissions (writable non-secret volumes, writable repo, non-writable otherwise)
- Inherit updates to collection to improve behavior in CI on long-running tasks
- Collect oc-mirror and openshift-install logs from every phase of tests

Fixes #326 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

The integration test slash command for ci-operator

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules