### PR TITLE
Bug 2087024: fix(mapping): modifies mapping.txt for compat…

### DIFF
--- a/pkg/cli/mirror/manifests.go
+++ b/pkg/cli/mirror/manifests.go
@@ -255,6 +255,8 @@ func WriteICSPs(dir string, icsps []operatorv1alpha1.ImageContentSourcePolicy) e
 		return nil
 	}
 
+	klog.Infof("Writing ICSP manifests to %s", dir)
+
 	// Stable ICSP generation.
 	sort.Slice(icsps, func(i, j int) bool {
 		return string(icsps[i].Name) < string(icsps[j].Name)
@@ -278,8 +280,6 @@ func WriteICSPs(dir string, icsps []operatorv1alpha1.ImageContentSourcePolicy) e
 		return fmt.Errorf("error writing ImageContentSourcePolicy: %v", err)
 	}
 
-	klog.Infof("Wrote ICSP manifests to %s", dir)
-
 	return nil
 }
 
@@ -289,6 +289,8 @@ func WriteCatalogSource(mapping image.TypedImageMapping, dir string) error {
 		klog.V(2).Info("No catalogs found in mapping")
 		return nil
 	}
+
+	klog.Infof("Writing CatalogSource manifests to %s", dir)
 
 	// Keep track of the names and to make sure no
 	// manifest are overwritten.
@@ -314,12 +316,12 @@ func WriteCatalogSource(mapping image.TypedImageMapping, dir string) error {
 			return fmt.Errorf("error writing CatalogSource: %v", err)
 		}
 	}
-	klog.Infof("Wrote CatalogSource manifests to %s", dir)
 	return nil
 }
 
 // WriteUpdateService will generate an UpdateService object and write it to disk
 func WriteUpdateService(release, graph image.TypedImage, dir string) error {
+	klog.Infof("Writing UpdateService manifests to %s", dir)
 	updateService, err := generateUpdateService("update-service-oc-mirror", release.Ref, graph.Ref)
 	if err != nil {
 		return err
@@ -327,6 +329,5 @@ func WriteUpdateService(release, graph image.TypedImage, dir string) error {
 	if err := ioutil.WriteFile(filepath.Join(dir, "updateService.yaml"), updateService, os.ModePerm); err != nil {
 		return fmt.Errorf("error writing UpdateService: %v", err)
 	}
-	klog.Infof("Wrote UpdateService manifests to %s", dir)
 	return nil
 }

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -515,8 +515,8 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 }
 
 func (o *MirrorOptions) outputDryRunMapping(mapping image.TypedImageMapping) error {
-	mappingPath := filepath.Join(filepath.Clean(o.Dir), mappingFile)
-	mappingFile, err := os.Create(mappingPath)
+	mappingPath := filepath.Join(o.Dir, mappingFile)
+	mappingFile, err := os.Create(filepath.Clean(mappingPath))
 	if err != nil {
 		return err
 	}
@@ -631,8 +631,8 @@ func (o *MirrorOptions) newMirrorImageOptions(insecure bool) (*mirror.MirrorImag
 
 func (o *MirrorOptions) generateResults(mapping image.TypedImageMapping, dir string) error {
 
-	mappingResultsPath := filepath.Join(filepath.Clean(dir), mappingFile)
-	mappingFile, err := os.Create(mappingResultsPath)
+	mappingResultsPath := filepath.Join(dir, mappingFile)
+	mappingFile, err := os.Create(filepath.Clean(mappingResultsPath))
 	if err != nil {
 		return err
 	}

--- a/pkg/image/mapping.go
+++ b/pkg/image/mapping.go
@@ -117,11 +117,7 @@ func ReadImageMapping(mappingsPath, separator string, typ v1alpha2.ImageType) (T
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := f.Close(); err != nil {
-			klog.Error(err)
-		}
-	}()
+	defer f.Close()
 
 	mappings := TypedImageMapping{}
 	scanner := bufio.NewScanner(f)


### PR DESCRIPTION
…abilty with oc

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

This PR edits the WriteImageMapping method for compatibility with `oc image mirror`
1. Makes a surface changes to logged message for uniformity (tense/capitalization)
2. Changes input to WriteImageMapping from file location to `io.Writer` for easier testing.
3. Prefers tag over ID in mapping to use with `oc image mirror`

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Test new mapping.txt with `oc image mirror`

# How to Verify
```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
storageConfig:
mirror:
  platform:
    channels:
    - name: stable-4.10
      type: ocp
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.11
    packages:
    - name: serverless-operator
      channels:
      - name: stable
  additionalImages:
  - name: registry.redhat.io/ubi8/ubi:latest
  helm: {}
```
```
oc-mirror --config imageset-config.yaml docker://localhost:5000/test --dry-run
oc image mirror  --filter-by-os '.*' -f oc-mirror-workspace/mapping.txt --max-per-registry 1  --skip-multiple-scopes=true
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules