### PR TITLE
Bug 2087271: fix(mirror): adds sequence checks for mirror to mirror operations

### DIFF
--- a/pkg/bundle/workspace.go
+++ b/pkg/bundle/workspace.go
@@ -16,6 +16,7 @@ func MakeWorkspaceDirs(rootDir string) error {
 		filepath.Join(config.SourceDir, config.PublishDir),
 		filepath.Join(config.SourceDir, config.V2Dir),
 		filepath.Join(config.SourceDir, config.HelmDir),
+		filepath.Join(config.SourceDir, config.ReleaseSignatureDir),
 	}
 	for _, p := range paths {
 		dir := filepath.Join(rootDir, p)

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -338,7 +338,7 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 		// registry backends.
 		mapping, err = o.Publish(cmd.Context())
 		if err != nil {
-			serr := &SequenceError{}
+			serr := &ErrInvalidSequence{}
 			if errors.As(err, &serr) {
 				return fmt.Errorf(
 					"error occurred during publishing, expecting imageset with prefix mirror_seq%d: %v",
@@ -375,6 +375,24 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 		if err != nil {
 			return err
 		}
+
+		// Imageset sequence check
+		metaImage := o.newMetadataImage(meta.Uid.String())
+		targetCfg := &v1alpha2.RegistryConfig{
+			ImageURL: metaImage,
+			SkipTLS:  destInsecure,
+		}
+
+		targetBackend, err := storage.NewRegistryBackend(targetCfg, o.Dir)
+		if err != nil {
+			return err
+		}
+		var curr v1alpha2.Metadata
+		berr := targetBackend.ReadMetadata(cmd.Context(), &curr, config.MetadataBasePath)
+		if err := o.checkSequence(meta, curr, berr); err != nil {
+			return err
+		}
+
 		// Change the destination to registry
 		// TODO(jpower432): Investigate whether oc can produce
 		// registry to registry mapping
@@ -426,7 +444,6 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 		if err := o.pruneRegistry(cmd.Context(), prevAssociations, prunedAssociations); err != nil {
 			return fmt.Errorf("error pruning from registry %q: %v", o.ToMirror, err)
 		}
-
 		meta.PastMirror.Associations, err = image.ConvertFromAssociationSet(assocs)
 		if err != nil {
 			return err
@@ -441,7 +458,6 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 		if err != nil {
 			return err
 		}
-
 		// process catalog FBC images
 		if len(cfg.Mirror.Operators) > 0 {
 			ctlgRefs, err := o.rebuildCatalogs(cmd.Context(), filepath.Join(o.Dir, config.SourceDir))
@@ -452,14 +468,6 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 		}
 		// process Cincinnati graph data image
 		if len(cfg.Mirror.Platform.Channels) > 0 {
-			// Move release signatures into results dir
-			srcSignaturePath := filepath.Join(o.Dir, config.SourceDir, config.ReleaseSignatureDir)
-			dstSignaturePath := filepath.Join(dir, config.ReleaseSignatureDir)
-			if err := os.Rename(srcSignaturePath, dstSignaturePath); err != nil {
-				return err
-			}
-			klog.V(1).Infof("Moved any release signatures to %s", dir)
-
 			if cfg.Mirror.Platform.Graph {
 				graphRef, err := o.buildGraphImage(cmd.Context(), filepath.Join(o.Dir, config.SourceDir))
 				if err != nil {
@@ -468,35 +476,21 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 				mapping.Merge(graphRef)
 			}
 		}
+
 		if err := o.generateResults(mapping, dir); err != nil {
 			return err
 		}
-		klog.V(1).Infof("Moved any release signatures to %s", dir)
 
-		// Move charts into results dir
-		srcHelmPath := filepath.Join(o.Dir, config.SourceDir, config.HelmDir)
-		dstHelmPath := filepath.Join(dir, config.HelmDir)
-		if err := os.Rename(srcHelmPath, dstHelmPath); err != nil {
+		if err := o.copyToResults(dir); err != nil {
 			return err
 		}
-		klog.V(1).Infof("Moved any downloaded Helm charts to %s", dir)
+
 		// Sync metadata from disk to source and target backends
 		if cfg.StorageConfig.IsSet() {
 			sourceBackend, err := storage.ByConfig(o.Dir, cfg.StorageConfig)
 			if err != nil {
 				return err
 			}
-			metaImage := o.newMetadataImage(meta.Uid.String())
-			targetCfg := &v1alpha2.RegistryConfig{
-				ImageURL: metaImage,
-				SkipTLS:  destInsecure,
-			}
-
-			targetBackend, err := storage.NewRegistryBackend(targetCfg, o.Dir)
-			if err != nil {
-				return err
-			}
-
 			workspace := filepath.Join(o.Dir, config.SourceDir)
 			if err = metadata.UpdateMetadata(cmd.Context(), sourceBackend, &meta, workspace, o.SourceSkipTLS, o.SourcePlainHTTP); err != nil {
 				return err
@@ -680,6 +674,28 @@ func (o *MirrorOptions) generateResults(mapping image.TypedImageMapping, dir str
 	}
 
 	return WriteICSPs(dir, allICSPs)
+}
+
+func (o *MirrorOptions) copyToResults(resultsDir string) error {
+
+	resultsDir = filepath.Clean(resultsDir)
+
+	srcSignaturePath := filepath.Join(o.Dir, config.SourceDir, config.ReleaseSignatureDir)
+	dstSignaturePath := filepath.Join(resultsDir, config.ReleaseSignatureDir)
+	if err := os.Rename(srcSignaturePath, dstSignaturePath); err != nil {
+		return err
+	}
+	klog.V(1).Infof("Moved any release signatures to %s", resultsDir)
+
+	// Move charts into results dir
+	srcHelmPath := filepath.Join(o.Dir, config.SourceDir, config.HelmDir)
+	dstHelmPath := filepath.Join(resultsDir, config.HelmDir)
+	if err := os.Rename(srcHelmPath, dstHelmPath); err != nil {
+		return err
+	}
+	klog.V(1).Infof("Moved any downloaded Helm charts to %s", resultsDir)
+
+	return nil
 }
 
 func (o *MirrorOptions) checkErr(err error, acceptableErr func(error) bool) error {

--- a/pkg/cli/mirror/publish_test.go
+++ b/pkg/cli/mirror/publish_test.go
@@ -58,7 +58,7 @@ func TestHandleMetadata(t *testing.T) {
 				DestSkipTLS: true,
 				From:        "testdata/artifacts/testbundle_seq2.tar",
 			},
-			want:    &SequenceError{1, 2},
+			want:    &ErrInvalidSequence{1, 2},
 			wantErr: true,
 		},
 		{
@@ -75,7 +75,7 @@ func TestHandleMetadata(t *testing.T) {
 				DestSkipTLS: true,
 				From:        "testdata/artifacts/testbundle_seq3.tar",
 			},
-			want:    &SequenceError{2, 3},
+			want:    &ErrInvalidSequence{2, 3},
 			wantErr: true,
 		},
 		{

--- a/pkg/cli/mirror/sequence.go
+++ b/pkg/cli/mirror/sequence.go
@@ -1,0 +1,48 @@
+package mirror
+
+import (
+	"errors"
+	"fmt"
+
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
+	"github.com/openshift/oc-mirror/pkg/metadata/storage"
+)
+
+// ErrInvalidSequence defines an error in imageset sequencing during
+// mirroring operations.
+type ErrInvalidSequence struct {
+	wantSeq int
+	gotSeq  int
+}
+
+func (s *ErrInvalidSequence) Error() string {
+	return fmt.Sprintf("invalid mirror sequence order, want %v, got %v", s.wantSeq, s.gotSeq)
+}
+
+func (o *MirrorOptions) checkSequence(incoming, current v1alpha2.Metadata, backendErr error) error {
+	switch {
+	case backendErr != nil && !errors.Is(backendErr, storage.ErrMetadataNotExist):
+		return backendErr
+	case o.SkipMetadataCheck:
+		return nil
+	case backendErr != nil:
+		klog.V(1).Infof("No existing metadata found. Setting up new workspace")
+		// Check that this is the first imageset
+		incomingRun := incoming.PastMirror
+		if incomingRun.Sequence != 1 {
+			return &ErrInvalidSequence{1, incomingRun.Sequence}
+		}
+	default:
+		// Complete metadata checks
+		// UUID mismatch will now be seen as a new workspace.
+		klog.V(3).Info("Checking metadata sequence number")
+		currRun := current.PastMirror
+		incomingRun := incoming.PastMirror
+		if incomingRun.Sequence != (currRun.Sequence + 1) {
+			return &ErrInvalidSequence{currRun.Sequence + 1, incomingRun.Sequence}
+		}
+	}
+	return nil
+}

--- a/pkg/cli/mirror/sequence_test.go
+++ b/pkg/cli/mirror/sequence_test.go
@@ -113,6 +113,54 @@ func TestCheckSequence(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Valid/FirstRun",
+			opts: &MirrorOptions{
+				RootOptions: &cli.RootOptions{
+					IOStreams: genericclioptions.IOStreams{
+						In:     os.Stdin,
+						Out:    os.Stdout,
+						ErrOut: os.Stderr,
+					},
+				},
+				SkipMetadataCheck: true,
+			},
+			incoming: v1alpha2.Metadata{
+				MetadataSpec: v1alpha2.MetadataSpec{
+					PastMirror: v1alpha2.PastMirror{
+						Sequence: 2,
+					},
+				},
+			},
+			backendErr: storage.ErrMetadataNotExist,
+		},
+		{
+			name: "Valid/DifferentialRun",
+			opts: &MirrorOptions{
+				RootOptions: &cli.RootOptions{
+					IOStreams: genericclioptions.IOStreams{
+						In:     os.Stdin,
+						Out:    os.Stdout,
+						ErrOut: os.Stderr,
+					},
+				},
+				SkipMetadataCheck: true,
+			},
+			incoming: v1alpha2.Metadata{
+				MetadataSpec: v1alpha2.MetadataSpec{
+					PastMirror: v1alpha2.PastMirror{
+						Sequence: 2,
+					},
+				},
+			},
+			current: v1alpha2.Metadata{
+				MetadataSpec: v1alpha2.MetadataSpec{
+					PastMirror: v1alpha2.PastMirror{
+						Sequence: 1,
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cli/mirror/sequence_test.go
+++ b/pkg/cli/mirror/sequence_test.go
@@ -1,0 +1,127 @@
+package mirror
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
+	"github.com/openshift/oc-mirror/pkg/cli"
+	"github.com/openshift/oc-mirror/pkg/metadata/storage"
+	"github.com/stretchr/testify/require"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func TestCheckSequence(t *testing.T) {
+	type spec struct {
+		name       string
+		opts       *MirrorOptions
+		incoming   v1alpha2.Metadata
+		current    v1alpha2.Metadata
+		backendErr error
+		expErr     error
+	}
+
+	tests := []spec{
+		{
+			name: "Invalid/FirstRun",
+			opts: &MirrorOptions{
+				RootOptions: &cli.RootOptions{
+					IOStreams: genericclioptions.IOStreams{
+						In:     os.Stdin,
+						Out:    os.Stdout,
+						ErrOut: os.Stderr,
+					},
+				},
+			},
+			incoming: v1alpha2.Metadata{
+				MetadataSpec: v1alpha2.MetadataSpec{
+					PastMirror: v1alpha2.PastMirror{
+						Sequence: 2,
+					},
+				},
+			},
+			backendErr: storage.ErrMetadataNotExist,
+			expErr:     &ErrInvalidSequence{1, 2},
+		},
+		{
+			name: "Invalid/OutOfOrder",
+			opts: &MirrorOptions{
+				RootOptions: &cli.RootOptions{
+					IOStreams: genericclioptions.IOStreams{
+						In:     os.Stdin,
+						Out:    os.Stdout,
+						ErrOut: os.Stderr,
+					},
+				},
+			},
+			incoming: v1alpha2.Metadata{
+				MetadataSpec: v1alpha2.MetadataSpec{
+					PastMirror: v1alpha2.PastMirror{
+						Sequence: 3,
+					},
+				},
+			},
+			current: v1alpha2.Metadata{
+				MetadataSpec: v1alpha2.MetadataSpec{
+					PastMirror: v1alpha2.PastMirror{
+						Sequence: 1,
+					},
+				},
+			},
+			expErr: &ErrInvalidSequence{2, 3},
+		},
+		{
+			name: "Invalid/UndefinedError",
+			opts: &MirrorOptions{
+				RootOptions: &cli.RootOptions{
+					IOStreams: genericclioptions.IOStreams{
+						In:     os.Stdin,
+						Out:    os.Stdout,
+						ErrOut: os.Stderr,
+					},
+				},
+				DestSkipTLS: true,
+			},
+			backendErr: errors.New("some error"),
+			expErr:     errors.New("some error"),
+		},
+		{
+			name: "Valid/SkipMetadataCheck",
+			opts: &MirrorOptions{
+				RootOptions: &cli.RootOptions{
+					IOStreams: genericclioptions.IOStreams{
+						In:     os.Stdin,
+						Out:    os.Stdout,
+						ErrOut: os.Stderr,
+					},
+				},
+				SkipMetadataCheck: true,
+			},
+			incoming: v1alpha2.Metadata{
+				MetadataSpec: v1alpha2.MetadataSpec{
+					PastMirror: v1alpha2.PastMirror{
+						Sequence: 2,
+					},
+				},
+			},
+			current: v1alpha2.Metadata{
+				MetadataSpec: v1alpha2.MetadataSpec{
+					PastMirror: v1alpha2.PastMirror{
+						Sequence: 2,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.checkSequence(tt.incoming, tt.current, tt.backendErr)
+			if tt.expErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tt.expErr.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description
Currently, mirror to mirror operations do not check the sequence number
when publishing since there are no layer differential considerations.
However, sequence checking still needs to be done to ensure the
target namespace is not changed on a differentials run.

Fixes #468

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Unit tests added for new helper function
- [X] Testing changing the namespace on a managed workspace with mirror to mirror

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules