### PR TITLE
Bug 2088634: fix(operator): adds validation after rendering dc to check for invali…

### DIFF
--- a/docs/examples/imageset-config-catalog-headsonly.yaml
+++ b/docs/examples/imageset-config-catalog-headsonly.yaml
@@ -6,4 +6,4 @@ apiVersion: mirror.openshift.io/v1alpha2
 kind: ImageSetConfiguration
 mirror:
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.8
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.10

--- a/docs/examples/imageset-config-filter-catalog.yaml
+++ b/docs/examples/imageset-config-filter-catalog.yaml
@@ -1,25 +1,42 @@
-# This config demonstrates how to mirror a single operator. By
-# specifying a startingVersion, that version and every version to the
+# This config demonstrates how to mirror a single operator. 
+
+# By specifying a minVersion, that version and every version to the
 # specified channel's latest (HEAD) version will be mirrored. 
 
-# If a package is specified with no startingVersion or channel, all
-# versions within every channel of the specified package will be mirrored.
+# If a package is specified with no minVersion/maxVersion or channel, each channel's latest
+# version in the specified package will be mirrored.
 
-# Alternatively, omit the channel and leave the startingVersion and all 
-# higher versions within every channel the startingVersion exists within 
-# the specified package will be mirrored.
+# If the package is specified with a minVersion and maxVersion, all bundles within that range
+# will be mirrored.
+# WARNING: Any specified channel information will override this setting. Setting versions by
+# package or channel are mutually exclusive.
 ---
 apiVersion: mirror.openshift.io/v1alpha2
 kind: ImageSetConfiguration
 mirror:
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.9
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.10
       packages:
         - name: elasticsearch-operator
           minVersion: '5.3.2-20'
-          channels:
-            - name: stable
+---
+apiVersion: mirror.openshift.io/v1alpha2
+kind: ImageSetConfiguration
+mirror:
+  operators:
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.10
+      packages:
+        - name: elasticsearch-operator
+---
+apiVersion: mirror.openshift.io/v1alpha2
+kind: ImageSetConfiguration
+mirror:
+  operators:
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.10
+      packages:
         - name: rhacs-operator
           channels:
             - name: stable
               minVersion: '3.67.0'
+              maxVersion: '3.67.2'
+

--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -29,12 +29,12 @@ import (
 	"github.com/sirupsen/logrus"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/klog/v2"
 
 	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
 	"github.com/openshift/oc-mirror/pkg/config"
 	"github.com/openshift/oc-mirror/pkg/image"
 	"github.com/openshift/oc-mirror/pkg/operator"
-	"k8s.io/klog/v2"
 )
 
 // OperatorOptions configures either a Full or Diff mirror operation
@@ -120,7 +120,7 @@ func (o *OperatorOptions) run(ctx context.Context, cfg v1alpha2.ImageSetConfigur
 		// Render the catalog to mirror into a declarative config.
 		dc, ic, err := renderDC(ctx, reg, ctlg)
 		if err != nil {
-			return nil, err
+			return nil, checkErr(err)
 		}
 
 		mappings, err := o.plan(ctx, dc, ic, ctlgRef, targetCtlg)
@@ -332,9 +332,6 @@ func (o *OperatorOptions) verifyDC(dic action.DiffIncludeConfig, dc *declcfg.Dec
 	// Converting the dc to the model results in running
 	// model validations. This checks default channels and
 	// replace chain.
-	// TODO(jpower432): Invalid replace chain may not appear very
-	// straight forward. Need a way to identify what bundle is missing
-	// from the replace chain.
 	if _, err := declcfg.ConvertToModel(*dc); err != nil {
 		return err
 	}
@@ -719,4 +716,26 @@ func validate(dc *declcfg.DeclarativeConfig) error {
 		return errors.New("bug: nil declarative config")
 	}
 	return nil
+}
+
+// checkError will check validation errors
+// from operator registry and return a modified
+// error messages for mirror usage
+// FIXME(jpower432): Checking against the errors string could be an issue since
+// this is depending on the strings returned from `opm validate`. It would be better to propose that
+// the validation error are exposed here https://github.com/operator-framework/operator-registry/blob/master/alpha/model/error.go
+// and adds structure errors that return package and channels information.
+func checkErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	// handle known error causes
+	switch {
+	case strings.Contains(err.Error(), "channel must contain at least one bundle"):
+		return fmt.Errorf("invalid catalog: check minVersion, maxVersion, and default channel on invalid packages\n%v", err)
+	case strings.Contains(err.Error(), "multiple channel heads found in graph"):
+		return fmt.Errorf("invalid catalog: check minVersion and maxVersion on invalid packages or channels\n%v", err)
+	default:
+		return err
+	}
 }


### PR DESCRIPTION
…d index

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

Using ranges to specify operator bundle versions can result in pruned
default channels and invalid replace chains (semver ordering is not
enforced on operator upgrade graphs). This adds a step that converts
the declarative config to a model which performs validation
on the FBC data.

Fixes #459

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Unit tests added to check for errors for default channels and invalid graphs

# Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules