### PR TITLE
Bug 2087764: fix(operators): updates operator registry to 1.22.1 inherit fix for e…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/openshift/cincinnati-operator v1.0.2-0.20220126212014-b56cf3346609
 	github.com/openshift/library-go v0.0.0-20210906100234-6754cfd64cb5
 	github.com/openshift/oc v0.0.0-alpha.0.0.20210721184532-4df50be4d929
-	github.com/operator-framework/operator-registry v1.22.0
+	github.com/operator-framework/operator-registry v1.22.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.7.1
 	github.com/spf13/cobra v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1332,8 +1332,8 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/operator-framework/api v0.12.0 h1:aHxHk50/Y1J4Ogdk2J6tYofgX+GEqyBPCMyun+JFqV4=
 github.com/operator-framework/api v0.12.0/go.mod h1:FTiYGm11fZQ3cSX+EQHc/UWoGZAwkGfyeHU+wMJ8jmA=
-github.com/operator-framework/operator-registry v1.22.0 h1:rTex7EYEflYT/xY9SjkwJU1Bufsjz0KMG5BPKcJ3804=
-github.com/operator-framework/operator-registry v1.22.0/go.mod h1:qDxBCYPeOMlOXd95Zi1q4GpiKwK9i9Mag1AkrMOoFNU=
+github.com/operator-framework/operator-registry v1.22.1 h1:myPsCo2Iyd5mRnm8Lwh1mEKeGfmuXO4fkeU9qB59dnE=
+github.com/operator-framework/operator-registry v1.22.1/go.mod h1:qDxBCYPeOMlOXd95Zi1q4GpiKwK9i9Mag1AkrMOoFNU=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=

--- a/vendor/github.com/operator-framework/operator-registry/alpha/declcfg/diff.go
+++ b/vendor/github.com/operator-framework/operator-registry/alpha/declcfg/diff.go
@@ -99,20 +99,19 @@ func (g *DiffGenerator) Run(oldModel, newModel model.Model) (model.Model, error)
 			if err := latestPruneFromOutput(); err != nil {
 				return nil, err
 			}
-		} else {
-			for _, outputPkg := range outputModel {
-				for _, ch := range outputPkg.Channels {
-					if len(ch.Bundles) == 0 {
-						delete(outputPkg.Channels, ch.Name)
-					}
-				}
-				if len(outputPkg.Channels) == 0 {
-					// Remove empty packages.
-					delete(outputModel, outputPkg.Name)
-				}
-			}
 		}
 
+		for _, outputPkg := range outputModel {
+			for _, ch := range outputPkg.Channels {
+				if len(ch.Bundles) == 0 {
+					delete(outputPkg.Channels, ch.Name)
+				}
+			}
+			if len(outputPkg.Channels) == 0 {
+				// Remove empty packages.
+				delete(outputModel, outputPkg.Name)
+			}
+		}
 	case isInclude: // Add included objects to outputModel.
 
 		// Assume heads-only is false for include additively since we already have the channel heads

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -692,7 +692,7 @@ github.com/operator-framework/api/pkg/validation
 github.com/operator-framework/api/pkg/validation/errors
 github.com/operator-framework/api/pkg/validation/interfaces
 github.com/operator-framework/api/pkg/validation/internal
-# github.com/operator-framework/operator-registry v1.22.0
+# github.com/operator-framework/operator-registry v1.22.1
 ## explicit; go 1.17
 github.com/operator-framework/operator-registry/alpha/action
 github.com/operator-framework/operator-registry/alpha/declcfg


### PR DESCRIPTION
…mpty channels

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

This PR updates the `operator-registry` library to inherit a fix for empty channels when full is true.

Fixes #471 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Manually verified against the test case in the issue

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules