### PR TITLE
Bug 2092887: Rename filter-options flag to filter-by-archs

### DIFF
--- a/pkg/cli/mirror/list/releases.go
+++ b/pkg/cli/mirror/list/releases.go
@@ -25,7 +25,7 @@ type ReleasesOptions struct {
 	Channel       string
 	Channels      bool
 	Version       string
-	FilterOptions []string
+	FilterByArchs []string
 }
 
 // used to capture major.minor version from release tags
@@ -67,7 +67,7 @@ func NewReleasesCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command 
 	fs.StringVar(&o.Channel, "channel", o.Channel, "List information for a specified channel")
 	fs.BoolVar(&o.Channels, "channels", o.Channels, "List all channel information")
 	fs.StringVar(&o.Version, "version", o.Version, "Specify an OpenShift release version")
-	fs.StringSliceVar(&o.FilterOptions, "filter-options", o.FilterOptions, "An architecture list to control the release image "+
+	fs.StringSliceVar(&o.FilterByArchs, "filter-by-archs", o.FilterByArchs, "An architecture list to control the release image "+
 		"picked when multiple variants are available")
 
 	o.BindFlags(cmd.PersistentFlags())
@@ -85,8 +85,8 @@ func (o *ReleasesOptions) Complete() error {
 
 		o.Channel = fmt.Sprintf("stable-%s", r.String())
 	}
-	if len(o.FilterOptions) == 0 {
-		o.FilterOptions = []string{v1alpha2.DefaultPlatformArchitecture}
+	if len(o.FilterByArchs) == 0 {
+		o.FilterByArchs = []string{v1alpha2.DefaultPlatformArchitecture}
 	}
 	return nil
 }
@@ -98,7 +98,7 @@ func (o *ReleasesOptions) Validate() error {
 	if o.Channel == "stable-" {
 		return errors.New("must specify --version or --channel")
 	}
-	for _, arch := range o.FilterOptions {
+	for _, arch := range o.FilterByArchs {
 		if _, ok := cincinnati.SupportedArchs[arch]; !ok {
 			return fmt.Errorf("architecture %q is not a supported release architecture", arch)
 		}
@@ -141,7 +141,7 @@ func listChannels(o *ReleasesOptions, w io.Writer, ctx context.Context, client c
 		}
 	}
 
-	for _, arch := range o.FilterOptions {
+	for _, arch := range o.FilterByArchs {
 		vers, err := cincinnati.GetVersions(ctx, client, arch, o.Channel)
 		if err != nil {
 			return err

--- a/pkg/cli/mirror/list/releases_test.go
+++ b/pkg/cli/mirror/list/releases_test.go
@@ -28,7 +28,7 @@ func TestReleasesComplete(t *testing.T) {
 			expOpts: &ReleasesOptions{
 				Channel:       "stable-4.8",
 				Version:       "4.8",
-				FilterOptions: []string{"amd64"},
+				FilterByArchs: []string{"amd64"},
 				RootOptions: &cli.RootOptions{
 					Dir: "bar",
 				},
@@ -46,7 +46,7 @@ func TestReleasesComplete(t *testing.T) {
 			expOpts: &ReleasesOptions{
 				Channel:       "stable-4.9",
 				Version:       "4.9.10",
-				FilterOptions: []string{"amd64"},
+				FilterByArchs: []string{"amd64"},
 				RootOptions: &cli.RootOptions{
 					Dir: "bar",
 				},
@@ -111,7 +111,7 @@ func TestReleasesValidate(t *testing.T) {
 		{
 			name: "Invalid/UnsupportedArch",
 			opts: &ReleasesOptions{
-				FilterOptions: []string{"fake"},
+				FilterByArchs: []string{"fake"},
 			},
 			expError: "architecture \"fake\" is not a supported release architecture",
 		},


### PR DESCRIPTION
# Description

Currently filter-options only supports filtering by architecture.
This PR changes flags name to filter-by-archs to better reflect
it's purpose and to be compatible with `oc release adm info`.

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules