### PR TITLE
feat(operator): allow ranges to be specified for package filtering

### DIFF
--- a/docs/examples/imageset-config-filter-catalog.yaml
+++ b/docs/examples/imageset-config-filter-catalog.yaml
@@ -16,6 +16,10 @@ mirror:
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.9
       packages:
         - name: elasticsearch-operator
-          startingVersion: '5.3.2-20'
+          minVersion: '5.3.2-20'
           channels:
             - name: stable
+        - name: rhacs-operator
+          channels:
+            - name: stable
+              minVersion: '3.67.0'

--- a/docs/imageset-config-ref.yaml
+++ b/docs/imageset-config-ref.yaml
@@ -17,7 +17,7 @@ mirror:
       full: true # full can be set to pull a full catalog and must be set to filter packages
       packages:
         - name: rhacs-operator
-          startingVersion: '3.67.0'
+          minVersion: '3.67.0'
           channels:
             - name: 'latest'
   additionalImages: # List of additional images to be included in imageset

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/openshift/cincinnati-operator v1.0.2-0.20220126212014-b56cf3346609
 	github.com/openshift/library-go v0.0.0-20210906100234-6754cfd64cb5
 	github.com/openshift/oc v0.0.0-alpha.0.0.20210721184532-4df50be4d929
-	github.com/operator-framework/operator-registry v1.21.1-0.20220324153146-de3610408773
+	github.com/operator-framework/operator-registry v1.21.1-0.20220502161945-aa8db09278a0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.7.1
 	github.com/spf13/cobra v1.3.0
@@ -220,5 +220,3 @@ replace (
 	k8s.io/client-go => github.com/openshift/kubernetes-client-go v0.0.0-20210730111819-978c4383ac68
 	k8s.io/kubectl => github.com/openshift/kubernetes-kubectl v0.0.0-20210730111826-9c6734b9d97d
 )
-
-replace github.com/operator-framework/operator-registry => github.com/dinhxuanvu/operator-registry v1.13.5-0.20220419220231-14e8b35c4105

--- a/go.mod
+++ b/go.mod
@@ -220,3 +220,5 @@ replace (
 	k8s.io/client-go => github.com/openshift/kubernetes-client-go v0.0.0-20210730111819-978c4383ac68
 	k8s.io/kubectl => github.com/openshift/kubernetes-kubectl v0.0.0-20210730111826-9c6734b9d97d
 )
+
+replace github.com/operator-framework/operator-registry => github.com/dinhxuanvu/operator-registry v1.13.5-0.20220419220231-14e8b35c4105

--- a/go.sum
+++ b/go.sum
@@ -459,6 +459,8 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/dhui/dktest v0.3.0/go.mod h1:cyzIUfGsBEbZ6BT7tnXqAShHSXCZhSNmFl70sZ7c1yc=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
+github.com/dinhxuanvu/operator-registry v1.13.5-0.20220419220231-14e8b35c4105 h1:Vbyis/pYsoJtlU/0ggqGsj7QxP+G+Psq0oqAQUwsOo0=
+github.com/dinhxuanvu/operator-registry v1.13.5-0.20220419220231-14e8b35c4105/go.mod h1:qDxBCYPeOMlOXd95Zi1q4GpiKwK9i9Mag1AkrMOoFNU=
 github.com/distribution/distribution/v3 v3.0.0-20210804104954-38ab4c606ee3 h1:rEK0juuU5idazw//KzUcL3yYwUU3DIe2OnfJwjDBqno=
 github.com/distribution/distribution/v3 v3.0.0-20210804104954-38ab4c606ee3/go.mod h1:gt38b7cvVKazi5XkHvINNytZXgTEntyhtyM3HQz46Nk=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
@@ -1331,8 +1333,6 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/operator-framework/api v0.12.0 h1:aHxHk50/Y1J4Ogdk2J6tYofgX+GEqyBPCMyun+JFqV4=
 github.com/operator-framework/api v0.12.0/go.mod h1:FTiYGm11fZQ3cSX+EQHc/UWoGZAwkGfyeHU+wMJ8jmA=
-github.com/operator-framework/operator-registry v1.21.1-0.20220324153146-de3610408773 h1:OEUAU/Fw7sPm+KU/mREYL7FnlZRAswaRqx2DM8wGM/Q=
-github.com/operator-framework/operator-registry v1.21.1-0.20220324153146-de3610408773/go.mod h1:qDxBCYPeOMlOXd95Zi1q4GpiKwK9i9Mag1AkrMOoFNU=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=

--- a/go.sum
+++ b/go.sum
@@ -459,8 +459,6 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/dhui/dktest v0.3.0/go.mod h1:cyzIUfGsBEbZ6BT7tnXqAShHSXCZhSNmFl70sZ7c1yc=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
-github.com/dinhxuanvu/operator-registry v1.13.5-0.20220419220231-14e8b35c4105 h1:Vbyis/pYsoJtlU/0ggqGsj7QxP+G+Psq0oqAQUwsOo0=
-github.com/dinhxuanvu/operator-registry v1.13.5-0.20220419220231-14e8b35c4105/go.mod h1:qDxBCYPeOMlOXd95Zi1q4GpiKwK9i9Mag1AkrMOoFNU=
 github.com/distribution/distribution/v3 v3.0.0-20210804104954-38ab4c606ee3 h1:rEK0juuU5idazw//KzUcL3yYwUU3DIe2OnfJwjDBqno=
 github.com/distribution/distribution/v3 v3.0.0-20210804104954-38ab4c606ee3/go.mod h1:gt38b7cvVKazi5XkHvINNytZXgTEntyhtyM3HQz46Nk=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
@@ -1333,6 +1331,8 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/operator-framework/api v0.12.0 h1:aHxHk50/Y1J4Ogdk2J6tYofgX+GEqyBPCMyun+JFqV4=
 github.com/operator-framework/api v0.12.0/go.mod h1:FTiYGm11fZQ3cSX+EQHc/UWoGZAwkGfyeHU+wMJ8jmA=
+github.com/operator-framework/operator-registry v1.21.1-0.20220502161945-aa8db09278a0 h1:MHvkLHeYBix8KYeZxFIYgjIvtm8wI4jNet80lV0RaoY=
+github.com/operator-framework/operator-registry v1.21.1-0.20220502161945-aa8db09278a0/go.mod h1:qDxBCYPeOMlOXd95Zi1q4GpiKwK9i9Mag1AkrMOoFNU=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=

--- a/pkg/api/v1alpha2/types_include_config.go
+++ b/pkg/api/v1alpha2/types_include_config.go
@@ -7,6 +7,8 @@ import (
 	"github.com/operator-framework/operator-registry/alpha/action"
 )
 
+// IncludeConfig defines a list of packages for
+// operator version selection.
 type IncludeConfig struct {
 	// Packages to include.
 	Packages []IncludePackage `json:"packages" yaml:"packages"`
@@ -34,19 +36,21 @@ type IncludeChannel struct {
 	IncludeBundle `json:",inline"`
 }
 
+// IncludeBundle contains a name (required) and versions (optional) to
+// include in the diff. The full package or channel is only included if no
+// versions are specified.
 type IncludeBundle struct {
 	// MinVersion to include, plus all versions in the upgrade graph to the MaxVersion.
 	MinVersion string `json:"minVersion,omitempty" yaml:"minVersion,omitempty"`
 	// MaxVersion to include as the channel head version.
 	MaxVersion string `json:"maxVersion,omitempty" yaml:"maxVersion,omitempty"`
-	// MinBundle to include, plus all bundles in the upgrade graph to the MaxBundle.
+	// MinBundle to include, plus all bundles in the upgrade graph to the channel head.
 	// Set this field only if the named bundle has no semantic version metadata.
 	MinBundle string `json:"minBundle,omitempty" yaml:"minBundle,omitempty"`
-	// MaxBundle to include as the channel head bundle.
-	// Set this field only if the named bundle has no semantic version metadata.
-	MaxBundle string `json:"maxBundle,omitempty" yaml:"maxBundle,omitempty"`
 }
 
+// ConvertToDiffIncludeConfig converts an IncludeConfig to a DiffIncludeConfig type to
+// interact with `operator-registry` libraries.
 func (ic *IncludeConfig) ConvertToDiffIncludeConfig() (dic action.DiffIncludeConfig, err error) {
 	if ic == nil {
 		return dic, nil
@@ -62,12 +66,16 @@ func (ic *IncludeConfig) ConvertToDiffIncludeConfig() (dic action.DiffIncludeCon
 
 		dpkg := action.DiffIncludePackage{Name: pkg.Name}
 		switch {
+		case pkg.MinVersion != "" && pkg.MaxVersion != "":
+			dpkg.Range = fmt.Sprintf(">=%s <=%s", pkg.MinVersion, pkg.MaxVersion)
 		case pkg.MinVersion != "":
 			minVer, err := semver.Parse(pkg.MinVersion)
 			if err != nil {
 				return dic, fmt.Errorf("package %s: %v", pkg.Name, err)
 			}
 			dpkg.Versions = []semver.Version{minVer}
+		case pkg.MaxVersion != "":
+			dpkg.Range = fmt.Sprintf("<=%s", pkg.MaxVersion)
 		case pkg.MinBundle != "":
 			dpkg.Bundles = []string{pkg.MinBundle}
 		}
@@ -82,12 +90,16 @@ func (ic *IncludeConfig) ConvertToDiffIncludeConfig() (dic action.DiffIncludeCon
 
 			dch := action.DiffIncludeChannel{Name: ch.Name}
 			switch {
+			case ch.MinVersion != "" && ch.MaxVersion != "":
+				dch.Range = fmt.Sprintf(">=%s <=%s", ch.MinVersion, ch.MaxVersion)
 			case ch.MinVersion != "":
-				minVer, err := semver.Parse(ch.MinVersion)
+				ver, err := semver.Parse(ch.MinVersion)
 				if err != nil {
 					return dic, fmt.Errorf("channel %s: %v", ch.Name, err)
 				}
-				dch.Versions = []semver.Version{minVer}
+				dch.Versions = []semver.Version{ver}
+			case ch.MaxVersion != "":
+				dch.Range = fmt.Sprintf("<=%s", ch.MaxVersion)
 			case ch.MinBundle != "":
 				dch.Bundles = []string{ch.MinBundle}
 			}
@@ -101,7 +113,7 @@ func (ic *IncludeConfig) ConvertToDiffIncludeConfig() (dic action.DiffIncludeCon
 
 func (b IncludeBundle) validate() error {
 	if b.MinVersion != "" && b.MinBundle != "" {
-		return fmt.Errorf("starting version and bundle are mutually exclusive")
+		return fmt.Errorf("minimum version and bundle are mutually exclusive")
 	}
 	return nil
 }

--- a/pkg/api/v1alpha2/types_include_config_test.go
+++ b/pkg/api/v1alpha2/types_include_config_test.go
@@ -10,9 +10,10 @@ import (
 
 func TestConvertToDiffIncludeConfig(t *testing.T) {
 	type spec struct {
-		name string
-		cfg  IncludeConfig
-		exp  action.DiffIncludeConfig
+		name     string
+		cfg      IncludeConfig
+		exp      action.DiffIncludeConfig
+		expError string
 	}
 
 	specs := []spec{
@@ -27,6 +28,7 @@ func TestConvertToDiffIncludeConfig(t *testing.T) {
 								Name: "stable",
 								IncludeBundle: IncludeBundle{
 									MinVersion: "0.1.0",
+									MaxVersion: "0.2.0",
 								},
 							},
 						},
@@ -50,10 +52,8 @@ func TestConvertToDiffIncludeConfig(t *testing.T) {
 						Name: "bar",
 						Channels: []action.DiffIncludeChannel{
 							{
-								Name: "stable",
-								Versions: []semver.Version{
-									semver.MustParse("0.1.0"),
-								},
+								Name:  "stable",
+								Range: ">=0.1.0 <=0.2.0",
 							},
 						},
 					},
@@ -79,10 +79,38 @@ func TestConvertToDiffIncludeConfig(t *testing.T) {
 						Name: "bar",
 						IncludeBundle: IncludeBundle{
 							MinVersion: "0.1.0",
+							MaxVersion: "0.2.0",
 						},
 					},
 					{
 						Name: "foo",
+						IncludeBundle: IncludeBundle{
+							MinVersion: "0.1.0",
+						},
+					},
+				},
+			},
+			exp: action.DiffIncludeConfig{
+				Packages: []action.DiffIncludePackage{
+					{
+						Name:  "bar",
+						Range: ">=0.1.0 <=0.2.0",
+					},
+					{
+						Name: "foo",
+						Versions: []semver.Version{
+							semver.MustParse("0.1.0"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Valid/WithMinVersionOnly",
+			cfg: IncludeConfig{
+				Packages: []IncludePackage{
+					{
+						Name: "bar",
 						IncludeBundle: IncludeBundle{
 							MinVersion: "0.1.0",
 						},
@@ -97,22 +125,120 @@ func TestConvertToDiffIncludeConfig(t *testing.T) {
 							semver.MustParse("0.1.0"),
 						},
 					},
+				},
+			},
+		},
+		{
+			name: "Valid/WithMaxVersionOnly",
+			cfg: IncludeConfig{
+				Packages: []IncludePackage{
+					{
+						Name: "bar",
+						IncludeBundle: IncludeBundle{
+							MaxVersion: "1.0.0",
+						},
+					},
 					{
 						Name: "foo",
-						Versions: []semver.Version{
-							semver.MustParse("0.1.0"),
+						Channels: []IncludeChannel{
+							{
+								Name: "stable",
+								IncludeBundle: IncludeBundle{
+									MaxVersion: "0.2.0",
+								},
+							},
 						},
 					},
 				},
 			},
+			exp: action.DiffIncludeConfig{
+				Packages: []action.DiffIncludePackage{
+					{
+						Name:  "bar",
+						Range: "<=1.0.0",
+					},
+					{
+						Name: "foo",
+						Channels: []action.DiffIncludeChannel{
+							{
+								Name:  "stable",
+								Range: "<=0.2.0",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Valid/WithMinAndMaxVersion",
+			cfg: IncludeConfig{
+				Packages: []IncludePackage{
+					{
+						Name: "bar",
+						IncludeBundle: IncludeBundle{
+							MinVersion: "0.1.0",
+							MaxVersion: "0.2.0",
+						},
+					},
+				},
+			},
+			exp: action.DiffIncludeConfig{
+				Packages: []action.DiffIncludePackage{
+					{
+						Name:  "bar",
+						Range: ">=0.1.0 <=0.2.0",
+					},
+				},
+			},
+		},
+		{
+			name: "Valid/WithMinBundle",
+			cfg: IncludeConfig{
+				Packages: []IncludePackage{
+					{
+						Name: "bar",
+						IncludeBundle: IncludeBundle{
+							MinBundle: "bundle-0.1.0",
+						},
+					},
+				},
+			},
+			exp: action.DiffIncludeConfig{
+				Packages: []action.DiffIncludePackage{
+					{
+						Name: "bar",
+						Bundles: []string{
+							"bundle-0.1.0",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Invalid/NoPackageName",
+			cfg: IncludeConfig{
+				Packages: []IncludePackage{
+					{
+						IncludeBundle: IncludeBundle{
+							MinVersion: "0.1.0",
+						},
+					},
+				},
+			},
+			exp:      action.DiffIncludeConfig{},
+			expError: "package 0 requires a name",
 		},
 	}
 
 	for _, s := range specs {
 		t.Run(s.name, func(t *testing.T) {
 			dic, err := s.cfg.ConvertToDiffIncludeConfig()
-			require.NoError(t, err)
-			require.Equal(t, s.exp, dic)
+			if s.expError != "" {
+				require.EqualError(t, err, s.expError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, s.exp, dic)
+			}
 		})
 	}
 }

--- a/pkg/api/v1alpha2/types_include_config_test.go
+++ b/pkg/api/v1alpha2/types_include_config_test.go
@@ -26,7 +26,7 @@ func TestConvertToDiffIncludeConfig(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									MinVersion: "0.1.0",
 								},
 							},
 						},
@@ -37,7 +37,7 @@ func TestConvertToDiffIncludeConfig(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									MinVersion: "0.1.0",
 								},
 							},
 						},
@@ -78,13 +78,13 @@ func TestConvertToDiffIncludeConfig(t *testing.T) {
 					{
 						Name: "bar",
 						IncludeBundle: IncludeBundle{
-							StartingVersion: semver.MustParse("0.1.0"),
+							MinVersion: "0.1.0",
 						},
 					},
 					{
 						Name: "foo",
 						IncludeBundle: IncludeBundle{
-							StartingVersion: semver.MustParse("0.1.0"),
+							MinVersion: "0.1.0",
 						},
 					},
 				},

--- a/pkg/cli/mirror/initcmd/initcmd.go
+++ b/pkg/cli/mirror/initcmd/initcmd.go
@@ -132,12 +132,14 @@ func (o *InitOptions) Run(ctx context.Context) error {
 		},
 	}
 
-	if "" != customRegistry {
+	if customRegistry != "" {
 		registry := &v1alpha2.RegistryConfig{
 			ImageURL: customRegistry,
 			SkipTLS:  false,
 		}
 		imageSetConfig.ImageSetConfigurationSpec.StorageConfig.Registry = registry
+		// Unset the local default backend
+		imageSetConfig.ImageSetConfigurationSpec.StorageConfig.Local = nil
 	}
 
 	switch o.Output {

--- a/pkg/cli/mirror/initcmd/initcmd_test.go
+++ b/pkg/cli/mirror/initcmd/initcmd_test.go
@@ -93,10 +93,8 @@ mirror:
   - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.11
     packages:
     - name: serverless-operator
-      startingVersion: 0.0.0
       channels:
       - name: stable
-        startingVersion: 0.0.0
   additionalImages:
   - name: registry.redhat.io/ubi8/ubi:latest
   helm: {}
@@ -130,11 +128,9 @@ mirror:
             "name": "serverless-operator",
             "channels": [
               {
-                "name": "stable",
-                "startingVersion": "0.0.0"
+                "name": "stable"
               }
-            ],
-            "startingVersion": "0.0.0"
+            ]
           }
         ],
         "catalog": "registry.redhat.io/redhat/redhat-operator-index:v4.11"
@@ -170,8 +166,6 @@ storageConfig:
   registry:
     imageURL: localhost:5000/test:latest
     skipTLS: false
-  local:
-    path: ./
 mirror:
   platform:
     channels:
@@ -181,10 +175,8 @@ mirror:
   - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.11
     packages:
     - name: serverless-operator
-      startingVersion: 0.0.0
       channels:
       - name: stable
-        startingVersion: 0.0.0
   additionalImages:
   - name: registry.redhat.io/ubi8/ubi:latest
   helm: {}
@@ -218,11 +210,9 @@ mirror:
             "name": "serverless-operator",
             "channels": [
               {
-                "name": "stable",
-                "startingVersion": "0.0.0"
+                "name": "stable"
               }
-            ],
-            "startingVersion": "0.0.0"
+            ]
           }
         ],
         "catalog": "registry.redhat.io/redhat/redhat-operator-index:v4.11"
@@ -239,9 +229,6 @@ mirror:
     "registry": {
       "imageURL": "localhost:5000/test:latest",
       "skipTLS": false
-    },
-    "local": {
-      "path": "./"
     }
   }
 }

--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -243,7 +243,7 @@ func (o *OperatorOptions) renderDCDiff(ctx context.Context, reg *containerdregis
 			return nil, err
 		}
 	case !hasInclude:
-		// If a previous specified starting version can be found on
+		// If a previous specified minimum version can be found on
 		// the mirror run update IncludeConfig , else, keep the
 		// IncludeConfig to get a new catalog at heads only.
 		prev, found := prevCatalog[ctlg.Catalog]
@@ -296,7 +296,7 @@ func verifyOperatorPkgFound(dic action.DiffIncludeConfig, dc *declcfg.Declarativ
 
 		if !dcMap[pkg.Name] {
 			// The operator package wasn't found. Log the error and continue on.
-			logrus.Errorf("Operator %s was not found, please check name, startingVersion, and channels in the config file.", pkg.Name)
+			logrus.Errorf("Operator %s was not found, please check name, minVersion, maxVersion, and channels in the config file.", pkg.Name)
 		}
 	}
 }

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -17,6 +17,8 @@ import (
 // versions do not matter to the caller.
 // See https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/config/config.go
 
+// ReadConfig opens an imageset configuration file at the given path
+// and loads it into a v1alpha2.ImageSetConfiguration instance for processing and validation.
 func ReadConfig(configPath string) (c v1alpha2.ImageSetConfiguration, err error) {
 
 	data, err := ioutil.ReadFile(filepath.Clean(configPath))
@@ -42,6 +44,7 @@ func ReadConfig(configPath string) (c v1alpha2.ImageSetConfiguration, err error)
 	return c, Validate(&c)
 }
 
+// LoadConfig loads data into a v1alpha2.ImageSetConfiguration instance
 func LoadConfig(data []byte) (c v1alpha2.ImageSetConfiguration, err error) {
 
 	gvk := v1alpha2.GroupVersion.WithKind(v1alpha2.ImageSetConfigurationKind)
@@ -61,6 +64,7 @@ func LoadConfig(data []byte) (c v1alpha2.ImageSetConfiguration, err error) {
 	return c, nil
 }
 
+// LoadMetadata loads data into a v1alpha2.Metadata instance
 func LoadMetadata(data []byte) (m v1alpha2.Metadata, err error) {
 
 	gvk := v1alpha2.GroupVersion.WithKind(v1alpha2.MetadataKind)

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/blang/semver/v4"
 	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
 	"github.com/stretchr/testify/require"
 )
@@ -59,7 +58,7 @@ func TestLoadConfig(t *testing.T) {
 									{
 										Name: "mongodb-operator",
 										IncludeBundle: v1alpha2.IncludeBundle{
-											StartingVersion: semver.Version{Major: 1, Minor: 4, Patch: 0},
+											MinVersion: "1.4.0",
 										},
 									},
 									{

--- a/pkg/config/testdata/config/valid.yaml
+++ b/pkg/config/testdata/config/valid.yaml
@@ -19,7 +19,7 @@ mirror:
       packages:
         - name: couchbase-operator
         - name: mongodb-operator
-          startingVersion: '1.4.0'
+          minVersion: '1.4.0'
         - name: crunchy-postgresql-operator
           channels:
             - name: 'stable'

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -12,6 +12,7 @@ type validationFunc func(cfg *v1alpha2.ImageSetConfiguration) error
 
 var validationChecks = []validationFunc{validateOperatorOptions, validateReleaseChannels}
 
+// Validation will check an ImageSetConfiguration for input errors.
 func Validate(cfg *v1alpha2.ImageSetConfiguration) error {
 	var errs []error
 	for _, check := range validationChecks {

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -50,7 +50,7 @@ func UpdateMetadata(ctx context.Context, backend storage.Backend, meta *v1alpha2
 	}
 
 	mirror := meta.PastMirror
-	// Store starting versions for new catalogs
+	// Store minimum versions for new catalogs
 	logrus.Debugf("Resolving operator metadata")
 	var operatorErrs []error
 
@@ -94,7 +94,7 @@ func UpdateMetadata(ctx context.Context, backend storage.Backend, meta *v1alpha2
 		return utilerrors.NewAggregate(operatorErrs)
 	}
 
-	// Store starting versions for new release channels
+	// Store minimum versions for new release channels
 	logrus.Debugf("Resolving OCP release metadata")
 	for _, channel := range mirror.Mirror.Platform.Channels {
 

--- a/pkg/metadata/store_test.go
+++ b/pkg/metadata/store_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
@@ -61,13 +60,13 @@ func TestUpdateMetadata_Catalogs(t *testing.T) {
 							{
 								Name: "alpha",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									MinVersion: "0.1.0",
 								},
 							},
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("1.0.0"),
+									MinVersion: "1.0.0",
 								},
 							},
 						},
@@ -78,7 +77,7 @@ func TestUpdateMetadata_Catalogs(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("1.0.0"),
+									MinVersion: "1.0.0",
 								},
 							},
 						},
@@ -89,7 +88,7 @@ func TestUpdateMetadata_Catalogs(t *testing.T) {
 							{
 								Name: "beta",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									MinVersion: "0.1.0",
 								},
 							},
 						},

--- a/pkg/operator/declfg_to_includecfg_test.go
+++ b/pkg/operator/declfg_to_includecfg_test.go
@@ -3,7 +3,6 @@ package operator
 import (
 	"testing"
 
-	"github.com/blang/semver/v4"
 	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/property"
@@ -63,7 +62,7 @@ func TestConvertDCToIncludeConfig(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									MinVersion: "0.1.0",
 								},
 							},
 						},
@@ -74,7 +73,7 @@ func TestConvertDCToIncludeConfig(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									MinVersion: "0.1.0",
 								},
 							},
 						},
@@ -149,7 +148,7 @@ func TestUpdateIncludeConfig(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									MinVersion: "0.1.0",
 								},
 							},
 						},
@@ -164,7 +163,7 @@ func TestUpdateIncludeConfig(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									MinVersion: "0.1.0",
 								},
 							},
 						},
@@ -175,7 +174,7 @@ func TestUpdateIncludeConfig(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									MinVersion: "0.1.0",
 								},
 							},
 						},
@@ -242,7 +241,7 @@ func TestUpdateIncludeConfig(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									MinVersion: "0.1.0",
 								},
 							},
 						},
@@ -253,7 +252,7 @@ func TestUpdateIncludeConfig(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									MinVersion: "0.1.0",
 								},
 							},
 						},
@@ -268,13 +267,13 @@ func TestUpdateIncludeConfig(t *testing.T) {
 							{
 								Name: "alpha",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									MinVersion: "0.1.0",
 								},
 							},
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									MinVersion: "0.1.0",
 								},
 							},
 						},
@@ -285,7 +284,7 @@ func TestUpdateIncludeConfig(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									MinVersion: "0.1.0",
 								},
 							},
 						},
@@ -390,7 +389,7 @@ func TestUpdateIncludeConfig(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									MinVersion: "0.1.0",
 								},
 							},
 						},
@@ -401,7 +400,7 @@ func TestUpdateIncludeConfig(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									MinVersion: "0.1.0",
 								},
 							},
 						},
@@ -416,7 +415,7 @@ func TestUpdateIncludeConfig(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.1"),
+									MinVersion: "0.1.1",
 								},
 							},
 						},
@@ -427,7 +426,7 @@ func TestUpdateIncludeConfig(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.2.0"),
+									MinVersion: "0.2.0",
 								},
 							},
 						},
@@ -480,7 +479,7 @@ func TestUpdateIncludeConfig(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									MinVersion: "0.1.0",
 								},
 							},
 						},
@@ -491,7 +490,7 @@ func TestUpdateIncludeConfig(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									MinVersion: "0.1.0",
 								},
 							},
 						},
@@ -506,7 +505,7 @@ func TestUpdateIncludeConfig(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.0.0"),
+									MinVersion: "0.0.0",
 								},
 							},
 						},
@@ -517,7 +516,7 @@ func TestUpdateIncludeConfig(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									MinVersion: "0.1.0",
 								},
 							},
 						},

--- a/test/e2e/configs/imageset-config-filter-max.yaml
+++ b/test/e2e/configs/imageset-config-filter-max.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: mirror.openshift.io/v1alpha2
+kind: ImageSetConfiguration
+storageConfig:
+  local:
+    path: DATA_TMP
+mirror:
+  operators:
+  - catalog: METADATA_CATALOGNAMESPACE:test-catalog-latest
+    full: true
+    skipDeps: true
+    packages:
+      - name: foo
+        maxVersion: 0.3.0

--- a/test/e2e/configs/imageset-config-filter-max.yaml
+++ b/test/e2e/configs/imageset-config-filter-max.yaml
@@ -8,7 +8,7 @@ mirror:
   operators:
   - catalog: METADATA_CATALOGNAMESPACE:test-catalog-latest
     full: true
-    skipDeps: true
+    skipDependencies: true
     packages:
       - name: foo
         maxVersion: 0.3.0

--- a/test/e2e/configs/imageset-config-filter-multi.yaml
+++ b/test/e2e/configs/imageset-config-filter-multi.yaml
@@ -11,4 +11,4 @@ mirror:
     packages:
       - name: foo
       - name: baz
-        startingVersion: 1.0.1
+        minVersion: 1.0.1

--- a/test/e2e/configs/imageset-config-filter-range.yaml
+++ b/test/e2e/configs/imageset-config-filter-range.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: mirror.openshift.io/v1alpha2
+kind: ImageSetConfiguration
+storageConfig:
+  local:
+    path: DATA_TMP
+mirror:
+  operators:
+  - catalog: METADATA_CATALOGNAMESPACE:test-catalog-latest
+    full: true
+    skipDeps: true
+    packages:
+      - name: foo
+        minVersion: 0.2.0
+        maxVersion: 0.3.0

--- a/test/e2e/configs/imageset-config-filter-range.yaml
+++ b/test/e2e/configs/imageset-config-filter-range.yaml
@@ -8,7 +8,7 @@ mirror:
   operators:
   - catalog: METADATA_CATALOGNAMESPACE:test-catalog-latest
     full: true
-    skipDeps: true
+    skipDependencies: true
     packages:
       - name: foo
         minVersion: 0.2.0

--- a/test/e2e/configs/imageset-config-filter-single.yaml
+++ b/test/e2e/configs/imageset-config-filter-single.yaml
@@ -8,9 +8,8 @@ mirror:
   operators:
   - catalog: METADATA_CATALOGNAMESPACE:test-catalog-latest
     full: true
-    skipDeps: true
+    skipDependencies: true
     packages:
       - name: baz
         minVersion: 1.0.1
         maxVersion: 1.0.1
-

--- a/test/e2e/configs/imageset-config-filter-single.yaml
+++ b/test/e2e/configs/imageset-config-filter-single.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: mirror.openshift.io/v1alpha2
+kind: ImageSetConfiguration
+storageConfig:
+  local:
+    path: DATA_TMP
+mirror:
+  operators:
+  - catalog: METADATA_CATALOGNAMESPACE:test-catalog-latest
+    full: true
+    skipDeps: true
+    packages:
+      - name: baz
+        minVersion: 1.0.1
+        maxVersion: 1.0.1
+

--- a/vendor/github.com/operator-framework/operator-registry/alpha/action/diff.go
+++ b/vendor/github.com/operator-framework/operator-registry/alpha/action/diff.go
@@ -117,6 +117,12 @@ type DiffIncludePackage struct {
 	// are parsed for an upgrade graph.
 	// Set this field only if the named bundle has no semantic version metadata.
 	Bundles []string `json:"bundles,omitempty" yaml:"bundles,omitempty"`
+	// Semver range of versions to include. All channels containing these versions
+	// are parsed for an upgrade graph. If the channels don't contain these versions,
+	// they will be ignored. This range can only be used with package exclusively
+	// and cannot combined with `Range` in `DiffIncludeChannel`.
+	// Range setting is mutually exclusive with channel versions/bundles/range settings.
+	Range string `json:"range,omitempty" yaml:"range,omitempty"`
 }
 
 // DiffIncludeChannel contains a name (required) and versions (optional)
@@ -129,6 +135,11 @@ type DiffIncludeChannel struct {
 	// Bundles are bundle names to include.
 	// Set this field only if the named bundle has no semantic version metadata.
 	Bundles []string `json:"bundles,omitempty" yaml:"bundles,omitempty"`
+	// Semver range of versions to include in the channel. If the channel don't contain
+	// these versions, an error will be raised. This range can only be used with
+	// channel exclusively and cannot combined with `Range` in `DiffIncludePackage`.
+	// Range setting is mutually exclusive with Versions and Bundles settings.
+	Range string `json:"range,omitempty" yaml:"range,omitempty"`
 }
 
 // LoadDiffIncludeConfig loads a (YAML or JSON) DiffIncludeConfig from r.
@@ -148,10 +159,32 @@ func LoadDiffIncludeConfig(r io.Reader) (c DiffIncludeConfig, err error) {
 			errs = append(errs, fmt.Errorf("package at index %v requires a name", pkgI))
 			continue
 		}
+		if pkg.Range != "" && (len(pkg.Versions) != 0 || len(pkg.Bundles) != 0) {
+			errs = append(errs, fmt.Errorf("package at index %v has an invalid settings for range/versions/bundles", pkgI))
+		}
+		if pkg.Range != "" {
+			_, err := semver.ParseRange(pkg.Range)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("package at index %v has an invalid version range %s", pkgI, pkg.Range))
+			}
+		}
 		for chI, ch := range pkg.Channels {
 			if ch.Name == "" {
 				errs = append(errs, fmt.Errorf("package %s: channel at index %v requires a name", pkg.Name, chI))
 				continue
+			}
+			if ch.Range == "" {
+				continue
+			}
+			if ch.Range != "" && (len(ch.Versions) != 0 || len(ch.Bundles) != 0) {
+				errs = append(errs, fmt.Errorf("package %s: channel at index %v has an invalid settings for range/versions/bundles", pkg.Name, chI))
+			}
+			if pkg.Range != "" && ch.Range != "" {
+				errs = append(errs, fmt.Errorf("version range settings in package (%s) and in channel (%s) must be mutually exclusive", pkg.Name, ch.Name))
+			}
+			_, err := semver.ParseRange(ch.Range)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("package %s: channel at index %v has an invalid version range %s", pkg.Name, chI, pkg.Range))
 			}
 		}
 	}
@@ -165,6 +198,9 @@ func convertIncludeConfigToIncluder(c DiffIncludeConfig) (includer declcfg.DiffI
 		pkg.Name = cpkg.Name
 		pkg.AllChannels.Versions = cpkg.Versions
 		pkg.AllChannels.Bundles = cpkg.Bundles
+		if cpkg.Range != "" {
+			pkg.Range, _ = semver.ParseRange(cpkg.Range)
+		}
 
 		if len(cpkg.Channels) != 0 {
 			pkg.Channels = make([]declcfg.DiffIncludeChannel, len(cpkg.Channels))
@@ -173,6 +209,9 @@ func convertIncludeConfigToIncluder(c DiffIncludeConfig) (includer declcfg.DiffI
 				ch.Name = cch.Name
 				ch.Versions = cch.Versions
 				ch.Bundles = cch.Bundles
+				if cch.Range != "" {
+					ch.Range, _ = semver.ParseRange(cch.Range)
+				}
 			}
 		}
 	}

--- a/vendor/github.com/operator-framework/operator-registry/alpha/action/diff.go
+++ b/vendor/github.com/operator-framework/operator-registry/alpha/action/diff.go
@@ -160,12 +160,12 @@ func LoadDiffIncludeConfig(r io.Reader) (c DiffIncludeConfig, err error) {
 			continue
 		}
 		if pkg.Range != "" && (len(pkg.Versions) != 0 || len(pkg.Bundles) != 0) {
-			errs = append(errs, fmt.Errorf("package at index %v has an invalid settings for range/versions/bundles", pkgI))
+			errs = append(errs, fmt.Errorf("package %q contains invalid settings: range and versions and/or bundles are mutually exclusive", pkg.Name))
 		}
 		if pkg.Range != "" {
 			_, err := semver.ParseRange(pkg.Range)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("package at index %v has an invalid version range %s", pkgI, pkg.Range))
+				errs = append(errs, fmt.Errorf("package %q has an invalid version range %s", pkg.Name, pkg.Range))
 			}
 		}
 		for chI, ch := range pkg.Channels {
@@ -177,14 +177,14 @@ func LoadDiffIncludeConfig(r io.Reader) (c DiffIncludeConfig, err error) {
 				continue
 			}
 			if ch.Range != "" && (len(ch.Versions) != 0 || len(ch.Bundles) != 0) {
-				errs = append(errs, fmt.Errorf("package %s: channel at index %v has an invalid settings for range/versions/bundles", pkg.Name, chI))
+				errs = append(errs, fmt.Errorf("package %q: channel %q contains invalid settings: range and versions and/or bundles are mutually exclusive", pkg.Name, ch.Name))
 			}
 			if pkg.Range != "" && ch.Range != "" {
-				errs = append(errs, fmt.Errorf("version range settings in package (%s) and in channel (%s) must be mutually exclusive", pkg.Name, ch.Name))
+				errs = append(errs, fmt.Errorf("version range settings in package %q and in channel %q must be mutually exclusive", pkg.Name, ch.Name))
 			}
 			_, err := semver.ParseRange(ch.Range)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("package %s: channel at index %v has an invalid version range %s", pkg.Name, chI, pkg.Range))
+				errs = append(errs, fmt.Errorf("package %s: channel %q has an invalid version range %s", pkg.Name, ch.Name, pkg.Range))
 			}
 		}
 	}

--- a/vendor/github.com/operator-framework/operator-registry/alpha/declcfg/diff.go
+++ b/vendor/github.com/operator-framework/operator-registry/alpha/declcfg/diff.go
@@ -438,7 +438,15 @@ func getBundlesThatProvide(pkg *model.Package, reqGVKs map[property.GVK]struct{}
 	latestBundles := make(map[string]*model.Bundle)
 	for gvk, bundles := range bundlesProvidingGVK {
 		sort.Slice(bundles, func(i, j int) bool {
-			return bundles[i].Version.LT(bundles[j].Version)
+			// sort by version
+			sortedByVersion := bundles[i].Version.LT(bundles[j].Version)
+
+			// sort by channel
+			// prioritize default channel bundles
+			if bundles[i].Version.EQ(bundles[j].Version) {
+				return bundles[i].Channel != pkg.DefaultChannel
+			}
+			return sortedByVersion
 		})
 		lb := bundles[len(bundles)-1]
 		latestBundles[lb.Version.String()] = lb
@@ -453,7 +461,15 @@ func getBundlesThatProvide(pkg *model.Package, reqGVKs map[property.GVK]struct{}
 			continue
 		}
 		sort.Slice(bundlesInRange, func(i, j int) bool {
-			return bundlesInRange[i].Version.LT(bundlesInRange[j].Version)
+			// sort by version
+			sortedByVersion := bundlesInRange[i].Version.LT(bundlesInRange[j].Version)
+
+			// sort by channel
+			// prioritize default channel bundles
+			if bundlesInRange[i].Version.EQ(bundlesInRange[j].Version) {
+				return bundlesInRange[i].Channel != pkg.DefaultChannel
+			}
+			return sortedByVersion
 		})
 		lb := bundlesInRange[len(bundlesInRange)-1]
 		latestBundles[lb.Version.String()] = lb

--- a/vendor/github.com/operator-framework/operator-registry/alpha/declcfg/diff_include.go
+++ b/vendor/github.com/operator-framework/operator-registry/alpha/declcfg/diff_include.go
@@ -73,7 +73,7 @@ func (dip DiffIncludePackage) Validate() error {
 	}
 
 	if len(errs) != 0 {
-		return fmt.Errorf("invalid DiffIncludePackage config:\n%v", utilerrors.NewAggregate(errs))
+		return fmt.Errorf("invalid DiffIncludePackage config for package %q:\n%v", dip.Name, utilerrors.NewAggregate(errs))
 	}
 	return nil
 }
@@ -94,7 +94,7 @@ func (dic DiffIncludeChannel) Validate() error {
 	}
 
 	if len(errs) != 0 {
-		return fmt.Errorf("invalid DiffIncludeChannel config:\n%v", utilerrors.NewAggregate(errs))
+		return fmt.Errorf("invalid DiffIncludeChannel config for channel %q:\n%v", dic.Name, utilerrors.NewAggregate(errs))
 	}
 	return nil
 }

--- a/vendor/github.com/operator-framework/operator-registry/alpha/declcfg/diff_include.go
+++ b/vendor/github.com/operator-framework/operator-registry/alpha/declcfg/diff_include.go
@@ -31,9 +31,14 @@ type DiffIncludePackage struct {
 	// Upgrade graphs from all channels in the named package containing a version
 	// from this field are included.
 	AllChannels DiffIncludeChannel
+	// The semver range of bundle versions.
+	// Package range setting is mutually exclusive with channel range/bundles/version
+	// settings.
+	Range semver.Range
 }
 
-// DiffIncludeChannel specifies a channel, and optionally bundles and bundle versions to include.
+// DiffIncludeChannel specifies a channel, and optionally bundles and bundle versions
+// (or version range) to include.
 type DiffIncludeChannel struct {
 	// Name of channel.
 	Name string
@@ -42,6 +47,71 @@ type DiffIncludeChannel struct {
 	// Bundles are bundle names to include.
 	// Set this field only if the named bundle has no semantic version metadata.
 	Bundles []string
+	// The semver range of bundle versions.
+	// Range setting is mutually exclusive with Versions and Bundles settings.
+	Range semver.Range
+}
+
+func (dip DiffIncludePackage) Validate() error {
+	var errs []error
+	if dip.Name == "" {
+		errs = append(errs, fmt.Errorf("missing package name"))
+	}
+
+	var isChannelSet bool
+	for _, ch := range dip.Channels {
+		isChannelSet = ch.isChannelSet()
+		err := ch.Validate()
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	isChannelSet = dip.AllChannels.isChannelSet()
+	if isChannelSet && dip.Range != nil {
+		errs = append(errs, fmt.Errorf("package range setting is mutually exclusive with channel versions/bundles/range settings"))
+	}
+
+	if len(errs) != 0 {
+		return fmt.Errorf("invalid DiffIncludePackage config:\n%v", utilerrors.NewAggregate(errs))
+	}
+	return nil
+}
+
+// isChannelSet returns true if at least one of Range/Bundles/Versions is set
+func (dic DiffIncludeChannel) isChannelSet() bool {
+	return dic.Range != nil || len(dic.Versions) != 0 || len(dic.Bundles) != 0
+}
+
+func (dic DiffIncludeChannel) Validate() error {
+	var errs []error
+	if dic.Name == "" {
+		errs = append(errs, fmt.Errorf("missing channel name"))
+	}
+
+	if dic.Range != nil && (len(dic.Versions) != 0 || len(dic.Bundles) != 0) {
+		errs = append(errs, fmt.Errorf("Channel %q: range and versions/bundles are mutually exclusive", dic.Name))
+	}
+
+	if len(errs) != 0 {
+		return fmt.Errorf("invalid DiffIncludeChannel config:\n%v", utilerrors.NewAggregate(errs))
+	}
+	return nil
+}
+
+func (i DiffIncluder) Validate() error {
+	var errs []error
+	for _, pkg := range i.Packages {
+		err := pkg.Validate()
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) != 0 {
+		return fmt.Errorf("invalid DiffIncluder config:\n%v", utilerrors.NewAggregate(errs))
+	}
+	return nil
 }
 
 // Run adds all packages and channels in DiffIncluder with matching names
@@ -49,6 +119,11 @@ type DiffIncludeChannel struct {
 // from newModel to outputModel.
 func (i DiffIncluder) Run(newModel, outputModel model.Model) error {
 	var includeErrs []error
+	if err := i.Validate(); err != nil {
+		includeErrs = append(includeErrs, err)
+		return fmt.Errorf("invalid DiffIncluder config:\n%v", utilerrors.NewAggregate(includeErrs))
+	}
+
 	for _, ipkg := range i.Packages {
 		pkgLog := i.Logger.WithField("package", ipkg.Name)
 		includeErrs = append(includeErrs, ipkg.includeNewInOutputModel(newModel, outputModel, pkgLog)...)
@@ -59,7 +134,7 @@ func (i DiffIncluder) Run(newModel, outputModel model.Model) error {
 	return nil
 }
 
-// includeNewInOutputModel adds all packages, channels, and versions (bundles)
+// includeNewInOutputModel adds all packages, channels, and range (or versions/bundles)
 // specified by ipkg that exist in newModel to outputModel. Any package, channel,
 // or version in ipkg not satisfied by newModel is an error.
 func (ipkg DiffIncludePackage) includeNewInOutputModel(newModel, outputModel model.Model, logger *logrus.Entry) (ierrs []error) {
@@ -72,26 +147,44 @@ func (ipkg DiffIncludePackage) includeNewInOutputModel(newModel, outputModel mod
 	pkgLog := logger.WithField("package", newPkg.Name)
 
 	// No channels or versions were specified, meaning "include the full package".
-	if len(ipkg.Channels) == 0 && len(ipkg.AllChannels.Versions) == 0 && len(ipkg.AllChannels.Bundles) == 0 {
+	if len(ipkg.Channels) == 0 && len(ipkg.AllChannels.Versions) == 0 && len(ipkg.AllChannels.Bundles) == 0 && ipkg.Range == nil {
 		outputModel[ipkg.Name] = newPkg
 		return nil
 	}
 
 	outputPkg := copyPackageNoChannels(newPkg)
 	outputModel[outputPkg.Name] = outputPkg
-
-	// Add all channels to ipkg.Channels if bundles or versions were specified to include across all channels.
-	// skipMissingBundleForChannels's value for a channel will be true IFF at least one version is specified,
-	// since some other channel may contain that version.
 	skipMissingBundleForChannels := map[string]bool{}
-	if len(ipkg.AllChannels.Versions) != 0 || len(ipkg.AllChannels.Bundles) != 0 {
-		for newChName := range newPkg.Channels {
-			ipkg.Channels = append(ipkg.Channels, DiffIncludeChannel{
-				Name:     newChName,
-				Versions: ipkg.AllChannels.Versions,
-				Bundles:  ipkg.AllChannels.Bundles,
-			})
-			skipMissingBundleForChannels[newChName] = true
+	if ipkg.Range != nil {
+		if len(ipkg.Channels) != 0 {
+			for _, ich := range ipkg.Channels {
+				if ich.Range != nil {
+					ierrs = append(ierrs, fmt.Errorf("[package=%q channel=%q] range setting is mutually exclusive between package and channel", newPkg.Name, ich.Name))
+				}
+			}
+		} else {
+			// Add package range setting to all existing channels if there is no
+			// channel setting in the config
+			for newChName := range newPkg.Channels {
+				ipkg.Channels = append(ipkg.Channels, DiffIncludeChannel{
+					Name:  newChName,
+					Range: ipkg.Range,
+				})
+			}
+		}
+	} else {
+		// Add all channels to ipkg.Channels if bundles or versions were specified to include across all channels.
+		// skipMissingBundleForChannels's value for a channel will be true IFF at least one version is specified,
+		// since some other channel may contain that version.
+		if len(ipkg.AllChannels.Versions) != 0 || len(ipkg.AllChannels.Bundles) != 0 {
+			for newChName := range newPkg.Channels {
+				ipkg.Channels = append(ipkg.Channels, DiffIncludeChannel{
+					Name:     newChName,
+					Versions: ipkg.AllChannels.Versions,
+					Bundles:  ipkg.AllChannels.Bundles,
+				})
+				skipMissingBundleForChannels[newChName] = true
+			}
 		}
 	}
 
@@ -103,7 +196,13 @@ func (ipkg DiffIncludePackage) includeNewInOutputModel(newModel, outputModel mod
 		}
 		chLog := pkgLog.WithField("channel", newCh.Name)
 
-		bundles, err := getBundlesForVersions(newCh, ich.Versions, ich.Bundles, chLog, skipMissingBundleForChannels[newCh.Name])
+		var bundles []*model.Bundle
+		var err error
+		if ich.Range != nil {
+			bundles, err = getBundlesForRange(newCh, ich.Range, chLog)
+		} else {
+			bundles, err = getBundlesForVersions(newCh, ich.Versions, ich.Bundles, chLog, skipMissingBundleForChannels[newCh.Name])
+		}
 		if err != nil {
 			ierrs = append(ierrs, fmt.Errorf("[package=%q channel=%q] %v", newPkg.Name, newCh.Name, err))
 			continue
@@ -173,11 +272,43 @@ func getBundlesForVersions(ch *model.Channel, vers []semver.Version, names []str
 		return nil, fmt.Errorf("bundles do not exist in channel: %s", strings.TrimSpace(sb.String()))
 	}
 
-	// Fill in the upgrade graph between each bundle and head.
-	// Regardless of semver order, this step needs to be performed
-	// for each included bundle because there might be leaf nodes
-	// in the upgrade graph for a particular version not captured
-	// by any other fill due to skips not being honored here.
+	bundles, err = fillUpgradeGraph(ch, bundles, logger)
+	if err != nil {
+		return nil, err
+	}
+	return bundles, nil
+}
+
+// getBundlesForRange returns all bundles matching the version range in vers
+// If the range is nil, return all bundles in the channel
+func getBundlesForRange(ch *model.Channel, vers semver.Range, logger *logrus.Entry) (bundles []*model.Bundle, err error) {
+	// Short circuit when an empty range was specified, meaning "include the whole channel"
+	if vers == nil {
+		for _, b := range ch.Bundles {
+			bundles = append(bundles, b)
+		}
+		return bundles, nil
+	}
+
+	for _, b := range ch.Bundles {
+		v, err := semver.Parse(b.Version.String())
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse bunble version: %s", err.Error())
+		}
+		if vers(v) {
+			bundles = append(bundles, b)
+		}
+	}
+
+	return bundles, nil
+}
+
+// fillUpgradeGraph fills in the upgrade graph between each bundle and head.
+// Regardless of semver order, this step needs to be performed
+// for each included bundle because there might be leaf nodes
+// in the upgrade graph for a particular version not captured
+// by any other fill due to skips not being honored here.
+func fillUpgradeGraph(ch *model.Channel, bundles []*model.Bundle, logger *logrus.Entry) (bd []*model.Bundle, err error) {
 	head, err := ch.Head()
 	if err != nil {
 		return nil, err
@@ -199,10 +330,10 @@ func getBundlesForVersions(ch *model.Channel, vers []semver.Version, names []str
 			bundleSet[rb.Name] = rb
 		}
 	}
+
 	for _, b := range bundleSet {
 		bundles = append(bundles, b)
 	}
-
 	return bundles, nil
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -692,7 +692,7 @@ github.com/operator-framework/api/pkg/validation
 github.com/operator-framework/api/pkg/validation/errors
 github.com/operator-framework/api/pkg/validation/interfaces
 github.com/operator-framework/api/pkg/validation/internal
-# github.com/operator-framework/operator-registry v1.21.1-0.20220324153146-de3610408773 => github.com/dinhxuanvu/operator-registry v1.13.5-0.20220419220231-14e8b35c4105
+# github.com/operator-framework/operator-registry v1.21.1-0.20220502161945-aa8db09278a0
 ## explicit; go 1.17
 github.com/operator-framework/operator-registry/alpha/action
 github.com/operator-framework/operator-registry/alpha/declcfg
@@ -1530,4 +1530,3 @@ sigs.k8s.io/yaml
 # k8s.io/cli-runtime => github.com/openshift/kubernetes-cli-runtime v0.0.0-20210730111823-1570202448c3
 # k8s.io/client-go => github.com/openshift/kubernetes-client-go v0.0.0-20210730111819-978c4383ac68
 # k8s.io/kubectl => github.com/openshift/kubernetes-kubectl v0.0.0-20210730111826-9c6734b9d97d
-# github.com/operator-framework/operator-registry => github.com/dinhxuanvu/operator-registry v1.13.5-0.20220419220231-14e8b35c4105

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -692,7 +692,7 @@ github.com/operator-framework/api/pkg/validation
 github.com/operator-framework/api/pkg/validation/errors
 github.com/operator-framework/api/pkg/validation/interfaces
 github.com/operator-framework/api/pkg/validation/internal
-# github.com/operator-framework/operator-registry v1.21.1-0.20220324153146-de3610408773
+# github.com/operator-framework/operator-registry v1.21.1-0.20220324153146-de3610408773 => github.com/dinhxuanvu/operator-registry v1.13.5-0.20220419220231-14e8b35c4105
 ## explicit; go 1.17
 github.com/operator-framework/operator-registry/alpha/action
 github.com/operator-framework/operator-registry/alpha/declcfg
@@ -1530,3 +1530,4 @@ sigs.k8s.io/yaml
 # k8s.io/cli-runtime => github.com/openshift/kubernetes-cli-runtime v0.0.0-20210730111823-1570202448c3
 # k8s.io/client-go => github.com/openshift/kubernetes-client-go v0.0.0-20210730111819-978c4383ac68
 # k8s.io/kubectl => github.com/openshift/kubernetes-kubectl v0.0.0-20210730111826-9c6734b9d97d
+# github.com/operator-framework/operator-registry => github.com/dinhxuanvu/operator-registry v1.13.5-0.20220419220231-14e8b35c4105


### PR DESCRIPTION
# Description

This PR adds the ability to specify a `MaxVersion` when package filtering on operators.
It also changes the `MinVersion` and MaxVersion from `semver.Version` types to strings to allow for DeepCopy methods to be used on API types later.

 (**Pointing to an operator-registry fork**)

Closes #302 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] Test cases added to E2E
- [X] Test cases added to unit test for conversion to DiffIncludeConfig

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules