### PR TITLE
WRKLDS-456 - Wrapper function for ParseReference

### DIFF
--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -103,7 +103,7 @@ func (o *OperatorOptions) run(ctx context.Context, cfg v1alpha2.ImageSetConfigur
 	mmapping := image.TypedImageMapping{}
 	for _, ctlg := range cfg.Mirror.Operators {
 
-		ctlgRef, err := imagesource.ParseReference(ctlg.Catalog)
+		ctlgRef, err := image.ParseReference(ctlg.Catalog)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing catalog: %v", err)
 		}

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -1,10 +1,18 @@
 package image
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"strings"
+	libgoref "github.com/openshift/library-go/pkg/image/reference"
+	"github.com/openshift/oc/pkg/cli/image/imagesource"
+)
+
+var (
+	DestinationOCI imagesource.DestinationType = "oci"
 )
 
 // GetVersionsFromImage gets the set of versions after stripping a dash-suffix,
@@ -30,4 +38,24 @@ func GetTagsFromImage(image string) ([]string, error) {
 	}
 	tags, err := remote.List(repo, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	return tags, err
+}
+
+/* ParseReference is a wrapper function of imagesource.ParseReference
+   It provides support for oci: prefixes
+*/
+func ParseReference(ref string) (imagesource.TypedImageReference, error) {
+	if !strings.HasPrefix(ref, "oci:") {
+		return imagesource.ParseReference(ref)
+	}
+
+	dstType := DestinationOCI
+	ref = strings.TrimPrefix(ref, "oci:")
+	ref = strings.TrimPrefix(ref, "//") //it could be that there is none
+	ref = strings.TrimPrefix(ref, "/")  // case of full path
+
+	dst, err := libgoref.Parse(ref)
+	if err != nil {
+		return imagesource.TypedImageReference{Ref: dst, Type: dstType}, fmt.Errorf("%q is not a valid image reference: %v", ref, err)
+	}
+	return imagesource.TypedImageReference{Ref: dst, Type: dstType}, nil
 }

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -1,0 +1,75 @@
+package image
+
+import (
+	"testing"
+
+	"github.com/openshift/library-go/pkg/image/reference"
+	"github.com/openshift/oc/pkg/cli/image/imagesource"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseReference(t *testing.T) {
+	type spec struct {
+		desc      string
+		inRef     string
+		expImgRef imagesource.TypedImageReference
+		err       string
+	}
+
+	cases := []spec{
+		{
+			desc:  "remote catalog OK",
+			inRef: "registry.redhat.io/redhat/redhat-operator-index:v4.11",
+			expImgRef: imagesource.TypedImageReference{
+				Type: imagesource.DestinationRegistry,
+				Ref: reference.DockerImageReference{
+					Registry:  "registry.redhat.io",
+					Namespace: "redhat",
+					Tag:       "v4.11",
+					Name:      "redhat-operator-index",
+					ID:        "",
+				},
+			},
+		},
+		{
+			desc:  "local file catalog OK",
+			inRef: "file:///home/user/catalogs/redhat-operator-index:v4.11",
+			expImgRef: imagesource.TypedImageReference{
+				Type: imagesource.DestinationFile,
+				Ref: reference.DockerImageReference{
+					Registry:  "home/user",
+					Namespace: "catalogs",
+					Tag:       "v4.11",
+					Name:      "redhat-operator-index",
+					ID:        "",
+				},
+			},
+		},
+		{
+			desc:  "oci local catalog OK",
+			inRef: "oci:///home/user/catalogs/redhat-operator-index:v4.11",
+			expImgRef: imagesource.TypedImageReference{
+				Type: DestinationOCI,
+				Ref: reference.DockerImageReference{
+					Registry:  "home/user",
+					Namespace: "catalogs",
+					Tag:       "v4.11",
+					Name:      "redhat-operator-index",
+					ID:        "",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			imgRef, err := ParseReference(c.inRef)
+			if c.err != "" {
+				require.EqualError(t, err, c.err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, c.expImgRef.String(), imgRef.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description
This is the first part of the implementation described in [the design document](https://docs.google.com/document/d/1-TESqErOjxxWVPCbhQUfnT3XezG2898fEREuhGena5Q/edit#heading=h.mqgxt28qr45k)
It creates ParseReference function in the image package, that wraps around imagesource.ParseReference, adding support for `oci:` prefix
This new function is used instead of imagesource.ParseReference in pkg/cli/mirror/operator.go


Fixes # [WRKLDS-456](https://issues.redhat.com//browse/WRKLDS-456) - Partial

## Type of change


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- pkg/image/image_test.go


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [NA] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules