### PR TITLE
Bug 2086974: fix(operator): adds context to error when bundles have invalid relate…

### DIFF
--- a/pkg/cli/mirror/create.go
+++ b/pkg/cli/mirror/create.go
@@ -28,7 +28,7 @@ func (o *MirrorOptions) Create(ctx context.Context, cfg v1alpha2.ImageSetConfigu
 	var err error
 	if !cfg.StorageConfig.IsSet() {
 		meta.SingleUse = true
-		klog.Warning("backend is not configured in %s, using stateless mode", o.ConfigPath)
+		klog.Warningf("backend is not configured in %s, using stateless mode", o.ConfigPath)
 		cfg.StorageConfig.Local = &v1alpha2.LocalConfig{Path: path}
 		backend, err = storage.ByConfig(path, cfg.StorageConfig)
 		if err != nil {

--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -438,20 +438,20 @@ func validateMapping(dc declcfg.DeclarativeConfig, mapping image.TypedImageMappi
 		if err != nil {
 			return err
 		}
-		_, ok := mapping[ref]
-		if !ok {
+
+		if _, ok := mapping[ref]; !ok {
 			klog.Warningf("image %s is not included in mapping", img)
 		}
 		return nil
 	}
 	for _, b := range dc.Bundles {
 		if err := validateFunc(b.Image); err != nil {
-			errs = append(errs, err)
+			errs = append(errs, fmt.Errorf("bundle %q image %q: %v", b.Name, b.Image, err))
 			continue
 		}
 		for _, relatedImg := range b.RelatedImages {
 			if err := validateFunc(relatedImg.Image); err != nil {
-				errs = append(errs, err)
+				errs = append(errs, fmt.Errorf("bundle %q related image %q: %v", b.Name, relatedImg.Name, err))
 				continue
 			}
 		}


### PR DESCRIPTION
…d images

# Description

Older catalogs may have bundles that contain related images with no actual
image information. The error that is thrown when this occur is not descriptive
enough to allow the user to take any kind of action. This change adds the bundle
and image information to allow the user to report back errors to the the publisher.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Manually tested this mirroring the Red Hat 4.8 catalog with the default configuration.

# How To Test This?

```
apiVersion: mirror.openshift.io/v1alpha2
kind: ImageSetConfiguration
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.8

```
```
oc-mirror --config imageset-config.yaml file://out
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules