### PR TITLE
fix: changes ConvertToAssociationSet methods to allow for shared chil…

### DIFF
--- a/pkg/image/convert.go
+++ b/pkg/image/convert.go
@@ -19,7 +19,13 @@ func ConvertToAssociationSet(assocs []v1alpha2.Association) (AssociationSet, err
 			errs = append(errs, err)
 			continue
 		}
-		assocMapping[a.Name] = a
+
+		// The association name itself
+		// is not unique because images can
+		// share child manifest so using the
+		// name and path/image as the key for
+		// unique combination.
+		assocMapping[a.Name+a.Path] = a
 	}
 	if len(errs) != 0 {
 		return assocSet, utilerrors.NewAggregate(errs)
@@ -35,7 +41,7 @@ func ConvertToAssociationSet(assocs []v1alpha2.Association) (AssociationSet, err
 			assocSet.Add(value.Name, value)
 			for _, digest := range value.ManifestDigests {
 				logrus.Debugf("image %q: processing child manifest %s", value.Name, digest)
-				child, ok := assocMapping[digest]
+				child, ok := assocMapping[digest+value.Path]
 				if !ok {
 					return assocSet, fmt.Errorf("invalid associations: association for %q is missing", digest)
 				}

--- a/pkg/image/convert_test.go
+++ b/pkg/image/convert_test.go
@@ -146,10 +146,10 @@ func TestConvertToAssociationSet(t *testing.T) {
 				"anotherimgname:latest": Associations{
 					"anotherimgname:latest": {
 						Name:       "anotherimgname:latest",
-						Path:       "index_manifest",
+						Path:       "another_index_manifest",
 						TagSymlink: "latest",
 						ID:         "sha256:d15a206e4ee462e82ab722ed84dfa514ab9ed8d85100d591c04314ae7c2162ed",
-						Type:       v1alpha2.TypeGeneric,
+						Type:       v1alpha2.TypeOperatorBundle,
 						ManifestDigests: []string{
 							"sha256:bab3a6153010b614c8764548f0dbe34c4a7dce4ea278a94713c3e9a936bb74e6",
 						},
@@ -157,10 +157,10 @@ func TestConvertToAssociationSet(t *testing.T) {
 					},
 					"sha256:bab3a6153010b614c8764548f0dbe34c4a7dce4ea278a94713c3e9a936bb74e6": {
 						Name:       "sha256:bab3a6153010b614c8764548f0dbe34c4a7dce4ea278a94713c3e9a936bb74e6",
-						Path:       "index_manifest",
+						Path:       "another_index_manifest",
 						TagSymlink: "",
 						ID:         "sha256:bab3a6153010b614c8764548f0dbe34c4a7dce4ea278a94713c3e9a936bb74e6",
-						Type:       v1alpha2.TypeGeneric,
+						Type:       v1alpha2.TypeOperatorBundle,
 						LayerDigests: []string{
 							"sha256:df20fa9351a15782c64e6dddb2d4a6f50bf6d3688060a34c4014b0d9a752eb4c",
 							"sha256:58445347cff86791f89717f3bf79ec6f597d146397d9e78136cf9e937f363555",
@@ -191,10 +191,10 @@ func TestConvertToAssociationSet(t *testing.T) {
 				},
 				{
 					Name:       "anotherimgname:latest",
-					Path:       "index_manifest",
+					Path:       "another_index_manifest",
 					TagSymlink: "latest",
 					ID:         "sha256:d15a206e4ee462e82ab722ed84dfa514ab9ed8d85100d591c04314ae7c2162ed",
-					Type:       v1alpha2.TypeGeneric,
+					Type:       v1alpha2.TypeOperatorBundle,
 					ManifestDigests: []string{
 						"sha256:bab3a6153010b614c8764548f0dbe34c4a7dce4ea278a94713c3e9a936bb74e6",
 					},
@@ -321,10 +321,10 @@ func TestConvertToAssociationSet(t *testing.T) {
 				},
 				{
 					Name:       "sha256:bab3a6153010b614c8764548f0dbe34c4a7dce4ea278a94713c3e9a936bb74e6",
-					Path:       "index_manifest",
+					Path:       "another_index_manifest",
 					TagSymlink: "",
 					ID:         "sha256:bab3a6153010b614c8764548f0dbe34c4a7dce4ea278a94713c3e9a936bb74e6",
-					Type:       v1alpha2.TypeGeneric,
+					Type:       v1alpha2.TypeOperatorBundle,
 					LayerDigests: []string{
 						"sha256:df20fa9351a15782c64e6dddb2d4a6f50bf6d3688060a34c4014b0d9a752eb4c",
 						"sha256:58445347cff86791f89717f3bf79ec6f597d146397d9e78136cf9e937f363555",
@@ -595,10 +595,10 @@ func TestConvertToAssociationSet(t *testing.T) {
 				},
 				{
 					Name:       "sha256:bab3a6153010b614c8764548f0dbe34c4a7dce4ea278a94713c3e9a936bb74e6",
-					Path:       "index_manifest",
+					Path:       "another_index_manifest",
 					TagSymlink: "",
 					ID:         "sha256:bab3a6153010b614c8764548f0dbe34c4a7dce4ea278a94713c3e9a936bb74e6",
-					Type:       v1alpha2.TypeGeneric,
+					Type:       v1alpha2.TypeOperatorBundle,
 					LayerDigests: []string{
 						"sha256:df20fa9351a15782c64e6dddb2d4a6f50bf6d3688060a34c4014b0d9a752eb4c",
 						"sha256:58445347cff86791f89717f3bf79ec6f597d146397d9e78136cf9e937f363555",


### PR DESCRIPTION
…d manifest

Currently, Associations contain multiple entries for one manifest that belong to more
than one image. These values are loaded into a map during the conversion which can
cause the child Association to end up with the wrong image data (e.g. Path/Type). Since the
combination of name(digest) and path(disk location) in the Association spec would be unique, that
is being used as the new key in the map so the image information is retained.

Related to PR #401
Fixes #402

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

^^

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] Convert unit test added to better reflect 
- [X] Published an imageset with images that have shared manifest successfully

# How To Test
```
apiVersion: mirror.openshift.io/v1alpha2
kind: ImageSetConfiguration
storageConfig:
  local:
    path: metadata
mirror:
  additionalImages:
  - name: registry.redhat.io/rhscl/php-73-rhel7:latest
  - name: registry.redhat.io/ubi7/php-73:latest
  - name: registry.redhat.io/ubi8/php-73:latest
  - name: registry.redhat.io/ubi8/php-74:latest
```
This appears when used with a disk to mirror workflow
Steps:
```
oc-mirror --config imageset-config.yaml file://archives
oc-mirror --from archives docker://test-registry.com
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules