### PR TITLE
fix(mapping): removes DockerClientDefaults from ctlgRef

### DIFF
--- a/pkg/cli/mirror/additional.go
+++ b/pkg/cli/mirror/additional.go
@@ -36,9 +36,7 @@ func (o *AdditionalOptions) Plan(ctx context.Context, imageList []v1alpha2.Image
 		if err != nil {
 			return mmappings, fmt.Errorf("error parsing source image %s: %v", img.Name, err)
 		}
-		if setLatest(srcRef) {
-			srcRef.Ref.Tag = "latest"
-		}
+		srcRef.Ref = srcRef.Ref.DockerClientDefaults()
 
 		// Instead of returning an error, just log it.
 		isSkipErr := func(err error) bool {
@@ -65,7 +63,6 @@ func (o *AdditionalOptions) Plan(ctx context.Context, imageList []v1alpha2.Image
 		// Set destination image information as file by default
 		dstRef := srcRef
 		dstRef.Type = imagesource.DestinationFile
-		dstRef.Ref = dstRef.Ref.DockerClientDefaults()
 		// The registry component is not included in the final path.
 		dstRef.Ref.Registry = ""
 
@@ -73,8 +70,4 @@ func (o *AdditionalOptions) Plan(ctx context.Context, imageList []v1alpha2.Image
 	}
 
 	return mmappings, nil
-}
-
-func setLatest(img imagesource.TypedImageReference) bool {
-	return len(img.Ref.ID) == 0 && len(img.Ref.Tag) == 0
 }

--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -106,7 +106,6 @@ func (o *OperatorOptions) run(ctx context.Context, cfg v1alpha2.ImageSetConfigur
 		if err != nil {
 			return nil, fmt.Errorf("error parsing catalog: %v", err)
 		}
-		ctlgRef.Ref = ctlgRef.Ref.DockerClientDefaults()
 
 		// Render the catalog to mirror into a declarative config.
 		dc, err := renderDC(ctx, reg, ctlg)
@@ -362,9 +361,9 @@ func (o *OperatorOptions) plan(ctx context.Context, dc *declcfg.DeclarativeConfi
 
 	// Remove the catalog image from mappings we are going to transfer this
 	// using an OCI layout.
-	ctlgImg := image.TypedImage{
-		TypedImageReference: ctlgRef,
-		Category:            v1alpha2.TypeOperatorBundle,
+	ctlgImg, err := image.ParseTypedImage(ctlgRef.Ref.Exact(), v1alpha2.TypeOperatorBundle)
+	if err != nil {
+		return nil, err
 	}
 	mappings.Remove(ctlgImg)
 	if err := o.writeLayout(ctx, ctlgRef.Ref); err != nil {

--- a/pkg/image/association_builder.go
+++ b/pkg/image/association_builder.go
@@ -123,8 +123,7 @@ func associateLocalImageLayers(image, localRoot, dirRef, tagOrID, defaultTag str
 		if defaultTag != "" {
 			// If set, add a subset of the digest to randomize the
 			// tag in the event multiple digests are pulled for the same
-			// image. The first 6 character from that hash will be used
-			// so checking that the hash value is long
+			// image.
 			partial, err := getPartialDigest(id)
 			if err != nil {
 				return nil, fmt.Errorf("error calculating partial digest for %s: %v", id, err)

--- a/pkg/image/association_builder.go
+++ b/pkg/image/association_builder.go
@@ -120,7 +120,7 @@ func associateLocalImageLayers(image, localRoot, dirRef, tagOrID, defaultTag str
 	case m.IsRegular():
 		// Layer ID is the file name, and no tag exists.
 		tag = defaultTag
-		if defaultTag != "" {
+		if defaultTag != "" && len(id) > 13 {
 			// If set, add a subset of the digest to randomize the
 			// tag in the event multiple digests are pulled for the same
 			// image

--- a/pkg/image/association_builder.go
+++ b/pkg/image/association_builder.go
@@ -120,11 +120,16 @@ func associateLocalImageLayers(image, localRoot, dirRef, tagOrID, defaultTag str
 	case m.IsRegular():
 		// Layer ID is the file name, and no tag exists.
 		tag = defaultTag
-		if defaultTag != "" && len(id) > 13 {
+		if defaultTag != "" {
 			// If set, add a subset of the digest to randomize the
 			// tag in the event multiple digests are pulled for the same
-			// image
-			tag = defaultTag + id[7:13]
+			// image. The first 6 character from that hash will be used
+			// so checking that the hash value is long
+			partial, err := getPartialDigest(id)
+			if err != nil {
+				return nil, fmt.Errorf("error calculating partial digest for %s: %v", id, err)
+			}
+			tag = defaultTag + partial
 			manifestDir := filepath.Dir(manifestPath)
 			symlink := filepath.Join(manifestDir, tag)
 			if err := os.Symlink(info.Name(), symlink); err != nil {

--- a/pkg/image/builder/image_builder.go
+++ b/pkg/image/builder/image_builder.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -40,6 +41,12 @@ func (b *ImageBuilder) Run(ctx context.Context, targetRef string, layoutPath lay
 
 	b.init()
 	var v2format bool
+
+	targetIdx := strings.Index(targetRef, "@")
+	if targetIdx != -1 {
+		return fmt.Errorf("target reference %q must have a tag reference", targetRef)
+	}
+
 	tag, err := name.NewTag(targetRef, b.NameOpts...)
 	if err != nil {
 		return err

--- a/pkg/image/digest.go
+++ b/pkg/image/digest.go
@@ -1,0 +1,13 @@
+package image
+
+import "github.com/opencontainers/go-digest"
+
+// getPartialDigest returns the first 6 characters of a digest
+// if valid.
+func getPartialDigest(d string) (string, error) {
+	_, err := digest.Parse(d)
+	if err != nil {
+		return "", err
+	}
+	return d[7:13], nil
+}

--- a/pkg/image/digest.go
+++ b/pkg/image/digest.go
@@ -18,8 +18,11 @@ func getPartialDigest(d string) (string, error) {
 		return "", err
 	}
 
-	if len(d) < 13 {
+	tagStart := 7
+	tagEnd := 13
+
+	if len(d) < tagEnd {
 		return "", fmt.Errorf("digest %q does not meet length requirements for partial calculations", d)
 	}
-	return d[7:13], nil
+	return d[tagStart:tagEnd], nil
 }

--- a/pkg/image/digest.go
+++ b/pkg/image/digest.go
@@ -1,13 +1,25 @@
 package image
 
-import "github.com/opencontainers/go-digest"
+import (
+	"fmt"
 
-// getPartialDigest returns the first 6 characters of a digest
-// if valid.
+	"github.com/opencontainers/go-digest"
+)
+
+// getPartialDigest returns the first 6 characters of a digest,
+// if valid. The purpose is to use this as a unique image tag.
+// The since the algorithm and deletimeter are the first 7 characters,
+// range 7-13 is used here.
+// Ex. sha256:fc07c1e2a5f012320ae672ca8546ff0d09eb8dba3c5acbbfc426c7984169ee84
+// would result in fc07c1.
 func getPartialDigest(d string) (string, error) {
 	_, err := digest.Parse(d)
 	if err != nil {
 		return "", err
+	}
+
+	if len(d) < 13 {
+		return "", fmt.Errorf("digest %q does not meet length requirements for partial calculations", d)
 	}
 	return d[7:13], nil
 }

--- a/pkg/image/mapping.go
+++ b/pkg/image/mapping.go
@@ -33,15 +33,20 @@ func ParseTypedImage(image string, typ v1alpha2.ImageType) (TypedImage, error) {
 // SetDefaults sets the default values for TypedImage fields
 func (t TypedImage) SetDefaults() TypedImage {
 	if len(t.Ref.Tag) == 0 {
-		if len(t.Ref.ID) > 13 {
-			t.Ref.Tag = t.Ref.ID[7:13]
-		} else {
+		partial, err := getPartialDigest(t.Ref.ID)
+		// If unable to get a partial digest
+		// Set the tag to latest
+		if err != nil {
 			t.Ref.Tag = "latest"
+		} else {
+			t.Ref.Tag = partial
 		}
 	}
 	return t
 }
 
+// TypedImageMapping is a mapping that contains a key,value pairs of
+// image sources and destinations.
 type TypedImageMapping map[TypedImage]TypedImage
 
 // ToRegistry will convert all mapping values to a registry destination

--- a/pkg/image/mapping_test.go
+++ b/pkg/image/mapping_test.go
@@ -280,6 +280,102 @@ func TestReadImageMapping(t *testing.T) {
 	}
 }
 
+func TestSetDefaults(t *testing.T) {
+	tests := []struct {
+		name     string
+		mapping  TypedImage
+		expected TypedImage
+	}{
+		{
+			name: "Valid/NoChanges",
+			mapping: TypedImage{
+				TypedImageReference: imagesource.TypedImageReference{
+					Ref: reference.DockerImageReference{
+						Registry:  "some-registry.com",
+						Namespace: "namespace",
+						Name:      "image",
+						Tag:       "latest",
+					},
+					Type: imagesource.DestinationRegistry,
+				},
+				Category: v1alpha2.TypeOperatorBundle,
+			},
+			expected: TypedImage{
+				TypedImageReference: imagesource.TypedImageReference{
+					Ref: reference.DockerImageReference{
+						Registry:  "some-registry.com",
+						Namespace: "namespace",
+						Name:      "image",
+						Tag:       "latest",
+					},
+					Type: imagesource.DestinationRegistry,
+				},
+				Category: v1alpha2.TypeOperatorBundle,
+			},
+		},
+		{
+			name: "Valid/SetLatest",
+			mapping: TypedImage{
+				TypedImageReference: imagesource.TypedImageReference{
+					Ref: reference.DockerImageReference{
+						Registry:  "some-registry.com",
+						Namespace: "namespace",
+						Name:      "image",
+					},
+					Type: imagesource.DestinationRegistry,
+				},
+				Category: v1alpha2.TypeOperatorBundle,
+			},
+			expected: TypedImage{
+				TypedImageReference: imagesource.TypedImageReference{
+					Ref: reference.DockerImageReference{
+						Registry:  "some-registry.com",
+						Namespace: "namespace",
+						Name:      "image",
+						Tag:       "latest",
+					},
+					Type: imagesource.DestinationRegistry,
+				},
+				Category: v1alpha2.TypeOperatorBundle,
+			},
+		},
+		{
+			name: "Valid/SetWithPartialDigest",
+			mapping: TypedImage{
+				TypedImageReference: imagesource.TypedImageReference{
+					Ref: reference.DockerImageReference{
+						Registry:  "some-registry.com",
+						Namespace: "namespace",
+						Name:      "image",
+						ID:        "sha256:fdb393d8227cbe9756537d3f215a3098ae797bd4bde422aaa10ebde84a940877",
+					},
+					Type: imagesource.DestinationRegistry,
+				},
+				Category: v1alpha2.TypeOperatorBundle,
+			},
+			expected: TypedImage{
+				TypedImageReference: imagesource.TypedImageReference{
+					Ref: reference.DockerImageReference{
+						Registry:  "some-registry.com",
+						Namespace: "namespace",
+						Name:      "image",
+						Tag:       "fdb393",
+						ID:        "sha256:fdb393d8227cbe9756537d3f215a3098ae797bd4bde422aaa10ebde84a940877",
+					},
+					Type: imagesource.DestinationRegistry,
+				},
+				Category: v1alpha2.TypeOperatorBundle,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := test.mapping.SetDefaults()
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
 func TestToRegistry(t *testing.T) {
 	toMirror := "test.registry"
 	inputMapping := TypedImageMapping{

--- a/test/e2e/configs/imageset-config-full-digest.yaml
+++ b/test/e2e/configs/imageset-config-full-digest.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: mirror.openshift.io/v1alpha2
+kind: ImageSetConfiguration
+mirror:
+  operators:
+  - catalog: METADATA_CATALOGNAMESPACE@CATALOG_DIGEST
+    full: true

--- a/test/e2e/lib/util.sh
+++ b/test/e2e/lib/util.sh
@@ -68,7 +68,11 @@ function prep_registry() {
   # Copy target catalog to connected registry
     crane copy --insecure ${CATALOGREGISTRY}/${CATALOGNAMESPACE}:${CATALOGTAG} \
     localhost.localdomain:${REGISTRY_CONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest
+
+    CATALOGDIGEST=$(crane digest --insecure localhost.localdomain:${REGISTRY_CONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest)
 }
+
+
 
 # parse_args will parse common arguments
 # for each workflow function
@@ -113,6 +117,7 @@ function setup_operator_testdata() {
   local OUTPUT_DIR="${2:?OUTPUT_DIR required}"
   local CONFIG_PATH="${3:?CONFIG_PATH required}"
   local DIFF="${4:?DIFF bool required}"
+  local CATALOG_DIGEST="${5:-""}"
   if $DIFF; then
     INDEX_PATH=diff
   else
@@ -122,6 +127,7 @@ function setup_operator_testdata() {
   mkdir -p "$OUTPUT_DIR"
   cp "${DIR}/configs/${CONFIG_PATH}" "${OUTPUT_DIR}/"
   find "$DATA_DIR" -type f -exec sed -i -E 's@METADATA_CATALOGNAMESPACE@'"$METADATA_CATALOGNAMESPACE"'@g' {} \;
+  find "$DATA_DIR" -type f -exec sed -i -E 's@CATALOG_DIGEST@'"$CATALOG_DIGEST"'@g' {} \;
   find "$DATA_DIR" -type f -exec sed -i -E 's@DATA_TMP@'"$DATA_DIR"'@g' {} \;
 }
 

--- a/test/e2e/lib/workflow.sh
+++ b/test/e2e/lib/workflow.sh
@@ -7,9 +7,11 @@ function workflow_full() {
   local config="${1:?config required}"
   local catalog_tag="${2:?catalog_tag required}"
   mkdir $PUBLISH_FULL_DIR
-  # Copy the catalog to the connected registry so they can have the same tag
-  setup_operator_testdata "${DATA_TMP}" "$CREATE_FULL_DIR" "$config" false
   prep_registry "${catalog_tag}"
+  # Copy the catalog to the connected registry so they can have the same tag
+  # Full is the only place catalog digests could be used so setting and using the
+  # CATALOGDIGEST set by prep_registry here.
+  setup_operator_testdata "${DATA_TMP}" "$CREATE_FULL_DIR" "$config" false $CATALOGDIGEST
   run_cmd --config "${CREATE_FULL_DIR}/$config" "file://${CREATE_FULL_DIR}" $CREATE_FLAGS
   pushd $PUBLISH_FULL_DIR
   if $DIFF; then

--- a/test/e2e/testcases.sh
+++ b/test/e2e/testcases.sh
@@ -4,21 +4,32 @@
 # run during end to end test
 declare -a TESTCASES
 TESTCASES[1]="full_catalog"
-TESTCASES[2]="headsonly_diff"
-TESTCASES[3]="pruned_catalogs"
-TESTCASES[4]="registry_backend"
-TESTCASES[5]="mirror_to_mirror"
-TESTCASES[6]="mirror_to_mirror_nostorage"
-TESTCASES[7]="custom_namespace"
-TESTCASES[8]="package_filtering"
-TESTCASES[9]="skip_deps"
-TESTCASES[10]="helm_local"
-TESTCASES[11]="no_updates_exist"
+TESTCASES[2]="full_catalog_with_digest"
+TESTCASES[3]="headsonly_diff"
+TESTCASES[4]="pruned_catalogs"
+TESTCASES[5]="registry_backend"
+TESTCASES[6]="mirror_to_mirror"
+TESTCASES[7]="mirror_to_mirror_nostorage"
+TESTCASES[8]="custom_namespace"
+TESTCASES[9]="package_filtering"
+TESTCASES[10]="skip_deps"
+TESTCASES[11]="helm_local"
+TESTCASES[12]="no_updates_exist"
 
 # Test full catalog mode.
 function full_catalog () {
     workflow_full imageset-config-full.yaml "test-catalog-latest" -c="--source-use-http"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
+    "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.0.0 baz.v1.0.1 baz.v1.1.0 foo.v0.1.0 foo.v0.2.0 foo.v0.3.0 foo.v0.3.1" \
+    localhost.localdomain:${REGISTRY_DISCONN_PORT}
+}
+
+# Test full catalog mode with digest.
+function full_catalog_with_digest() {
+    workflow_full imageset-config-full-digest.yaml "test-catalog-latest" -c="--source-use-http"
+    TMPTAG=$(echo $CATALOGDIGEST | cut -d: -f 2)
+    TMPTAG=${TMPTAG:0:6}
+    check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:${TMPTAG}\
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.0.0 baz.v1.0.1 baz.v1.1.0 foo.v0.1.0 foo.v0.2.0 foo.v0.3.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
 }


### PR DESCRIPTION
When reading the catalog reference provided by the configuration,
the run method in operator.go was modifying the reference in a way
that resulted in the reference differing from the mapping. The DockerClientDefaults
call has been removed and a SetDefaults method has been added to TypedImage as a way to set
fields in a standard way on this type.

Closes #423 

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Manually tested
- [X] Unit test for new method
- [X] Add e2e test case for an operator specified by digest

# How to Test

```
apiVersion: mirror.openshift.io/v1alpha2
kind: ImageSetConfiguration
storageConfig:
  local:
    path: metadata
mirror:
    operators:
      - catalog: quay.io/redhatgov/oc-mirror-dev@sha256:f74bd3f08c971fafd64c9c95fe9839f54bf776d00ac363f2c3882c0e37c946ef
```
`oc-mirror --config imageset-config.yaml docker://localhost:5000/test`

This should not result in `error: repository name must have at least one component`

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules