### PR TITLE
OCPBUGS-617: fix: remove release architecture validation at the config level

### DIFF
--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -27,12 +27,6 @@ const (
 	OkdUpdateURL = "https://origin-release.ci.openshift.org/graph"
 )
 
-// SupportedArchs are architectures accepted when calculating
-// upgrades with Cincinnati.
-// TODO(jpower432): Validate this in all inclusive and applies to
-// OKD
-var SupportedArchs = map[string]struct{}{"amd64": {}, "ppc64le": {}, "s390x": {}}
-
 // Error is returned when are unable to get updates.
 type Error struct {
 	// Reason is the reason suggested for the Cincinnati calculation error.

--- a/pkg/cli/mirror/list/releases.go
+++ b/pkg/cli/mirror/list/releases.go
@@ -98,11 +98,6 @@ func (o *ReleasesOptions) Validate() error {
 	if o.Channel == "stable-" {
 		return errors.New("must specify --version or --channel")
 	}
-	for _, arch := range o.FilterByArchs {
-		if _, ok := cincinnati.SupportedArchs[arch]; !ok {
-			return fmt.Errorf("architecture %q is not a supported release architecture", arch)
-		}
-	}
 	return nil
 }
 

--- a/pkg/cli/mirror/list/releases_test.go
+++ b/pkg/cli/mirror/list/releases_test.go
@@ -3,8 +3,9 @@ package list
 import (
 	"testing"
 
-	"github.com/openshift/oc-mirror/pkg/cli"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openshift/oc-mirror/pkg/cli"
 )
 
 func TestReleasesComplete(t *testing.T) {
@@ -107,13 +108,6 @@ func TestReleasesValidate(t *testing.T) {
 				Channels: true,
 			},
 			expError: `must specify --version`,
-		},
-		{
-			name: "Invalid/UnsupportedArch",
-			opts: &ReleasesOptions{
-				FilterByArchs: []string{"fake"},
-			},
-			expError: "architecture \"fake\" is not a supported release architecture",
 		},
 		{
 			name: "Valid/Channels",

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -6,12 +6,11 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
-	"github.com/openshift/oc-mirror/pkg/cincinnati"
 )
 
 type validationFunc func(cfg *v1alpha2.ImageSetConfiguration) error
 
-var validationChecks = []validationFunc{validateOperatorOptions, validateReleaseChannels, validateReleaseArchitectures}
+var validationChecks = []validationFunc{validateOperatorOptions, validateReleaseChannels}
 
 // Validate will check an ImagesetConfiguration for input errors.
 func Validate(cfg *v1alpha2.ImageSetConfiguration) error {
@@ -50,15 +49,6 @@ func validateReleaseChannels(cfg *v1alpha2.ImageSetConfiguration) error {
 			)
 		}
 		seen[channel.Name] = true
-	}
-	return nil
-}
-
-func validateReleaseArchitectures(cfg *v1alpha2.ImageSetConfiguration) error {
-	for _, arch := range cfg.Mirror.Platform.Architectures {
-		if _, ok := cincinnati.SupportedArchs[arch]; !ok {
-			return fmt.Errorf("release architecture %q is not a supported architecture", arch)
-		}
 	}
 	return nil
 }

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -3,8 +3,9 @@ package config
 import (
 	"testing"
 
-	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
 )
 
 func TestValidate(t *testing.T) {
@@ -129,27 +130,6 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			expError: "invalid configuration: release channel \"channel\": duplicate found in configuration",
-		},
-		{
-			name: "Invalid/UnsupportedReleaseArchitecture",
-			config: &v1alpha2.ImageSetConfiguration{
-				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
-					Mirror: v1alpha2.Mirror{
-						Platform: v1alpha2.Platform{
-							Architectures: []string{"fake"},
-							Channels: []v1alpha2.ReleaseChannel{
-								{
-									Name: "channel1",
-								},
-								{
-									Name: "channel2",
-								},
-							},
-						},
-					},
-				},
-			},
-			expError: "invalid configuration: release architecture \"fake\" is not a supported architecture",
 		},
 	}
 


### PR DESCRIPTION
# Description

This change removes the release architecture validation to allow error
in architecture to be handled by the respective Cincinnati API calls.

Fixes #500

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with this imageset config
```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
storageConfig:
  local:
    path: ./
mirror:
  platform:
    architectures:
    - arm64
    channels:
    - name: stable-4.10
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules