### PR TITLE
Correct testdata publishing

### DIFF
--- a/test/operator/bundles/bar/bar-bundle-v1.0.0/metadata/annotations.yaml
+++ b/test/operator/bundles/bar/bar-bundle-v1.0.0/metadata/annotations.yaml
@@ -1,4 +1,4 @@
 annotations:
   operators.operatorframework.io.bundle.package.v1: bar
-  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: alpha,stable
   operators.operatorframework.io.bundle.channel.default.v1: stable

--- a/test/operator/bundles/foo/foo-bundle-v0.2.0/metadata/annotations.yaml
+++ b/test/operator/bundles/foo/foo-bundle-v0.2.0/metadata/annotations.yaml
@@ -1,4 +1,4 @@
 annotations:
   operators.operatorframework.io.bundle.package.v1: foo
-  operators.operatorframework.io.bundle.channels.v1: beta,stable
+  operators.operatorframework.io.bundle.channels.v1: beta
   operators.operatorframework.io.bundle.channel.default.v1: beta

--- a/test/operator/bundles/foo/foo-bundle-v0.3.1/metadata/dependencies.yaml
+++ b/test/operator/bundles/foo/foo-bundle-v0.3.1/metadata/dependencies.yaml
@@ -3,7 +3,7 @@ dependencies:
   - type: olm.package
     value:
       packageName: bar
-      version: <0.3.0
+      version: <0.2.0
   - type: olm.gvk
     value:
       group: "test.bar"

--- a/test/operator/publish_images.py
+++ b/test/operator/publish_images.py
@@ -99,7 +99,7 @@ def build_and_push(context: Path = None, image: str = None, extra_args: str = No
     os.chdir(context)
 
     # Build
-    base_command = f'{RUNTIME} build . --format=oci -t {image}'
+    base_command = f'{RUNTIME} build . --format=docker -t {image}'
     if extra_args is None:
         command = base_command
     else:
@@ -108,7 +108,7 @@ def build_and_push(context: Path = None, image: str = None, extra_args: str = No
         logger.debug(line)
 
     # Push
-    for line in shell(f'{RUNTIME} push --format=oci {image}'):
+    for line in shell(f'{RUNTIME} push --format=docker {image}'):
         logger.debug(line)
 
     logger.debug(f'Returning to {prev_dir}')


### PR DESCRIPTION
# Description

- Forces publishing in docker image format instead of OCI image format
- Aligns bundle data and metadata with old hand-crafted indexes

Fixes #404 
Fixes #403 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- `make publish-catalog`
- `make test-e2e`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules