### PR TITLE
fix: adds default tags to digest references and image pinning to remo…

### DIFF
--- a/pkg/bundle/image.go
+++ b/pkg/bundle/image.go
@@ -1,15 +1,12 @@
 package bundle
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/openshift/library-go/pkg/image/reference"
-	"github.com/operator-framework/operator-registry/pkg/image/containerdregistry"
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
-	"github.com/openshift/oc-mirror/pkg/image"
 )
 
 type ErrBlocked struct {
@@ -33,15 +30,4 @@ func IsBlocked(blocked []v1alpha2.BlockedImages, imgRef reference.DockerImageRef
 		}
 	}
 	return false
-}
-
-func PinImages(ctx context.Context, ref, resolverConfigPath string, skipTLSVerify, plainHTTP bool) (string, error) {
-	resolver, err := containerdregistry.NewResolver(resolverConfigPath, skipTLSVerify, plainHTTP, nil)
-	if err != nil {
-		return "", fmt.Errorf("error creating image resolver: %v", err)
-	}
-	if !image.IsImagePinned(ref) {
-		return image.ResolveToPin(ctx, resolver, ref)
-	}
-	return ref, nil
 }

--- a/pkg/cli/mirror/additional.go
+++ b/pkg/cli/mirror/additional.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/openshift/oc/pkg/cli/image/imagesource"
+	"github.com/operator-framework/operator-registry/pkg/image/containerdregistry"
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
-	"github.com/openshift/oc-mirror/pkg/bundle"
 	"github.com/openshift/oc-mirror/pkg/image"
 )
 
@@ -26,11 +26,15 @@ func NewAdditionalOptions(mo *MirrorOptions) *AdditionalOptions {
 // Plan provides an image mapping with source and destination for provided AdditionalImages
 func (o *AdditionalOptions) Plan(ctx context.Context, imageList []v1alpha2.AdditionalImages) (image.TypedImageMapping, error) {
 	mmappings := make(image.TypedImageMapping, len(imageList))
+	resolver, err := containerdregistry.NewResolver("", o.SourceSkipTLS, o.SourcePlainHTTP, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating image resolver: %v", err)
+	}
 	for _, img := range imageList {
 		// Get source image information
 		srcRef, err := imagesource.ParseReference(img.Name)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing source image %s: %v", img.Name, err)
+			return mmappings, fmt.Errorf("error parsing source image %s: %v", img.Name, err)
 		}
 		if setLatest(srcRef) {
 			srcRef.Ref.Tag = "latest"
@@ -41,19 +45,22 @@ func (o *AdditionalOptions) Plan(ctx context.Context, imageList []v1alpha2.Addit
 			return o.ContinueOnError || (o.SkipMissing && errors.Is(err, errdefs.ErrNotFound))
 		}
 
-		srcImage, err := bundle.PinImages(ctx, srcRef.Ref.Exact(), "", o.SourceSkipTLS, o.SourcePlainHTTP)
-		if err != nil {
-			if !isSkipErr(err) {
-				return nil, err
+		ref := srcRef.Ref.Exact()
+		if !image.IsImagePinned(ref) {
+			srcImage, err := image.ResolveToPin(ctx, resolver, ref)
+			if err != nil {
+				if !isSkipErr(err) {
+					return mmappings, err
+				}
+				logrus.Warn(err)
+				continue
 			}
-			logrus.Warn(err)
-			continue
+			pinnedRef, err := imagesource.ParseReference(srcImage)
+			if err != nil {
+				return mmappings, fmt.Errorf("error parsing source image %s: %v", img.Name, err)
+			}
+			srcRef.Ref.ID = pinnedRef.Ref.ID
 		}
-		pinnedRef, err := imagesource.ParseReference(srcImage)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing source image %s: %v", img.Name, err)
-		}
-		srcRef.Ref.ID = pinnedRef.Ref.ID
 
 		// Set destination image information as file by default
 		dstRef := srcRef

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containerd/containerd/errdefs"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -331,11 +332,11 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 			return err
 		}
 		// Create associations
-		assocs, errs := image.AssociateRemoteImageLayers(cmd.Context(), mapping, sourceInsecure, o.SkipVerification)
+		assocs, errs := image.AssociateRemoteImageLayers(cmd.Context(), mapping, o.SourceSkipTLS, o.SourcePlainHTTP, o.SkipVerification)
 		skipErr := func(err error) bool {
 			ierr := &image.ErrInvalidImage{}
 			cerr := &image.ErrInvalidComponent{}
-			return errors.As(err, &ierr) || errors.As(err, &cerr)
+			return errors.As(err, &ierr) || errors.As(err, &cerr) || (o.SkipMissing && errors.Is(err, errdefs.ErrNotFound))
 		}
 
 		if errs != nil {

--- a/pkg/image/association_builder_test.go
+++ b/pkg/image/association_builder_test.go
@@ -285,6 +285,46 @@ func TestAssociateRemoteImageLayers(t *testing.T) {
 		wantErr    bool
 	}{
 		{
+			name:   "Valid/ManifestWithTag",
+			imgTyp: v1alpha2.TypeGeneric,
+			imgMapping: map[TypedImage]TypedImage{
+				{
+					TypedImageReference: imagesource.TypedImageReference{
+						Ref: reference.DockerImageReference{
+							Name:     "single_manifest",
+							Tag:      "latest",
+							Registry: u.Host,
+						}},
+					Category: v1alpha2.TypeGeneric}: {
+					TypedImageReference: imagesource.TypedImageReference{
+						Ref: reference.DockerImageReference{
+							Name:     "single_manifest",
+							Tag:      "latest",
+							Registry: "test-registry",
+						},
+						Type: imagesource.DestinationRegistry,
+					},
+					Category: v1alpha2.TypeGeneric}},
+			expResult: AssociationSet{fmt.Sprintf("%s/single_manifest@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19", u.Host): Associations{
+				fmt.Sprintf("%s/single_manifest@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19", u.Host): {
+					Name:            fmt.Sprintf("%s/single_manifest@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19", u.Host),
+					Path:            "test-registry/single_manifest:latest",
+					TagSymlink:      "latest",
+					ID:              "sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
+					Type:            v1alpha2.TypeGeneric,
+					ManifestDigests: nil,
+					LayerDigests: []string{
+						"sha256:e8614d09b7bebabd9d8a450f44e88a8807c98a438a2ddd63146865286b132d1b",
+						"sha256:601401253d0aac2bc95cccea668761a6e69216468809d1cee837b2e8b398e241",
+						"sha256:211941188a4f55ffc6bcefa4f69b69b32c13fafb65738075de05808bbfcec086",
+						"sha256:f0fd5be261dfd2e36d01069a387a3e5125f5fd5adfec90f3cb190d1d5f1d1ad9",
+						"sha256:0c0beb258254c0566315c641b4107b080a96fa78d4f96833453dd6c5b9edf2b7",
+						"sha256:30c794a11b4c340c77238c5b7ca845752904bd8b74b73a9b16d31253234da031",
+					},
+				},
+			}},
+		},
+		{
 			name:   "Valid/ManifestWithDigest",
 			imgTyp: v1alpha2.TypeGeneric,
 			imgMapping: map[TypedImage]TypedImage{
@@ -455,7 +495,7 @@ func TestAssociateRemoteImageLayers(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			asSet, err := AssociateRemoteImageLayers(context.TODO(), test.imgMapping, true, false)
+			asSet, err := AssociateRemoteImageLayers(context.TODO(), test.imgMapping, true, true, false)
 			if !test.wantErr {
 				require.NoError(t, err)
 				require.Equal(t, test.expResult, asSet)

--- a/pkg/image/mapping.go
+++ b/pkg/image/mapping.go
@@ -37,6 +37,9 @@ func (m TypedImageMapping) ToRegistry(registry, namespace string) {
 		dest.Ref.Registry = registry
 		dest.Ref.Namespace = path.Join(namespace, dest.Ref.Namespace)
 		dest.Ref.ID = src.Ref.ID
+		if dest.Ref.Tag == "" && len(src.Ref.ID) > 13 {
+			dest.Ref.Tag = src.Ref.ID[7:13]
+		}
 		m[src] = dest
 	}
 }

--- a/pkg/image/mapping_test.go
+++ b/pkg/image/mapping_test.go
@@ -279,3 +279,54 @@ func TestReadImageMapping(t *testing.T) {
 		})
 	}
 }
+
+func TestToRegistry(t *testing.T) {
+	toMirror := "test.registry"
+	inputMapping := TypedImageMapping{
+		{TypedImageReference: imagesource.TypedImageReference{
+			Ref: reference.DockerImageReference{
+				Registry:  "some-registry",
+				Namespace: "namespace",
+				Name:      "image",
+				ID:        "sha256:30c794a11b4c340c77238c5b7ca845752904bd8b74b73a9b16d31253234da031",
+			},
+			Type: imagesource.DestinationRegistry,
+		},
+			Category: v1alpha2.TypeOperatorBundle}: {
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "disconn-registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "sha256:30c794a11b4c340c77238c5b7ca845752904bd8b74b73a9b16d31253234da031",
+				},
+				Type: imagesource.DestinationFile,
+			},
+			Category: v1alpha2.TypeOperatorBundle}}
+
+	expMapping := TypedImageMapping{
+		{TypedImageReference: imagesource.TypedImageReference{
+			Ref: reference.DockerImageReference{
+				Registry:  "some-registry",
+				Namespace: "namespace",
+				Name:      "image",
+				ID:        "sha256:30c794a11b4c340c77238c5b7ca845752904bd8b74b73a9b16d31253234da031",
+			},
+			Type: imagesource.DestinationRegistry,
+		},
+			Category: v1alpha2.TypeOperatorBundle}: {
+			TypedImageReference: imagesource.TypedImageReference{
+				Ref: reference.DockerImageReference{
+					Registry:  "test.registry",
+					Namespace: "namespace",
+					Name:      "image",
+					ID:        "sha256:30c794a11b4c340c77238c5b7ca845752904bd8b74b73a9b16d31253234da031",
+					Tag:       "30c794",
+				},
+				Type: imagesource.DestinationRegistry,
+			},
+			Category: v1alpha2.TypeOperatorBundle}}
+
+	inputMapping.ToRegistry(toMirror, "")
+	require.Equal(t, expMapping, inputMapping)
+}


### PR DESCRIPTION
…te association gathering

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

This PR adds default tags for mirror to mirror operations to ensure mirrored manifests are pullable in the destination registry. This adds modifies the `AssociateRemoteImageLayers` method to include support for tagged source images to make it compatible with  `--skip-image-pin`.

Fixes #395 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Manually tested
- [X] Unit test cases added in image package for change.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules