### PR TITLE
[CI] Set integration test to use mirror_registry

### DIFF
--- a/test/integration/requirements.yml
+++ b/test/integration/requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
   - name: jharmison_redhat.oc_mirror_e2e
-    version: 0.6.3
+    version: 0.7.0

--- a/test/integration/vars.yml
+++ b/test/integration/vars.yml
@@ -15,7 +15,7 @@ aws_region: us-west-2
 storage_config_backend: registry
 
 # The type of registry to use in the integration test (choose from docker_registry or redhat_quay)
-registry_type: docker_registry
+registry_type: mirror_registry
 
 # The operators to mirror, install, and test
 # Choose any of the following (or none):


### PR DESCRIPTION
Also update collection to inherit new Mirror Registry changes

# Description

This change in the collection makes it easier to test the OpenShift Mirror Registry with a full workflow, including installation of OpenShift from these sources. There are some extra changes exposing a few more variables to make it easier to test some alternate scenarios as well, including changes to the location of the release images for OSUS.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`/test integration`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules