### PR TITLE
fix(publish): adds back evaluation of current associations in publish.go

### DIFF
--- a/pkg/cli/mirror/publish.go
+++ b/pkg/cli/mirror/publish.go
@@ -59,7 +59,6 @@ func (o *MirrorOptions) Publish(ctx context.Context) (image.TypedImageMapping, e
 
 	logrus.Infof("Publishing image set from archive %q to registry %q", o.From, o.ToMirror)
 	allMappings := image.TypedImageMapping{}
-	currentAssocs := image.AssociationSet{}
 
 	// Set target dir for resulting artifacts
 	if o.OutputDir == "" {
@@ -120,8 +119,14 @@ func (o *MirrorOptions) Publish(ctx context.Context) (image.TypedImageMapping, e
 	}
 	allMappings.Merge(imgMappings)
 
-	if err := o.pruneRegistry(ctx, currentAssocs, incomingAssocs); err != nil {
-		return allMappings, err
+	if len(currentMeta.PastAssociations) != 0 {
+		currentAssocs, err := image.ConvertToAssociationSet(currentMeta.PastAssociations)
+		if err != nil {
+			return allMappings, fmt.Errorf("error processing incoming past associations: %v", err)
+		}
+		if err := o.pruneRegistry(ctx, currentAssocs, incomingAssocs); err != nil {
+			return allMappings, err
+		}
 	}
 
 	logrus.Debug("unpack release signatures")

--- a/test/e2e/lib/check.sh
+++ b/test/e2e/lib/check.sh
@@ -62,12 +62,11 @@ function check_bundles() {
   done
 }
 
-# check_helm ensures the image(s) found in the chart is correct and
-# images are pullable.
-function check_helm() {
+# check_images_exists ensures the image(s) is found and pullable.
+function check_image_exists() {
   local expected_image="${1:?expected image required}"
    if ! crane digest --insecure $expected_image; then
-      echo "helm image $expected_image not pushed to registry"
+      echo "image $expected_image not pushed to registry"
       return 1
     fi
 }
@@ -80,4 +79,15 @@ function check_sequence_number() {
     echo "expected_past_mirrors does not match actual_past_mirrors"
     return 1
   fi
+}
+
+# check_image_removed will check if an image has been pruned from the registry
+function check_image_removed() {
+   local removed_image="${1:?removed image required}"
+   set -e
+   output=$(crane digest --insecure $removed_image 2>&1) && returncode=$? || returncode=$?
+   if [[ $returncode != 1 ]]; then
+      echo "image $removed_image still exists in registry"
+      return 1
+    fi
 }

--- a/test/e2e/lib/util.sh
+++ b/test/e2e/lib/util.sh
@@ -93,7 +93,7 @@ function parse_args() {
       shift # past argument=value
       ;;
     --diff)
-      DIFF=YES
+      DIFF=true
       shift # past argument with no value
       ;;
     -*|--*)

--- a/test/e2e/lib/workflow.sh
+++ b/test/e2e/lib/workflow.sh
@@ -12,7 +12,7 @@ function workflow_full() {
   prep_registry "${catalog_tag}"
   run_cmd --config "${CREATE_FULL_DIR}/$config" "file://${CREATE_FULL_DIR}" $CREATE_FLAGS
   pushd $PUBLISH_FULL_DIR
-  if $DIFF; then
+  if !$DIFF; then
     cleanup_conn
   fi
   run_cmd --from "${CREATE_FULL_DIR}/mirror_seq1_000000.tar" "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}${NS}" $PUBLISH_FLAGS
@@ -40,7 +40,7 @@ function workflow_diff() {
 function workflow_no_updates() {
   parse_args "$@"
   local config="${1:?config required}"
-   local catalog_tag="${2:?catalog_tag required}"
+  local catalog_tag="${2:?catalog_tag required}"
   mkdir $PUBLISH_FULL_DIR
   # Copy the catalog to the connected registry so they can have the same tag
   setup_operator_testdata "${DATA_TMP}" "$CREATE_FULL_DIR" "$config" false
@@ -57,9 +57,10 @@ function workflow_no_updates() {
 function workflow_mirror2mirror() {
   parse_args "$@"
   local config="${1:?config required}"
+  local catalog_tag="${2:?catalog_tag required}"
    # Copy the catalog to the connected registry so they can have the same tag
   setup_operator_testdata "${DATA_TMP}" "${CREATE_FULL_DIR}" "$config" false
-  prep_registry "test-catalog-latest"
+  prep_registry "$catalog_tag"
   pushd ${CREATE_FULL_DIR}
   run_cmd --config "${CREATE_FULL_DIR}/$config" "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}${NS}" $CREATE_FLAGS
   popd

--- a/test/e2e/testcases.sh
+++ b/test/e2e/testcases.sh
@@ -42,12 +42,30 @@ function pruned_catalogs() {
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.1.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
+    check_image_exists "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:535b8534"
 
     workflow_diff imageset-config-headsonly.yaml "test-catalog-prune-diff" -c="--source-use-http"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.2.0" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
+    check_image_removed "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:535b8534"
 }
+
+# Test heads-only mode with catalogs that prune bundles
+function pruned_catalogs_mirror_to_mirror() {
+    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-prune" -c="--source-use-http"
+    check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
+    "bar.v0.1.0 foo.v0.1.1" \
+    localhost.localdomain:${REGISTRY_DISCONN_PORT}
+    check_image_exists "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:535b8534"
+
+    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-prune-diff" -c="--source-use-http"
+    check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
+    "bar.v0.1.0 foo.v0.2.0" \
+    localhost.localdomain:${REGISTRY_DISCONN_PORT}
+    check_image_removed "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:535b8534"
+}
+
 
 # Test registry backend
 function registry_backend () {
@@ -117,7 +135,7 @@ function skip_deps {
 # Test local helm chart
 function helm_local {
     workflow_helm imageset-config-helm.yaml podinfo-6.0.0.tgz
-    check_helm "localhost.localdomain:${REGISTRY_DISCONN_PORT}/stefanprodan/podinfo:6.0.0"
+    check_image_exists "localhost.localdomain:${REGISTRY_DISCONN_PORT}/stefanprodan/podinfo:6.0.0"
 }
 
 # Test no udpates


### PR DESCRIPTION
This fixes a regression introduced by #412 to the ability to prune in disk
to mirror workflows

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

^^

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Manually verified in the mirror to mirror and disk to mirror workflows
- [X] Add image pruning checks to e2e tests

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules