### PR TITLE
fix: modifies release.go to remove and add release images to the mapping

### DIFF
--- a/pkg/cli/mirror/release.go
+++ b/pkg/cli/mirror/release.go
@@ -388,10 +388,11 @@ func (o *ReleaseOptions) getMapping(opts *release.MirrorOptions) (image.TypedIma
 	if !ok {
 		return nil, fmt.Errorf("release images %s not found in mapping", opts.From)
 	}
-	releaseImageRef.Category = v1alpha2.TypeOCPRelease
-	dstReleaseRef.Category = v1alpha2.TypeOCPRelease
+	// Remove and readd the release image to the
+	// mapping with the correct repo name and image type.
+	mappings.Remove(releaseImageRef)
 	dstReleaseRef.Ref.Name = releaseRepo
-	mappings[releaseImageRef] = dstReleaseRef
+	mappings.Add(releaseImageRef.TypedImageReference, dstReleaseRef.TypedImageReference, v1alpha2.TypeOCPRelease)
 
 	return mappings, nil
 }


### PR DESCRIPTION
Currently, the release images are being added as an additional key in the
mapping instead of overwriting the existing key pair. This is causing the
final release images to be written to the wrong repo.

Fixes #439

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Manual verification of the disk to mirror workflow per the issue

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules