### PR TITLE
Bug 2094866: fix(pruning): handles child manifest deletion and tagged references

### DIFF
--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -473,14 +473,16 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 
 		// Prune the images that differ between the previous Associations and the
 		// pruned Associations.
-		if err := o.pruneRegistry(cmd.Context(), prevAssociations, prunedAssociations); err != nil {
-			return fmt.Errorf("error pruning from registry %q: %v", o.ToMirror, err)
-		}
 		meta.PastMirror.Associations, err = image.ConvertFromAssociationSet(assocs)
 		if err != nil {
 			return err
 		}
 		prunedAssociations.Merge(assocs)
+
+		if err := o.pruneRegistry(cmd.Context(), prevAssociations, prunedAssociations); err != nil {
+			return fmt.Errorf("error pruning from registry %q: %v", o.ToMirror, err)
+		}
+
 		meta.PastAssociations, err = image.ConvertFromAssociationSet(prunedAssociations)
 		if err != nil {
 			return err
@@ -557,7 +559,7 @@ func (o *MirrorOptions) removePreviouslyMirrored(images image.TypedImageMapping,
 	var keep []string
 	for srcRef := range images {
 		// All keys need to specify image with digest.
-		// Tagged images will need to be redownloaded to
+		// Tagged images will need to be re-downloaded to
 		// ensure their digests have not been updated.
 		if srcRef.Ref.ID == "" {
 			continue

--- a/pkg/cli/mirror/prune.go
+++ b/pkg/cli/mirror/prune.go
@@ -135,11 +135,10 @@ func (o *MirrorOptions) pruneImages(deleter imageprune.ManifestDeleter, manifest
 		return nil
 	}
 
-	klog.Infof("Pruning %d image(s) from registry", len(manifestsByRepo))
-
 	var keys []string
-	for k := range manifestsByRepo {
-		keys = append(keys, k)
+	for repo, manifests := range manifestsByRepo {
+		klog.Infof("Pruning %d manifest(s) from repository %s", len(manifests), repo)
+		keys = append(keys, repo)
 	}
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

The PR adds logic to ensure child manifests are deleted in the case the images have multi-arch manifests. The current associations will be evaluated to determine what manifest should be in each repo to allow pruning to work properly when switching from a fully disconnected environment to a partially disconnected one and vice versa.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Unit tests added for workflow changes and old child manifests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules