### PR TITLE
fix(associations): ensure that the correct error types are thrown whe…

### DIFF
--- a/pkg/image/association_builder.go
+++ b/pkg/image/association_builder.go
@@ -219,7 +219,7 @@ func AssociateRemoteImageLayers(ctx context.Context, imgMappings TypedImageMappi
 			}
 			imgWithID, err := ResolveToPin(ctx, resolver, srcImg.Ref.Exact())
 			if err != nil {
-				errs = append(errs, err)
+				errs = append(errs, &ErrInvalidComponent{srcImg.String(), srcImg.Ref.Tag})
 				continue
 			}
 			pinnedRef, err := imagesource.ParseReference(imgWithID)
@@ -238,7 +238,7 @@ func AssociateRemoteImageLayers(ctx context.Context, imgMappings TypedImageMappi
 
 		repo, err := regctx.RepositoryForRef(ctx, srcImg.Ref, insecure)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("create repo for %s: %v", srcImg.Ref.Exact(), err))
+			errs = append(errs, &ErrInvalidImage{srcImg.Ref.Exact()})
 			continue
 		}
 
@@ -273,7 +273,7 @@ func associateRemoteImageLayers(ctx context.Context, srcImg, dstImg string, srcI
 	}
 	mn, err := ms.Get(ctx, dgst, preferManifestList)
 	if err != nil {
-		return nil, fmt.Errorf("error getting manifest %s: %v", dgst, err)
+		return nil, &ErrInvalidComponent{srcImg, dgst.String()}
 	}
 	mt, payload, err := mn.Payload()
 	if err != nil {

--- a/pkg/image/association_builder_test.go
+++ b/pkg/image/association_builder_test.go
@@ -473,7 +473,7 @@ func TestAssociateRemoteImageLayers(t *testing.T) {
 			}},
 		},
 		{
-			name:   "Invalid/InvalidComponent",
+			name:   "Invalid/InvalidComponentNoTag",
 			imgTyp: v1alpha2.TypeGeneric,
 			imgMapping: map[TypedImage]TypedImage{
 				{
@@ -491,6 +491,50 @@ func TestAssociateRemoteImageLayers(t *testing.T) {
 					Category: v1alpha2.TypeGeneric}},
 			wantErr:  true,
 			expError: &ErrInvalidComponent{},
+		},
+		{
+			name:   "Invalid/InvalidComponentWrongTag",
+			imgTyp: v1alpha2.TypeGeneric,
+			imgMapping: map[TypedImage]TypedImage{
+				{
+					TypedImageReference: imagesource.TypedImageReference{
+						Ref: reference.DockerImageReference{
+							Name: "imgname",
+							Tag:  "fake",
+						}},
+					Category: v1alpha2.TypeGeneric}: {
+					TypedImageReference: imagesource.TypedImageReference{
+						Ref: reference.DockerImageReference{
+							Name: "single_manifest",
+						},
+						Type: imagesource.DestinationRegistry,
+					},
+					Category: v1alpha2.TypeGeneric}},
+			wantErr:  true,
+			expError: &ErrInvalidComponent{},
+		},
+		{
+			name:   "Invalid/MissingImage",
+			imgTyp: v1alpha2.TypeGeneric,
+			imgMapping: map[TypedImage]TypedImage{
+				{
+					TypedImageReference: imagesource.TypedImageReference{
+						Ref: reference.DockerImageReference{
+							Name:     "fake_manifest",
+							Tag:      "latest",
+							Registry: u.Host,
+						}},
+					Category: v1alpha2.TypeGeneric}: {
+					TypedImageReference: imagesource.TypedImageReference{
+						Ref: reference.DockerImageReference{
+							Name:     "single_manifest",
+							Registry: "test-registry.com",
+						},
+						Type: imagesource.DestinationRegistry,
+					},
+					Category: v1alpha2.TypeGeneric}},
+			wantErr:  true,
+			expError: &ErrInvalidImage{},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
…n collecting remote associations

# Description

The AssociateRemoteImageLayer method was not returning the structured errors
defined which caused the --continue-on-error check to not view the errors thrown
as skippable. The structured errors have been added where they are needed.

Fixes #427

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Unit tests update to the scenarios

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules