### PR TITLE
refactor(ux): list updates ux and adds unit tests for describe command

### DIFF
--- a/pkg/cli/mirror/describe/describe.go
+++ b/pkg/cli/mirror/describe/describe.go
@@ -39,7 +39,7 @@ func NewDescribeCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command 
 		`),
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			kcmdutil.CheckErr(o.Complete(cmd, f, args))
+			kcmdutil.CheckErr(o.Complete(args))
 			kcmdutil.CheckErr(o.Validate())
 			kcmdutil.CheckErr(o.Run(cmd.Context()))
 		},
@@ -50,12 +50,17 @@ func NewDescribeCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command 
 	return cmd
 }
 
-func (o *DescribeOptions) Complete(cmd *cobra.Command, f kcmdutil.Factory, args []string) error {
-	o.From = args[0]
+func (o *DescribeOptions) Complete(args []string) error {
+	if len(args) == 1 {
+		o.From = args[0]
+	}
 	return nil
 }
 
 func (o *DescribeOptions) Validate() error {
+	if len(o.From) == 0 {
+		return errors.New("must specify path to imageset archive")
+	}
 	return nil
 }
 

--- a/pkg/cli/mirror/describe/describe_test.go
+++ b/pkg/cli/mirror/describe/describe_test.go
@@ -1,0 +1,75 @@
+package describe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescribeComplete(t *testing.T) {
+	type spec struct {
+		name     string
+		opts     *DescribeOptions
+		args     []string
+		expOpts  *DescribeOptions
+		expError string
+	}
+
+	cases := []spec{
+		{
+			name: "Valid/DefaultArchitecture",
+			opts: &DescribeOptions{},
+			args: []string{"foo"},
+			expOpts: &DescribeOptions{
+				From: "foo",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.opts.Complete(c.args)
+			if c.expError != "" {
+				require.EqualError(t, err, c.expError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, c.expOpts, c.opts)
+			}
+		})
+	}
+}
+
+func TestDescribeValidate(t *testing.T) {
+
+	type spec struct {
+		name     string
+		opts     *DescribeOptions
+		expError string
+	}
+
+	cases := []spec{
+		{
+			name:     "Invalid/NoConfigPath",
+			opts:     &DescribeOptions{},
+			expError: `must specify path to imageset archive`,
+		},
+		{
+			name: "Valid/WithArchivePath",
+			opts: &DescribeOptions{
+				From: "foo",
+			},
+			expError: "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.opts.Validate()
+			if c.expError != "" {
+				require.EqualError(t, err, c.expError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/cli/mirror/list/list.go
+++ b/pkg/cli/mirror/list/list.go
@@ -3,7 +3,6 @@ package list
 import (
 	"github.com/spf13/cobra"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/openshift/oc-mirror/pkg/cli"
 )
@@ -12,27 +11,8 @@ func NewListCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List available platform and operator content and their version",
-		Example: templates.Examples(`
-			# Output operator catalogs
-			oc-mirror list operators --version=4.9
-
-			# Output OCP release channel list
-			oc-mirror list releases --channels --version=4.9
-
-			# List all OCP versions in a specified channel
-			oc-mirror list releases --channel=stable-4.8
-
-			# List all operators in a catalog
-			oc-mirror list operators --catalog=catalog-name
-
-			# List all available versions for a specified operator
-			oc-mirror list operators --catalog=catalog-name --channel=channel-name --package=operator-name
-
-			# List updates between remote and current workspace
-			oc-mirror list updates --config mirror-config.yaml
-		`),
-		Run: kcmdutil.DefaultSubCommandRun(ro.IOStreams.ErrOut),
+		Short: "List available platform and operator content and their versions.",
+		Run:   kcmdutil.DefaultSubCommandRun(ro.IOStreams.ErrOut),
 	}
 
 	cmd.AddCommand(NewOperatorsCommand(f, ro))

--- a/pkg/cli/mirror/list/updates.go
+++ b/pkg/cli/mirror/list/updates.go
@@ -70,7 +70,10 @@ func NewUpdatesCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command {
 }
 
 func (o *UpdatesOptions) Complete(args []string) error {
-	o.ConfigPath = args[0]
+	if len(args) == 1 {
+		o.ConfigPath = args[0]
+	}
+
 	if len(o.FilterOptions) == 0 {
 		o.FilterOptions = []string{v1alpha2.DefaultPlatformArchitecture}
 	}
@@ -79,7 +82,7 @@ func (o *UpdatesOptions) Complete(args []string) error {
 
 func (o *UpdatesOptions) Validate() error {
 	if len(o.ConfigPath) == 0 {
-		return fmt.Errorf("must specify imageset configuration using --config")
+		return errors.New("must specify imageset configuration")
 	}
 	for _, arch := range o.FilterOptions {
 		if _, ok := cincinnati.SupportedArchs[arch]; !ok {

--- a/pkg/cli/mirror/list/updates.go
+++ b/pkg/cli/mirror/list/updates.go
@@ -38,17 +38,18 @@ func NewUpdatesCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "updates",
-		Short: "List available updates in upgrade graph from upstream sources",
+		Short: "List available updates in upgrade graph from upstream sources.",
 		Long: templates.LongDesc(`
 		List available updates in the upgrade graph for releases and operators from upstream sources
 		based on current state. A storage configuration must be specified to use this command.
 	`),
 		Example: templates.Examples(`
 			# List updates between remote and current workspace
-			oc-mirror list updates --config mirror-config.yaml
+			oc-mirror list updates mirror-config.yaml
 		`),
+		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			kcmdutil.CheckErr(o.Complete())
+			kcmdutil.CheckErr(o.Complete(args))
 			kcmdutil.CheckErr(o.Validate())
 			kcmdutil.CheckErr(o.Run(cmd.Context()))
 		},
@@ -57,7 +58,6 @@ func NewUpdatesCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command {
 	o.BindFlags(cmd.PersistentFlags())
 
 	fs := cmd.Flags()
-	fs.StringVarP(&o.ConfigPath, "config", "c", o.ConfigPath, "Path to imageset configuration file")
 	fs.StringSliceVar(&o.FilterOptions, "filter-options", o.FilterOptions, "An architecture list to control the release image"+
 		"picked when multiple variants are available")
 
@@ -69,7 +69,8 @@ func NewUpdatesCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command {
 	return cmd
 }
 
-func (o *UpdatesOptions) Complete() error {
+func (o *UpdatesOptions) Complete(args []string) error {
+	o.ConfigPath = args[0]
 	if len(o.FilterOptions) == 0 {
 		o.FilterOptions = []string{v1alpha2.DefaultPlatformArchitecture}
 	}
@@ -78,7 +79,7 @@ func (o *UpdatesOptions) Complete() error {
 
 func (o *UpdatesOptions) Validate() error {
 	if len(o.ConfigPath) == 0 {
-		return fmt.Errorf("must specify config using --config")
+		return fmt.Errorf("must specify imageset configuration using --config")
 	}
 	for _, arch := range o.FilterOptions {
 		if _, ok := cincinnati.SupportedArchs[arch]; !ok {
@@ -126,7 +127,6 @@ func (o *UpdatesOptions) Run(ctx context.Context) error {
 }
 
 func (o UpdatesOptions) releaseUpdates(ctx context.Context, arch string, cfg v1alpha2.ImageSetConfiguration, last v1alpha2.PastMirror) error {
-	logrus.Info("Getting release update information")
 	lastMaxVersion := map[string]semver.Version{}
 	for _, ch := range last.Mirror.Platform.Channels {
 		version, err := semver.Parse(ch.MaxVersion)
@@ -178,7 +178,6 @@ func (o UpdatesOptions) releaseUpdates(ctx context.Context, arch string, cfg v1a
 }
 
 func (o UpdatesOptions) operatorUpdates(ctx context.Context, cfg v1alpha2.ImageSetConfiguration, meta v1alpha2.Metadata) error {
-	logrus.Info("Getting operator update information")
 	dstDir, err := os.MkdirTemp(o.Dir, "updatetmp-")
 	if err != nil {
 		return err
@@ -238,13 +237,10 @@ func (o UpdatesOptions) writeReleaseColumns(upgrades []semver.Version, arch, cha
 		return nil
 	}
 	tw := tabwriter.NewWriter(o.IOStreams.Out, 0, 4, 2, ' ', 0)
-	if _, err := fmt.Fprintf(tw, "CHANNEL:\t%s\n", channel); err != nil {
+	if _, err := fmt.Fprintf(tw, "Listing update for release channel:\t%s\n", channel); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintf(tw, "ARCHITECTURE:\t%s\n", arch); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintln(tw, "VERSIONS"); err != nil {
+	if _, err := fmt.Fprintf(tw, "Architecture:\t%s\n", arch); err != nil {
 		return err
 	}
 	for _, upgrade := range upgrades {
@@ -263,10 +259,10 @@ func (o UpdatesOptions) writeCatalogColumns(dc declcfg.DeclarativeConfig, catalo
 		return nil
 	}
 	tw := tabwriter.NewWriter(o.IOStreams.Out, 0, 4, 2, ' ', 0)
-	if _, err := fmt.Fprintf(tw, "Listing update for catalog:\t%s", catalog); err != nil {
+	if _, err := fmt.Fprintf(tw, "Listing update for catalog:\t%s\n", catalog); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintln(tw, "PACKAGE\tCHANNEL\tBUNDLE\tREPLACES"); err != nil {
+	if _, err := fmt.Fprintln(tw, "Package\tChannel\tBundle\tReplaces"); err != nil {
 		return err
 	}
 	mod, err := declcfg.ConvertToModel(dc)

--- a/pkg/cli/mirror/list/updates_test.go
+++ b/pkg/cli/mirror/list/updates_test.go
@@ -11,17 +11,29 @@ func TestUpdatesComplete(t *testing.T) {
 	type spec struct {
 		name     string
 		opts     *UpdatesOptions
+		args     []string
 		expOpts  *UpdatesOptions
 		expError string
 	}
 
 	cases := []spec{
 		{
-			opts: &UpdatesOptions{
-				ConfigPath: "foo",
-			},
+			name: "Valid/DefaultArchitecture",
+			opts: &UpdatesOptions{},
+			args: []string{"foo"},
 			expOpts: &UpdatesOptions{
 				FilterOptions: []string{v1alpha2.DefaultPlatformArchitecture},
+				ConfigPath:    "foo",
+			},
+		},
+		{
+			name: "Valid/SuppliedArchitecture",
+			opts: &UpdatesOptions{
+				FilterOptions: []string{"test"},
+			},
+			args: []string{"foo"},
+			expOpts: &UpdatesOptions{
+				FilterOptions: []string{"test"},
 				ConfigPath:    "foo",
 			},
 		},
@@ -29,7 +41,7 @@ func TestUpdatesComplete(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			err := c.opts.Complete()
+			err := c.opts.Complete(c.args)
 			if c.expError != "" {
 				require.EqualError(t, err, c.expError)
 			} else {
@@ -52,7 +64,7 @@ func TestUpdatesValidate(t *testing.T) {
 		{
 			name:     "Invalid/NoConfigPath",
 			opts:     &UpdatesOptions{},
-			expError: `must specify config using --config`,
+			expError: `must specify imageset configuration using --config`,
 		},
 		{
 			name: "Invalid/UnsupportedArch",

--- a/pkg/cli/mirror/list/updates_test.go
+++ b/pkg/cli/mirror/list/updates_test.go
@@ -64,7 +64,7 @@ func TestUpdatesValidate(t *testing.T) {
 		{
 			name:     "Invalid/NoConfigPath",
 			opts:     &UpdatesOptions{},
-			expError: `must specify imageset configuration using --config`,
+			expError: `must specify imageset configuration`,
 		},
 		{
 			name: "Invalid/UnsupportedArch",


### PR DESCRIPTION
…of other list commands

With updates to the oc-mirror list commands `list updates` is left disjointed with different
output styles. This also makes the config path an argument since it is a required input
to get updated information.

Adds unit tests for describe package

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description
^^

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Manually and updates unit tests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules