### PR TITLE
Bug 2095347: removes extra results directories when mirroring disk to mirror

### DIFF
--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -364,6 +364,12 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 		// Publish from disk to registry
 		// this takes care of syncing the metadata to the
 		// registry backends.
+		dir, err := o.createResultsDir()
+		if err != nil {
+			return err
+		}
+		o.OutputDir = dir
+
 		mapping, err = o.Publish(cmd.Context())
 		if err != nil {
 			serr := &ErrInvalidSequence{}
@@ -384,11 +390,7 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 			return cleanup()
 		}
 
-		dir, err := o.createResultsDir()
-		if err != nil {
-			return err
-		}
-		if err := o.generateResults(mapping, dir); err != nil {
+		if err := o.generateResults(mapping, o.OutputDir); err != nil {
 			return err
 		}
 	case mirrorToMirror:

--- a/pkg/cli/mirror/publish.go
+++ b/pkg/cli/mirror/publish.go
@@ -93,7 +93,7 @@ func (o *MirrorOptions) Publish(ctx context.Context) (image.TypedImageMapping, e
 		return allMappings, err
 	}
 
-	klog.V(3).Infof("process all images in imageset")
+	klog.V(3).Infof("Process all images in imageset")
 	imgMappings, err := o.processMirroredImages(ctx, assocs, filesInArchive, currentMeta)
 	if err != nil {
 		return allMappings, fmt.Errorf("error occurred during image processing: %v", err)
@@ -116,7 +116,7 @@ func (o *MirrorOptions) Publish(ctx context.Context) (image.TypedImageMapping, e
 		return allMappings, err
 	}
 
-	klog.V(1).Infof("unpack release signatures")
+	klog.V(1).Infof("Unpack release signatures")
 	if err = o.unpackReleaseSignatures(o.OutputDir, filesInArchive); err != nil {
 		return allMappings, err
 	}


### PR DESCRIPTION
# Description

This PR removes the creation of an extra results directory when using disk to mirror by specifying the output directory
before the unpacking process begins.

Fixes #481 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Manually test case in issue to verify only one results directory exists

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules