### PR TITLE
fix: modifies binary search algorithm to keep from a stack overflow

### DIFF
--- a/pkg/operator/declcfg_to_includecfg.go
+++ b/pkg/operator/declcfg_to_includecfg.go
@@ -181,7 +181,7 @@ func search(versions []semver.Version, target semver.Version, low, high int) sem
 		return semver.Version{}
 	}
 
-	mid := low + (high+low)/2
+	mid := low + (high-low)/2
 	if versions[mid].EQ(target) {
 		return versions[mid+1]
 	}
@@ -190,7 +190,7 @@ func search(versions []semver.Version, target semver.Version, low, high int) sem
 		return search(versions, target, mid+1, high)
 	}
 
-	return search(versions, target, low, high)
+	return search(versions, target, low, mid-1)
 }
 
 // getChannelHeads proccess each channel in package and sets the starting

--- a/pkg/operator/declfg_to_includecfg_test.go
+++ b/pkg/operator/declfg_to_includecfg_test.go
@@ -303,6 +303,8 @@ func TestUpdateIncludeConfig(t *testing.T) {
 				Channels: []declcfg.Channel{
 					{Schema: "olm.channel", Name: "stable", Package: "bar", Entries: []declcfg.ChannelEntry{
 						{Name: "bar.v0.1.1", Skips: []string{"bar.v0.1.0"}},
+						{Name: "bar.v0.1.2", Skips: []string{"bar.v0.1.1"}},
+						{Name: "bar.v0.1.3", Skips: []string{"bar.v0.1.2"}},
 					}},
 					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
 						{Name: "foo.v0.1.0"},
@@ -317,6 +319,26 @@ func TestUpdateIncludeConfig(t *testing.T) {
 						Properties: []property.Property{
 							property.MustBuildGVKRequired("etcd.database.coreos.com", "v1", "EtcdBackup"),
 							property.MustBuildPackage("bar", "0.1.1"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "bar.v0.1.2",
+						Package: "bar",
+						Image:   "reg/bar:latest",
+						Properties: []property.Property{
+							property.MustBuildGVKRequired("etcd.database.coreos.com", "v1", "EtcdBackup"),
+							property.MustBuildPackage("bar", "0.1.2"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "bar.v0.1.3",
+						Package: "bar",
+						Image:   "reg/bar:latest",
+						Properties: []property.Property{
+							property.MustBuildGVKRequired("etcd.database.coreos.com", "v1", "EtcdBackup"),
+							property.MustBuildPackage("bar", "0.1.3"),
 						},
 					},
 					{

--- a/pkg/operator/declfg_to_includecfg_test.go
+++ b/pkg/operator/declfg_to_includecfg_test.go
@@ -307,7 +307,10 @@ func TestUpdateIncludeConfig(t *testing.T) {
 						{Name: "bar.v0.1.3", Skips: []string{"bar.v0.1.2"}},
 					}},
 					{Schema: "olm.channel", Name: "stable", Package: "foo", Entries: []declcfg.ChannelEntry{
-						{Name: "foo.v0.1.0"},
+						{Name: "foo.v0.0.1"},
+						{Name: "foo.v0.0.2", Replaces: "foo.v0.0.1"},
+						{Name: "foo.v0.0.3", Replaces: "foo.v0.0.2"},
+						{Name: "foo.v0.2.0", Replaces: "foo.v0.0.3"},
 					}},
 				},
 				Bundles: []declcfg.Bundle{
@@ -343,11 +346,38 @@ func TestUpdateIncludeConfig(t *testing.T) {
 					},
 					{
 						Schema:  "olm.bundle",
-						Name:    "foo.v0.1.0",
+						Name:    "foo.v0.0.1",
 						Package: "foo",
 						Image:   "reg/foo:latest",
 						Properties: []property.Property{
-							property.MustBuildPackage("foo", "0.1.0"),
+							property.MustBuildPackage("foo", "0.0.1"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.0.2",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.0.2"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.0.3",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.0.3"),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.2.0",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.2.0"),
 						},
 					},
 				},
@@ -397,7 +427,7 @@ func TestUpdateIncludeConfig(t *testing.T) {
 							{
 								Name: "stable",
 								IncludeBundle: v1alpha2.IncludeBundle{
-									StartingVersion: semver.MustParse("0.1.0"),
+									StartingVersion: semver.MustParse("0.2.0"),
 								},
 							},
 						},


### PR DESCRIPTION
# Description

An error in the binary search method in the operator package
in declcfg_to_includecfg.go was causing a stack overflow

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Unit tests updated

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules