### PR TITLE
feat(mirror): adds a skip-metadata-check flag to mirror command

### DIFF
--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -434,14 +434,12 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 				return err
 			}
 			metaImage := o.newMetadataImage(meta.Uid.String())
-			targetCfg := v1alpha2.StorageConfig{
-				Registry: &v1alpha2.RegistryConfig{
-					ImageURL: metaImage,
-					SkipTLS:  destInsecure,
-				},
+			targetCfg := &v1alpha2.RegistryConfig{
+				ImageURL: metaImage,
+				SkipTLS:  destInsecure,
 			}
 
-			targetBackend, err := storage.ByConfig(o.Dir, targetCfg)
+			targetBackend, err := storage.NewRegistryBackend(targetCfg, o.Dir)
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -15,25 +15,26 @@ import (
 
 type MirrorOptions struct {
 	*cli.RootOptions
-	OutputDir        string
-	ConfigPath       string
-	SkipImagePin     bool
-	ManifestsOnly    bool
-	From             string
-	ToMirror         string
-	UserNamespace    string
-	DryRun           bool
-	SourceSkipTLS    bool
-	DestSkipTLS      bool
-	SourcePlainHTTP  bool
-	DestPlainHTTP    bool
-	SkipVerification bool
-	SkipCleanup      bool
-	SkipMissing      bool
-	ContinueOnError  bool
-	IgnoreHistory    bool
-	FilterOptions    []string
-	MaxPerRegistry   int
+	OutputDir         string
+	ConfigPath        string
+	SkipImagePin      bool
+	ManifestsOnly     bool
+	From              string
+	ToMirror          string
+	UserNamespace     string
+	DryRun            bool
+	SourceSkipTLS     bool
+	DestSkipTLS       bool
+	SourcePlainHTTP   bool
+	DestPlainHTTP     bool
+	SkipVerification  bool
+	SkipCleanup       bool
+	SkipMissing       bool
+	SkipMetadataCheck bool
+	ContinueOnError   bool
+	IgnoreHistory     bool
+	FilterOptions     []string
+	MaxPerRegistry    int
 	// cancelCh is a channel listening for command cancellations
 	cancelCh         <-chan struct{}
 	once             sync.Once
@@ -51,11 +52,15 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.DestSkipTLS, "dest-skip-tls", o.DestSkipTLS, "Disable TLS validation for destination registry")
 	fs.BoolVar(&o.SourcePlainHTTP, "source-use-http", o.SourcePlainHTTP, "Use plain HTTP for source registry")
 	fs.BoolVar(&o.DestPlainHTTP, "dest-use-http", o.DestPlainHTTP, "Use plain HTTP for destination registry")
-	fs.BoolVar(&o.SkipVerification, "skip-verification", o.SkipVerification, "Skip digest verification")
+	fs.BoolVar(&o.SkipVerification, "skip-verification", o.SkipVerification, "Skip verifying the integrity of the retrieved content."+
+		"This is not recommended, but may be necessary when importing images from older image registries."+
+		"Only bypass verification if the registry is known to be trustworthy.")
 	fs.BoolVar(&o.SkipCleanup, "skip-cleanup", o.SkipCleanup, "Skip removal of artifact directories")
-	fs.BoolVar(&o.IgnoreHistory, "ignore-history", o.IgnoreHistory, "Ignores past mirrors when downloading images and packing layers")
 	fs.StringSliceVar(&o.FilterOptions, "filter-options", o.FilterOptions, "An architecture list to control the release image"+
 		"picked when multiple variants are available")
+	fs.BoolVar(&o.IgnoreHistory, "ignore-history", o.IgnoreHistory, "Ignore past mirrors when downloading images and packing layers")
+	fs.BoolVar(&o.SkipMetadataCheck, "skip-metadata-check", o.SkipMetadataCheck, "Skip metadata when publishing an imageset."+
+		"This is only recommended when the imageset was created --ignore-history")
 	fs.BoolVar(&o.ContinueOnError, "continue-on-error", o.ContinueOnError, "If an error occurs, keep going "+
 		"and attempt to mirror as much as possible")
 	fs.BoolVar(&o.SkipMissing, "skip-missing", o.SkipMissing, "If an input image is not found, skip them. "+

--- a/pkg/cli/mirror/pack.go
+++ b/pkg/cli/mirror/pack.go
@@ -39,10 +39,7 @@ func (o *MirrorOptions) Pack(ctx context.Context, prevAssocs, currAssocs image.A
 	if err != nil {
 		return nil, err
 	}
-	cfg := v1alpha2.StorageConfig{
-		Local: &v1alpha2.LocalConfig{Path: tmpdir},
-	}
-	tmpBackend, err := storage.ByConfig(tmpdir, cfg)
+	tmpBackend, err := storage.NewLocalBackend(tmpdir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/metadata/storage/registry.go
+++ b/pkg/metadata/storage/registry.go
@@ -154,10 +154,16 @@ func (b *registryBackend) unpack(ctx context.Context, fpath string) error {
 		StripComponents:        0,
 		ContinueOnError:        false,
 	}
-	if err := arc.Unarchive(filepath.Join(b.localDirBackend.dir, tempTar), b.localDirBackend.dir); err != nil {
+	tempTar = filepath.Join(b.localDirBackend.dir, tempTar)
+	if err := arc.Unarchive(tempTar, b.localDirBackend.dir); err != nil {
 		return err
-	} // adjust perms, unpack leaves the file user-writable only
-	return b.localDirBackend.fs.Chmod(fpath, 0600)
+	}
+	// adjust perms, unpack leaves the file user-writable only
+	if err := b.localDirBackend.fs.Chmod(fpath, 0600); err != nil {
+		return fmt.Errorf("metadata %q does not contain required content: %v", b.src.Ref.Exact(), err)
+	}
+
+	return nil
 }
 
 // Stat checks the existence of the metadata from a registry source


### PR DESCRIPTION
Currently, if imagesets are published out of sequence, the metadata check
will fail. If used with an imageset generated with the --ignore-history flag,
--skip-metadata-check allows for metadata overwrites in the case that imageset
archives are lost or cannot be published.

Closes #408 

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

^^

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] Unit test cases added
- [X] Manually verified with `--ignore-history`

# How to test
```
apiVersion: mirror.openshift.io/v1alpha2
kind: ImageSetConfiguration
storageConfig:
  local:
   path: metadata
mirror:
  additionalimages:
    - name: registry.redhat.io/ubi8/ubi:latest
 ```
```
# Run oc-mirror three times
oc-mirror --config imageset-config.yaml file://archives 
oc-mirror --config imageset-config.yaml file://archives --ignore-history
oc-mirror --config imageset-config.yaml file://archives --ignore-history
# The use-case scenario would be that the sequence 2 archive was lost
oc-mirror --from archives/mirror_seq1_000000.tar docker://localhost:5000
oc-mirror --from archives/mirror_seq2_000000.tar docker://localhost:5000 --skip-metadata-check
```
This should not produce an error and allow the mirror to proceed without checking the sequence. 
Note: In practice, this causes an error if the imageset was not created with `--ignore-history` due to layer differentiation between runs.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules