### PR TITLE
docs: adds more details to use, description. and examples to oc-mirro…

### DIFF
--- a/pkg/cli/mirror/describe/describe.go
+++ b/pkg/cli/mirror/describe/describe.go
@@ -31,7 +31,7 @@ func NewDescribeCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command 
 	o.RootOptions = ro
 
 	cmd := &cobra.Command{
-		Use:   "describe",
+		Use:   "describe <archive path>",
 		Short: "Pretty print the contents of mirror metadata",
 		Example: templates.Examples(`
 			# Output the contents of 'mirror_seq1_00000.tar'

--- a/pkg/cli/mirror/list/updates.go
+++ b/pkg/cli/mirror/list/updates.go
@@ -37,7 +37,7 @@ func NewUpdatesCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command {
 	o.RootOptions = ro
 
 	cmd := &cobra.Command{
-		Use:   "updates",
+		Use:   "updates <configuration path>",
 		Short: "List available updates in upgrade graph from upstream sources.",
 		Long: templates.LongDesc(`
 		List available updates in the upgrade graph for releases and operators from upstream sources

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -45,10 +45,14 @@ var (
 
 		When using file mirroring, the --from and --config flags control the location of the images to mirror. The --config flag accepts
 		an imageset configuration file and the --from flag accepts the location of the imageset on disk. The --from input can be passed as a 
-		file or directory, but must contain only one image sequence. The naming convention for an imageset is mirror_seq<sequence number>_<tar count>.tar.
+		file or directory, but must contain only one image sequence. The naming convention for an imageset is mirror\_seq<sequence number>\_<tar count>.tar.
 
-		The location of the workspace used defaults to oc-mirror-workspace in the current directory when publishing image content or using the  to 
-		mirror workflow. If using the file:// destination scheme, the oc-mirror-workspace directory will be located in the directory specified by the argument.
+		The location of the directory used by oc-mirror as a workspace defaults to the name oc-mirror-workspace. The location of this directory
+		is outlined in the following: 
+
+		1. Destination prefix is docker:// - The current working directory will be used.
+		2. Destination prefix is file:// - The destination directory specified will be used.
+
 		`,
 	)
 	mirrorExamples = templates.Examples(
@@ -68,14 +72,12 @@ var (
 		# Publish to a registry and add a top-level namespace
 		oc-mirror --from mirror_seq1_000000.tar docker://localhost:5000/namespace
 
-		# Publish to a registry and add a top-level namespace
-		oc-mirror --from mirror_seq1_000000.tar docker://localhost:5000/namespace
-
 		# Generate manifests for previously created mirror archive
 		oc-mirror --from mirror_seq1_000000.tar docker://localhost:5000/namespace --manifests-only
 
-		# Skip metadata check during imageset publishing. Example shown with --ignore-history creation
-		# as this the required workflow with --skip-metadata-check.
+		# Skip metadata check during imageset publishing. This example shows a two-step process.
+		# A differential imageset would have to be created with --ignore-history to be
+		# successfully published with --skip-metadata-check.
 		oc-mirror --config mirror-config.yaml file://mirror --ignore-history
 		oc-mirror --from mirror_seq2_000000.tar docker://localhost:5000/namespace --skip-metadata-check
 		`,

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -40,7 +40,7 @@ var (
 		` 
 		Create and publish user-configured mirrors with a declarative configuration input.
 		Accepts an argument defining the destination for the mirrored images using the prefix file:// for a local mirror packed into a 
-		tar archive or docker:// for images to be stream registry to registry without being stored locally. The default docker credentials are 
+		tar archive or docker:// for images to be streamed registry to registry without being stored locally. The default docker credentials are 
 		used for authenticating to the registries. The podman location for credentials is also supported as a secondary location.
 
 		When using file mirroring, the --from and --config flags control the location of the images to mirror. The --config flag accepts
@@ -75,7 +75,7 @@ var (
 		oc-mirror --from mirror_seq1_000000.tar docker://localhost:5000/namespace --manifests-only
 
 		# Skip metadata check during imageset publishing. Example shown with --ignore-history creation
-		# as this the the required workflow with skip-metadata-check.
+		# as this the required workflow with --skip-metadata-check.
 		oc-mirror --config mirror-config.yaml file://mirror --ignore-history
 		oc-mirror --from mirror_seq2_000000.tar docker://localhost:5000/namespace --skip-metadata-check
 		`,


### PR DESCRIPTION
…r commands and subcommands

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

This PR adds a more detailed description and more examples for the oc-mirror root command. It makes better use of the `Use` field when defining the commands to document required arguments.

Closes #426 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules