### PR TITLE
feat(mirror): image pruning from registry on mirroring workflows

### DIFF
--- a/pkg/cli/mirror/list/releases.go
+++ b/pkg/cli/mirror/list/releases.go
@@ -78,6 +78,9 @@ func (o *ReleasesOptions) Run(ctx context.Context) error {
 	w := o.IOStreams.Out
 
 	client, err := cincinnati.NewOCPClient(uuid.New())
+	if err != nil {
+		return err
+	}
 
 	if o.Channels {
 		channels, err := cincinnati.GetChannels(ctx, client, o.Channel)

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -223,7 +223,7 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 			return err
 		}
 
-		prevAssociations, err := o.removePreviouslyMirrored(mapping, meta)
+		prunedAssociations, err := o.removePreviouslyMirrored(mapping, meta)
 		if err != nil {
 			if errors.Is(err, ErrNoUpdatesExist) {
 				logrus.Infof("no new images detected, process stopping")
@@ -265,7 +265,7 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 		}
 
 		// Pack the images set
-		tmpBackend, err := o.Pack(cmd.Context(), prevAssociations, assocs, &meta, cfg.ArchiveSize)
+		tmpBackend, err := o.Pack(cmd.Context(), prunedAssociations, assocs, &meta, cfg.ArchiveSize)
 		if err != nil {
 			if errors.Is(err, ErrNoUpdatesExist) {
 				logrus.Infof("no updates detected, process stopping")
@@ -324,7 +324,7 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 		// registry to registry mapping
 		mapping.ToRegistry(o.ToMirror, o.UserNamespace)
 
-		prevAssociations, err := o.removePreviouslyMirrored(mapping, meta)
+		prunedAssociations, err := o.removePreviouslyMirrored(mapping, meta)
 		if err != nil {
 			if errors.Is(err, ErrNoUpdatesExist) {
 				logrus.Infof("no new images detected, process stopping")
@@ -364,12 +364,22 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 			}
 		}
 
+		// Prune the images that differ between the previous Associations and the
+		// pruned Associations.
+		prevAssociations, err := image.ConvertToAssociationSet(meta.PastAssociations)
+		if err != nil {
+			return err
+		}
+		if err := o.pruneRegistry(cmd.Context(), prevAssociations, prunedAssociations); err != nil {
+			return fmt.Errorf("error pruning from registry %q: %v", o.ToMirror, err)
+		}
+
 		meta.PastMirror.Associations, err = image.ConvertFromAssociationSet(assocs)
 		if err != nil {
 			return err
 		}
-		prevAssociations.Merge(assocs)
-		meta.PastAssociations, err = image.ConvertFromAssociationSet(prevAssociations)
+		prunedAssociations.Merge(assocs)
+		meta.PastAssociations, err = image.ConvertFromAssociationSet(prunedAssociations)
 		if err != nil {
 			return err
 		}
@@ -501,11 +511,12 @@ func (o *MirrorOptions) mirrorMappings(cfg v1alpha2.ImageSetConfiguration, image
 		return err
 	}
 
-	// Create mapping from source and destination images
 	var mappings []mirror.Mapping
 	for srcRef, dstRef := range images {
 		if bundle.IsBlocked(cfg.Mirror.BlockedImages, srcRef.Ref) {
 			logrus.Warnf("skipping blocked image %s", srcRef.String())
+			// Remove to make sure this does end up in the metadata
+			images.Remove(srcRef)
 			continue
 		}
 

--- a/pkg/cli/mirror/prune.go
+++ b/pkg/cli/mirror/prune.go
@@ -1,0 +1,95 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/sirupsen/logrus"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/openshift/library-go/pkg/image/reference"
+	"github.com/openshift/oc-mirror/pkg/image"
+)
+
+func (o *MirrorOptions) pruneRegistry(ctx context.Context, prev, curr image.AssociationSet) error {
+	toRemove, err := o.prepAssociationSets(curr, prev)
+	if err != nil {
+		return err
+	}
+	return o.pruneImages(ctx, toRemove)
+}
+
+func (o *MirrorOptions) pruneImages(ctx context.Context, as image.AssociationSet) error {
+	if len(as) == 0 {
+		logrus.Debug("No image specified for pruning")
+		return nil
+	}
+
+	logrus.Info("Pruning images outside out range from registry")
+	var destInsecure bool
+	var terr *transport.Error
+	var errs []error
+	if o.DestPlainHTTP || o.DestSkipTLS {
+		destInsecure = true
+	}
+	nameOpts := getNameOpts(destInsecure)
+	remoteOpts := getRemoteOpts(ctx, destInsecure)
+
+	for imageName := range as {
+
+		// Need to parse twice because name reference cannot be updated
+		nameRef, err := name.ParseReference(imageName, nameOpts...)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		err = remote.Delete(nameRef, remoteOpts...)
+		switch {
+		case err == nil:
+			logrus.Debugf("image %q removed", imageName)
+		case errors.As(err, &terr):
+			logrus.Warnf("registry %q: %d response code for image deletion request, ending pruning attempt", o.ToMirror, terr.StatusCode)
+			return nil
+		default:
+			errs = append(errs, fmt.Errorf("image %q: pruning error: %v", nameRef.String(), err))
+			continue
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+// prepAssociationSets diff the previous and current set and updated the image key to
+// reflect the current mirror and top-level namespace
+func (o *MirrorOptions) prepAssociationSets(curr, prev image.AssociationSet) (image.AssociationSet, error) {
+	var remove []string
+	// TODO(jpower432): Adds Associations for images that are referenced by tag
+	// but the manifests have been updated.
+	for _, key := range prev.Keys() {
+		if found := curr.SetContainsKey(key); !found {
+			remove = append(remove, key)
+		}
+	}
+
+	outputSet, err := image.Prune(prev, remove)
+	if err != nil {
+		return outputSet, err
+	}
+
+	for _, key := range outputSet.Keys() {
+		sourceRef, err := reference.Parse(key)
+		if err != nil {
+			return outputSet, err
+		}
+		sourceRef.Registry = o.ToMirror
+		sourceRef.Namespace = path.Join(o.UserNamespace, sourceRef.Namespace)
+		outputSet.UpdateKey(key, sourceRef.Exact())
+	}
+	return outputSet, nil
+}

--- a/pkg/cli/mirror/prune_test.go
+++ b/pkg/cli/mirror/prune_test.go
@@ -1,0 +1,144 @@
+package mirror
+
+import (
+	"testing"
+
+	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
+	"github.com/openshift/oc-mirror/pkg/cli"
+	"github.com/openshift/oc-mirror/pkg/image"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepAssociationSet(t *testing.T) {
+	type spec struct {
+		desc string
+		opts *MirrorOptions
+		curr image.AssociationSet
+		prev image.AssociationSet
+		exp  image.AssociationSet
+	}
+
+	cases := []spec{
+		{
+			desc: "Success/FirstRun",
+			opts: &MirrorOptions{
+				RootOptions:   &cli.RootOptions{},
+				ToMirror:      "test-registry",
+				UserNamespace: "namespace",
+			},
+			prev: image.AssociationSet{},
+			curr: image.AssociationSet{"imgname@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19": image.Associations{
+				"imgname@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19": {
+					Name:            "imgname@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
+					Path:            "single_manifest",
+					TagSymlink:      "latest",
+					ID:              "sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
+					Type:            v1alpha2.TypeGeneric,
+					ManifestDigests: nil,
+					LayerDigests: []string{
+						"sha256:e8614d09b7bebabd9d8a450f44e88a8807c98a438a2ddd63146865286b132d1b",
+						"sha256:601401253d0aac2bc95cccea668761a6e69216468809d1cee837b2e8b398e241",
+						"sha256:211941188a4f55ffc6bcefa4f69b69b32c13fafb65738075de05808bbfcec086",
+						"sha256:f0fd5be261dfd2e36d01069a387a3e5125f5fd5adfec90f3cb190d1d5f1d1ad9",
+						"sha256:0c0beb258254c0566315c641b4107b080a96fa78d4f96833453dd6c5b9edf2b7",
+						"sha256:30c794a11b4c340c77238c5b7ca845752904bd8b74b73a9b16d31253234da031",
+					},
+				},
+			},
+			},
+			exp: image.AssociationSet{},
+		},
+		{
+			desc: "Success/DifferentialRun",
+			opts: &MirrorOptions{
+				RootOptions:   &cli.RootOptions{},
+				ToMirror:      "test-registry",
+				UserNamespace: "namespace",
+			},
+			prev: image.AssociationSet{
+				"imgname@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19": image.Associations{
+					"imgname@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19": {
+						Name:            "imgname@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
+						Path:            "single_manifest",
+						TagSymlink:      "latest",
+						ID:              "sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
+						Type:            v1alpha2.TypeGeneric,
+						ManifestDigests: nil,
+						LayerDigests: []string{
+							"sha256:e8614d09b7bebabd9d8a450f44e88a8807c98a438a2ddd63146865286b132d1b",
+							"sha256:601401253d0aac2bc95cccea668761a6e69216468809d1cee837b2e8b398e241",
+							"sha256:211941188a4f55ffc6bcefa4f69b69b32c13fafb65738075de05808bbfcec086",
+							"sha256:f0fd5be261dfd2e36d01069a387a3e5125f5fd5adfec90f3cb190d1d5f1d1ad9",
+							"sha256:0c0beb258254c0566315c641b4107b080a96fa78d4f96833453dd6c5b9edf2b7",
+							"sha256:30c794a11b4c340c77238c5b7ca845752904bd8b74b73a9b16d31253234da031",
+						},
+					},
+				},
+				"imgname@sha256:e8614d09b7bebabd9d8a450f44e88a8807c98a438a2ddd63146865286b132d1b": image.Associations{
+					"imgname@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19": {
+						Name:            "imgname@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
+						Path:            "single_manifest",
+						TagSymlink:      "latest",
+						ID:              "sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
+						Type:            v1alpha2.TypeGeneric,
+						ManifestDigests: nil,
+						LayerDigests: []string{
+							"sha256:e8614d09b7bebabd9d8a450f44e88a8807c98a438a2ddd63146865286b132d1b",
+							"sha256:601401253d0aac2bc95cccea668761a6e69216468809d1cee837b2e8b398e241",
+							"sha256:211941188a4f55ffc6bcefa4f69b69b32c13fafb65738075de05808bbfcec086",
+							"sha256:f0fd5be261dfd2e36d01069a387a3e5125f5fd5adfec90f3cb190d1d5f1d1ad9",
+							"sha256:0c0beb258254c0566315c641b4107b080a96fa78d4f96833453dd6c5b9edf2b7",
+							"sha256:30c794a11b4c340c77238c5b7ca845752904bd8b74b73a9b16d31253234da031",
+						},
+					},
+				},
+			},
+			curr: image.AssociationSet{"imgname@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19": image.Associations{
+				"imgname@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19": {
+					Name:            "imgname@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
+					Path:            "single_manifest",
+					TagSymlink:      "latest",
+					ID:              "sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
+					Type:            v1alpha2.TypeGeneric,
+					ManifestDigests: nil,
+					LayerDigests: []string{
+						"sha256:e8614d09b7bebabd9d8a450f44e88a8807c98a438a2ddd63146865286b132d1b",
+						"sha256:601401253d0aac2bc95cccea668761a6e69216468809d1cee837b2e8b398e241",
+						"sha256:211941188a4f55ffc6bcefa4f69b69b32c13fafb65738075de05808bbfcec086",
+						"sha256:f0fd5be261dfd2e36d01069a387a3e5125f5fd5adfec90f3cb190d1d5f1d1ad9",
+						"sha256:0c0beb258254c0566315c641b4107b080a96fa78d4f96833453dd6c5b9edf2b7",
+						"sha256:30c794a11b4c340c77238c5b7ca845752904bd8b74b73a9b16d31253234da031",
+					},
+				},
+			},
+			},
+			exp: image.AssociationSet{"test-registry/namespace/imgname@sha256:e8614d09b7bebabd9d8a450f44e88a8807c98a438a2ddd63146865286b132d1b": image.Associations{
+				"imgname@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19": {
+					Name:            "imgname@sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
+					Path:            "single_manifest",
+					TagSymlink:      "latest",
+					ID:              "sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
+					Type:            v1alpha2.TypeGeneric,
+					ManifestDigests: nil,
+					LayerDigests: []string{
+						"sha256:e8614d09b7bebabd9d8a450f44e88a8807c98a438a2ddd63146865286b132d1b",
+						"sha256:601401253d0aac2bc95cccea668761a6e69216468809d1cee837b2e8b398e241",
+						"sha256:211941188a4f55ffc6bcefa4f69b69b32c13fafb65738075de05808bbfcec086",
+						"sha256:f0fd5be261dfd2e36d01069a387a3e5125f5fd5adfec90f3cb190d1d5f1d1ad9",
+						"sha256:0c0beb258254c0566315c641b4107b080a96fa78d4f96833453dd6c5b9edf2b7",
+						"sha256:30c794a11b4c340c77238c5b7ca845752904bd8b74b73a9b16d31253234da031",
+					},
+				},
+			},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			actual, err := c.opts.prepAssociationSets(c.curr, c.prev)
+			require.NoError(t, err)
+			require.Equal(t, c.exp, actual)
+		})
+	}
+}

--- a/pkg/image/association_set.go
+++ b/pkg/image/association_set.go
@@ -44,9 +44,7 @@ func (as AssociationSet) UpdateKey(oldKey, newKey string) error {
 	if !found {
 		return errors.New("key does not exist in map")
 	}
-	for _, value := range values {
-		as.Add(newKey, value)
-	}
+	as.Add(newKey, values...)
 	delete(as, oldKey)
 
 	return nil

--- a/pkg/image/builder/image_builder_test.go
+++ b/pkg/image/builder/image_builder_test.go
@@ -209,6 +209,6 @@ func prepareImage(t *testing.T, dir string) string {
 	require.NoError(t, lp.AppendImage(i))
 	idx, err := lp.ImageIndex()
 	require.NoError(t, err)
-	remote.WriteIndex(tag, idx)
+	require.NoError(t, remote.WriteIndex(tag, idx))
 	return targetRef
 }


### PR DESCRIPTION
# Description

Adds image pruning based on metadata functionality to mirroring workflows 

Fixes #302
Blocked by #387 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Unit test added for association diff
- [X] Manually verified pruned images

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

Notes: 
Overall docs updates are coming on a separate PR