### PR TITLE
Bug 2092815: fix(pruning): allows continue-on-error to be used with pruning operat…

### DIFF
--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -95,7 +95,7 @@ During the “publish diff” phase for differential updates:
 ## Imageset Configuration
 
 The imageset configuration is intended to reflect the current state of the registry mirroring. Any content types or images that are added to the 
-configuration will be added to the mirror and this is also applies to content types that are removed from the imageset configuration. Image pruning is done on a best-effort basis. `oc-mirror` will attempt image deletion and if a registry does not allow for this type of request,`oc-mirror` will log the pruning attempt and continue. If you are using the heads-only workflow option, `oc-mirror` will store starting versions from the initial run in the metadata and using this to maintain ranges. 
+configuration will be added to the mirror and this is also applies to content types that are removed from the imageset configuration. Image pruning is done on a best-effort basis. `oc-mirror` will attempt image deletion and if a registry does not allow for this type of request,`oc-mirror` will return an error. the `--continue-on-error` flag can be used if desired to ignore pruning errors if the registry does not allow DELETE operations. If you are using the heads-only workflow option, `oc-mirror` will store starting versions from the initial run in the metadata and using this to maintain ranges. 
 
 More information on  the `oc-mirror` imageset configuration can be found [here](imageset-configuration.md).
 

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -334,7 +334,7 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 
 		if errs != nil {
 			for _, e := range errs.Errors() {
-				if err := o.checkErr(e, skipErr); err != nil {
+				if err := o.checkErr(e, skipErr, nil); err != nil {
 					return err
 				}
 			}
@@ -465,7 +465,7 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 
 		if errs != nil {
 			for _, e := range errs.Errors() {
-				if err := o.checkErr(e, skipErr); err != nil {
+				if err := o.checkErr(e, skipErr, nil); err != nil {
 					return err
 				}
 			}
@@ -612,7 +612,7 @@ func (o *MirrorOptions) mirrorMappings(cfg v1alpha2.ImageSetConfiguration, image
 	if err := opts.Validate(); err != nil {
 		return err
 	}
-	return o.checkErr(opts.Run(), nil)
+	return o.checkErr(opts.Run(), nil, nil)
 }
 
 func (o *MirrorOptions) newMirrorImageOptions(insecure bool) (*mirror.MirrorImageOptions, error) {

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -721,29 +721,6 @@ func (o *MirrorOptions) copyToResults(resultsDir string) error {
 	return nil
 }
 
-func (o *MirrorOptions) checkErr(err error, acceptableErr func(error) bool) error {
-
-	if err == nil {
-		return nil
-	}
-
-	var skip, skipAllTypes bool
-	if acceptableErr != nil {
-		skip = acceptableErr(err)
-	} else {
-		skipAllTypes = true
-	}
-	// Instead of returning an error, just log it.
-	if o.ContinueOnError && (skip || skipAllTypes) {
-		klog.Error(err)
-		o.continuedOnError = true
-	} else {
-		return err
-	}
-
-	return nil
-}
-
 func writeMappingFile(mappingPath string, mapping image.TypedImageMapping) error {
 	path := filepath.Clean(mappingPath)
 	mappingFile, err := os.Create(path)

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -57,7 +57,7 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.SkipMetadataCheck, "skip-metadata-check", o.SkipMetadataCheck, "Skip metadata when publishing an imageset."+
 		"This is only recommended when the imageset was created --ignore-history")
 	fs.BoolVar(&o.ContinueOnError, "continue-on-error", o.ContinueOnError, "If an error occurs, keep going "+
-		"and attempt to mirror as much as possible")
+		"and attempt to complete operations if possible")
 	fs.BoolVar(&o.SkipMissing, "skip-missing", o.SkipMissing, "If an input image is not found, skip them. "+
 		"404/NotFound errors encountered while pulling images explicitly specified in the config "+
 		"will not be skipped")

--- a/pkg/cli/mirror/util.go
+++ b/pkg/cli/mirror/util.go
@@ -85,7 +85,7 @@ func getTLSConfig() (*tls.Config, error) {
 	return config, nil
 }
 
-func (o *MirrorOptions) checkErr(err error, acceptableErr func(error) bool) error {
+func (o *MirrorOptions) checkErr(err error, acceptableErr func(error) bool, logMessage func(error) string) error {
 
 	if err == nil {
 		return nil
@@ -97,12 +97,18 @@ func (o *MirrorOptions) checkErr(err error, acceptableErr func(error) bool) erro
 	} else {
 		skipAllTypes = true
 	}
+
+	message := err.Error()
+	if logMessage != nil {
+		message = logMessage(err)
+	}
+
 	// Instead of returning an error, just log it.
 	if o.ContinueOnError && (skip || skipAllTypes) {
-		klog.Errorf("error: %v", err)
+		klog.Errorf("error: %v", message)
 		o.continuedOnError = true
 	} else {
-		return err
+		return fmt.Errorf("%v", message)
 	}
 
 	return nil


### PR DESCRIPTION
…ions

Currently, if pruning errors are transport errors, only a warning is logged.
For users who want the pruning functionality, this can cause errors on runs
if the registry or authorization is not configured to handle deletion. Instead
of logging an error, an error is returned when pruning operations fail, but
if the error is a transport error, it can be ignored with continue-on-error.

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

This PR changes the way errors are handled during pruning operations. Transport errors are currently logged instead of returned. This change returns the errors by default but allows them to be skipped with `continue-on-error`.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Docs Updated

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit tests added to test `continue-on-error`

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules