### PR TITLE
Bug 2098172: Adds validation for inaccessible registry endpoints

### DIFF
--- a/pkg/cli/mirror/publish.go
+++ b/pkg/cli/mirror/publish.go
@@ -44,10 +44,10 @@ func (o *MirrorOptions) Publish(ctx context.Context) (image.TypedImageMapping, e
 	// Set target dir for resulting artifacts
 	if o.OutputDir == "" {
 		dir, err := o.createResultsDir()
-		o.OutputDir = dir
 		if err != nil {
 			return allMappings, err
 		}
+		o.OutputDir = dir
 	}
 
 	// Create workspace

--- a/pkg/config/metadata.go
+++ b/pkg/config/metadata.go
@@ -27,7 +27,7 @@ const (
 	// MetadataFile is the filename that contains
 	// the metadata.
 	MetadataFile = ".metadata.json"
-	// ReleaseSignaturesDir is the top-level
+	// ReleaseSignatureDir is the top-level
 	// directory where platform release-signature
 	// configmaps are stored.
 	ReleaseSignatureDir = "release-signatures"
@@ -44,7 +44,7 @@ const (
 	// IndexDir is the location of the
 	// file-based catalog json file.
 	IndexDir = "index"
-	// IncludeConfigPath is the file where
+	// IncludeConfigFile is the file where
 	// catalog include config data for incorporation
 	// into the metadata is located.
 	IncludeConfigFile = "include-config.gob"

--- a/pkg/metadata/storage/registry_test.go
+++ b/pkg/metadata/storage/registry_test.go
@@ -104,9 +104,20 @@ func TestRegistryBackend(t *testing.T) {
 			// Ensure when the server is close the metadata error is not thrown
 			if test.closeServer {
 				server.Close()
-				require.Error(t, backend.ReadMetadata(ctx, readMeta, config.MetadataBasePath))
-				require.NotErrorIs(t, backend.ReadMetadata(ctx, readMeta, config.MetadataBasePath), ErrMetadataNotExist)
+				err := backend.ReadMetadata(ctx, readMeta, config.MetadataBasePath)
+				require.Error(t, err)
+				require.NotErrorIs(t, err, ErrMetadataNotExist)
 			}
+
+			cfg = v1alpha2.RegistryConfig{
+				ImageURL: "fakehost:5000",
+				SkipTLS:  true,
+			}
+			backend, err = NewRegistryBackend(&cfg, filepath.Join("foo", config.SourceDir))
+			require.NoError(t, err)
+			err = backend.ReadMetadata(ctx, readMeta, config.MetadataBasePath)
+			require.Error(t, err)
+			require.NotErrorIs(t, err, ErrMetadataNotExist)
 		})
 	}
 }


### PR DESCRIPTION
# Description

This change checks the registry endpoint before continuing `oc-mirror` operations on initial runs.

Fixes #249 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Manual test with `storageConfig` on linked issue
- [X] Unit test adds


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules