### PR TITLE
Bug 2088130: fix(init): bug/init cmd force prompting

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,20 @@
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v1alpha2
+storageConfig:
+  registry:
+    imageURL: localhost:5001/test:latest
+    skipTLS: false
+mirror:
+  platform:
+    channels:
+    - name: stable-0.2
+      type: ocp
+  operators:
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.11
+    packages:
+    - name: serverless-operator
+      channels:
+      - name: stable
+  additionalImages:
+  - name: registry.redhat.io/ubi8/ubi:latest
+  helm: {}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,6 +7,7 @@
     - [Certificate Trust](#certificate-trust)
   - [Basic Usage](#basic-usage)
     - [oc-mirror vs oc mirror](#oc-mirror-vs-oc-mirror)
+  - [Create an initial oc-mirror imageset configuration](#create-an-initial-oc-mirror-imageset-configuration)
     - [Content Discovery](#content-discovery)
       - [Updates](#updates)
       - [Releases](#releases)
@@ -44,6 +45,13 @@ There are two ways to use oc-mirror, either standalone or part of the oc plugin 
 In short:
 - To use `oc-mirror` build this repo and use the binary produced. 
 - To use `oc mirror` build this repo and move the binary into a directory on the PATH.
+
+
+## Create an initial oc-mirror imageset configuration
+
+```sh
+oc-mirror init
+```
 
 ### Content Discovery
 

--- a/pkg/cli/mirror/initcmd/initcmd.go
+++ b/pkg/cli/mirror/initcmd/initcmd.go
@@ -1,14 +1,12 @@
 package initcmd
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
 	"sort"
-	"strings"
 
 	"github.com/blang/semver/v4"
 	"github.com/spf13/cobra"
@@ -76,10 +74,6 @@ func (o *InitOptions) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	customRegistry, err := o.promptCustomRegistry()
-	if err != nil {
-		return err
-	}
 
 	imageSetConfig := v1alpha2.ImageSetConfiguration{
 		TypeMeta: metav1.TypeMeta{
@@ -130,16 +124,6 @@ func (o *InitOptions) Run(ctx context.Context) error {
 				BlockedImages: nil,
 			},
 		},
-	}
-
-	if customRegistry != "" {
-		registry := &v1alpha2.RegistryConfig{
-			ImageURL: customRegistry,
-			SkipTLS:  false,
-		}
-		imageSetConfig.ImageSetConfigurationSpec.StorageConfig.Registry = registry
-		// Unset the local default backend
-		imageSetConfig.ImageSetConfigurationSpec.StorageConfig.Local = nil
 	}
 
 	switch o.Output {
@@ -201,17 +185,6 @@ func getCatalog(catalogBase string) (string, error) {
 	}
 	catalog := fmt.Sprintf("%s:%s", catalogBase, catalogLatestVersionString)
 	return catalog, nil
-}
-
-func (o *InitOptions) promptCustomRegistry() (string, error) {
-	fmt.Fprintln(o.ErrOut, "Enter custom registry image URL or blank for none.")
-	fmt.Fprintln(o.ErrOut, "Example: localhost:5000/test:latest") // Obvious placeholder to prevent using a bad default
-	customRegistry, err := bufio.NewReader(o.In).ReadString('\n')
-	if err != nil {
-		return "", fmt.Errorf("error reading custom registry image URL: %w", err)
-	}
-	customRegistry = strings.TrimSpace(customRegistry)
-	return customRegistry, nil
 }
 
 // Key order doesn't matter to machines, but is nice for humans.

--- a/pkg/cli/mirror/initcmd/initcmd_test.go
+++ b/pkg/cli/mirror/initcmd/initcmd_test.go
@@ -145,6 +145,115 @@ mirror:
 }
 `,
 		},
+		{
+			name: "Default yaml output",
+			opts: &InitOptions{
+				RootOptions: &cli.RootOptions{},
+				Output:      "yaml",
+			},
+			expError: "",
+			expStdout: `kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v1alpha2
+storageConfig:
+  local:
+    path: ./
+mirror:
+  platform:
+    channels:
+    - name: stable-0.0
+      type: ocp
+  operators:
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.11
+    packages:
+    - name: serverless-operator
+      channels:
+      - name: stable
+  additionalImages:
+  - name: registry.redhat.io/ubi8/ubi:latest
+  helm: {}
+`,
+		},
+		{
+			name: "Custom json output",
+			opts: &InitOptions{
+				RootOptions: &cli.RootOptions{},
+				Registry:    "localhost:5000/test:latest",
+				Output:      "json",
+			},
+			expError: "",
+			expStdout: `{
+  "kind": "ImageSetConfiguration",
+  "apiVersion": "mirror.openshift.io/v1alpha2",
+  "mirror": {
+    "platform": {
+      "channels": [
+        {
+          "name": "stable-0.0",
+          "type": "ocp"
+        }
+      ]
+    },
+    "operators": [
+      {
+        "packages": [
+          {
+            "name": "serverless-operator",
+            "channels": [
+              {
+                "name": "stable"
+              }
+            ]
+          }
+        ],
+        "catalog": "registry.redhat.io/redhat/redhat-operator-index:v4.11"
+      }
+    ],
+    "additionalImages": [
+      {
+        "name": "registry.redhat.io/ubi8/ubi:latest"
+      }
+    ],
+    "helm": {}
+  },
+  "storageConfig": {
+    "registry": {
+      "imageURL": "localhost:5000/test:latest",
+      "skipTLS": false
+    }
+  }
+}
+`,
+		},
+		{
+			name: "Custom yaml output",
+			opts: &InitOptions{
+				RootOptions: &cli.RootOptions{},
+				Registry:    "localhost:5000/test:latest",
+				Output:      "yaml",
+			},
+			expError: "",
+			expStdout: `kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v1alpha2
+storageConfig:
+  registry:
+    imageURL: localhost:5000/test:latest
+    skipTLS: false
+mirror:
+  platform:
+    channels:
+    - name: stable-0.0
+      type: ocp
+  operators:
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.11
+    packages:
+    - name: serverless-operator
+      channels:
+      - name: stable
+  additionalImages:
+  - name: registry.redhat.io/ubi8/ubi:latest
+  helm: {}
+`,
+		},
 	}
 
 	for _, c := range cases {

--- a/pkg/cli/mirror/initcmd/initcmd_test.go
+++ b/pkg/cli/mirror/initcmd/initcmd_test.go
@@ -67,9 +67,6 @@ func TestInitOptions_Run(t *testing.T) {
 		expStdout string
 		expStderr string
 	}
-	promptStderr := `Enter custom registry image URL or blank for none.
-Example: localhost:5000/test:latest
-`
 	cases := []spec{
 		{
 			name: "Default yaml output",
@@ -78,7 +75,6 @@ Example: localhost:5000/test:latest
 				Output:      "yaml",
 			},
 			expError: "",
-			stdIn:    "\n",
 			expStdout: `kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
 storageConfig:
@@ -99,7 +95,6 @@ mirror:
   - name: registry.redhat.io/ubi8/ubi:latest
   helm: {}
 `,
-			expStderr: promptStderr,
 		},
 		{
 			name: "Default json output",
@@ -108,7 +103,6 @@ mirror:
 				Output:      "json",
 			},
 			expError: "",
-			stdIn:    "\n",
 			expStdout: `{
   "kind": "ImageSetConfiguration",
   "apiVersion": "mirror.openshift.io/v1alpha2",
@@ -150,90 +144,6 @@ mirror:
   }
 }
 `,
-			expStderr: promptStderr,
-		},
-		{
-			name: "Custom registry yaml output",
-			opts: &InitOptions{
-				RootOptions: &cli.RootOptions{},
-				Output:      "yaml",
-			},
-			expError: "",
-			stdIn:    "localhost:5000/test:latest\n",
-			expStdout: `kind: ImageSetConfiguration
-apiVersion: mirror.openshift.io/v1alpha2
-storageConfig:
-  registry:
-    imageURL: localhost:5000/test:latest
-    skipTLS: false
-mirror:
-  platform:
-    channels:
-    - name: stable-0.0
-      type: ocp
-  operators:
-  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.11
-    packages:
-    - name: serverless-operator
-      channels:
-      - name: stable
-  additionalImages:
-  - name: registry.redhat.io/ubi8/ubi:latest
-  helm: {}
-`,
-			expStderr: promptStderr,
-		},
-		{
-			name: "Custom registry json output",
-			opts: &InitOptions{
-				RootOptions: &cli.RootOptions{},
-				Output:      "json",
-			},
-			expError: "",
-			stdIn:    "localhost:5000/test:latest\n",
-			expStdout: `{
-  "kind": "ImageSetConfiguration",
-  "apiVersion": "mirror.openshift.io/v1alpha2",
-  "mirror": {
-    "platform": {
-      "channels": [
-        {
-          "name": "stable-0.0",
-          "type": "ocp"
-        }
-      ]
-    },
-    "operators": [
-      {
-        "packages": [
-          {
-            "name": "serverless-operator",
-            "channels": [
-              {
-                "name": "stable"
-              }
-            ]
-          }
-        ],
-        "catalog": "registry.redhat.io/redhat/redhat-operator-index:v4.11"
-      }
-    ],
-    "additionalImages": [
-      {
-        "name": "registry.redhat.io/ubi8/ubi:latest"
-      }
-    ],
-    "helm": {}
-  },
-  "storageConfig": {
-    "registry": {
-      "imageURL": "localhost:5000/test:latest",
-      "skipTLS": false
-    }
-  }
-}
-`,
-			expStderr: promptStderr,
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

This PR removes the required prompting from the `oc-mirror init` command

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Updated unit tests
- [X] Manually tested

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules