### PR TITLE
Bug 2098610: fix(mirror): removes push permission check with manifest-only is used

### DIFF
--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -215,7 +215,7 @@ func (o *MirrorOptions) Validate() error {
 	// Attempt to login to registry
 	// FIXME(jpower432): CheckPushPermissions is slated for deprecation
 	// must replace with its replacement
-	if len(o.ToMirror) > 0 {
+	if len(o.ToMirror) > 0 && !o.ManifestsOnly {
 		klog.Infof("Checking push permissions for %s", o.ToMirror)
 		ref := path.Join(o.ToMirror, o.UserNamespace, "oc-mirror")
 		klog.V(2).Infof("Using image %s to check permissions", ref)

--- a/pkg/cli/mirror/mirror_test.go
+++ b/pkg/cli/mirror/mirror_test.go
@@ -275,6 +275,15 @@ func TestMirrorValidate(t *testing.T) {
 			expError: `must specify a configuration file with --config`,
 		},
 		{
+			name: "Valid/ManifestOnlyWithFakeMirror",
+			opts: &MirrorOptions{
+				ManifestsOnly: true,
+				From:          t.TempDir(),
+				ToMirror:      "test.mirror.com",
+			},
+			expError: "",
+		},
+		{
 			name: "Valid/MirrortoDisk",
 			opts: &MirrorOptions{
 				ConfigPath: "foo",


### PR DESCRIPTION
Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

This PR removes the push permission check with the `manifests-only` flag and is used with a `docker` prefix destination argument.

Fixes Bug 2098610

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Manually tested with a registry that was not accessible
- [X] Unit test case added to `MirrorValidate`

# How To Test
> This is with a ready-made imageset archive
```
oc-mirror --from mirror_seq1_000000.tar docker://fakehost.com  --manifests-only  -v 9
```
Outcome: Manifests should be written with no registry check

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules