### PR TITLE
Bug 2029367: fix(config): Parse X.Y format minVersion and maxVersion

### DIFF
--- a/pkg/api/v1alpha2/types_config.go
+++ b/pkg/api/v1alpha2/types_config.go
@@ -107,9 +107,9 @@ func (r *ReleaseChannel) UnmarshalJSON(data []byte) error {
 			if err := json.Unmarshal(value, &minVersionString); err != nil {
 				minVersionString = string(value)
 			}
-			ver, err := semver.ParseTolerant(minVersionString)
+			ver, err := semver.Parse(minVersionString)
 			if err != nil {
-				return fmt.Errorf("unable to parse config; minVersion must be a version if present: %w", err)
+				return fmt.Errorf("unable to parse config; minVersion must be in valid semver format if present: %w", err)
 			}
 			r.MinVersion = ver.String()
 		case "maxVersion":
@@ -117,9 +117,9 @@ func (r *ReleaseChannel) UnmarshalJSON(data []byte) error {
 			if err := json.Unmarshal(value, &maxVersionString); err != nil {
 				maxVersionString = string(value)
 			}
-			ver, err := semver.ParseTolerant(maxVersionString)
+			ver, err := semver.Parse(maxVersionString)
 			if err != nil {
-				return fmt.Errorf("unable to parse config; maxVersion must be a version if present: %w", err)
+				return fmt.Errorf("unable to parse config; maxVersion must be in valid semver format if present: %w", err)
 			}
 			r.MaxVersion = ver.String()
 		case "shortestPath":

--- a/pkg/api/v1alpha2/types_config_test.go
+++ b/pkg/api/v1alpha2/types_config_test.go
@@ -42,37 +42,29 @@ full: true
 `)},
 		},
 		{
-			name: "Valid/SemverMajorMinor",
-			expected: ReleaseChannel{
-				Name:       "name",
-				MinVersion: "1.2.0",
-				MaxVersion: "4.5.0",
-			},
+			name:     "Invalid/MajorMinorVersionOnly",
+			expected: ReleaseChannel{},
 			args: args{data: []byte(`
-name: name
 minVersion: 1.2
 maxVersion: 4.5
 `)},
+			expectedErr: "error unmarshaling JSON: while decoding JSON: unable to parse config; maxVersion must be in valid semver format if present: No Major.Minor.Patch elements found",
 		},
 		{
-			name: "Valid/SemverMajor",
-			expected: ReleaseChannel{
-				Name:       "name",
-				MaxVersion: "1.0.0",
-			},
+			name:     "Invalid/MajorVersionOnly",
+			expected: ReleaseChannel{},
 			args: args{data: []byte(`
-name: name
 maxVersion: 1
 `)},
+			expectedErr: "error unmarshaling JSON: while decoding JSON: unable to parse config; maxVersion must be in valid semver format if present: No Major.Minor.Patch elements found",
 		},
 		{
 			name:     "Invalid/NonSemver",
 			expected: ReleaseChannel{},
 			args: args{data: []byte(`
-name: name
 minVersion: 1.2.3.4
 `)},
-			expectedErr: "error unmarshaling JSON: while decoding JSON: unable to parse config; minVersion must be a version if present: Invalid character(s) found in patch number \"3.4\"",
+			expectedErr: "error unmarshaling JSON: while decoding JSON: unable to parse config; minVersion must be in valid semver format if present: Invalid character(s) found in patch number \"3.4\"",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/api/v1alpha2/types_config_test.go
+++ b/pkg/api/v1alpha2/types_config_test.go
@@ -1,0 +1,88 @@
+package v1alpha2
+
+import (
+	"sigs.k8s.io/yaml"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReleaseChannel_UnmarshalJSON(t *testing.T) {
+	type args struct {
+		data []byte
+	}
+	tests := []struct {
+		name        string
+		expected    ReleaseChannel
+		args        args
+		expectedErr string
+	}{
+		{
+			name:     "Valid/EmptyFields",
+			expected: ReleaseChannel{},
+			args:     args{},
+		},
+		{
+			name: "Valid/AllFieldsPresent",
+			expected: ReleaseChannel{
+				Name:         "name",
+				Type:         TypeOKD,
+				MinVersion:   "1.2.3",
+				MaxVersion:   "4.5.6",
+				ShortestPath: true,
+				Full:         true,
+			},
+			args: args{data: []byte(`
+name: name
+type: okd
+minVersion: 1.2.3
+maxVersion: 4.5.6
+shortestPath: true
+full: true
+`)},
+		},
+		{
+			name: "Valid/SemverMajorMinor",
+			expected: ReleaseChannel{
+				Name:       "name",
+				MinVersion: "1.2.0",
+				MaxVersion: "4.5.0",
+			},
+			args: args{data: []byte(`
+name: name
+minVersion: 1.2
+maxVersion: 4.5
+`)},
+		},
+		{
+			name: "Valid/SemverMajor",
+			expected: ReleaseChannel{
+				Name:       "name",
+				MaxVersion: "1.0.0",
+			},
+			args: args{data: []byte(`
+name: name
+maxVersion: 1
+`)},
+		},
+		{
+			name:     "Invalid/NonSemver",
+			expected: ReleaseChannel{},
+			args: args{data: []byte(`
+name: name
+minVersion: 1.2.3.4
+`)},
+			expectedErr: "error unmarshaling JSON: while decoding JSON: unable to parse config; minVersion must be a version if present: Invalid character(s) found in patch number \"3.4\"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var actual = ReleaseChannel{}
+			err := yaml.Unmarshal(tt.args.data, &actual)
+			if err != nil && tt.expectedErr != "" {
+				require.EqualError(t, err, tt.expectedErr)
+			}
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
# Description

Error info is ambiguous when minVersion and maxVersion are wrong in the
ImageSetConfiguration, especially when using yaml.

The yaml unmarshaler parses unquoted X.Y values as a number, but users
intend that to be a semver version string.

The k8s yaml unmarshaler serializes to JSON and deserializes from JSON
in order to use the json marshaler's struct tags.

The json unmarshaler can't read a number into a string field, so a
custom UnmarshalJSON method is needed.

The custom json unmarshaling code would be simpler if MinVersion and
MaxVersion were extracted to a dedicated struct and inlined back into
ReleaseChannel, but there are a bunch of usages that would need to be
updated and I chose to prefer slightly-more-complicated unmarshaling
over clobbering history in a bunch of other places.

Bug 2029367
Fixes github issue #240

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This is a client-side configuration parsing bug, so I wrote unit tests. Run `make test`

**Test Configuration**:
* Toolchain: go version go1.18.3 linux/amd64

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (I don't think any change is needed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules