### PR TITLE
Bug 2099899: fix(publish): modifies layer fetcher to gather repos into a map and u…

### DIFF
--- a/pkg/cli/mirror/publish.go
+++ b/pkg/cli/mirror/publish.go
@@ -394,9 +394,9 @@ func (o *MirrorOptions) fetchBlobs(ctx context.Context, meta v1alpha2.Metadata, 
 	}
 
 	var errs []error
-	reposByLayer := image.ReposForBlobs(asSet)
+	pathsByLayer := image.AssocPathsForBlobs(asSet)
 	for layerDigest, dstBlobPaths := range missingLayers {
-		imgRef, err := o.findBlobRepo(reposByLayer, layerDigest)
+		imgRef, err := o.findBlobRepo(pathsByLayer, layerDigest)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("error finding remote layer %q: %v", layerDigest, err))
 		}
@@ -507,17 +507,26 @@ func (o *MirrorOptions) publishImage(mappings []imgmirror.Mapping, fromDir strin
 	return nil
 }
 
-func (o *MirrorOptions) findBlobRepo(reposByLayer map[string]string, layerDigest string) (imagesource.TypedImageReference, error) {
+func (o *MirrorOptions) findBlobRepo(assocPathsByLayer map[string]string, layerDigest string) (imagesource.TypedImageReference, error) {
 
-	srcRef, ok := reposByLayer[layerDigest]
+	srcRef, ok := assocPathsByLayer[layerDigest]
 	if !ok {
 		return imagesource.TypedImageReference{}, fmt.Errorf("layer %q is not present in previous metadata", layerDigest)
 	}
 
-	dstRef, err := imagesource.ParseReference("file://" + srcRef)
-	dstRef.Ref.Registry = o.ToMirror
-	dstRef.Ref.Namespace = path.Join(o.UserNamespace, dstRef.Ref.Namespace)
-	dstRef.Type = imagesource.DestinationRegistry
-	return dstRef, err
+	dstRef, err := imagesource.ParseReference(srcRef)
+	if err != nil {
+		return imagesource.TypedImageReference{}, err
 
+	}
+
+	// If the imageAssoc path is the location
+	// in the target registry (i.e. mirror to mirror), do nothing.
+	// If a local reference add the registry and user namespace.
+	if dstRef.Ref.Registry == "" {
+		dstRef.Ref.Registry = o.ToMirror
+		dstRef.Ref.Namespace = path.Join(o.UserNamespace, dstRef.Ref.Namespace)
+	}
+
+	return dstRef, err
 }

--- a/pkg/cli/mirror/publish.go
+++ b/pkg/cli/mirror/publish.go
@@ -394,8 +394,9 @@ func (o *MirrorOptions) fetchBlobs(ctx context.Context, meta v1alpha2.Metadata, 
 	}
 
 	var errs []error
+	reposByLayer := image.ReposForBlobs(asSet)
 	for layerDigest, dstBlobPaths := range missingLayers {
-		imgRef, err := o.findBlobRepo(asSet, layerDigest)
+		imgRef, err := o.findBlobRepo(reposByLayer, layerDigest)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("error finding remote layer %q: %v", layerDigest, err))
 		}
@@ -506,16 +507,17 @@ func (o *MirrorOptions) publishImage(mappings []imgmirror.Mapping, fromDir strin
 	return nil
 }
 
-func (o *MirrorOptions) findBlobRepo(assocs image.AssociationSet, layerDigest string) (imagesource.TypedImageReference, error) {
+func (o *MirrorOptions) findBlobRepo(reposByLayer map[string]string, layerDigest string) (imagesource.TypedImageReference, error) {
 
-	srcRef := image.GetImageFromBlob(assocs, layerDigest)
-	if srcRef == "" {
+	srcRef, ok := reposByLayer[layerDigest]
+	if !ok {
 		return imagesource.TypedImageReference{}, fmt.Errorf("layer %q is not present in previous metadata", layerDigest)
 	}
 
-	dstRef, err := imagesource.ParseReference(srcRef)
+	dstRef, err := imagesource.ParseReference("file://" + srcRef)
 	dstRef.Ref.Registry = o.ToMirror
 	dstRef.Ref.Namespace = path.Join(o.UserNamespace, dstRef.Ref.Namespace)
+	dstRef.Type = imagesource.DestinationRegistry
 	return dstRef, err
 
 }

--- a/pkg/cli/mirror/publish_test.go
+++ b/pkg/cli/mirror/publish_test.go
@@ -189,7 +189,7 @@ func TestFindBlobRepo(t *testing.T) {
 			assocs := image.AssociationSet{"registry.com/test3/baz": image.Associations{
 				"registry.com/test3/baz": {
 					Name:            "registry.com/test3/baz",
-					Path:            "single_manifest",
+					Path:            "test3/baz",
 					TagSymlink:      "latest",
 					ID:              "",
 					Type:            v1alpha2.TypeGeneric,
@@ -199,7 +199,9 @@ func TestFindBlobRepo(t *testing.T) {
 			},
 			}
 
-			ref, err := test.options.findBlobRepo(assocs, test.digest)
+			rByL := image.ReposForBlobs(assocs)
+
+			ref, err := test.options.findBlobRepo(rByL, test.digest)
 			if len(test.err) != 0 {
 				require.Equal(t, err.Error(), test.err)
 			} else {

--- a/pkg/cli/mirror/publish_test.go
+++ b/pkg/cli/mirror/publish_test.go
@@ -146,62 +146,93 @@ func TestFindBlobRepo(t *testing.T) {
 		options  *MirrorOptions
 		expected imagesource.TypedImageReference
 		err      string
-	}{{
-		name:   "Valid/NoUserNamespace",
-		digest: "found",
-		options: &MirrorOptions{
-			ToMirror: "registry.com",
-		},
-		expected: imagesource.TypedImageReference{
-			Type: "docker",
-			Ref: reference.DockerImageReference{
-				Registry:  "registry.com",
-				Namespace: "test3",
-				Name:      "baz",
+	}{
+		{
+			name:   "Valid/NoUserNamespace",
+			digest: "found",
+			options: &MirrorOptions{
+				ToMirror: "registry.com",
+			},
+			expected: imagesource.TypedImageReference{
+				Type: "docker",
+				Ref: reference.DockerImageReference{
+					Registry:  "registry.com",
+					Namespace: "test3",
+					Name:      "baz",
+				},
 			},
 		},
-	}, {
-		name:   "Valid/UserNamespaceAdded",
-		digest: "found",
-		options: &MirrorOptions{
-			ToMirror:      "registry.com",
-			UserNamespace: "foo",
-		},
-		expected: imagesource.TypedImageReference{
-			Type: "docker",
-			Ref: reference.DockerImageReference{
-				Registry:  "registry.com",
-				Namespace: "foo/test3",
-				Name:      "baz",
+		{
+			name:   "Valid/UserNamespaceAdded",
+			digest: "found",
+			options: &MirrorOptions{
+				ToMirror:      "registry.com",
+				UserNamespace: "foo",
+			},
+			expected: imagesource.TypedImageReference{
+				Type: "docker",
+				Ref: reference.DockerImageReference{
+					Registry:  "registry.com",
+					Namespace: "foo/test3",
+					Name:      "baz",
+				},
 			},
 		},
-	}, {
-		name:   "Invalid/NoRefExisting",
-		digest: "notfound",
-		options: &MirrorOptions{
-			ToMirror: "registry.com",
+		{
+			name:   "Valid/AssocImagePath",
+			digest: "found2",
+			options: &MirrorOptions{
+				ToMirror:      "registry.com",
+				UserNamespace: "foo",
+			},
+			expected: imagesource.TypedImageReference{
+				Type: "docker",
+				Ref: reference.DockerImageReference{
+					Registry:  "registry.com",
+					Namespace: "foo",
+					Name:      "test2/baz",
+				},
+			},
 		},
-		err: "layer \"notfound\" is not present in previous metadata",
-	}}
+		{
+			name:   "Invalid/NoRefExisting",
+			digest: "notfound",
+			options: &MirrorOptions{
+				ToMirror: "registry.com",
+			},
+			err: "layer \"notfound\" is not present in previous metadata",
+		}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			assocs := image.AssociationSet{"registry.com/test3/baz": image.Associations{
-				"registry.com/test3/baz": {
-					Name:            "registry.com/test3/baz",
-					Path:            "test3/baz",
-					TagSymlink:      "latest",
-					ID:              "",
-					Type:            v1alpha2.TypeGeneric,
-					ManifestDigests: nil,
-					LayerDigests:    []string{"found"},
+			assocs := image.AssociationSet{
+				"registry.com/test3/baz": image.Associations{
+					"registry.com/test3/baz": {
+						Name:            "registry.com/test3/baz",
+						Path:            "test3/baz",
+						TagSymlink:      "latest",
+						ID:              "",
+						Type:            v1alpha2.TypeGeneric,
+						ManifestDigests: nil,
+						LayerDigests:    []string{"found"},
+					},
 				},
-			},
+				"registry.com/test2/baz": image.Associations{
+					"registry.com/test3/baz": {
+						Name:            "registry.com/test2/baz",
+						Path:            "registry.com/foo/test2/baz",
+						TagSymlink:      "latest",
+						ID:              "",
+						Type:            v1alpha2.TypeGeneric,
+						ManifestDigests: nil,
+						LayerDigests:    []string{"found2"},
+					},
+				},
 			}
 
-			rByL := image.ReposForBlobs(assocs)
+			aByL := image.AssocPathsForBlobs(assocs)
 
-			ref, err := test.options.findBlobRepo(rByL, test.digest)
+			ref, err := test.options.findBlobRepo(aByL, test.digest)
 			if len(test.err) != 0 {
 				require.Equal(t, err.Error(), test.err)
 			} else {

--- a/pkg/image/association_set.go
+++ b/pkg/image/association_set.go
@@ -192,10 +192,11 @@ func (as *AssociationSet) GetDigests() []string {
 	return digests
 }
 
-// ReposForBlobs returns a map with the first repos found
-// for each layer digest in the imageset. This can be used
-// to pull layers to reform images.
-func ReposForBlobs(as AssociationSet) map[string]string {
+// AssocPathsForBlobs returns a map with the first association path found
+// for each layer digest in the Association Set. This can be used
+// to pull layers to reform images. As defined in the Association spec,
+// the path can be a local or remote reference.
+func AssocPathsForBlobs(as AssociationSet) map[string]string {
 	reposByBlob := map[string]string{}
 	for _, assocs := range as {
 		for _, assoc := range assocs {

--- a/pkg/image/association_set.go
+++ b/pkg/image/association_set.go
@@ -192,20 +192,22 @@ func (as *AssociationSet) GetDigests() []string {
 	return digests
 }
 
-// GetImageFromBlob will search the AssociationSet for a blob and return the first
-// found image it is associated to
-func GetImageFromBlob(as AssociationSet, digest string) string {
-	for imageName, assocs := range as {
+// ReposForBlobs returns a map with the first repos found
+// for each layer digest in the imageset. This can be used
+// to pull layers to reform images.
+func ReposForBlobs(as AssociationSet) map[string]string {
+	reposByBlob := map[string]string{}
+	for _, assocs := range as {
 		for _, assoc := range assocs {
 			for _, dgst := range assoc.LayerDigests {
-				if dgst == digest {
-					return imageName
+				if _, found := reposByBlob[dgst]; found {
+					continue
 				}
-
+				reposByBlob[dgst] = assoc.Path
 			}
 		}
 	}
-	return ""
+	return reposByBlob
 }
 
 // Prune will return a pruned AssociationSet containing provided keys

--- a/pkg/image/association_set_test.go
+++ b/pkg/image/association_set_test.go
@@ -110,7 +110,7 @@ func TestAdd(t *testing.T) {
 
 func TestReposForBlobs(t *testing.T) {
 	asSet := makeTestAssocationSet()
-	ref := ReposForBlobs(asSet)
+	ref := AssocPathsForBlobs(asSet)
 	exp := map[string]string{
 		"test-layer": "test",
 	}

--- a/pkg/image/association_set_test.go
+++ b/pkg/image/association_set_test.go
@@ -108,12 +108,13 @@ func TestAdd(t *testing.T) {
 	require.Equal(t, newAssoc, assoc)
 }
 
-func TestGetImageFromBlob(t *testing.T) {
+func TestReposForBlobs(t *testing.T) {
 	asSet := makeTestAssocationSet()
-	ref := GetImageFromBlob(asSet, "test-layer")
-	require.Equal(t, setTestKeyName, ref)
-	ref = GetImageFromBlob(asSet, "fake")
-	require.Equal(t, "", ref)
+	ref := ReposForBlobs(asSet)
+	exp := map[string]string{
+		"test-layer": "test",
+	}
+	require.Equal(t, exp, ref)
 }
 
 func makeTestAssocationSet() AssociationSet {


### PR DESCRIPTION
…ses assoc.Path instead of images

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

Currently, the image repo is being calculated each time a missing layer is identified.
Since the association set used is always the same, this is pretty inefficient. This change
creates a map with blobs as the keys and repo as the value. The first found repo will
be the value. This also changes the values from the image key to the assoc.Path values to account
for images being mapped to different repos (e.g. release images).

Fixes #491 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Unit tests updated and added
- [X] Manually test performed per the issue described below

# How To Test

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
storageConfig:
  local:
    path: ./
mirror:
  platform:
    channels:
    - name: stable-4.10
      type: ocp
      minVersion: 4.10.15
      maxVersion: 4.10.15
```
```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
storageConfig:
  local:
    path: ./
mirror:
  platform:
    channels:
    - name: stable-4.10
      type: ocp
      minVersion: 4.10.15
      maxVersion: 4.10.16
```
```
# Create both archives
oc-mirror --config ~/configs/imageset.yaml file://archive
oc-mirror --from archive/mirror_seq1_000000.tar docker://localhost:5001/test

# On the main this will fail
oc-mirror --from archive/mirror_seq2_000000.tar docker://localhost:5001/test
```


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules