### PR TITLE
fix(makefile): remove clean from all target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ GO_LD_EXTRAFLAGS :=-X k8s.io/component-base/version.gitMajor="1" \
 GO_BUILD_FLAGS :=-tags 'json1'
 GO_BUILD_BINDIR :=./bin
 
-all: clean tidy test-unit build
+all: tidy test-unit build
 .PHONY: all
 
 cross-build-linux-amd64:


### PR DESCRIPTION
# Description

With the addition of build-machinery-go, the build is occurring
before the clean when running the all target. The clean has
been removed and will be optional when directly running the all target.
The clean prerequisite is staying on the hack-build target to maintain reproducible
builds.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Manuallty tested `hack/build.sh`

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules