### PR TITLE
Bug 2088663: fix(mirror): changes default value for max-per-registry from 2 to 6

### DIFF
--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -61,7 +61,7 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.SkipMissing, "skip-missing", o.SkipMissing, "If an input image is not found, skip them. "+
 		"404/NotFound errors encountered while pulling images explicitly specified in the config "+
 		"will not be skipped")
-	fs.IntVar(&o.MaxPerRegistry, "max-per-registry", 2, "Number of concurrent requests allowed per registry")
+	fs.IntVar(&o.MaxPerRegistry, "max-per-registry", 6, "Number of concurrent requests allowed per registry")
 }
 
 func (o *MirrorOptions) init() {


### PR DESCRIPTION
Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

Changes default `max-per-registry` from 2 to 6 to match `oc`.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

N/A

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules