### PR TITLE
feat(release): expose architecture filter options for Platforms

### DIFF
--- a/docs/examples/imageset-config-release-alt-arch.yaml
+++ b/docs/examples/imageset-config-release-alt-arch.yaml
@@ -1,0 +1,13 @@
+# This config demonstrates how to mirror a version range
+# in the specified channel for an OpenShift release.
+---
+apiVersion: mirror.openshift.io/v1alpha2
+kind: ImageSetConfiguration
+mirror:
+  platform:
+    architectures:
+      - "s390x"
+    channels:
+      - name: stable-4.9
+        minVersion: 4.9.13
+        maxVersion: 4.9.26

--- a/docs/imageset-config-ref.yaml
+++ b/docs/imageset-config-ref.yaml
@@ -6,6 +6,8 @@ storageConfig:
     skipTLS: true # Disable TLS certificate checking or use plain HTTP 
 mirror:
   platform:
+    architectures:
+      - "s390x" # Architectures to mirror for the collection of release versions (defaults to amd64)
     channels:
       - name: stable-4.9 # References latest stable release
       - name: stable-4.7 # Annotation references min and max version. 

--- a/pkg/api/v1alpha2/types_config.go
+++ b/pkg/api/v1alpha2/types_config.go
@@ -55,6 +55,10 @@ type Platform struct {
 	// Channels defines the configuration for individual
 	// OCP and OKD channels
 	Channels []ReleaseChannel `json:"channels,omitempty"`
+	// Architectures defines one or more architectures
+	// to mirror for the release image. This is defined at the
+	// platform level to enable cross-channel upgrades.
+	Architectures []string `json:"architectures,omitempty"`
 }
 
 // ReleaseChannel defines the configuration for individual

--- a/pkg/cli/mirror/list/releases.go
+++ b/pkg/cli/mirror/list/releases.go
@@ -67,7 +67,7 @@ func NewReleasesCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command 
 	fs.StringVar(&o.Channel, "channel", o.Channel, "List information for a specified channel")
 	fs.BoolVar(&o.Channels, "channels", o.Channels, "List all channel information")
 	fs.StringVar(&o.Version, "version", o.Version, "Specify an OpenShift release version")
-	fs.StringSliceVar(&o.FilterOptions, "filter-options", o.FilterOptions, "An architecture list to control the release image"+
+	fs.StringSliceVar(&o.FilterOptions, "filter-options", o.FilterOptions, "An architecture list to control the release image "+
 		"picked when multiple variants are available")
 
 	o.BindFlags(cmd.PersistentFlags())

--- a/pkg/cli/mirror/list/releases.go
+++ b/pkg/cli/mirror/list/releases.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -70,12 +69,6 @@ func NewReleasesCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command 
 	fs.StringVar(&o.Version, "version", o.Version, "Specify an OpenShift release version")
 	fs.StringSliceVar(&o.FilterOptions, "filter-options", o.FilterOptions, "An architecture list to control the release image"+
 		"picked when multiple variants are available")
-
-	// TODO(jpower432): Make this flag visible again once release architecture selection
-	// has been more thouroughly vetted
-	if err := fs.MarkHidden("filter-options"); err != nil {
-		logrus.Panic(err.Error())
-	}
 
 	o.BindFlags(cmd.PersistentFlags())
 

--- a/pkg/cli/mirror/list/updates.go
+++ b/pkg/cli/mirror/list/updates.go
@@ -60,12 +60,6 @@ func NewUpdatesCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command {
 	fs := cmd.Flags()
 	fs.StringSliceVar(&o.FilterOptions, "filter-options", o.FilterOptions, "An architecture list to control the release image"+
 		"picked when multiple variants are available")
-
-	// TODO(jpower432): Make this flag visible again once release architecture selection
-	// has been more thouroughly vetted
-	if err := fs.MarkHidden("filter-options"); err != nil {
-		logrus.Panic(err.Error())
-	}
 	return cmd
 }
 

--- a/pkg/cli/mirror/list/updates.go
+++ b/pkg/cli/mirror/list/updates.go
@@ -28,8 +28,7 @@ import (
 
 type UpdatesOptions struct {
 	*cli.RootOptions
-	ConfigPath    string
-	FilterOptions []string
+	ConfigPath string
 }
 
 func NewUpdatesCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command {
@@ -57,9 +56,6 @@ func NewUpdatesCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command {
 
 	o.BindFlags(cmd.PersistentFlags())
 
-	fs := cmd.Flags()
-	fs.StringSliceVar(&o.FilterOptions, "filter-options", o.FilterOptions, "An architecture list to control the release image"+
-		"picked when multiple variants are available")
 	return cmd
 }
 
@@ -67,21 +63,12 @@ func (o *UpdatesOptions) Complete(args []string) error {
 	if len(args) == 1 {
 		o.ConfigPath = args[0]
 	}
-
-	if len(o.FilterOptions) == 0 {
-		o.FilterOptions = []string{v1alpha2.DefaultPlatformArchitecture}
-	}
 	return nil
 }
 
 func (o *UpdatesOptions) Validate() error {
 	if len(o.ConfigPath) == 0 {
 		return errors.New("must specify imageset configuration")
-	}
-	for _, arch := range o.FilterOptions {
-		if _, ok := cincinnati.SupportedArchs[arch]; !ok {
-			return fmt.Errorf("architecture %q is not a supported release architecture", arch)
-		}
 	}
 	return nil
 }
@@ -105,7 +92,7 @@ func (o *UpdatesOptions) Run(ctx context.Context) error {
 	case err != nil && errors.Is(err, storage.ErrMetadataNotExist):
 		return fmt.Errorf("no metadata detected")
 	default:
-		for _, arch := range o.FilterOptions {
+		for _, arch := range cfg.Mirror.Platform.Architectures {
 			if len(cfg.Mirror.Platform.Channels) != 0 {
 				if err := o.releaseUpdates(ctx, arch, cfg, meta.PastMirror); err != nil {
 					return err

--- a/pkg/cli/mirror/list/updates_test.go
+++ b/pkg/cli/mirror/list/updates_test.go
@@ -3,7 +3,6 @@ package list
 import (
 	"testing"
 
-	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,19 +21,7 @@ func TestUpdatesComplete(t *testing.T) {
 			opts: &UpdatesOptions{},
 			args: []string{"foo"},
 			expOpts: &UpdatesOptions{
-				FilterOptions: []string{v1alpha2.DefaultPlatformArchitecture},
-				ConfigPath:    "foo",
-			},
-		},
-		{
-			name: "Valid/SuppliedArchitecture",
-			opts: &UpdatesOptions{
-				FilterOptions: []string{"test"},
-			},
-			args: []string{"foo"},
-			expOpts: &UpdatesOptions{
-				FilterOptions: []string{"test"},
-				ConfigPath:    "foo",
+				ConfigPath: "foo",
 			},
 		},
 	}
@@ -65,14 +52,6 @@ func TestUpdatesValidate(t *testing.T) {
 			name:     "Invalid/NoConfigPath",
 			opts:     &UpdatesOptions{},
 			expError: `must specify imageset configuration`,
-		},
-		{
-			name: "Invalid/UnsupportedArch",
-			opts: &UpdatesOptions{
-				ConfigPath:    "foo",
-				FilterOptions: []string{"fake"},
-			},
-			expError: "architecture \"fake\" is not a supported release architecture",
 		},
 		{
 			name: "Valid/WithConfig",

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
 	"github.com/openshift/oc-mirror/pkg/bundle"
-	"github.com/openshift/oc-mirror/pkg/cincinnati"
 	"github.com/openshift/oc-mirror/pkg/cli"
 	"github.com/openshift/oc-mirror/pkg/cli/mirror/describe"
 	"github.com/openshift/oc-mirror/pkg/cli/mirror/initcmd"
@@ -167,10 +166,6 @@ func (o *MirrorOptions) Complete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unknown destination scheme %q", typStr)
 	}
 
-	if len(o.FilterOptions) == 0 {
-		o.FilterOptions = []string{v1alpha2.DefaultPlatformArchitecture}
-	}
-
 	return nil
 }
 
@@ -210,12 +205,6 @@ func (o *MirrorOptions) Validate() error {
 	if len(o.From) > 0 {
 		if _, err := os.Stat(o.From); err != nil {
 			return err
-		}
-	}
-
-	for _, arch := range o.FilterOptions {
-		if _, ok := cincinnati.SupportedArchs[arch]; !ok {
-			return fmt.Errorf("architecture %q is not a supported release architecture", arch)
 		}
 	}
 

--- a/pkg/cli/mirror/mirror_test.go
+++ b/pkg/cli/mirror/mirror_test.go
@@ -40,7 +40,6 @@ func TestMirrorComplete(t *testing.T) {
 				RootOptions: &cli.RootOptions{
 					Dir: "foo/bar",
 				},
-				FilterOptions: []string{"amd64"},
 			},
 		},
 		{
@@ -56,7 +55,6 @@ func TestMirrorComplete(t *testing.T) {
 				RootOptions: &cli.RootOptions{
 					Dir: "foo/bar",
 				},
-				FilterOptions: []string{"amd64"},
 			},
 		},
 		{
@@ -72,7 +70,6 @@ func TestMirrorComplete(t *testing.T) {
 				RootOptions: &cli.RootOptions{
 					Dir: "bar",
 				},
-				FilterOptions: []string{"amd64"},
 			},
 		},
 		{
@@ -80,8 +77,7 @@ func TestMirrorComplete(t *testing.T) {
 			args: []string{"docker://reg.com"},
 			opts: &MirrorOptions{},
 			expOpts: &MirrorOptions{
-				ToMirror:      "reg.com",
-				FilterOptions: []string{"amd64"},
+				ToMirror: "reg.com",
 			},
 		},
 		{
@@ -91,7 +87,6 @@ func TestMirrorComplete(t *testing.T) {
 			expOpts: &MirrorOptions{
 				ToMirror:      "reg.com",
 				UserNamespace: "foo/bar",
-				FilterOptions: []string{"amd64"},
 			},
 		},
 		{
@@ -101,14 +96,12 @@ func TestMirrorComplete(t *testing.T) {
 				RootOptions: &cli.RootOptions{
 					Dir: "bar",
 				},
-				FilterOptions: []string{"amd64", "ppc64le"},
 			},
 			expOpts: &MirrorOptions{
 				OutputDir: "foo",
 				RootOptions: &cli.RootOptions{
 					Dir: "foo/bar",
 				},
-				FilterOptions: []string{"amd64", "ppc64le"},
 			},
 		},
 		{
@@ -193,15 +186,6 @@ func TestMirrorValidate(t *testing.T) {
 				OutputDir: "dir",
 			},
 			expError: `must specify a configuration file with --config`,
-		},
-		{
-			name: "Invalid/UnsupportedReleaseArch",
-			opts: &MirrorOptions{
-				ConfigPath:    "foo",
-				ToMirror:      u.Host,
-				FilterOptions: []string{"arm64"},
-			},
-			expError: "architecture \"arm64\" is not a supported release architecture",
 		},
 		{
 			name: "Valid/MirrortoDisk",

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -8,7 +8,6 @@ import (
 	"syscall"
 
 	"github.com/spf13/pflag"
-	"k8s.io/klog/v2"
 
 	"github.com/openshift/oc-mirror/pkg/cli"
 )
@@ -66,12 +65,6 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 		"404/NotFound errors encountered while pulling images explicitly specified in the config "+
 		"will not be skipped")
 	fs.IntVar(&o.MaxPerRegistry, "max-per-registry", 2, "Number of concurrent requests allowed per registry")
-
-	// TODO(jpower432): Make this flag visible again once release architecture selection
-	// has been more thouroughly vetted
-	if err := fs.MarkHidden("filter-options"); err != nil {
-		klog.Fatal(err.Error())
-	}
 }
 
 func (o *MirrorOptions) init() {

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -32,7 +32,6 @@ type MirrorOptions struct {
 	SkipMetadataCheck bool
 	ContinueOnError   bool
 	IgnoreHistory     bool
-	FilterOptions     []string
 	MaxPerRegistry    int
 	// cancelCh is a channel listening for command cancellations
 	cancelCh         <-chan struct{}
@@ -54,8 +53,6 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 		"This is not recommended, but may be necessary when importing images from older image registries."+
 		"Only bypass verification if the registry is known to be trustworthy.")
 	fs.BoolVar(&o.SkipCleanup, "skip-cleanup", o.SkipCleanup, "Skip removal of artifact directories")
-	fs.StringSliceVar(&o.FilterOptions, "filter-options", o.FilterOptions, "An architecture list to control the release image"+
-		"picked when multiple variants are available")
 	fs.BoolVar(&o.IgnoreHistory, "ignore-history", o.IgnoreHistory, "Ignore past mirrors when downloading images and packing layers")
 	fs.BoolVar(&o.SkipMetadataCheck, "skip-metadata-check", o.SkipMetadataCheck, "Skip metadata when publishing an imageset."+
 		"This is only recommended when the imageset was created --ignore-history")

--- a/pkg/cli/mirror/release.go
+++ b/pkg/cli/mirror/release.go
@@ -43,7 +43,6 @@ const (
 // on a particular release image.
 type ReleaseOptions struct {
 	*MirrorOptions
-	arch []string
 	// insecure indicates whether the source
 	// registry is insecure
 	insecure bool
@@ -54,7 +53,6 @@ type ReleaseOptions struct {
 func NewReleaseOptions(mo *MirrorOptions) *ReleaseOptions {
 	relOpts := &ReleaseOptions{
 		MirrorOptions: mo,
-		arch:          mo.FilterOptions,
 		uuid:          uuid.New(),
 	}
 	if mo.SourcePlainHTTP || mo.SourceSkipTLS {
@@ -78,7 +76,7 @@ func (o *ReleaseOptions) Plan(ctx context.Context, lastRun v1alpha2.PastMirror, 
 		prevChannels[ch.ReleaseChannel] = ch.MinVersion
 	}
 
-	for _, arch := range o.arch {
+	for _, arch := range cfg.Mirror.Platform.Architectures {
 
 		versionsByChannel := make(map[string]v1alpha2.ReleaseChannel, len(cfg.Mirror.Platform.Channels))
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
+)
+
+// Complete set default values in the ImageSetConfiguration
+// when applicable
+func Complete(cfg *v1alpha2.ImageSetConfiguration) {
+	completeReleaseArchitectures(cfg)
+}
+
+func completeReleaseArchitectures(cfg *v1alpha2.ImageSetConfiguration) {
+	if len(cfg.Mirror.Platform.Channels) != 0 && len(cfg.Mirror.Platform.Architectures) == 0 {
+		cfg.Mirror.Platform.Architectures = []string{v1alpha2.DefaultPlatformArchitecture}
+	}
+}

--- a/pkg/config/defaults_test.go
+++ b/pkg/config/defaults_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComplete(t *testing.T) {
+
+	type spec struct {
+		name      string
+		config    v1alpha2.ImageSetConfiguration
+		expConfig v1alpha2.ImageSetConfiguration
+	}
+
+	cases := []spec{
+		{
+			name: "Invalid/UnsupportedReleaseArchitecture",
+			config: v1alpha2.ImageSetConfiguration{
+				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+					Mirror: v1alpha2.Mirror{
+						Platform: v1alpha2.Platform{
+							Architectures: []string{},
+							Channels: []v1alpha2.ReleaseChannel{
+								{
+									Name: "channel1",
+								},
+								{
+									Name: "channel2",
+								},
+							},
+						},
+					},
+				},
+			},
+			expConfig: v1alpha2.ImageSetConfiguration{
+				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+					Mirror: v1alpha2.Mirror{
+						Platform: v1alpha2.Platform{
+							Architectures: []string{v1alpha2.DefaultPlatformArchitecture},
+							Channels: []v1alpha2.ReleaseChannel{
+								{
+									Name: "channel1",
+								},
+								{
+									Name: "channel2",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			Complete(&c.config)
+			require.Equal(t, c.config, c.expConfig)
+		})
+	}
+}

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -41,6 +41,8 @@ func ReadConfig(configPath string) (c v1alpha2.ImageSetConfiguration, err error)
 		return c, fmt.Errorf("config GVK not recognized: %s", typeMeta.GroupVersionKind())
 	}
 
+	Complete(&c)
+
 	return c, Validate(&c)
 }
 

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -6,13 +6,14 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
+	"github.com/openshift/oc-mirror/pkg/cincinnati"
 )
 
 type validationFunc func(cfg *v1alpha2.ImageSetConfiguration) error
 
-var validationChecks = []validationFunc{validateOperatorOptions, validateReleaseChannels}
+var validationChecks = []validationFunc{validateOperatorOptions, validateReleaseChannels, validateReleaseArchitectures}
 
-// Validation will check an ImageSetConfiguration for input errors.
+// Validate will check an ImagesetConfiguration for input errors.
 func Validate(cfg *v1alpha2.ImageSetConfiguration) error {
 	var errs []error
 	for _, check := range validationChecks {
@@ -49,6 +50,15 @@ func validateReleaseChannels(cfg *v1alpha2.ImageSetConfiguration) error {
 			)
 		}
 		seen[channel.Name] = true
+	}
+	return nil
+}
+
+func validateReleaseArchitectures(cfg *v1alpha2.ImageSetConfiguration) error {
+	for _, arch := range cfg.Mirror.Platform.Architectures {
+		if _, ok := cincinnati.SupportedArchs[arch]; !ok {
+			return fmt.Errorf("release architecture %q is not a supported architecture", arch)
+		}
 	}
 	return nil
 }

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -58,6 +58,7 @@ func TestValidate(t *testing.T) {
 				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
 					Mirror: v1alpha2.Mirror{
 						Platform: v1alpha2.Platform{
+							Architectures: []string{v1alpha2.DefaultPlatformArchitecture},
 							Channels: []v1alpha2.ReleaseChannel{
 								{
 									Name: "channel1",
@@ -128,6 +129,27 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			expError: "invalid configuration: release channel \"channel\": duplicate found in configuration",
+		},
+		{
+			name: "Invalid/UnsupportedReleaseArchitecture",
+			config: &v1alpha2.ImageSetConfiguration{
+				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+					Mirror: v1alpha2.Mirror{
+						Platform: v1alpha2.Platform{
+							Architectures: []string{"fake"},
+							Channels: []v1alpha2.ReleaseChannel{
+								{
+									Name: "channel1",
+								},
+								{
+									Name: "channel2",
+								},
+							},
+						},
+					},
+				},
+			},
+			expError: "invalid configuration: release architecture \"fake\" is not a supported architecture",
 		},
 	}
 


### PR DESCRIPTION
# Description

This PR moves the Platform architecture specifications from flags to the ImagesetConfigurationSpec. The default functionality remains unchanged ("amd64"). Since release architectures are handled in a separate manner from image architecture filtering, this has been moved to describe the Platforms in the configuration.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit tests added
- [X] Manually verified
- [ ] Integration tests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

/kind feature