### PR TITLE
WIP: WRKLDS-517 - Extracting configs from the OCI FBC catalog for rendering

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -824,11 +824,8 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-containerregistry v0.5.1/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
 github.com/google/go-containerregistry v0.8.0 h1:mtR24eN6rapCN+shds82qFEIWWmg64NPMuyCNT7/Ogc=

--- a/pkg/cli/mirror/additional.go
+++ b/pkg/cli/mirror/additional.go
@@ -32,7 +32,7 @@ func (o *AdditionalOptions) Plan(ctx context.Context, imageList []v1alpha2.Image
 	}
 	for _, img := range imageList {
 		// Get source image information
-		srcRef, err := imagesource.ParseReference(img.Name)
+		srcRef, err := image.ParseReference(img.Name)
 		if err != nil {
 			return mmappings, fmt.Errorf("error parsing source image %s: %v", img.Name, err)
 		}
@@ -53,7 +53,7 @@ func (o *AdditionalOptions) Plan(ctx context.Context, imageList []v1alpha2.Image
 				klog.Warning(err)
 				continue
 			}
-			pinnedRef, err := imagesource.ParseReference(srcImage)
+			pinnedRef, err := image.ParseReference(srcImage)
 			if err != nil {
 				return mmappings, fmt.Errorf("error parsing source image %s: %v", img.Name, err)
 			}

--- a/pkg/cli/mirror/catalog_images.go
+++ b/pkg/cli/mirror/catalog_images.go
@@ -84,7 +84,7 @@ func (o *MirrorOptions) rebuildCatalogs(ctx context.Context, dstDir string) (ima
 			}
 			ctlgRef := image.TypedImage{}
 			ctlgRef.Type = imagesource.DestinationRegistry
-			sourceRef, err := imagesource.ParseReference(img)
+			sourceRef, err := image.ParseReference(img)
 			if err != nil {
 				return fmt.Errorf("error parsing index dir path %q as image %q: %v", fpath, img, err)
 			}

--- a/pkg/cli/mirror/cincinnati_graph_image.go
+++ b/pkg/cli/mirror/cincinnati_graph_image.go
@@ -70,7 +70,7 @@ func (o *MirrorOptions) buildGraphImage(ctx context.Context, dstDir string) (ima
 
 	// The UBI image has been pulled and is expected to be available
 	// as a base for the graph image
-	ubiImage, err := imagesource.ParseReference(graphBaseImage)
+	ubiImage, err := image.ParseReference(graphBaseImage)
 	if err != nil {
 		return refs, fmt.Errorf("error parsing image %q: %v", graphBaseImage, err)
 	}

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -130,7 +130,6 @@ func NewMirrorCmd() *cobra.Command {
 }
 
 func (o *MirrorOptions) Complete(cmd *cobra.Command, args []string) error {
-
 	destination := args[0]
 	splitIdx := strings.Index(destination, "://")
 	if splitIdx == -1 {
@@ -152,7 +151,7 @@ func (o *MirrorOptions) Complete(cmd *cobra.Command, args []string) error {
 		// parent dir for the workspace
 		o.Dir = filepath.Join(o.OutputDir, o.Dir)
 	case "docker":
-		mirror, err := imagesource.ParseReference(ref)
+		mirror, err := image.ParseReference(ref)
 		if err != nil {
 			return err
 		}
@@ -269,6 +268,7 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 	diskToMirror := len(o.ToMirror) > 0 && len(o.From) > 0
 	mirrorToMirror := len(o.ToMirror) > 0 && len(o.ConfigPath) > 0
 
+	fmt.Printf("mirrorToDisk %v, diskToMirror %v, mirrorToMirror %v", mirrorToDisk, diskToMirror, mirrorToMirror)
 	switch {
 	case o.ManifestsOnly:
 		meta, err := bundle.ReadMetadataFromFile(cmd.Context(), o.From)

--- a/pkg/image/association_builder.go
+++ b/pkg/image/association_builder.go
@@ -238,7 +238,7 @@ func AssociateRemoteImageLayers(ctx context.Context, imgMappings TypedImageMappi
 				errs = append(errs, &ErrInvalidImage{srcImg.String(), err})
 				continue
 			}
-			pinnedRef, err := imagesource.ParseReference(imgWithID)
+			pinnedRef, err := ParseReference(imgWithID)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("error parsing source image %s: %v", imgWithID, err))
 				continue

--- a/pkg/image/convert.go
+++ b/pkg/image/convert.go
@@ -3,7 +3,6 @@ package image
 import (
 	"fmt"
 
-	"github.com/openshift/oc/pkg/cli/image/imagesource"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 
@@ -99,7 +98,7 @@ func ConvertToTypedMapping(assocs []v1alpha2.Association) (TypedImageMapping, er
 		if _, ok := childManifest[a.Name]; ok {
 			continue
 		}
-		typedImg, err := imagesource.ParseReference(a.Name)
+		typedImg, err := ParseReference(a.Name)
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -8,6 +8,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//TODO: add preparation step that saves a catalog locally before testing
+// func TestGetManifestFromIndex(t *testing.T) {
+// 	type spec struct {
+// 		desc  string
+// 		inRef string
+// 		err   string
+// 	}
+
+// 	cases := []spec{
+// 		{
+// 			desc:  "Nominal case",
+// 			inRef: "oci:/home/skhoury/go/src/github.com/openshift/oc-mirror/rhop-ctlg-oci",
+// 			err:   "",
+// 		},
+// 	}
+// 	for _, c := range cases {
+// 		t.Run(c.desc, func(t *testing.T) {
+// 			manifest, err := GetConfigDirFromOCICatalog(context.TODO(), c.inRef)
+// 			if c.err != "" {
+// 				require.EqualError(t, err, c.err)
+// 			} else {
+// 				require.NoError(t, err)
+// 				fmt.Printf("manifest: %v\n", manifest)
+// 			}
+// 		})
+// 	}
+// }
+
 func TestParseReference(t *testing.T) {
 	type spec struct {
 		desc      string

--- a/pkg/image/mapping.go
+++ b/pkg/image/mapping.go
@@ -23,7 +23,7 @@ type TypedImage struct {
 
 // ParseTypedImage will create a TypedImage from a string and type
 func ParseTypedImage(image string, typ v1alpha2.ImageType) (TypedImage, error) {
-	ref, err := imagesource.ParseReference(image)
+	ref, err := ParseReference(image)
 	if err != nil {
 		return TypedImage{}, err
 	}

--- a/pkg/metadata/storage/registry.go
+++ b/pkg/metadata/storage/registry.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
+	"github.com/openshift/oc-mirror/pkg/image"
 	"github.com/openshift/oc/pkg/cli/image/imagesource"
 )
 
@@ -44,7 +45,7 @@ func NewRegistryBackend(cfg *v1alpha2.RegistryConfig, dir string) (Backend, erro
 	b := registryBackend{}
 	b.insecure = cfg.SkipTLS
 
-	ref, err := imagesource.ParseReference(cfg.ImageURL)
+	ref, err := image.ParseReference(cfg.ImageURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/catalog_dir.go
+++ b/pkg/operator/catalog_dir.go
@@ -1,7 +1,6 @@
 package operator
 
 import (
-	"fmt"
 	"path/filepath"
 
 	imgreference "github.com/openshift/library-go/pkg/image/reference"
@@ -14,7 +13,8 @@ func GenerateCatalogDir(ctlgRef imgreference.DockerImageReference) (string, erro
 		leafDir = ctlgRef.ID
 	}
 	if leafDir == "" {
-		return "", fmt.Errorf("catalog %q must have either a tag or digest", ctlgRef.Exact())
+		// return "", fmt.Errorf("catalog %q must have either a tag or digest", ctlgRef.Exact())
+		return filepath.Join(ctlgRef.Registry, ctlgRef.Namespace, ctlgRef.Name), nil
 	}
 	return filepath.Join(ctlgRef.Registry, ctlgRef.Namespace, ctlgRef.Name, leafDir), nil
 }

--- a/vendor/github.com/containers/image/v5/directory/explicitfilepath/path.go
+++ b/vendor/github.com/containers/image/v5/directory/explicitfilepath/path.go
@@ -1,0 +1,56 @@
+package explicitfilepath
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// ResolvePathToFullyExplicit returns the input path converted to an absolute, no-symlinks, cleaned up path.
+// To do so, all elements of the input path must exist; as a special case, the final component may be
+// a non-existent name (but not a symlink pointing to a non-existent name)
+// This is intended as a a helper for implementations of types.ImageReference.PolicyConfigurationIdentity etc.
+func ResolvePathToFullyExplicit(path string) (string, error) {
+	switch _, err := os.Lstat(path); {
+	case err == nil:
+		return resolveExistingPathToFullyExplicit(path)
+	case os.IsNotExist(err):
+		parent, file := filepath.Split(path)
+		resolvedParent, err := resolveExistingPathToFullyExplicit(parent)
+		if err != nil {
+			return "", err
+		}
+		if file == "." || file == ".." {
+			// Coverage: This can happen, but very rarely: if we have successfully resolved the parent, both "." and ".." in it should have been resolved as well.
+			// This can still happen if there is a filesystem race condition, causing the Lstat() above to fail but the later resolution to succeed.
+			// We do not care to promise anything if such filesystem race conditions can happen, but we definitely don't want to return "."/".." components
+			// in the resulting path, and especially not at the end.
+			return "", errors.Errorf("Unexpectedly missing special filename component in %s", path)
+		}
+		resolvedPath := filepath.Join(resolvedParent, file)
+		// As a sanity check, ensure that there are no "." or ".." components.
+		cleanedResolvedPath := filepath.Clean(resolvedPath)
+		if cleanedResolvedPath != resolvedPath {
+			// Coverage: This should never happen.
+			return "", errors.Errorf("Internal inconsistency: Path %s resolved to %s still cleaned up to %s", path, resolvedPath, cleanedResolvedPath)
+		}
+		return resolvedPath, nil
+	default: // err != nil, unrecognized
+		return "", err
+	}
+}
+
+// resolveExistingPathToFullyExplicit is the same as ResolvePathToFullyExplicit,
+// but without the special case for missing final component.
+func resolveExistingPathToFullyExplicit(path string) (string, error) {
+	resolved, err := filepath.Abs(path)
+	if err != nil {
+		return "", err // Coverage: This can fail only if os.Getwd() fails.
+	}
+	resolved, err = filepath.EvalSymlinks(resolved)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(resolved), nil
+}

--- a/vendor/github.com/containers/image/v5/image/docker_list.go
+++ b/vendor/github.com/containers/image/v5/image/docker_list.go
@@ -1,0 +1,34 @@
+package image
+
+import (
+	"context"
+
+	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/types"
+	"github.com/pkg/errors"
+)
+
+func manifestSchema2FromManifestList(ctx context.Context, sys *types.SystemContext, src types.ImageSource, manblob []byte) (genericManifest, error) {
+	list, err := manifest.Schema2ListFromManifest(manblob)
+	if err != nil {
+		return nil, errors.Wrapf(err, "parsing schema2 manifest list")
+	}
+	targetManifestDigest, err := list.ChooseInstance(sys)
+	if err != nil {
+		return nil, errors.Wrapf(err, "choosing image instance")
+	}
+	manblob, mt, err := src.GetManifest(ctx, &targetManifestDigest)
+	if err != nil {
+		return nil, errors.Wrapf(err, "loading manifest for target platform")
+	}
+
+	matches, err := manifest.MatchesDigest(manblob, targetManifestDigest)
+	if err != nil {
+		return nil, errors.Wrap(err, "computing manifest digest")
+	}
+	if !matches {
+		return nil, errors.Errorf("Image manifest does not match selected manifest digest %s", targetManifestDigest)
+	}
+
+	return manifestInstanceFromBlob(ctx, sys, src, manblob, mt)
+}

--- a/vendor/github.com/containers/image/v5/image/docker_schema1.go
+++ b/vendor/github.com/containers/image/v5/image/docker_schema1.go
@@ -1,0 +1,248 @@
+package image
+
+import (
+	"context"
+
+	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/types"
+	"github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+type manifestSchema1 struct {
+	m *manifest.Schema1
+}
+
+func manifestSchema1FromManifest(manifestBlob []byte) (genericManifest, error) {
+	m, err := manifest.Schema1FromManifest(manifestBlob)
+	if err != nil {
+		return nil, err
+	}
+	return &manifestSchema1{m: m}, nil
+}
+
+// manifestSchema1FromComponents builds a new manifestSchema1 from the supplied data.
+func manifestSchema1FromComponents(ref reference.Named, fsLayers []manifest.Schema1FSLayers, history []manifest.Schema1History, architecture string) (genericManifest, error) {
+	m, err := manifest.Schema1FromComponents(ref, fsLayers, history, architecture)
+	if err != nil {
+		return nil, err
+	}
+	return &manifestSchema1{m: m}, nil
+}
+
+func (m *manifestSchema1) serialize() ([]byte, error) {
+	return m.m.Serialize()
+}
+
+func (m *manifestSchema1) manifestMIMEType() string {
+	return manifest.DockerV2Schema1SignedMediaType
+}
+
+// ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.
+// Note that the config object may not exist in the underlying storage in the return value of UpdatedImage! Use ConfigBlob() below.
+func (m *manifestSchema1) ConfigInfo() types.BlobInfo {
+	return m.m.ConfigInfo()
+}
+
+// ConfigBlob returns the blob described by ConfigInfo, iff ConfigInfo().Digest != ""; nil otherwise.
+// The result is cached; it is OK to call this however often you need.
+func (m *manifestSchema1) ConfigBlob(context.Context) ([]byte, error) {
+	return nil, nil
+}
+
+// OCIConfig returns the image configuration as per OCI v1 image-spec. Information about
+// layers in the resulting configuration isn't guaranteed to be returned to due how
+// old image manifests work (docker v2s1 especially).
+func (m *manifestSchema1) OCIConfig(ctx context.Context) (*imgspecv1.Image, error) {
+	v2s2, err := m.convertToManifestSchema2(ctx, &types.ManifestUpdateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return v2s2.OCIConfig(ctx)
+}
+
+// LayerInfos returns a list of BlobInfos of layers referenced by this image, in order (the root layer first, and then successive layered layers).
+// The Digest field is guaranteed to be provided; Size may be -1.
+// WARNING: The list may contain duplicates, and they are semantically relevant.
+func (m *manifestSchema1) LayerInfos() []types.BlobInfo {
+	return manifestLayerInfosToBlobInfos(m.m.LayerInfos())
+}
+
+// EmbeddedDockerReferenceConflicts whether a Docker reference embedded in the manifest, if any, conflicts with destination ref.
+// It returns false if the manifest does not embed a Docker reference.
+// (This embedding unfortunately happens for Docker schema1, please do not add support for this in any new formats.)
+func (m *manifestSchema1) EmbeddedDockerReferenceConflicts(ref reference.Named) bool {
+	// This is a bit convoluted: We can’t just have a "get embedded docker reference" method
+	// and have the “does it conflict” logic in the generic copy code, because the manifest does not actually
+	// embed a full docker/distribution reference, but only the repo name and tag (without the host name).
+	// So we would have to provide a “return repo without host name, and tag” getter for the generic code,
+	// which would be very awkward.  Instead, we do the matching here in schema1-specific code, and all the
+	// generic copy code needs to know about is reference.Named and that a manifest may need updating
+	// for some destinations.
+	name := reference.Path(ref)
+	var tag string
+	if tagged, isTagged := ref.(reference.NamedTagged); isTagged {
+		tag = tagged.Tag()
+	} else {
+		tag = ""
+	}
+	return m.m.Name != name || m.m.Tag != tag
+}
+
+// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
+func (m *manifestSchema1) Inspect(context.Context) (*types.ImageInspectInfo, error) {
+	return m.m.Inspect(nil)
+}
+
+// UpdatedImageNeedsLayerDiffIDs returns true iff UpdatedImage(options) needs InformationOnly.LayerDiffIDs.
+// This is a horribly specific interface, but computing InformationOnly.LayerDiffIDs can be very expensive to compute
+// (most importantly it forces us to download the full layers even if they are already present at the destination).
+func (m *manifestSchema1) UpdatedImageNeedsLayerDiffIDs(options types.ManifestUpdateOptions) bool {
+	return (options.ManifestMIMEType == manifest.DockerV2Schema2MediaType || options.ManifestMIMEType == imgspecv1.MediaTypeImageManifest)
+}
+
+// UpdatedImage returns a types.Image modified according to options.
+// This does not change the state of the original Image object.
+func (m *manifestSchema1) UpdatedImage(ctx context.Context, options types.ManifestUpdateOptions) (types.Image, error) {
+	copy := manifestSchema1{m: manifest.Schema1Clone(m.m)}
+
+	// We have 2 MIME types for schema 1, which are basically equivalent (even the un-"Signed" MIME type will be rejected if there isn’t a signature; so,
+	// handle conversions between them by doing nothing.
+	if options.ManifestMIMEType != manifest.DockerV2Schema1MediaType && options.ManifestMIMEType != manifest.DockerV2Schema1SignedMediaType {
+		converted, err := convertManifestIfRequiredWithUpdate(ctx, options, map[string]manifestConvertFn{
+			imgspecv1.MediaTypeImageManifest:  copy.convertToManifestOCI1,
+			manifest.DockerV2Schema2MediaType: copy.convertToManifestSchema2Generic,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		if converted != nil {
+			return converted, nil
+		}
+	}
+
+	// No conversion required, update manifest
+	if options.LayerInfos != nil {
+		if err := copy.m.UpdateLayerInfos(options.LayerInfos); err != nil {
+			return nil, err
+		}
+	}
+	if options.EmbeddedDockerReference != nil {
+		copy.m.Name = reference.Path(options.EmbeddedDockerReference)
+		if tagged, isTagged := options.EmbeddedDockerReference.(reference.NamedTagged); isTagged {
+			copy.m.Tag = tagged.Tag()
+		} else {
+			copy.m.Tag = ""
+		}
+	}
+
+	return memoryImageFromManifest(&copy), nil
+}
+
+// convertToManifestSchema2Generic returns a genericManifest implementation converted to manifest.DockerV2Schema2MediaType.
+// It may use options.InformationOnly and also adjust *options to be appropriate for editing the returned
+// value.
+// This does not change the state of the original manifestSchema1 object.
+//
+// We need this function just because a function returning an implementation of the genericManifest
+// interface is not automatically assignable to a function type returning the genericManifest interface
+func (m *manifestSchema1) convertToManifestSchema2Generic(ctx context.Context, options *types.ManifestUpdateOptions) (genericManifest, error) {
+	return m.convertToManifestSchema2(ctx, options)
+}
+
+// convertToManifestSchema2 returns a genericManifest implementation converted to manifest.DockerV2Schema2MediaType.
+// It may use options.InformationOnly and also adjust *options to be appropriate for editing the returned
+// value.
+// This does not change the state of the original manifestSchema1 object.
+//
+// Based on github.com/docker/docker/distribution/pull_v2.go
+func (m *manifestSchema1) convertToManifestSchema2(_ context.Context, options *types.ManifestUpdateOptions) (*manifestSchema2, error) {
+	uploadedLayerInfos := options.InformationOnly.LayerInfos
+	layerDiffIDs := options.InformationOnly.LayerDiffIDs
+
+	if len(m.m.ExtractedV1Compatibility) == 0 {
+		// What would this even mean?! Anyhow, the rest of the code depends on FSLayers[0] and ExtractedV1Compatibility[0] existing.
+		return nil, errors.Errorf("Cannot convert an image with 0 history entries to %s", manifest.DockerV2Schema2MediaType)
+	}
+	if len(m.m.ExtractedV1Compatibility) != len(m.m.FSLayers) {
+		return nil, errors.Errorf("Inconsistent schema 1 manifest: %d history entries, %d fsLayers entries", len(m.m.ExtractedV1Compatibility), len(m.m.FSLayers))
+	}
+	if uploadedLayerInfos != nil && len(uploadedLayerInfos) != len(m.m.FSLayers) {
+		return nil, errors.Errorf("Internal error: uploaded %d blobs, but schema1 manifest has %d fsLayers", len(uploadedLayerInfos), len(m.m.FSLayers))
+	}
+	if layerDiffIDs != nil && len(layerDiffIDs) != len(m.m.FSLayers) {
+		return nil, errors.Errorf("Internal error: collected %d DiffID values, but schema1 manifest has %d fsLayers", len(layerDiffIDs), len(m.m.FSLayers))
+	}
+
+	var convertedLayerUpdates []types.BlobInfo // Only used if options.LayerInfos != nil
+	if options.LayerInfos != nil {
+		if len(options.LayerInfos) != len(m.m.FSLayers) {
+			return nil, errors.Errorf("Error converting image: layer edits for %d layers vs %d existing layers",
+				len(options.LayerInfos), len(m.m.FSLayers))
+		}
+		convertedLayerUpdates = []types.BlobInfo{}
+	}
+
+	// Build a list of the diffIDs for the non-empty layers.
+	diffIDs := []digest.Digest{}
+	var layers []manifest.Schema2Descriptor
+	for v1Index := len(m.m.ExtractedV1Compatibility) - 1; v1Index >= 0; v1Index-- {
+		v2Index := (len(m.m.ExtractedV1Compatibility) - 1) - v1Index
+
+		if !m.m.ExtractedV1Compatibility[v1Index].ThrowAway {
+			var size int64
+			if uploadedLayerInfos != nil {
+				size = uploadedLayerInfos[v2Index].Size
+			}
+			var d digest.Digest
+			if layerDiffIDs != nil {
+				d = layerDiffIDs[v2Index]
+			}
+			layers = append(layers, manifest.Schema2Descriptor{
+				MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+				Size:      size,
+				Digest:    m.m.FSLayers[v1Index].BlobSum,
+			})
+			if options.LayerInfos != nil {
+				convertedLayerUpdates = append(convertedLayerUpdates, options.LayerInfos[v2Index])
+			}
+			diffIDs = append(diffIDs, d)
+		}
+	}
+	configJSON, err := m.m.ToSchema2Config(diffIDs)
+	if err != nil {
+		return nil, err
+	}
+	configDescriptor := manifest.Schema2Descriptor{
+		MediaType: "application/vnd.docker.container.image.v1+json",
+		Size:      int64(len(configJSON)),
+		Digest:    digest.FromBytes(configJSON),
+	}
+
+	if options.LayerInfos != nil {
+		options.LayerInfos = convertedLayerUpdates
+	}
+	return manifestSchema2FromComponents(configDescriptor, nil, configJSON, layers), nil
+}
+
+// convertToManifestOCI1 returns a genericManifest implementation converted to imgspecv1.MediaTypeImageManifest.
+// It may use options.InformationOnly and also adjust *options to be appropriate for editing the returned
+// value.
+// This does not change the state of the original manifestSchema1 object.
+func (m *manifestSchema1) convertToManifestOCI1(ctx context.Context, options *types.ManifestUpdateOptions) (genericManifest, error) {
+	// We can't directly convert to OCI, but we can transitively convert via a Docker V2.2 Distribution manifest
+	m2, err := m.convertToManifestSchema2(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return m2.convertToManifestOCI1(ctx, options)
+}
+
+// SupportsEncryption returns if encryption is supported for the manifest type
+func (m *manifestSchema1) SupportsEncryption(context.Context) bool {
+	return false
+}

--- a/vendor/github.com/containers/image/v5/image/docker_schema2.go
+++ b/vendor/github.com/containers/image/v5/image/docker_schema2.go
@@ -1,0 +1,400 @@
+package image
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/internal/iolimits"
+	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/pkg/blobinfocache/none"
+	"github.com/containers/image/v5/types"
+	"github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// GzippedEmptyLayer is a gzip-compressed version of an empty tar file (1024 NULL bytes)
+// This comes from github.com/docker/distribution/manifest/schema1/config_builder.go; there is
+// a non-zero embedded timestamp; we could zero that, but that would just waste storage space
+// in registries, so let’s use the same values.
+var GzippedEmptyLayer = []byte{
+	31, 139, 8, 0, 0, 9, 110, 136, 0, 255, 98, 24, 5, 163, 96, 20, 140, 88,
+	0, 8, 0, 0, 255, 255, 46, 175, 181, 239, 0, 4, 0, 0,
+}
+
+// GzippedEmptyLayerDigest is a digest of GzippedEmptyLayer
+const GzippedEmptyLayerDigest = digest.Digest("sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4")
+
+type manifestSchema2 struct {
+	src        types.ImageSource // May be nil if configBlob is not nil
+	configBlob []byte            // If set, corresponds to contents of ConfigDescriptor.
+	m          *manifest.Schema2
+}
+
+func manifestSchema2FromManifest(src types.ImageSource, manifestBlob []byte) (genericManifest, error) {
+	m, err := manifest.Schema2FromManifest(manifestBlob)
+	if err != nil {
+		return nil, err
+	}
+	return &manifestSchema2{
+		src: src,
+		m:   m,
+	}, nil
+}
+
+// manifestSchema2FromComponents builds a new manifestSchema2 from the supplied data:
+func manifestSchema2FromComponents(config manifest.Schema2Descriptor, src types.ImageSource, configBlob []byte, layers []manifest.Schema2Descriptor) *manifestSchema2 {
+	return &manifestSchema2{
+		src:        src,
+		configBlob: configBlob,
+		m:          manifest.Schema2FromComponents(config, layers),
+	}
+}
+
+func (m *manifestSchema2) serialize() ([]byte, error) {
+	return m.m.Serialize()
+}
+
+func (m *manifestSchema2) manifestMIMEType() string {
+	return m.m.MediaType
+}
+
+// ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.
+// Note that the config object may not exist in the underlying storage in the return value of UpdatedImage! Use ConfigBlob() below.
+func (m *manifestSchema2) ConfigInfo() types.BlobInfo {
+	return m.m.ConfigInfo()
+}
+
+// OCIConfig returns the image configuration as per OCI v1 image-spec. Information about
+// layers in the resulting configuration isn't guaranteed to be returned to due how
+// old image manifests work (docker v2s1 especially).
+func (m *manifestSchema2) OCIConfig(ctx context.Context) (*imgspecv1.Image, error) {
+	configBlob, err := m.ConfigBlob(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// docker v2s2 and OCI v1 are mostly compatible but v2s2 contains more fields
+	// than OCI v1. This unmarshal makes sure we drop docker v2s2
+	// fields that aren't needed in OCI v1.
+	configOCI := &imgspecv1.Image{}
+	if err := json.Unmarshal(configBlob, configOCI); err != nil {
+		return nil, err
+	}
+	return configOCI, nil
+}
+
+// ConfigBlob returns the blob described by ConfigInfo, iff ConfigInfo().Digest != ""; nil otherwise.
+// The result is cached; it is OK to call this however often you need.
+func (m *manifestSchema2) ConfigBlob(ctx context.Context) ([]byte, error) {
+	if m.configBlob == nil {
+		if m.src == nil {
+			return nil, errors.Errorf("Internal error: neither src nor configBlob set in manifestSchema2")
+		}
+		stream, _, err := m.src.GetBlob(ctx, manifest.BlobInfoFromSchema2Descriptor(m.m.ConfigDescriptor), none.NoCache)
+		if err != nil {
+			return nil, err
+		}
+		defer stream.Close()
+		blob, err := iolimits.ReadAtMost(stream, iolimits.MaxConfigBodySize)
+		if err != nil {
+			return nil, err
+		}
+		computedDigest := digest.FromBytes(blob)
+		if computedDigest != m.m.ConfigDescriptor.Digest {
+			return nil, errors.Errorf("Download config.json digest %s does not match expected %s", computedDigest, m.m.ConfigDescriptor.Digest)
+		}
+		m.configBlob = blob
+	}
+	return m.configBlob, nil
+}
+
+// LayerInfos returns a list of BlobInfos of layers referenced by this image, in order (the root layer first, and then successive layered layers).
+// The Digest field is guaranteed to be provided; Size may be -1.
+// WARNING: The list may contain duplicates, and they are semantically relevant.
+func (m *manifestSchema2) LayerInfos() []types.BlobInfo {
+	return manifestLayerInfosToBlobInfos(m.m.LayerInfos())
+}
+
+// EmbeddedDockerReferenceConflicts whether a Docker reference embedded in the manifest, if any, conflicts with destination ref.
+// It returns false if the manifest does not embed a Docker reference.
+// (This embedding unfortunately happens for Docker schema1, please do not add support for this in any new formats.)
+func (m *manifestSchema2) EmbeddedDockerReferenceConflicts(ref reference.Named) bool {
+	return false
+}
+
+// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
+func (m *manifestSchema2) Inspect(ctx context.Context) (*types.ImageInspectInfo, error) {
+	getter := func(info types.BlobInfo) ([]byte, error) {
+		if info.Digest != m.ConfigInfo().Digest {
+			// Shouldn't ever happen
+			return nil, errors.New("asked for a different config blob")
+		}
+		config, err := m.ConfigBlob(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return config, nil
+	}
+	return m.m.Inspect(getter)
+}
+
+// UpdatedImageNeedsLayerDiffIDs returns true iff UpdatedImage(options) needs InformationOnly.LayerDiffIDs.
+// This is a horribly specific interface, but computing InformationOnly.LayerDiffIDs can be very expensive to compute
+// (most importantly it forces us to download the full layers even if they are already present at the destination).
+func (m *manifestSchema2) UpdatedImageNeedsLayerDiffIDs(options types.ManifestUpdateOptions) bool {
+	return false
+}
+
+// UpdatedImage returns a types.Image modified according to options.
+// This does not change the state of the original Image object.
+// The returned error will be a manifest.ManifestLayerCompressionIncompatibilityError
+// if the CompressionOperation and CompressionAlgorithm specified in one or more
+// options.LayerInfos items is anything other than gzip.
+func (m *manifestSchema2) UpdatedImage(ctx context.Context, options types.ManifestUpdateOptions) (types.Image, error) {
+	copy := manifestSchema2{ // NOTE: This is not a deep copy, it still shares slices etc.
+		src:        m.src,
+		configBlob: m.configBlob,
+		m:          manifest.Schema2Clone(m.m),
+	}
+
+	converted, err := convertManifestIfRequiredWithUpdate(ctx, options, map[string]manifestConvertFn{
+		manifest.DockerV2Schema1MediaType:       copy.convertToManifestSchema1,
+		manifest.DockerV2Schema1SignedMediaType: copy.convertToManifestSchema1,
+		imgspecv1.MediaTypeImageManifest:        copy.convertToManifestOCI1,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if converted != nil {
+		return converted, nil
+	}
+
+	// No conversion required, update manifest
+	if options.LayerInfos != nil {
+		if err := copy.m.UpdateLayerInfos(options.LayerInfos); err != nil {
+			return nil, err
+		}
+	}
+	// Ignore options.EmbeddedDockerReference: it may be set when converting from schema1 to schema2, but we really don't care.
+
+	return memoryImageFromManifest(&copy), nil
+}
+
+func oci1DescriptorFromSchema2Descriptor(d manifest.Schema2Descriptor) imgspecv1.Descriptor {
+	return imgspecv1.Descriptor{
+		MediaType: d.MediaType,
+		Size:      d.Size,
+		Digest:    d.Digest,
+		URLs:      d.URLs,
+	}
+}
+
+// convertToManifestOCI1 returns a genericManifest implementation converted to imgspecv1.MediaTypeImageManifest.
+// It may use options.InformationOnly and also adjust *options to be appropriate for editing the returned
+// value.
+// This does not change the state of the original manifestSchema2 object.
+func (m *manifestSchema2) convertToManifestOCI1(ctx context.Context, _ *types.ManifestUpdateOptions) (genericManifest, error) {
+	configOCI, err := m.OCIConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	configOCIBytes, err := json.Marshal(configOCI)
+	if err != nil {
+		return nil, err
+	}
+
+	config := imgspecv1.Descriptor{
+		MediaType: imgspecv1.MediaTypeImageConfig,
+		Size:      int64(len(configOCIBytes)),
+		Digest:    digest.FromBytes(configOCIBytes),
+	}
+
+	layers := make([]imgspecv1.Descriptor, len(m.m.LayersDescriptors))
+	for idx := range layers {
+		layers[idx] = oci1DescriptorFromSchema2Descriptor(m.m.LayersDescriptors[idx])
+		switch m.m.LayersDescriptors[idx].MediaType {
+		case manifest.DockerV2Schema2ForeignLayerMediaType:
+			layers[idx].MediaType = imgspecv1.MediaTypeImageLayerNonDistributable
+		case manifest.DockerV2Schema2ForeignLayerMediaTypeGzip:
+			layers[idx].MediaType = imgspecv1.MediaTypeImageLayerNonDistributableGzip
+		case manifest.DockerV2SchemaLayerMediaTypeUncompressed:
+			layers[idx].MediaType = imgspecv1.MediaTypeImageLayer
+		case manifest.DockerV2Schema2LayerMediaType:
+			layers[idx].MediaType = imgspecv1.MediaTypeImageLayerGzip
+		default:
+			return nil, fmt.Errorf("Unknown media type during manifest conversion: %q", m.m.LayersDescriptors[idx].MediaType)
+		}
+	}
+
+	return manifestOCI1FromComponents(config, m.src, configOCIBytes, layers), nil
+}
+
+// convertToManifestSchema1 returns a genericManifest implementation converted to manifest.DockerV2Schema1{Signed,}MediaType.
+// It may use options.InformationOnly and also adjust *options to be appropriate for editing the returned
+// value.
+// This does not change the state of the original manifestSchema2 object.
+//
+// Based on docker/distribution/manifest/schema1/config_builder.go
+func (m *manifestSchema2) convertToManifestSchema1(ctx context.Context, options *types.ManifestUpdateOptions) (genericManifest, error) {
+	dest := options.InformationOnly.Destination
+
+	var convertedLayerUpdates []types.BlobInfo // Only used if options.LayerInfos != nil
+	if options.LayerInfos != nil {
+		if len(options.LayerInfos) != len(m.m.LayersDescriptors) {
+			return nil, fmt.Errorf("Error converting image: layer edits for %d layers vs %d existing layers",
+				len(options.LayerInfos), len(m.m.LayersDescriptors))
+		}
+		convertedLayerUpdates = []types.BlobInfo{}
+	}
+
+	configBytes, err := m.ConfigBlob(ctx)
+	if err != nil {
+		return nil, err
+	}
+	imageConfig := &manifest.Schema2Image{}
+	if err := json.Unmarshal(configBytes, imageConfig); err != nil {
+		return nil, err
+	}
+
+	// Build fsLayers and History, discarding all configs. We will patch the top-level config in later.
+	fsLayers := make([]manifest.Schema1FSLayers, len(imageConfig.History))
+	history := make([]manifest.Schema1History, len(imageConfig.History))
+	nonemptyLayerIndex := 0
+	var parentV1ID string // Set in the loop
+	v1ID := ""
+	haveGzippedEmptyLayer := false
+	if len(imageConfig.History) == 0 {
+		// What would this even mean?! Anyhow, the rest of the code depends on fsLayers[0] and history[0] existing.
+		return nil, errors.Errorf("Cannot convert an image with 0 history entries to %s", manifest.DockerV2Schema1SignedMediaType)
+	}
+	for v2Index, historyEntry := range imageConfig.History {
+		parentV1ID = v1ID
+		v1Index := len(imageConfig.History) - 1 - v2Index
+
+		var blobDigest digest.Digest
+		if historyEntry.EmptyLayer {
+			emptyLayerBlobInfo := types.BlobInfo{Digest: GzippedEmptyLayerDigest, Size: int64(len(GzippedEmptyLayer))}
+
+			if !haveGzippedEmptyLayer {
+				logrus.Debugf("Uploading empty layer during conversion to schema 1")
+				// Ideally we should update the relevant BlobInfoCache about this layer, but that would require passing it down here,
+				// and anyway this blob is so small that it’s easier to just copy it than to worry about figuring out another location where to get it.
+				info, err := dest.PutBlob(ctx, bytes.NewReader(GzippedEmptyLayer), emptyLayerBlobInfo, none.NoCache, false)
+				if err != nil {
+					return nil, errors.Wrap(err, "uploading empty layer")
+				}
+				if info.Digest != emptyLayerBlobInfo.Digest {
+					return nil, errors.Errorf("Internal error: Uploaded empty layer has digest %#v instead of %s", info.Digest, emptyLayerBlobInfo.Digest)
+				}
+				haveGzippedEmptyLayer = true
+			}
+			if options.LayerInfos != nil {
+				convertedLayerUpdates = append(convertedLayerUpdates, emptyLayerBlobInfo)
+			}
+			blobDigest = emptyLayerBlobInfo.Digest
+		} else {
+			if nonemptyLayerIndex >= len(m.m.LayersDescriptors) {
+				return nil, errors.Errorf("Invalid image configuration, needs more than the %d distributed layers", len(m.m.LayersDescriptors))
+			}
+			if options.LayerInfos != nil {
+				convertedLayerUpdates = append(convertedLayerUpdates, options.LayerInfos[nonemptyLayerIndex])
+			}
+			blobDigest = m.m.LayersDescriptors[nonemptyLayerIndex].Digest
+			nonemptyLayerIndex++
+		}
+
+		// AFAICT pull ignores these ID values, at least nowadays, so we could use anything unique, including a simple counter. Use what Docker uses for cargo-cult consistency.
+		v, err := v1IDFromBlobDigestAndComponents(blobDigest, parentV1ID)
+		if err != nil {
+			return nil, err
+		}
+		v1ID = v
+
+		fakeImage := manifest.Schema1V1Compatibility{
+			ID:        v1ID,
+			Parent:    parentV1ID,
+			Comment:   historyEntry.Comment,
+			Created:   historyEntry.Created,
+			Author:    historyEntry.Author,
+			ThrowAway: historyEntry.EmptyLayer,
+		}
+		fakeImage.ContainerConfig.Cmd = []string{historyEntry.CreatedBy}
+		v1CompatibilityBytes, err := json.Marshal(&fakeImage)
+		if err != nil {
+			return nil, errors.Errorf("Internal error: Error creating v1compatibility for %#v", fakeImage)
+		}
+
+		fsLayers[v1Index] = manifest.Schema1FSLayers{BlobSum: blobDigest}
+		history[v1Index] = manifest.Schema1History{V1Compatibility: string(v1CompatibilityBytes)}
+		// Note that parentV1ID of the top layer is preserved when exiting this loop
+	}
+
+	// Now patch in real configuration for the top layer (v1Index == 0)
+	v1ID, err = v1IDFromBlobDigestAndComponents(fsLayers[0].BlobSum, parentV1ID, string(configBytes)) // See above WRT v1ID value generation and cargo-cult consistency.
+	if err != nil {
+		return nil, err
+	}
+	v1Config, err := v1ConfigFromConfigJSON(configBytes, v1ID, parentV1ID, imageConfig.History[len(imageConfig.History)-1].EmptyLayer)
+	if err != nil {
+		return nil, err
+	}
+	history[0].V1Compatibility = string(v1Config)
+
+	if options.LayerInfos != nil {
+		options.LayerInfos = convertedLayerUpdates
+	}
+	m1, err := manifestSchema1FromComponents(dest.Reference().DockerReference(), fsLayers, history, imageConfig.Architecture)
+	if err != nil {
+		return nil, err // This should never happen, we should have created all the components correctly.
+	}
+	return m1, nil
+}
+
+func v1IDFromBlobDigestAndComponents(blobDigest digest.Digest, others ...string) (string, error) {
+	if err := blobDigest.Validate(); err != nil {
+		return "", err
+	}
+	parts := append([]string{blobDigest.Hex()}, others...)
+	v1IDHash := sha256.Sum256([]byte(strings.Join(parts, " ")))
+	return hex.EncodeToString(v1IDHash[:]), nil
+}
+
+func v1ConfigFromConfigJSON(configJSON []byte, v1ID, parentV1ID string, throwaway bool) ([]byte, error) {
+	// Preserve everything we don't specifically know about.
+	// (This must be a *json.RawMessage, even though *[]byte is fairly redundant, because only *RawMessage implements json.Marshaler.)
+	rawContents := map[string]*json.RawMessage{}
+	if err := json.Unmarshal(configJSON, &rawContents); err != nil { // We have already unmarshaled it before, using a more detailed schema?!
+		return nil, err
+	}
+	delete(rawContents, "rootfs")
+	delete(rawContents, "history")
+
+	updates := map[string]interface{}{"id": v1ID}
+	if parentV1ID != "" {
+		updates["parent"] = parentV1ID
+	}
+	if throwaway {
+		updates["throwaway"] = throwaway
+	}
+	for field, value := range updates {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return nil, err
+		}
+		rawContents[field] = (*json.RawMessage)(&encoded)
+	}
+	return json.Marshal(rawContents)
+}
+
+// SupportsEncryption returns if encryption is supported for the manifest type
+func (m *manifestSchema2) SupportsEncryption(context.Context) bool {
+	return false
+}

--- a/vendor/github.com/containers/image/v5/image/manifest.go
+++ b/vendor/github.com/containers/image/v5/image/manifest.go
@@ -1,0 +1,113 @@
+package image
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/types"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+// genericManifest is an interface for parsing, modifying image manifests and related data.
+// Note that the public methods are intended to be a subset of types.Image
+// so that embedding a genericManifest into structs works.
+// will support v1 one day...
+type genericManifest interface {
+	serialize() ([]byte, error)
+	manifestMIMEType() string
+	// ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.
+	// Note that the config object may not exist in the underlying storage in the return value of UpdatedImage! Use ConfigBlob() below.
+	ConfigInfo() types.BlobInfo
+	// ConfigBlob returns the blob described by ConfigInfo, iff ConfigInfo().Digest != ""; nil otherwise.
+	// The result is cached; it is OK to call this however often you need.
+	ConfigBlob(context.Context) ([]byte, error)
+	// OCIConfig returns the image configuration as per OCI v1 image-spec. Information about
+	// layers in the resulting configuration isn't guaranteed to be returned to due how
+	// old image manifests work (docker v2s1 especially).
+	OCIConfig(context.Context) (*imgspecv1.Image, error)
+	// LayerInfos returns a list of BlobInfos of layers referenced by this image, in order (the root layer first, and then successive layered layers).
+	// The Digest field is guaranteed to be provided; Size may be -1.
+	// WARNING: The list may contain duplicates, and they are semantically relevant.
+	LayerInfos() []types.BlobInfo
+	// EmbeddedDockerReferenceConflicts whether a Docker reference embedded in the manifest, if any, conflicts with destination ref.
+	// It returns false if the manifest does not embed a Docker reference.
+	// (This embedding unfortunately happens for Docker schema1, please do not add support for this in any new formats.)
+	EmbeddedDockerReferenceConflicts(ref reference.Named) bool
+	// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
+	Inspect(context.Context) (*types.ImageInspectInfo, error)
+	// UpdatedImageNeedsLayerDiffIDs returns true iff UpdatedImage(options) needs InformationOnly.LayerDiffIDs.
+	// This is a horribly specific interface, but computing InformationOnly.LayerDiffIDs can be very expensive to compute
+	// (most importantly it forces us to download the full layers even if they are already present at the destination).
+	UpdatedImageNeedsLayerDiffIDs(options types.ManifestUpdateOptions) bool
+	// UpdatedImage returns a types.Image modified according to options.
+	// This does not change the state of the original Image object.
+	UpdatedImage(ctx context.Context, options types.ManifestUpdateOptions) (types.Image, error)
+	// SupportsEncryption returns if encryption is supported for the manifest type
+	//
+	// Deprecated: Initially used to determine if a manifest can be copied from a source manifest type since
+	// the process of updating a manifest between different manifest types was to update then convert.
+	// This resulted in some fields in the update being lost. This has been fixed by: https://github.com/containers/image/pull/836
+	SupportsEncryption(ctx context.Context) bool
+}
+
+// manifestInstanceFromBlob returns a genericManifest implementation for (manblob, mt) in src.
+// If manblob is a manifest list, it implicitly chooses an appropriate image from the list.
+func manifestInstanceFromBlob(ctx context.Context, sys *types.SystemContext, src types.ImageSource, manblob []byte, mt string) (genericManifest, error) {
+	switch manifest.NormalizedMIMEType(mt) {
+	case manifest.DockerV2Schema1MediaType, manifest.DockerV2Schema1SignedMediaType:
+		return manifestSchema1FromManifest(manblob)
+	case imgspecv1.MediaTypeImageManifest:
+		return manifestOCI1FromManifest(src, manblob)
+	case manifest.DockerV2Schema2MediaType:
+		return manifestSchema2FromManifest(src, manblob)
+	case manifest.DockerV2ListMediaType:
+		return manifestSchema2FromManifestList(ctx, sys, src, manblob)
+	case imgspecv1.MediaTypeImageIndex:
+		return manifestOCI1FromImageIndex(ctx, sys, src, manblob)
+	default: // Note that this may not be reachable, manifest.NormalizedMIMEType has a default for unknown values.
+		return nil, fmt.Errorf("Unimplemented manifest MIME type %s", mt)
+	}
+}
+
+// manifestLayerInfosToBlobInfos extracts a []types.BlobInfo from a []manifest.LayerInfo.
+func manifestLayerInfosToBlobInfos(layers []manifest.LayerInfo) []types.BlobInfo {
+	blobs := make([]types.BlobInfo, len(layers))
+	for i, layer := range layers {
+		blobs[i] = layer.BlobInfo
+	}
+	return blobs
+}
+
+// manifestConvertFn (a method of genericManifest object) returns a genericManifest implementation
+// converted to a specific manifest MIME type.
+// It may use options.InformationOnly and also adjust *options to be appropriate for editing the returned
+// value.
+// This does not change the state of the original genericManifest object.
+type manifestConvertFn func(ctx context.Context, options *types.ManifestUpdateOptions) (genericManifest, error)
+
+// convertManifestIfRequiredWithUpdate will run conversion functions of a manifest if
+// required and re-apply the options to the converted type.
+// It returns (nil, nil) if no conversion was requested.
+func convertManifestIfRequiredWithUpdate(ctx context.Context, options types.ManifestUpdateOptions, converters map[string]manifestConvertFn) (types.Image, error) {
+	if options.ManifestMIMEType == "" {
+		return nil, nil
+	}
+
+	converter, ok := converters[options.ManifestMIMEType]
+	if !ok {
+		return nil, errors.Errorf("Unsupported conversion type: %v", options.ManifestMIMEType)
+	}
+
+	optionsCopy := options
+	convertedManifest, err := converter(ctx, &optionsCopy)
+	if err != nil {
+		return nil, err
+	}
+	convertedImage := memoryImageFromManifest(convertedManifest)
+
+	optionsCopy.ManifestMIMEType = ""
+	return convertedImage.UpdatedImage(ctx, optionsCopy)
+}

--- a/vendor/github.com/containers/image/v5/image/memory.go
+++ b/vendor/github.com/containers/image/v5/image/memory.go
@@ -1,0 +1,64 @@
+package image
+
+import (
+	"context"
+
+	"github.com/containers/image/v5/types"
+	"github.com/pkg/errors"
+)
+
+// memoryImage is a mostly-implementation of types.Image assembled from data
+// created in memory, used primarily as a return value of types.Image.UpdatedImage
+// as a way to carry various structured information in a type-safe and easy-to-use way.
+// Note that this _only_ carries the immediate metadata; it is _not_ a stand-alone
+// collection of all related information, e.g. there is no way to get layer blobs
+// from a memoryImage.
+type memoryImage struct {
+	genericManifest
+	serializedManifest []byte // A private cache for Manifest()
+}
+
+func memoryImageFromManifest(m genericManifest) types.Image {
+	return &memoryImage{
+		genericManifest:    m,
+		serializedManifest: nil,
+	}
+}
+
+// Reference returns the reference used to set up this source, _as specified by the user_
+// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
+func (i *memoryImage) Reference() types.ImageReference {
+	// It would really be inappropriate to return the ImageReference of the image this was based on.
+	return nil
+}
+
+// Size returns the size of the image as stored, if known, or -1 if not.
+func (i *memoryImage) Size() (int64, error) {
+	return -1, nil
+}
+
+// Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
+func (i *memoryImage) Manifest(ctx context.Context) ([]byte, string, error) {
+	if i.serializedManifest == nil {
+		m, err := i.genericManifest.serialize()
+		if err != nil {
+			return nil, "", err
+		}
+		i.serializedManifest = m
+	}
+	return i.serializedManifest, i.genericManifest.manifestMIMEType(), nil
+}
+
+// Signatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
+func (i *memoryImage) Signatures(ctx context.Context) ([][]byte, error) {
+	// Modifying an image invalidates signatures; a caller asking the updated image for signatures
+	// is probably confused.
+	return nil, errors.New("Internal error: Image.Signatures() is not supported for images modified in memory")
+}
+
+// LayerInfosForCopy returns an updated set of layer blob information which may not match the manifest.
+// The Digest field is guaranteed to be provided; Size may be -1.
+// WARNING: The list may contain duplicates, and they are semantically relevant.
+func (i *memoryImage) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+	return nil, nil
+}

--- a/vendor/github.com/containers/image/v5/image/oci.go
+++ b/vendor/github.com/containers/image/v5/image/oci.go
@@ -1,0 +1,248 @@
+package image
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/internal/iolimits"
+	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/pkg/blobinfocache/none"
+	"github.com/containers/image/v5/types"
+	"github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+type manifestOCI1 struct {
+	src        types.ImageSource // May be nil if configBlob is not nil
+	configBlob []byte            // If set, corresponds to contents of m.Config.
+	m          *manifest.OCI1
+}
+
+func manifestOCI1FromManifest(src types.ImageSource, manifestBlob []byte) (genericManifest, error) {
+	m, err := manifest.OCI1FromManifest(manifestBlob)
+	if err != nil {
+		return nil, err
+	}
+	return &manifestOCI1{
+		src: src,
+		m:   m,
+	}, nil
+}
+
+// manifestOCI1FromComponents builds a new manifestOCI1 from the supplied data:
+func manifestOCI1FromComponents(config imgspecv1.Descriptor, src types.ImageSource, configBlob []byte, layers []imgspecv1.Descriptor) genericManifest {
+	return &manifestOCI1{
+		src:        src,
+		configBlob: configBlob,
+		m:          manifest.OCI1FromComponents(config, layers),
+	}
+}
+
+func (m *manifestOCI1) serialize() ([]byte, error) {
+	return m.m.Serialize()
+}
+
+func (m *manifestOCI1) manifestMIMEType() string {
+	return imgspecv1.MediaTypeImageManifest
+}
+
+// ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.
+// Note that the config object may not exist in the underlying storage in the return value of UpdatedImage! Use ConfigBlob() below.
+func (m *manifestOCI1) ConfigInfo() types.BlobInfo {
+	return m.m.ConfigInfo()
+}
+
+// ConfigBlob returns the blob described by ConfigInfo, iff ConfigInfo().Digest != ""; nil otherwise.
+// The result is cached; it is OK to call this however often you need.
+func (m *manifestOCI1) ConfigBlob(ctx context.Context) ([]byte, error) {
+	if m.configBlob == nil {
+		if m.src == nil {
+			return nil, errors.Errorf("Internal error: neither src nor configBlob set in manifestOCI1")
+		}
+		stream, _, err := m.src.GetBlob(ctx, manifest.BlobInfoFromOCI1Descriptor(m.m.Config), none.NoCache)
+		if err != nil {
+			return nil, err
+		}
+		defer stream.Close()
+		blob, err := iolimits.ReadAtMost(stream, iolimits.MaxConfigBodySize)
+		if err != nil {
+			return nil, err
+		}
+		computedDigest := digest.FromBytes(blob)
+		if computedDigest != m.m.Config.Digest {
+			return nil, errors.Errorf("Download config.json digest %s does not match expected %s", computedDigest, m.m.Config.Digest)
+		}
+		m.configBlob = blob
+	}
+	return m.configBlob, nil
+}
+
+// OCIConfig returns the image configuration as per OCI v1 image-spec. Information about
+// layers in the resulting configuration isn't guaranteed to be returned to due how
+// old image manifests work (docker v2s1 especially).
+func (m *manifestOCI1) OCIConfig(ctx context.Context) (*imgspecv1.Image, error) {
+	cb, err := m.ConfigBlob(ctx)
+	if err != nil {
+		return nil, err
+	}
+	configOCI := &imgspecv1.Image{}
+	if err := json.Unmarshal(cb, configOCI); err != nil {
+		return nil, err
+	}
+	return configOCI, nil
+}
+
+// LayerInfos returns a list of BlobInfos of layers referenced by this image, in order (the root layer first, and then successive layered layers).
+// The Digest field is guaranteed to be provided; Size may be -1.
+// WARNING: The list may contain duplicates, and they are semantically relevant.
+func (m *manifestOCI1) LayerInfos() []types.BlobInfo {
+	return manifestLayerInfosToBlobInfos(m.m.LayerInfos())
+}
+
+// EmbeddedDockerReferenceConflicts whether a Docker reference embedded in the manifest, if any, conflicts with destination ref.
+// It returns false if the manifest does not embed a Docker reference.
+// (This embedding unfortunately happens for Docker schema1, please do not add support for this in any new formats.)
+func (m *manifestOCI1) EmbeddedDockerReferenceConflicts(ref reference.Named) bool {
+	return false
+}
+
+// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
+func (m *manifestOCI1) Inspect(ctx context.Context) (*types.ImageInspectInfo, error) {
+	getter := func(info types.BlobInfo) ([]byte, error) {
+		if info.Digest != m.ConfigInfo().Digest {
+			// Shouldn't ever happen
+			return nil, errors.New("asked for a different config blob")
+		}
+		config, err := m.ConfigBlob(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return config, nil
+	}
+	return m.m.Inspect(getter)
+}
+
+// UpdatedImageNeedsLayerDiffIDs returns true iff UpdatedImage(options) needs InformationOnly.LayerDiffIDs.
+// This is a horribly specific interface, but computing InformationOnly.LayerDiffIDs can be very expensive to compute
+// (most importantly it forces us to download the full layers even if they are already present at the destination).
+func (m *manifestOCI1) UpdatedImageNeedsLayerDiffIDs(options types.ManifestUpdateOptions) bool {
+	return false
+}
+
+// UpdatedImage returns a types.Image modified according to options.
+// This does not change the state of the original Image object.
+// The returned error will be a manifest.ManifestLayerCompressionIncompatibilityError
+// if the combination of CompressionOperation and CompressionAlgorithm specified
+// in one or more options.LayerInfos items indicates that a layer is compressed using
+// an algorithm that is not allowed in OCI.
+func (m *manifestOCI1) UpdatedImage(ctx context.Context, options types.ManifestUpdateOptions) (types.Image, error) {
+	copy := manifestOCI1{ // NOTE: This is not a deep copy, it still shares slices etc.
+		src:        m.src,
+		configBlob: m.configBlob,
+		m:          manifest.OCI1Clone(m.m),
+	}
+
+	converted, err := convertManifestIfRequiredWithUpdate(ctx, options, map[string]manifestConvertFn{
+		manifest.DockerV2Schema2MediaType:       copy.convertToManifestSchema2Generic,
+		manifest.DockerV2Schema1MediaType:       copy.convertToManifestSchema1,
+		manifest.DockerV2Schema1SignedMediaType: copy.convertToManifestSchema1,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if converted != nil {
+		return converted, nil
+	}
+
+	// No conversion required, update manifest
+	if options.LayerInfos != nil {
+		if err := copy.m.UpdateLayerInfos(options.LayerInfos); err != nil {
+			return nil, err
+		}
+	}
+	// Ignore options.EmbeddedDockerReference: it may be set when converting from schema1, but we really don't care.
+
+	return memoryImageFromManifest(&copy), nil
+}
+
+func schema2DescriptorFromOCI1Descriptor(d imgspecv1.Descriptor) manifest.Schema2Descriptor {
+	return manifest.Schema2Descriptor{
+		MediaType: d.MediaType,
+		Size:      d.Size,
+		Digest:    d.Digest,
+		URLs:      d.URLs,
+	}
+}
+
+// convertToManifestSchema2Generic returns a genericManifest implementation converted to manifest.DockerV2Schema2MediaType.
+// It may use options.InformationOnly and also adjust *options to be appropriate for editing the returned
+// value.
+// This does not change the state of the original manifestSchema1 object.
+//
+// We need this function just because a function returning an implementation of the genericManifest
+// interface is not automatically assignable to a function type returning the genericManifest interface
+func (m *manifestOCI1) convertToManifestSchema2Generic(ctx context.Context, options *types.ManifestUpdateOptions) (genericManifest, error) {
+	return m.convertToManifestSchema2(ctx, options)
+}
+
+// convertToManifestSchema2 returns a genericManifest implementation converted to manifest.DockerV2Schema2MediaType.
+// It may use options.InformationOnly and also adjust *options to be appropriate for editing the returned
+// value.
+// This does not change the state of the original manifestOCI1 object.
+func (m *manifestOCI1) convertToManifestSchema2(_ context.Context, _ *types.ManifestUpdateOptions) (*manifestSchema2, error) {
+	// Create a copy of the descriptor.
+	config := schema2DescriptorFromOCI1Descriptor(m.m.Config)
+
+	// The only difference between OCI and DockerSchema2 is the mediatypes. The
+	// media type of the manifest is handled by manifestSchema2FromComponents.
+	config.MediaType = manifest.DockerV2Schema2ConfigMediaType
+
+	layers := make([]manifest.Schema2Descriptor, len(m.m.Layers))
+	for idx := range layers {
+		layers[idx] = schema2DescriptorFromOCI1Descriptor(m.m.Layers[idx])
+		switch layers[idx].MediaType {
+		case imgspecv1.MediaTypeImageLayerNonDistributable:
+			layers[idx].MediaType = manifest.DockerV2Schema2ForeignLayerMediaType
+		case imgspecv1.MediaTypeImageLayerNonDistributableGzip:
+			layers[idx].MediaType = manifest.DockerV2Schema2ForeignLayerMediaTypeGzip
+		case imgspecv1.MediaTypeImageLayerNonDistributableZstd:
+			return nil, fmt.Errorf("Error during manifest conversion: %q: zstd compression is not supported for docker images", layers[idx].MediaType)
+		case imgspecv1.MediaTypeImageLayer:
+			layers[idx].MediaType = manifest.DockerV2SchemaLayerMediaTypeUncompressed
+		case imgspecv1.MediaTypeImageLayerGzip:
+			layers[idx].MediaType = manifest.DockerV2Schema2LayerMediaType
+		case imgspecv1.MediaTypeImageLayerZstd:
+			return nil, fmt.Errorf("Error during manifest conversion: %q: zstd compression is not supported for docker images", layers[idx].MediaType)
+		default:
+			return nil, fmt.Errorf("Unknown media type during manifest conversion: %q", layers[idx].MediaType)
+		}
+	}
+
+	// Rather than copying the ConfigBlob now, we just pass m.src to the
+	// translated manifest, since the only difference is the mediatype of
+	// descriptors there is no change to any blob stored in m.src.
+	return manifestSchema2FromComponents(config, m.src, nil, layers), nil
+}
+
+// convertToManifestSchema1 returns a genericManifest implementation converted to manifest.DockerV2Schema1{Signed,}MediaType.
+// It may use options.InformationOnly and also adjust *options to be appropriate for editing the returned
+// value.
+// This does not change the state of the original manifestOCI1 object.
+func (m *manifestOCI1) convertToManifestSchema1(ctx context.Context, options *types.ManifestUpdateOptions) (genericManifest, error) {
+	// We can't directly convert to V1, but we can transitively convert via a V2 image
+	m2, err := m.convertToManifestSchema2(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return m2.convertToManifestSchema1(ctx, options)
+}
+
+// SupportsEncryption returns if encryption is supported for the manifest type
+func (m *manifestOCI1) SupportsEncryption(context.Context) bool {
+	return true
+}

--- a/vendor/github.com/containers/image/v5/image/oci_index.go
+++ b/vendor/github.com/containers/image/v5/image/oci_index.go
@@ -1,0 +1,34 @@
+package image
+
+import (
+	"context"
+
+	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/types"
+	"github.com/pkg/errors"
+)
+
+func manifestOCI1FromImageIndex(ctx context.Context, sys *types.SystemContext, src types.ImageSource, manblob []byte) (genericManifest, error) {
+	index, err := manifest.OCI1IndexFromManifest(manblob)
+	if err != nil {
+		return nil, errors.Wrapf(err, "parsing OCI1 index")
+	}
+	targetManifestDigest, err := index.ChooseInstance(sys)
+	if err != nil {
+		return nil, errors.Wrapf(err, "choosing image instance")
+	}
+	manblob, mt, err := src.GetManifest(ctx, &targetManifestDigest)
+	if err != nil {
+		return nil, errors.Wrapf(err, "loading manifest for target platform")
+	}
+
+	matches, err := manifest.MatchesDigest(manblob, targetManifestDigest)
+	if err != nil {
+		return nil, errors.Wrap(err, "computing manifest digest")
+	}
+	if !matches {
+		return nil, errors.Errorf("Image manifest does not match selected manifest digest %s", targetManifestDigest)
+	}
+
+	return manifestInstanceFromBlob(ctx, sys, src, manblob, mt)
+}

--- a/vendor/github.com/containers/image/v5/image/sourced.go
+++ b/vendor/github.com/containers/image/v5/image/sourced.go
@@ -1,0 +1,104 @@
+// Package image consolidates knowledge about various container image formats
+// (as opposed to image storage mechanisms, which are handled by types.ImageSource)
+// and exposes all of them using an unified interface.
+package image
+
+import (
+	"context"
+
+	"github.com/containers/image/v5/types"
+)
+
+// imageCloser implements types.ImageCloser, perhaps allowing simple users
+// to use a single object without having keep a reference to a types.ImageSource
+// only to call types.ImageSource.Close().
+type imageCloser struct {
+	types.Image
+	src types.ImageSource
+}
+
+// FromSource returns a types.ImageCloser implementation for the default instance of source.
+// If source is a manifest list, .Manifest() still returns the manifest list,
+// but other methods transparently return data from an appropriate image instance.
+//
+// The caller must call .Close() on the returned ImageCloser.
+//
+// FromSource “takes ownership” of the input ImageSource and will call src.Close()
+// when the image is closed.  (This does not prevent callers from using both the
+// Image and ImageSource objects simultaneously, but it means that they only need to
+// the Image.)
+//
+// NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
+// verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage instead of calling this function.
+func FromSource(ctx context.Context, sys *types.SystemContext, src types.ImageSource) (types.ImageCloser, error) {
+	img, err := FromUnparsedImage(ctx, sys, UnparsedInstance(src, nil))
+	if err != nil {
+		return nil, err
+	}
+	return &imageCloser{
+		Image: img,
+		src:   src,
+	}, nil
+}
+
+func (ic *imageCloser) Close() error {
+	return ic.src.Close()
+}
+
+// sourcedImage is a general set of utilities for working with container images,
+// whatever is their underlying location (i.e. dockerImageSource-independent).
+// Note the existence of skopeo/docker.Image: some instances of a `types.Image`
+// may not be a `sourcedImage` directly. However, most users of `types.Image`
+// do not care, and those who care about `skopeo/docker.Image` know they do.
+type sourcedImage struct {
+	*UnparsedImage
+	manifestBlob     []byte
+	manifestMIMEType string
+	// genericManifest contains data corresponding to manifestBlob.
+	// NOTE: The manifest may have been modified in the process; DO NOT reserialize and store genericManifest
+	// if you want to preserve the original manifest; use manifestBlob directly.
+	genericManifest
+}
+
+// FromUnparsedImage returns a types.Image implementation for unparsed.
+// If unparsed represents a manifest list, .Manifest() still returns the manifest list,
+// but other methods transparently return data from an appropriate single image.
+//
+// The Image must not be used after the underlying ImageSource is Close()d.
+func FromUnparsedImage(ctx context.Context, sys *types.SystemContext, unparsed *UnparsedImage) (types.Image, error) {
+	// Note that the input parameter above is specifically *image.UnparsedImage, not types.UnparsedImage:
+	// we want to be able to use unparsed.src.  We could make that an explicit interface, but, well,
+	// this is the only UnparsedImage implementation around, anyway.
+
+	// NOTE: It is essential for signature verification that all parsing done in this object happens on the same manifest which is returned by unparsed.Manifest().
+	manifestBlob, manifestMIMEType, err := unparsed.Manifest(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	parsedManifest, err := manifestInstanceFromBlob(ctx, sys, unparsed.src, manifestBlob, manifestMIMEType)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sourcedImage{
+		UnparsedImage:    unparsed,
+		manifestBlob:     manifestBlob,
+		manifestMIMEType: manifestMIMEType,
+		genericManifest:  parsedManifest,
+	}, nil
+}
+
+// Size returns the size of the image as stored, if it's known, or -1 if it isn't.
+func (i *sourcedImage) Size() (int64, error) {
+	return -1, nil
+}
+
+// Manifest overrides the UnparsedImage.Manifest to always use the fields which we have already fetched.
+func (i *sourcedImage) Manifest(ctx context.Context) ([]byte, string, error) {
+	return i.manifestBlob, i.manifestMIMEType, nil
+}
+
+func (i *sourcedImage) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+	return i.UnparsedImage.src.LayerInfosForCopy(ctx, i.UnparsedImage.instanceDigest)
+}

--- a/vendor/github.com/containers/image/v5/image/unparsed.go
+++ b/vendor/github.com/containers/image/v5/image/unparsed.go
@@ -1,0 +1,95 @@
+package image
+
+import (
+	"context"
+
+	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/types"
+	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+)
+
+// UnparsedImage implements types.UnparsedImage .
+// An UnparsedImage is a pair of (ImageSource, instance digest); it can represent either a manifest list or a single image instance.
+type UnparsedImage struct {
+	src            types.ImageSource
+	instanceDigest *digest.Digest
+	cachedManifest []byte // A private cache for Manifest(); nil if not yet known.
+	// A private cache for Manifest(), may be the empty string if guessing failed.
+	// Valid iff cachedManifest is not nil.
+	cachedManifestMIMEType string
+	cachedSignatures       [][]byte // A private cache for Signatures(); nil if not yet known.
+}
+
+// UnparsedInstance returns a types.UnparsedImage implementation for (source, instanceDigest).
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list).
+//
+// The UnparsedImage must not be used after the underlying ImageSource is Close()d.
+func UnparsedInstance(src types.ImageSource, instanceDigest *digest.Digest) *UnparsedImage {
+	return &UnparsedImage{
+		src:            src,
+		instanceDigest: instanceDigest,
+	}
+}
+
+// Reference returns the reference used to set up this source, _as specified by the user_
+// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
+func (i *UnparsedImage) Reference() types.ImageReference {
+	// Note that this does not depend on instanceDigest; e.g. all instances within a manifest list need to be signed with the manifest list identity.
+	return i.src.Reference()
+}
+
+// Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
+func (i *UnparsedImage) Manifest(ctx context.Context) ([]byte, string, error) {
+	if i.cachedManifest == nil {
+		m, mt, err := i.src.GetManifest(ctx, i.instanceDigest)
+		if err != nil {
+			return nil, "", err
+		}
+
+		// ImageSource.GetManifest does not do digest verification, but we do;
+		// this immediately protects also any user of types.Image.
+		if digest, haveDigest := i.expectedManifestDigest(); haveDigest {
+			matches, err := manifest.MatchesDigest(m, digest)
+			if err != nil {
+				return nil, "", errors.Wrap(err, "computing manifest digest")
+			}
+			if !matches {
+				return nil, "", errors.Errorf("Manifest does not match provided manifest digest %s", digest)
+			}
+		}
+
+		i.cachedManifest = m
+		i.cachedManifestMIMEType = mt
+	}
+	return i.cachedManifest, i.cachedManifestMIMEType, nil
+}
+
+// expectedManifestDigest returns a the expected value of the manifest digest, and an indicator whether it is known.
+// The bool return value seems redundant with digest != ""; it is used explicitly
+// to refuse (unexpected) situations when the digest exists but is "".
+func (i *UnparsedImage) expectedManifestDigest() (digest.Digest, bool) {
+	if i.instanceDigest != nil {
+		return *i.instanceDigest, true
+	}
+	ref := i.Reference().DockerReference()
+	if ref != nil {
+		if canonical, ok := ref.(reference.Canonical); ok {
+			return canonical.Digest(), true
+		}
+	}
+	return "", false
+}
+
+// Signatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
+func (i *UnparsedImage) Signatures(ctx context.Context) ([][]byte, error) {
+	if i.cachedSignatures == nil {
+		sigs, err := i.src.GetSignatures(ctx, i.instanceDigest)
+		if err != nil {
+			return nil, err
+		}
+		i.cachedSignatures = sigs
+	}
+	return i.cachedSignatures, nil
+}

--- a/vendor/github.com/containers/image/v5/internal/blobinfocache/blobinfocache.go
+++ b/vendor/github.com/containers/image/v5/internal/blobinfocache/blobinfocache.go
@@ -1,0 +1,64 @@
+package blobinfocache
+
+import (
+	"github.com/containers/image/v5/pkg/compression"
+	compressiontypes "github.com/containers/image/v5/pkg/compression/types"
+	"github.com/containers/image/v5/types"
+	digest "github.com/opencontainers/go-digest"
+)
+
+// FromBlobInfoCache returns a BlobInfoCache2 based on a BlobInfoCache, returning the original
+// object if it implements BlobInfoCache2, or a wrapper which discards compression information
+// if it only implements BlobInfoCache.
+func FromBlobInfoCache(bic types.BlobInfoCache) BlobInfoCache2 {
+	if bic2, ok := bic.(BlobInfoCache2); ok {
+		return bic2
+	}
+	return &v1OnlyBlobInfoCache{
+		BlobInfoCache: bic,
+	}
+}
+
+type v1OnlyBlobInfoCache struct {
+	types.BlobInfoCache
+}
+
+func (bic *v1OnlyBlobInfoCache) RecordDigestCompressorName(anyDigest digest.Digest, compressorName string) {
+}
+
+func (bic *v1OnlyBlobInfoCache) CandidateLocations2(transport types.ImageTransport, scope types.BICTransportScope, digest digest.Digest, canSubstitute bool) []BICReplacementCandidate2 {
+	return nil
+}
+
+// CandidateLocationsFromV2 converts a slice of BICReplacementCandidate2 to a slice of
+// types.BICReplacementCandidate, dropping compression information.
+func CandidateLocationsFromV2(v2candidates []BICReplacementCandidate2) []types.BICReplacementCandidate {
+	candidates := make([]types.BICReplacementCandidate, 0, len(v2candidates))
+	for _, c := range v2candidates {
+		candidates = append(candidates, types.BICReplacementCandidate{
+			Digest:   c.Digest,
+			Location: c.Location,
+		})
+	}
+	return candidates
+}
+
+// OperationAndAlgorithmForCompressor returns CompressionOperation and CompressionAlgorithm
+// values suitable for inclusion in a types.BlobInfo structure, based on the name of the
+// compression algorithm, or Uncompressed, or UnknownCompression.  This is typically used by
+// TryReusingBlob() implementations to set values in the BlobInfo structure that they return
+// upon success.
+func OperationAndAlgorithmForCompressor(compressorName string) (types.LayerCompression, *compressiontypes.Algorithm, error) {
+	switch compressorName {
+	case Uncompressed:
+		return types.Decompress, nil, nil
+	case UnknownCompression:
+		return types.PreserveOriginal, nil, nil
+	default:
+		algo, err := compression.AlgorithmByName(compressorName)
+		if err == nil {
+			return types.Compress, &algo, nil
+		}
+		return types.PreserveOriginal, nil, err
+	}
+}

--- a/vendor/github.com/containers/image/v5/internal/blobinfocache/types.go
+++ b/vendor/github.com/containers/image/v5/internal/blobinfocache/types.go
@@ -1,0 +1,45 @@
+package blobinfocache
+
+import (
+	"github.com/containers/image/v5/types"
+	digest "github.com/opencontainers/go-digest"
+)
+
+const (
+	// Uncompressed is the value we store in a blob info cache to indicate that we know that
+	// the blob in the corresponding location is not compressed.
+	Uncompressed = "uncompressed"
+	// UnknownCompression is the value we store in a blob info cache to indicate that we don't
+	// know if the blob in the corresponding location is compressed (and if so, how) or not.
+	UnknownCompression = "unknown"
+)
+
+// BlobInfoCache2 extends BlobInfoCache by adding the ability to track information about what kind
+// of compression was applied to the blobs it keeps information about.
+type BlobInfoCache2 interface {
+	types.BlobInfoCache
+	// RecordDigestCompressorName records a compressor for the blob with the specified digest,
+	// or Uncompressed or UnknownCompression.
+	// WARNING: Only call this with LOCALLY VERIFIED data; don’t record a compressor for a
+	// digest just because some remote author claims so (e.g. because a manifest says so);
+	// otherwise the cache could be poisoned and cause us to make incorrect edits to type
+	// information in a manifest.
+	RecordDigestCompressorName(anyDigest digest.Digest, compressorName string)
+	// CandidateLocations2 returns a prioritized, limited, number of blobs and their locations
+	// that could possibly be reused within the specified (transport scope) (if they still
+	// exist, which is not guaranteed).
+	//
+	// If !canSubstitute, the returned cadidates will match the submitted digest exactly; if
+	// canSubstitute, data from previous RecordDigestUncompressedPair calls is used to also look
+	// up variants of the blob which have the same uncompressed digest.
+	//
+	// The CompressorName fields in returned data must never be UnknownCompression.
+	CandidateLocations2(transport types.ImageTransport, scope types.BICTransportScope, digest digest.Digest, canSubstitute bool) []BICReplacementCandidate2
+}
+
+// BICReplacementCandidate2 is an item returned by BlobInfoCache2.CandidateLocations2.
+type BICReplacementCandidate2 struct {
+	Digest         digest.Digest
+	CompressorName string // either the Name() of a known pkg/compression.Algorithm, or Uncompressed or UnknownCompression
+	Location       types.BICLocationReference
+}

--- a/vendor/github.com/containers/image/v5/internal/iolimits/iolimits.go
+++ b/vendor/github.com/containers/image/v5/internal/iolimits/iolimits.go
@@ -1,0 +1,60 @@
+package iolimits
+
+import (
+	"io"
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+)
+
+// All constants below are intended to be used as limits for `ReadAtMost`. The
+// immediate use-case for limiting the size of in-memory copied data is to
+// protect against OOM DOS attacks as described inCVE-2020-1702. Instead of
+// copying data until running out of memory, we error out after hitting the
+// specified limit.
+const (
+	// megaByte denotes one megabyte and is intended to be used as a limit in
+	// `ReadAtMost`.
+	megaByte = 1 << 20
+	// MaxManifestBodySize is the maximum allowed size of a manifest. The limit
+	// of 4 MB aligns with the one of a Docker registry:
+	// https://github.com/docker/distribution/blob/a8371794149d1d95f1e846744b05c87f2f825e5a/registry/handlers/manifests.go#L30
+	MaxManifestBodySize = 4 * megaByte
+	// MaxAuthTokenBodySize is the maximum allowed size of an auth token.
+	// The limit of 1 MB is considered to be greatly sufficient.
+	MaxAuthTokenBodySize = megaByte
+	// MaxSignatureListBodySize is the maximum allowed size of a signature list.
+	// The limit of 4 MB is considered to be greatly sufficient.
+	MaxSignatureListBodySize = 4 * megaByte
+	// MaxSignatureBodySize is the maximum allowed size of a signature.
+	// The limit of 4 MB is considered to be greatly sufficient.
+	MaxSignatureBodySize = 4 * megaByte
+	// MaxErrorBodySize is the maximum allowed size of an error-response body.
+	// The limit of 1 MB is considered to be greatly sufficient.
+	MaxErrorBodySize = megaByte
+	// MaxConfigBodySize is the maximum allowed size of a config blob.
+	// The limit of 4 MB is considered to be greatly sufficient.
+	MaxConfigBodySize = 4 * megaByte
+	// MaxOpenShiftStatusBody is the maximum allowed size of an OpenShift status body.
+	// The limit of 4 MB is considered to be greatly sufficient.
+	MaxOpenShiftStatusBody = 4 * megaByte
+	// MaxTarFileManifestSize is the maximum allowed size of a (docker save)-like manifest (which may contain multiple images)
+	// The limit of 1 MB is considered to be greatly sufficient.
+	MaxTarFileManifestSize = megaByte
+)
+
+// ReadAtMost reads from reader and errors out if the specified limit (in bytes) is exceeded.
+func ReadAtMost(reader io.Reader, limit int) ([]byte, error) {
+	limitedReader := io.LimitReader(reader, int64(limit+1))
+
+	res, err := ioutil.ReadAll(limitedReader)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(res) > limit {
+		return nil, errors.Errorf("exceeded maximum allowed size of %d bytes", limit)
+	}
+
+	return res, nil
+}

--- a/vendor/github.com/containers/image/v5/internal/putblobdigest/put_blob_digest.go
+++ b/vendor/github.com/containers/image/v5/internal/putblobdigest/put_blob_digest.go
@@ -1,0 +1,57 @@
+package putblobdigest
+
+import (
+	"io"
+
+	"github.com/containers/image/v5/types"
+	"github.com/opencontainers/go-digest"
+)
+
+// Digester computes a digest of the provided stream, if not known yet.
+type Digester struct {
+	knownDigest digest.Digest   // Or ""
+	digester    digest.Digester // Or nil
+}
+
+// newDigester initiates computation of a digest.Canonical digest of stream,
+// if !validDigest; otherwise it just records knownDigest to be returned later.
+// The caller MUST use the returned stream instead of the original value.
+func newDigester(stream io.Reader, knownDigest digest.Digest, validDigest bool) (Digester, io.Reader) {
+	if validDigest {
+		return Digester{knownDigest: knownDigest}, stream
+	} else {
+		res := Digester{
+			digester: digest.Canonical.Digester(),
+		}
+		stream = io.TeeReader(stream, res.digester.Hash())
+		return res, stream
+	}
+}
+
+// DigestIfUnknown initiates computation of a digest.Canonical digest of stream,
+// if no digest is supplied in the provided blobInfo; otherwise blobInfo.Digest will
+// be used (accepting any algorithm).
+// The caller MUST use the returned stream instead of the original value.
+func DigestIfUnknown(stream io.Reader, blobInfo types.BlobInfo) (Digester, io.Reader) {
+	d := blobInfo.Digest
+	return newDigester(stream, d, d != "")
+}
+
+// DigestIfCanonicalUnknown initiates computation of a digest.Canonical digest of stream,
+// if a digest.Canonical digest is not supplied in the provided blobInfo;
+// otherwise blobInfo.Digest will be used.
+// The caller MUST use the returned stream instead of the original value.
+func DigestIfCanonicalUnknown(stream io.Reader, blobInfo types.BlobInfo) (Digester, io.Reader) {
+	d := blobInfo.Digest
+	return newDigester(stream, d, d != "" && d.Algorithm() == digest.Canonical)
+}
+
+// Digest() returns a digest value possibly computed by Digester.
+// This must be called only after all of the stream returned by a Digester constructor
+// has been successfully read.
+func (d Digester) Digest() digest.Digest {
+	if d.digester != nil {
+		return d.digester.Digest()
+	}
+	return d.knownDigest
+}

--- a/vendor/github.com/containers/image/v5/oci/internal/oci_util.go
+++ b/vendor/github.com/containers/image/v5/oci/internal/oci_util.go
@@ -1,0 +1,126 @@
+package internal
+
+import (
+	"github.com/pkg/errors"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+// annotation spex from https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
+const (
+	separator = `(?:[-._:@+]|--)`
+	alphanum  = `(?:[A-Za-z0-9]+)`
+	component = `(?:` + alphanum + `(?:` + separator + alphanum + `)*)`
+)
+
+var refRegexp = regexp.MustCompile(`^` + component + `(?:/` + component + `)*$`)
+var windowsRefRegexp = regexp.MustCompile(`^([a-zA-Z]:\\.+?):(.*)$`)
+
+// ValidateImageName returns nil if the image name is empty or matches the open-containers image name specs.
+// In any other case an error is returned.
+func ValidateImageName(image string) error {
+	if len(image) == 0 {
+		return nil
+	}
+
+	var err error
+	if !refRegexp.MatchString(image) {
+		err = errors.Errorf("Invalid image %s", image)
+	}
+	return err
+}
+
+// SplitPathAndImage tries to split the provided OCI reference into the OCI path and image.
+// Neither path nor image parts are validated at this stage.
+func SplitPathAndImage(reference string) (string, string) {
+	if runtime.GOOS == "windows" {
+		return splitPathAndImageWindows(reference)
+	}
+	return splitPathAndImageNonWindows(reference)
+}
+
+func splitPathAndImageWindows(reference string) (string, string) {
+	groups := windowsRefRegexp.FindStringSubmatch(reference)
+	// nil group means no match
+	if groups == nil {
+		return reference, ""
+	}
+
+	// we expect three elements. First one full match, second the capture group for the path and
+	// the third the capture group for the image
+	if len(groups) != 3 {
+		return reference, ""
+	}
+	return groups[1], groups[2]
+}
+
+func splitPathAndImageNonWindows(reference string) (string, string) {
+	sep := strings.SplitN(reference, ":", 2)
+	path := sep[0]
+
+	var image string
+	if len(sep) == 2 {
+		image = sep[1]
+	}
+	return path, image
+}
+
+// ValidateOCIPath takes the OCI path and validates it.
+func ValidateOCIPath(path string) error {
+	if runtime.GOOS == "windows" {
+		// On Windows we must allow for a ':' as part of the path
+		if strings.Count(path, ":") > 1 {
+			return errors.Errorf("Invalid OCI reference: path %s contains more than one colon", path)
+		}
+	} else {
+		if strings.Contains(path, ":") {
+			return errors.Errorf("Invalid OCI reference: path %s contains a colon", path)
+		}
+	}
+	return nil
+}
+
+// ValidateScope validates a policy configuration scope for an OCI transport.
+func ValidateScope(scope string) error {
+	var err error
+	if runtime.GOOS == "windows" {
+		err = validateScopeWindows(scope)
+	} else {
+		err = validateScopeNonWindows(scope)
+	}
+	if err != nil {
+		return err
+	}
+
+	cleaned := filepath.Clean(scope)
+	if cleaned != scope {
+		return errors.Errorf(`Invalid scope %s: Uses non-canonical path format, perhaps try with path %s`, scope, cleaned)
+	}
+
+	return nil
+}
+
+func validateScopeWindows(scope string) error {
+	matched, _ := regexp.Match(`^[a-zA-Z]:\\`, []byte(scope))
+	if !matched {
+		return errors.Errorf("Invalid scope '%s'. Must be an absolute path", scope)
+	}
+
+	return nil
+}
+
+func validateScopeNonWindows(scope string) error {
+	if !strings.HasPrefix(scope, "/") {
+		return errors.Errorf("Invalid scope %s: must be an absolute path", scope)
+	}
+
+	// Refuse also "/", otherwise "/" and "" would have the same semantics,
+	// and "" could be unexpectedly shadowed by the "/" entry.
+	if scope == "/" {
+		return errors.New(`Invalid scope "/": Use the generic default scope ""`)
+	}
+
+	return nil
+}

--- a/vendor/github.com/containers/image/v5/oci/layout/oci_dest.go
+++ b/vendor/github.com/containers/image/v5/oci/layout/oci_dest.go
@@ -1,0 +1,347 @@
+package layout
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/containers/image/v5/internal/putblobdigest"
+	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/types"
+	digest "github.com/opencontainers/go-digest"
+	imgspec "github.com/opencontainers/image-spec/specs-go"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+type ociImageDestination struct {
+	ref                      ociReference
+	index                    imgspecv1.Index
+	sharedBlobDir            string
+	acceptUncompressedLayers bool
+}
+
+// newImageDestination returns an ImageDestination for writing to an existing directory.
+func newImageDestination(sys *types.SystemContext, ref ociReference) (types.ImageDestination, error) {
+	var index *imgspecv1.Index
+	if indexExists(ref) {
+		var err error
+		index, err = ref.getIndex()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		index = &imgspecv1.Index{
+			Versioned: imgspec.Versioned{
+				SchemaVersion: 2,
+			},
+			Annotations: make(map[string]string),
+		}
+	}
+
+	d := &ociImageDestination{ref: ref, index: *index}
+	if sys != nil {
+		d.sharedBlobDir = sys.OCISharedBlobDirPath
+		d.acceptUncompressedLayers = sys.OCIAcceptUncompressedLayers
+	}
+
+	if err := ensureDirectoryExists(d.ref.dir); err != nil {
+		return nil, err
+	}
+	// Per the OCI image specification, layouts MUST have a "blobs" subdirectory,
+	// but it MAY be empty (e.g. if we never end up calling PutBlob)
+	// https://github.com/opencontainers/image-spec/blame/7c889fafd04a893f5c5f50b7ab9963d5d64e5242/image-layout.md#L19
+	if err := ensureDirectoryExists(filepath.Join(d.ref.dir, "blobs")); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// Reference returns the reference used to set up this destination.  Note that this should directly correspond to user's intent,
+// e.g. it should use the public hostname instead of the result of resolving CNAMEs or following redirects.
+func (d *ociImageDestination) Reference() types.ImageReference {
+	return d.ref
+}
+
+// Close removes resources associated with an initialized ImageDestination, if any.
+func (d *ociImageDestination) Close() error {
+	return nil
+}
+
+func (d *ociImageDestination) SupportedManifestMIMETypes() []string {
+	return []string{
+		imgspecv1.MediaTypeImageManifest,
+		imgspecv1.MediaTypeImageIndex,
+	}
+}
+
+// SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
+// Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
+func (d *ociImageDestination) SupportsSignatures(ctx context.Context) error {
+	return errors.Errorf("Pushing signatures for OCI images is not supported")
+}
+
+func (d *ociImageDestination) DesiredLayerCompression() types.LayerCompression {
+	if d.acceptUncompressedLayers {
+		return types.PreserveOriginal
+	}
+	return types.Compress
+}
+
+// AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
+// uploaded to the image destination, true otherwise.
+func (d *ociImageDestination) AcceptsForeignLayerURLs() bool {
+	return true
+}
+
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime architecture and OS. False otherwise.
+func (d *ociImageDestination) MustMatchRuntimeOS() bool {
+	return false
+}
+
+// IgnoresEmbeddedDockerReference returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
+// and would prefer to receive an unmodified manifest instead of one modified for the destination.
+// Does not make a difference if Reference().DockerReference() is nil.
+func (d *ociImageDestination) IgnoresEmbeddedDockerReference() bool {
+	return false // N/A, DockerReference() returns nil.
+}
+
+// HasThreadSafePutBlob indicates whether PutBlob can be executed concurrently.
+func (d *ociImageDestination) HasThreadSafePutBlob() bool {
+	return false
+}
+
+// PutBlob writes contents of stream and returns data representing the result.
+// inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
+// inputInfo.Size is the expected length of stream, if known.
+// inputInfo.MediaType describes the blob format, if known.
+// May update cache.
+// WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
+// to any other readers for download using the supplied digest.
+// If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
+func (d *ociImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
+	blobFile, err := ioutil.TempFile(d.ref.dir, "oci-put-blob")
+	if err != nil {
+		return types.BlobInfo{}, err
+	}
+	succeeded := false
+	explicitClosed := false
+	defer func() {
+		if !explicitClosed {
+			blobFile.Close()
+		}
+		if !succeeded {
+			os.Remove(blobFile.Name())
+		}
+	}()
+
+	digester, stream := putblobdigest.DigestIfCanonicalUnknown(stream, inputInfo)
+	// TODO: This can take quite some time, and should ideally be cancellable using ctx.Done().
+	size, err := io.Copy(blobFile, stream)
+	if err != nil {
+		return types.BlobInfo{}, err
+	}
+	blobDigest := digester.Digest()
+	if inputInfo.Size != -1 && size != inputInfo.Size {
+		return types.BlobInfo{}, errors.Errorf("Size mismatch when copying %s, expected %d, got %d", blobDigest, inputInfo.Size, size)
+	}
+	if err := blobFile.Sync(); err != nil {
+		return types.BlobInfo{}, err
+	}
+
+	// On POSIX systems, blobFile was created with mode 0600, so we need to make it readable.
+	// On Windows, the “permissions of newly created files” argument to syscall.Open is
+	// ignored and the file is already readable; besides, blobFile.Chmod, i.e. syscall.Fchmod,
+	// always fails on Windows.
+	if runtime.GOOS != "windows" {
+		if err := blobFile.Chmod(0644); err != nil {
+			return types.BlobInfo{}, err
+		}
+	}
+
+	blobPath, err := d.ref.blobPath(blobDigest, d.sharedBlobDir)
+	if err != nil {
+		return types.BlobInfo{}, err
+	}
+	if err := ensureParentDirectoryExists(blobPath); err != nil {
+		return types.BlobInfo{}, err
+	}
+
+	// need to explicitly close the file, since a rename won't otherwise not work on Windows
+	blobFile.Close()
+	explicitClosed = true
+	if err := os.Rename(blobFile.Name(), blobPath); err != nil {
+		return types.BlobInfo{}, err
+	}
+	succeeded = true
+	return types.BlobInfo{Digest: blobDigest, Size: size}, nil
+}
+
+// TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
+// (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
+// info.Digest must not be empty.
+// If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
+// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size, and may
+// include CompressionOperation and CompressionAlgorithm fields to indicate that a change to the compression type should be
+// reflected in the manifest that will be written.
+// If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
+// May use and/or update cache.
+func (d *ociImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
+	if info.Digest == "" {
+		return false, types.BlobInfo{}, errors.Errorf(`"Can not check for a blob with unknown digest`)
+	}
+	blobPath, err := d.ref.blobPath(info.Digest, d.sharedBlobDir)
+	if err != nil {
+		return false, types.BlobInfo{}, err
+	}
+	finfo, err := os.Stat(blobPath)
+	if err != nil && os.IsNotExist(err) {
+		return false, types.BlobInfo{}, nil
+	}
+	if err != nil {
+		return false, types.BlobInfo{}, err
+	}
+
+	return true, types.BlobInfo{Digest: info.Digest, Size: finfo.Size()}, nil
+}
+
+// PutManifest writes a manifest to the destination.  Per our list of supported manifest MIME types,
+// this should be either an OCI manifest (possibly converted to this format by the caller) or index,
+// neither of which we'll need to modify further.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to overwrite the manifest for (when
+// the primary manifest is a manifest list); this should always be nil if the primary manifest is not a manifest list.
+// It is expected but not enforced that the instanceDigest, when specified, matches the digest of `manifest` as generated
+// by `manifest.Digest()`.
+// FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
+// If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
+// but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
+func (d *ociImageDestination) PutManifest(ctx context.Context, m []byte, instanceDigest *digest.Digest) error {
+	var digest digest.Digest
+	var err error
+	if instanceDigest != nil {
+		digest = *instanceDigest
+	} else {
+		digest, err = manifest.Digest(m)
+		if err != nil {
+			return err
+		}
+	}
+
+	blobPath, err := d.ref.blobPath(digest, d.sharedBlobDir)
+	if err != nil {
+		return err
+	}
+	if err := ensureParentDirectoryExists(blobPath); err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(blobPath, m, 0644); err != nil {
+		return err
+	}
+
+	if instanceDigest != nil {
+		return nil
+	}
+
+	// If we had platform information, we'd build an imgspecv1.Platform structure here.
+
+	// Start filling out the descriptor for this entry
+	desc := imgspecv1.Descriptor{}
+	desc.Digest = digest
+	desc.Size = int64(len(m))
+	if d.ref.image != "" {
+		desc.Annotations = make(map[string]string)
+		desc.Annotations[imgspecv1.AnnotationRefName] = d.ref.image
+	}
+
+	// If we knew the MIME type, we wouldn't have to guess here.
+	desc.MediaType = manifest.GuessMIMEType(m)
+
+	d.addManifest(&desc)
+
+	return nil
+}
+
+func (d *ociImageDestination) addManifest(desc *imgspecv1.Descriptor) {
+	// If the new entry has a name, remove any conflicting names which we already have.
+	if desc.Annotations != nil && desc.Annotations[imgspecv1.AnnotationRefName] != "" {
+		// The name is being set on a new entry, so remove any older ones that had the same name.
+		// We might be storing an index and all of its component images, and we'll want to attach
+		// the name to the last one, which is the index.
+		for i, manifest := range d.index.Manifests {
+			if manifest.Annotations[imgspecv1.AnnotationRefName] == desc.Annotations[imgspecv1.AnnotationRefName] {
+				delete(d.index.Manifests[i].Annotations, imgspecv1.AnnotationRefName)
+				break
+			}
+		}
+	}
+	// If it has the same digest as another entry in the index, we already overwrote the file,
+	// so just pick up the other information.
+	for i, manifest := range d.index.Manifests {
+		if manifest.Digest == desc.Digest && manifest.Annotations[imgspecv1.AnnotationRefName] == "" {
+			// Replace it completely.
+			d.index.Manifests[i] = *desc
+			return
+		}
+	}
+	// It's a new entry to be added to the index.
+	d.index.Manifests = append(d.index.Manifests, *desc)
+}
+
+// PutSignatures would add the given signatures to the oci layout (currently not supported).
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to write or overwrite the signatures for
+// (when the primary manifest is a manifest list); this should always be nil if the primary manifest is not a manifest list.
+func (d *ociImageDestination) PutSignatures(ctx context.Context, signatures [][]byte, instanceDigest *digest.Digest) error {
+	if len(signatures) != 0 {
+		return errors.Errorf("Pushing signatures for OCI images is not supported")
+	}
+	return nil
+}
+
+// Commit marks the process of storing the image as successful and asks for the image to be persisted.
+// unparsedToplevel contains data about the top-level manifest of the source (which may be a single-arch image or a manifest list
+// if PutManifest was only called for the single-arch image with instanceDigest == nil), primarily to allow lookups by the
+// original manifest list digest, if desired.
+// WARNING: This does not have any transactional semantics:
+// - Uploaded data MAY be visible to others before Commit() is called
+// - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
+func (d *ociImageDestination) Commit(context.Context, types.UnparsedImage) error {
+	if err := ioutil.WriteFile(d.ref.ociLayoutPath(), []byte(`{"imageLayoutVersion": "1.0.0"}`), 0644); err != nil {
+		return err
+	}
+	indexJSON, err := json.Marshal(d.index)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(d.ref.indexPath(), indexJSON, 0644)
+}
+
+func ensureDirectoryExists(path string) error {
+	if _, err := os.Stat(path); err != nil && os.IsNotExist(err) {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ensureParentDirectoryExists ensures the parent of the supplied path exists.
+func ensureParentDirectoryExists(path string) error {
+	return ensureDirectoryExists(filepath.Dir(path))
+}
+
+// indexExists checks whether the index location specified in the OCI reference exists.
+// The implementation is opinionated, since in case of unexpected errors false is returned
+func indexExists(ref ociReference) bool {
+	_, err := os.Stat(ref.indexPath())
+	if err == nil {
+		return true
+	}
+	if os.IsNotExist(err) {
+		return false
+	}
+	return true
+}

--- a/vendor/github.com/containers/image/v5/oci/layout/oci_src.go
+++ b/vendor/github.com/containers/image/v5/oci/layout/oci_src.go
@@ -1,0 +1,193 @@
+package layout
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/pkg/tlsclientconfig"
+	"github.com/containers/image/v5/types"
+	"github.com/docker/go-connections/tlsconfig"
+	"github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+type ociImageSource struct {
+	ref           ociReference
+	index         *imgspecv1.Index
+	descriptor    imgspecv1.Descriptor
+	client        *http.Client
+	sharedBlobDir string
+}
+
+// newImageSource returns an ImageSource for reading from an existing directory.
+func newImageSource(sys *types.SystemContext, ref ociReference) (types.ImageSource, error) {
+	tr := tlsclientconfig.NewTransport()
+	tr.TLSClientConfig = tlsconfig.ServerDefault()
+
+	if sys != nil && sys.OCICertPath != "" {
+		if err := tlsclientconfig.SetupCertificates(sys.OCICertPath, tr.TLSClientConfig); err != nil {
+			return nil, err
+		}
+		tr.TLSClientConfig.InsecureSkipVerify = sys.OCIInsecureSkipTLSVerify
+	}
+
+	client := &http.Client{}
+	client.Transport = tr
+	descriptor, err := ref.getManifestDescriptor()
+	if err != nil {
+		return nil, err
+	}
+	index, err := ref.getIndex()
+	if err != nil {
+		return nil, err
+	}
+	d := &ociImageSource{ref: ref, index: index, descriptor: descriptor, client: client}
+	if sys != nil {
+		// TODO(jonboulle): check dir existence?
+		d.sharedBlobDir = sys.OCISharedBlobDirPath
+	}
+	return d, nil
+}
+
+// Reference returns the reference used to set up this source.
+func (s *ociImageSource) Reference() types.ImageReference {
+	return s.ref
+}
+
+// Close removes resources associated with an initialized ImageSource, if any.
+func (s *ociImageSource) Close() error {
+	return nil
+}
+
+// GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
+// It may use a remote (= slow) service.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
+// this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+func (s *ociImageSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
+	var dig digest.Digest
+	var mimeType string
+	var err error
+
+	if instanceDigest == nil {
+		dig = digest.Digest(s.descriptor.Digest)
+		mimeType = s.descriptor.MediaType
+	} else {
+		dig = *instanceDigest
+		for _, md := range s.index.Manifests {
+			if md.Digest == dig {
+				mimeType = md.MediaType
+				break
+			}
+		}
+	}
+
+	manifestPath, err := s.ref.blobPath(dig, s.sharedBlobDir)
+	if err != nil {
+		return nil, "", err
+	}
+
+	m, err := ioutil.ReadFile(manifestPath)
+	if err != nil {
+		return nil, "", err
+	}
+	if mimeType == "" {
+		mimeType = manifest.GuessMIMEType(m)
+	}
+
+	return m, mimeType, nil
+}
+
+// HasThreadSafeGetBlob indicates whether GetBlob can be executed concurrently.
+func (s *ociImageSource) HasThreadSafeGetBlob() bool {
+	return false
+}
+
+// GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
+// The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
+// May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
+func (s *ociImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
+	if len(info.URLs) != 0 {
+		return s.getExternalBlob(ctx, info.URLs)
+	}
+
+	path, err := s.ref.blobPath(info.Digest, s.sharedBlobDir)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	r, err := os.Open(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	fi, err := r.Stat()
+	if err != nil {
+		return nil, 0, err
+	}
+	return r, fi.Size(), nil
+}
+
+// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve signatures for
+// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+// (e.g. if the source never returns manifest lists).
+func (s *ociImageSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
+	return [][]byte{}, nil
+}
+
+func (s *ociImageSource) getExternalBlob(ctx context.Context, urls []string) (io.ReadCloser, int64, error) {
+	if len(urls) == 0 {
+		return nil, 0, errors.New("internal error: getExternalBlob called with no URLs")
+	}
+
+	errWrap := errors.New("failed fetching external blob from all urls")
+	for _, url := range urls {
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			errWrap = errors.Wrapf(errWrap, "fetching %s failed %s", url, err.Error())
+			continue
+		}
+
+		resp, err := s.client.Do(req)
+		if err != nil {
+			errWrap = errors.Wrapf(errWrap, "fetching %s failed %s", url, err.Error())
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			errWrap = errors.Wrapf(errWrap, "fetching %s failed, response code not 200", url)
+			continue
+		}
+
+		return resp.Body, getBlobSize(resp), nil
+	}
+
+	return nil, 0, errWrap
+}
+
+// LayerInfosForCopy returns either nil (meaning the values in the manifest are fine), or updated values for the layer
+// blobsums that are listed in the image's manifest.  If values are returned, they should be used when using GetBlob()
+// to read the image's layers.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve BlobInfos for
+// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+// (e.g. if the source never returns manifest lists).
+// The Digest field is guaranteed to be provided; Size may be -1.
+// WARNING: The list may contain duplicates, and they are semantically relevant.
+func (s *ociImageSource) LayerInfosForCopy(context.Context, *digest.Digest) ([]types.BlobInfo, error) {
+	return nil, nil
+}
+
+func getBlobSize(resp *http.Response) int64 {
+	size, err := strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 64)
+	if err != nil {
+		size = -1
+	}
+	return size
+}

--- a/vendor/github.com/containers/image/v5/oci/layout/oci_transport.go
+++ b/vendor/github.com/containers/image/v5/oci/layout/oci_transport.go
@@ -1,0 +1,264 @@
+package layout
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containers/image/v5/directory/explicitfilepath"
+	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/image"
+	"github.com/containers/image/v5/oci/internal"
+	"github.com/containers/image/v5/transports"
+	"github.com/containers/image/v5/types"
+	"github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+func init() {
+	transports.Register(Transport)
+}
+
+var (
+	// Transport is an ImageTransport for OCI directories.
+	Transport = ociTransport{}
+
+	// ErrMoreThanOneImage is an error returned when the manifest includes
+	// more than one image and the user should choose which one to use.
+	ErrMoreThanOneImage = errors.New("more than one image in oci, choose an image")
+)
+
+type ociTransport struct{}
+
+func (t ociTransport) Name() string {
+	return "oci"
+}
+
+// ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an ImageReference.
+func (t ociTransport) ParseReference(reference string) (types.ImageReference, error) {
+	return ParseReference(reference)
+}
+
+// ValidatePolicyConfigurationScope checks that scope is a valid name for a signature.PolicyTransportScopes keys
+// (i.e. a valid PolicyConfigurationIdentity() or PolicyConfigurationNamespaces() return value).
+// It is acceptable to allow an invalid value which will never be matched, it can "only" cause user confusion.
+// scope passed to this function will not be "", that value is always allowed.
+func (t ociTransport) ValidatePolicyConfigurationScope(scope string) error {
+	return internal.ValidateScope(scope)
+}
+
+// ociReference is an ImageReference for OCI directory paths.
+type ociReference struct {
+	// Note that the interpretation of paths below depends on the underlying filesystem state, which may change under us at any time!
+	// Either of the paths may point to a different, or no, inode over time.  resolvedDir may contain symbolic links, and so on.
+
+	// Generally we follow the intent of the user, and use the "dir" member for filesystem operations (e.g. the user can use a relative path to avoid
+	// being exposed to symlinks and renames in the parent directories to the working directory).
+	// (But in general, we make no attempt to be completely safe against concurrent hostile filesystem modifications.)
+	dir         string // As specified by the user. May be relative, contain symlinks, etc.
+	resolvedDir string // Absolute path with no symlinks, at least at the time of its creation. Primarily used for policy namespaces.
+	// If image=="", it means the "only image" in the index.json is used in the case it is a source
+	// for destinations, the image name annotation "image.ref.name" is not added to the index.json
+	image string
+}
+
+// ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an OCI ImageReference.
+func ParseReference(reference string) (types.ImageReference, error) {
+	dir, image := internal.SplitPathAndImage(reference)
+	return NewReference(dir, image)
+}
+
+// NewReference returns an OCI reference for a directory and a image.
+//
+// We do not expose an API supplying the resolvedDir; we could, but recomputing it
+// is generally cheap enough that we prefer being confident about the properties of resolvedDir.
+func NewReference(dir, image string) (types.ImageReference, error) {
+	resolved, err := explicitfilepath.ResolvePathToFullyExplicit(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := internal.ValidateOCIPath(dir); err != nil {
+		return nil, err
+	}
+
+	if err = internal.ValidateImageName(image); err != nil {
+		return nil, err
+	}
+
+	return ociReference{dir: dir, resolvedDir: resolved, image: image}, nil
+}
+
+func (ref ociReference) Transport() types.ImageTransport {
+	return Transport
+}
+
+// StringWithinTransport returns a string representation of the reference, which MUST be such that
+// reference.Transport().ParseReference(reference.StringWithinTransport()) returns an equivalent reference.
+// NOTE: The returned string is not promised to be equal to the original input to ParseReference;
+// e.g. default attribute values omitted by the user may be filled in in the return value, or vice versa.
+// WARNING: Do not use the return value in the UI to describe an image, it does not contain the Transport().Name() prefix.
+func (ref ociReference) StringWithinTransport() string {
+	return fmt.Sprintf("%s:%s", ref.dir, ref.image)
+}
+
+// DockerReference returns a Docker reference associated with this reference
+// (fully explicit, i.e. !reference.IsNameOnly, but reflecting user intent,
+// not e.g. after redirect or alias processing), or nil if unknown/not applicable.
+func (ref ociReference) DockerReference() reference.Named {
+	return nil
+}
+
+// PolicyConfigurationIdentity returns a string representation of the reference, suitable for policy lookup.
+// This MUST reflect user intent, not e.g. after processing of third-party redirects or aliases;
+// The value SHOULD be fully explicit about its semantics, with no hidden defaults, AND canonical
+// (i.e. various references with exactly the same semantics should return the same configuration identity)
+// It is fine for the return value to be equal to StringWithinTransport(), and it is desirable but
+// not required/guaranteed that it will be a valid input to Transport().ParseReference().
+// Returns "" if configuration identities for these references are not supported.
+func (ref ociReference) PolicyConfigurationIdentity() string {
+	// NOTE: ref.image is not a part of the image identity, because "$dir:$someimage" and "$dir:" may mean the
+	// same image and the two can’t be statically disambiguated.  Using at least the repository directory is
+	// less granular but hopefully still useful.
+	return ref.resolvedDir
+}
+
+// PolicyConfigurationNamespaces returns a list of other policy configuration namespaces to search
+// for if explicit configuration for PolicyConfigurationIdentity() is not set.  The list will be processed
+// in order, terminating on first match, and an implicit "" is always checked at the end.
+// It is STRONGLY recommended for the first element, if any, to be a prefix of PolicyConfigurationIdentity(),
+// and each following element to be a prefix of the element preceding it.
+func (ref ociReference) PolicyConfigurationNamespaces() []string {
+	res := []string{}
+	path := ref.resolvedDir
+	for {
+		lastSlash := strings.LastIndex(path, "/")
+		// Note that we do not include "/"; it is redundant with the default "" global default,
+		// and rejected by ociTransport.ValidatePolicyConfigurationScope above.
+		if lastSlash == -1 || path == "/" {
+			break
+		}
+		res = append(res, path)
+		path = path[:lastSlash]
+	}
+	return res
+}
+
+// NewImage returns a types.ImageCloser for this reference, possibly specialized for this ImageTransport.
+// The caller must call .Close() on the returned ImageCloser.
+// NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
+// verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
+// WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
+func (ref ociReference) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
+	src, err := newImageSource(sys, ref)
+	if err != nil {
+		return nil, err
+	}
+	return image.FromSource(ctx, sys, src)
+}
+
+// getIndex returns a pointer to the index references by this ociReference. If an error occurs opening an index nil is returned together
+// with an error.
+func (ref ociReference) getIndex() (*imgspecv1.Index, error) {
+	indexJSON, err := os.Open(ref.indexPath())
+	if err != nil {
+		return nil, err
+	}
+	defer indexJSON.Close()
+
+	index := &imgspecv1.Index{}
+	if err := json.NewDecoder(indexJSON).Decode(index); err != nil {
+		return nil, err
+	}
+	return index, nil
+}
+
+func (ref ociReference) getManifestDescriptor() (imgspecv1.Descriptor, error) {
+	index, err := ref.getIndex()
+	if err != nil {
+		return imgspecv1.Descriptor{}, err
+	}
+
+	var d *imgspecv1.Descriptor
+	if ref.image == "" {
+		// return manifest if only one image is in the oci directory
+		if len(index.Manifests) == 1 {
+			d = &index.Manifests[0]
+		} else {
+			// ask user to choose image when more than one image in the oci directory
+			return imgspecv1.Descriptor{}, ErrMoreThanOneImage
+		}
+	} else {
+		// if image specified, look through all manifests for a match
+		for _, md := range index.Manifests {
+			if md.MediaType != imgspecv1.MediaTypeImageManifest && md.MediaType != imgspecv1.MediaTypeImageIndex {
+				continue
+			}
+			refName, ok := md.Annotations[imgspecv1.AnnotationRefName]
+			if !ok {
+				continue
+			}
+			if refName == ref.image {
+				d = &md
+				break
+			}
+		}
+	}
+	if d == nil {
+		return imgspecv1.Descriptor{}, fmt.Errorf("no descriptor found for reference %q", ref.image)
+	}
+	return *d, nil
+}
+
+// LoadManifestDescriptor loads the manifest descriptor to be used to retrieve the image name
+// when pulling an image
+func LoadManifestDescriptor(imgRef types.ImageReference) (imgspecv1.Descriptor, error) {
+	ociRef, ok := imgRef.(ociReference)
+	if !ok {
+		return imgspecv1.Descriptor{}, errors.Errorf("error typecasting, need type ociRef")
+	}
+	return ociRef.getManifestDescriptor()
+}
+
+// NewImageSource returns a types.ImageSource for this reference.
+// The caller must call .Close() on the returned ImageSource.
+func (ref ociReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	return newImageSource(sys, ref)
+}
+
+// NewImageDestination returns a types.ImageDestination for this reference.
+// The caller must call .Close() on the returned ImageDestination.
+func (ref ociReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
+	return newImageDestination(sys, ref)
+}
+
+// DeleteImage deletes the named image from the registry, if supported.
+func (ref ociReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
+	return errors.Errorf("Deleting images not implemented for oci: images")
+}
+
+// ociLayoutPath returns a path for the oci-layout within a directory using OCI conventions.
+func (ref ociReference) ociLayoutPath() string {
+	return filepath.Join(ref.dir, "oci-layout")
+}
+
+// indexPath returns a path for the index.json within a directory using OCI conventions.
+func (ref ociReference) indexPath() string {
+	return filepath.Join(ref.dir, "index.json")
+}
+
+// blobPath returns a path for a blob within a directory using OCI image-layout conventions.
+func (ref ociReference) blobPath(digest digest.Digest, sharedBlobDir string) (string, error) {
+	if err := digest.Validate(); err != nil {
+		return "", errors.Wrapf(err, "unexpected digest reference %s", digest)
+	}
+	blobDir := filepath.Join(ref.dir, "blobs")
+	if sharedBlobDir != "" {
+		blobDir = sharedBlobDir
+	}
+	return filepath.Join(blobDir, digest.Algorithm().String(), digest.Hex()), nil
+}

--- a/vendor/github.com/containers/image/v5/pkg/blobinfocache/none/none.go
+++ b/vendor/github.com/containers/image/v5/pkg/blobinfocache/none/none.go
@@ -1,0 +1,50 @@
+// Package none implements a dummy BlobInfoCache which records no data.
+package none
+
+import (
+	"github.com/containers/image/v5/internal/blobinfocache"
+	"github.com/containers/image/v5/types"
+	"github.com/opencontainers/go-digest"
+)
+
+// noCache implements a dummy BlobInfoCache which records no data.
+type noCache struct {
+}
+
+// NoCache implements BlobInfoCache by not recording any data.
+//
+// This exists primarily for implementations of configGetter for
+// Manifest.Inspect, because configs only have one representation.
+// Any use of BlobInfoCache with blobs should usually use at least a
+// short-lived cache, ideally blobinfocache.DefaultCache.
+var NoCache blobinfocache.BlobInfoCache2 = blobinfocache.FromBlobInfoCache(&noCache{})
+
+// UncompressedDigest returns an uncompressed digest corresponding to anyDigest.
+// May return anyDigest if it is known to be uncompressed.
+// Returns "" if nothing is known about the digest (it may be compressed or uncompressed).
+func (noCache) UncompressedDigest(anyDigest digest.Digest) digest.Digest {
+	return ""
+}
+
+// RecordDigestUncompressedPair records that the uncompressed version of anyDigest is uncompressed.
+// It’s allowed for anyDigest == uncompressed.
+// WARNING: Only call this for LOCALLY VERIFIED data; don’t record a digest pair just because some remote author claims so (e.g.
+// because a manifest/config pair exists); otherwise the cache could be poisoned and allow substituting unexpected blobs.
+// (Eventually, the DiffIDs in image config could detect the substitution, but that may be too late, and not all image formats contain that data.)
+func (noCache) RecordDigestUncompressedPair(anyDigest digest.Digest, uncompressed digest.Digest) {
+}
+
+// RecordKnownLocation records that a blob with the specified digest exists within the specified (transport, scope) scope,
+// and can be reused given the opaque location data.
+func (noCache) RecordKnownLocation(transport types.ImageTransport, scope types.BICTransportScope, blobDigest digest.Digest, location types.BICLocationReference) {
+}
+
+// CandidateLocations returns a prioritized, limited, number of blobs and their locations that could possibly be reused
+// within the specified (transport scope) (if they still exist, which is not guaranteed).
+//
+// If !canSubstitute, the returned candidates will match the submitted digest exactly; if canSubstitute,
+// data from previous RecordDigestUncompressedPair calls is used to also look up variants of the blob which have the same
+// uncompressed digest.
+func (noCache) CandidateLocations(transport types.ImageTransport, scope types.BICTransportScope, digest digest.Digest, canSubstitute bool) []types.BICReplacementCandidate {
+	return nil
+}

--- a/vendor/github.com/containers/image/v5/pkg/compression/compression.go
+++ b/vendor/github.com/containers/image/v5/pkg/compression/compression.go
@@ -1,0 +1,167 @@
+package compression
+
+import (
+	"bytes"
+	"compress/bzip2"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/containers/image/v5/pkg/compression/internal"
+	"github.com/containers/image/v5/pkg/compression/types"
+	"github.com/containers/storage/pkg/chunked/compressor"
+	"github.com/klauspost/pgzip"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/ulikunitz/xz"
+)
+
+// Algorithm is a compression algorithm that can be used for CompressStream.
+type Algorithm = types.Algorithm
+
+var (
+	// Gzip compression.
+	Gzip = internal.NewAlgorithm(types.GzipAlgorithmName, types.GzipAlgorithmName,
+		[]byte{0x1F, 0x8B, 0x08}, GzipDecompressor, gzipCompressor)
+	// Bzip2 compression.
+	Bzip2 = internal.NewAlgorithm(types.Bzip2AlgorithmName, types.Bzip2AlgorithmName,
+		[]byte{0x42, 0x5A, 0x68}, Bzip2Decompressor, bzip2Compressor)
+	// Xz compression.
+	Xz = internal.NewAlgorithm(types.XzAlgorithmName, types.XzAlgorithmName,
+		[]byte{0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00}, XzDecompressor, xzCompressor)
+	// Zstd compression.
+	Zstd = internal.NewAlgorithm(types.ZstdAlgorithmName, types.ZstdAlgorithmName,
+		[]byte{0x28, 0xb5, 0x2f, 0xfd}, ZstdDecompressor, zstdCompressor)
+	// Zstd:chunked compression.
+	ZstdChunked = internal.NewAlgorithm(types.ZstdChunkedAlgorithmName, types.ZstdAlgorithmName, /* Note: InternalUnstableUndocumentedMIMEQuestionMark is not ZstdChunkedAlgorithmName */
+		nil, ZstdDecompressor, compressor.ZstdCompressor)
+
+	compressionAlgorithms = map[string]Algorithm{
+		Gzip.Name():        Gzip,
+		Bzip2.Name():       Bzip2,
+		Xz.Name():          Xz,
+		Zstd.Name():        Zstd,
+		ZstdChunked.Name(): ZstdChunked,
+	}
+)
+
+// AlgorithmByName returns the compressor by its name
+func AlgorithmByName(name string) (Algorithm, error) {
+	algorithm, ok := compressionAlgorithms[name]
+	if ok {
+		return algorithm, nil
+	}
+	return Algorithm{}, fmt.Errorf("cannot find compressor for %q", name)
+}
+
+// DecompressorFunc returns the decompressed stream, given a compressed stream.
+// The caller must call Close() on the decompressed stream (even if the compressed input stream does not need closing!).
+type DecompressorFunc = internal.DecompressorFunc
+
+// GzipDecompressor is a DecompressorFunc for the gzip compression algorithm.
+func GzipDecompressor(r io.Reader) (io.ReadCloser, error) {
+	return pgzip.NewReader(r)
+}
+
+// Bzip2Decompressor is a DecompressorFunc for the bzip2 compression algorithm.
+func Bzip2Decompressor(r io.Reader) (io.ReadCloser, error) {
+	return ioutil.NopCloser(bzip2.NewReader(r)), nil
+}
+
+// XzDecompressor is a DecompressorFunc for the xz compression algorithm.
+func XzDecompressor(r io.Reader) (io.ReadCloser, error) {
+	r, err := xz.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.NopCloser(r), nil
+}
+
+// gzipCompressor is a CompressorFunc for the gzip compression algorithm.
+func gzipCompressor(r io.Writer, metadata map[string]string, level *int) (io.WriteCloser, error) {
+	if level != nil {
+		return pgzip.NewWriterLevel(r, *level)
+	}
+	return pgzip.NewWriter(r), nil
+}
+
+// bzip2Compressor is a CompressorFunc for the bzip2 compression algorithm.
+func bzip2Compressor(r io.Writer, metadata map[string]string, level *int) (io.WriteCloser, error) {
+	return nil, fmt.Errorf("bzip2 compression not supported")
+}
+
+// xzCompressor is a CompressorFunc for the xz compression algorithm.
+func xzCompressor(r io.Writer, metadata map[string]string, level *int) (io.WriteCloser, error) {
+	return xz.NewWriter(r)
+}
+
+// CompressStream returns the compressor by its name
+func CompressStream(dest io.Writer, algo Algorithm, level *int) (io.WriteCloser, error) {
+	m := map[string]string{}
+	return internal.AlgorithmCompressor(algo)(dest, m, level)
+}
+
+// CompressStreamWithMetadata returns the compressor by its name.  If the compression
+// generates any metadata, it is written to the provided metadata map.
+func CompressStreamWithMetadata(dest io.Writer, metadata map[string]string, algo Algorithm, level *int) (io.WriteCloser, error) {
+	return internal.AlgorithmCompressor(algo)(dest, metadata, level)
+}
+
+// DetectCompressionFormat returns an Algorithm and DecompressorFunc if the input is recognized as a compressed format, an invalid
+// value and nil otherwise.
+// Because it consumes the start of input, other consumers must use the returned io.Reader instead to also read from the beginning.
+func DetectCompressionFormat(input io.Reader) (Algorithm, DecompressorFunc, io.Reader, error) {
+	buffer := [8]byte{}
+
+	n, err := io.ReadAtLeast(input, buffer[:], len(buffer))
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+		// This is a “real” error. We could just ignore it this time, process the data we have, and hope that the source will report the same error again.
+		// Instead, fail immediately with the original error cause instead of a possibly secondary/misleading error returned later.
+		return Algorithm{}, nil, nil, err
+	}
+
+	var retAlgo Algorithm
+	var decompressor DecompressorFunc
+	for _, algo := range compressionAlgorithms {
+		prefix := internal.AlgorithmPrefix(algo)
+		if len(prefix) > 0 && bytes.HasPrefix(buffer[:n], prefix) {
+			logrus.Debugf("Detected compression format %s", algo.Name())
+			retAlgo = algo
+			decompressor = internal.AlgorithmDecompressor(algo)
+			break
+		}
+	}
+	if decompressor == nil {
+		logrus.Debugf("No compression detected")
+	}
+
+	return retAlgo, decompressor, io.MultiReader(bytes.NewReader(buffer[:n]), input), nil
+}
+
+// DetectCompression returns a DecompressorFunc if the input is recognized as a compressed format, nil otherwise.
+// Because it consumes the start of input, other consumers must use the returned io.Reader instead to also read from the beginning.
+func DetectCompression(input io.Reader) (DecompressorFunc, io.Reader, error) {
+	_, d, r, e := DetectCompressionFormat(input)
+	return d, r, e
+}
+
+// AutoDecompress takes a stream and returns an uncompressed version of the
+// same stream.
+// The caller must call Close() on the returned stream (even if the input does not need,
+// or does not even support, closing!).
+func AutoDecompress(stream io.Reader) (io.ReadCloser, bool, error) {
+	decompressor, stream, err := DetectCompression(stream)
+	if err != nil {
+		return nil, false, errors.Wrapf(err, "detecting compression")
+	}
+	var res io.ReadCloser
+	if decompressor != nil {
+		res, err = decompressor(stream)
+		if err != nil {
+			return nil, false, errors.Wrapf(err, "initializing decompression")
+		}
+	} else {
+		res = ioutil.NopCloser(stream)
+	}
+	return res, decompressor != nil, nil
+}

--- a/vendor/github.com/containers/image/v5/pkg/compression/zstd.go
+++ b/vendor/github.com/containers/image/v5/pkg/compression/zstd.go
@@ -1,0 +1,59 @@
+package compression
+
+import (
+	"io"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+type wrapperZstdDecoder struct {
+	decoder *zstd.Decoder
+}
+
+func (w *wrapperZstdDecoder) Close() error {
+	w.decoder.Close()
+	return nil
+}
+
+func (w *wrapperZstdDecoder) DecodeAll(input, dst []byte) ([]byte, error) {
+	return w.decoder.DecodeAll(input, dst)
+}
+
+func (w *wrapperZstdDecoder) Read(p []byte) (int, error) {
+	return w.decoder.Read(p)
+}
+
+func (w *wrapperZstdDecoder) Reset(r io.Reader) error {
+	return w.decoder.Reset(r)
+}
+
+func (w *wrapperZstdDecoder) WriteTo(wr io.Writer) (int64, error) {
+	return w.decoder.WriteTo(wr)
+}
+
+func zstdReader(buf io.Reader) (io.ReadCloser, error) {
+	decoder, err := zstd.NewReader(buf)
+	return &wrapperZstdDecoder{decoder: decoder}, err
+}
+
+func zstdWriter(dest io.Writer) (io.WriteCloser, error) {
+	return zstd.NewWriter(dest)
+}
+
+func zstdWriterWithLevel(dest io.Writer, level int) (*zstd.Encoder, error) {
+	el := zstd.EncoderLevelFromZstd(level)
+	return zstd.NewWriter(dest, zstd.WithEncoderLevel(el))
+}
+
+// zstdCompressor is a CompressorFunc for the zstd compression algorithm.
+func zstdCompressor(r io.Writer, metadata map[string]string, level *int) (io.WriteCloser, error) {
+	if level == nil {
+		return zstdWriter(r)
+	}
+	return zstdWriterWithLevel(r, *level)
+}
+
+// ZstdDecompressor is a DecompressorFunc for the zstd compression algorithm.
+func ZstdDecompressor(r io.Reader) (io.ReadCloser, error) {
+	return zstdReader(r)
+}

--- a/vendor/github.com/containers/image/v5/pkg/tlsclientconfig/tlsclientconfig.go
+++ b/vendor/github.com/containers/image/v5/pkg/tlsclientconfig/tlsclientconfig.go
@@ -1,0 +1,111 @@
+package tlsclientconfig
+
+import (
+	"crypto/tls"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/docker/go-connections/sockets"
+	"github.com/docker/go-connections/tlsconfig"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// SetupCertificates opens all .crt, .cert, and .key files in dir and appends / loads certs and key pairs as appropriate to tlsc
+func SetupCertificates(dir string, tlsc *tls.Config) error {
+	logrus.Debugf("Looking for TLS certificates and private keys in %s", dir)
+	fs, err := ioutil.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if os.IsPermission(err) {
+			logrus.Debugf("Skipping scan of %s due to permission error: %v", dir, err)
+			return nil
+		}
+		return err
+	}
+
+	for _, f := range fs {
+		fullPath := filepath.Join(dir, f.Name())
+		if strings.HasSuffix(f.Name(), ".crt") {
+			logrus.Debugf(" crt: %s", fullPath)
+			data, err := ioutil.ReadFile(fullPath)
+			if err != nil {
+				if os.IsNotExist(err) {
+					// Dangling symbolic link?
+					// Race with someone who deleted the
+					// file after we read the directory's
+					// list of contents?
+					logrus.Warnf("error reading certificate %q: %v", fullPath, err)
+					continue
+				}
+				return err
+			}
+			if tlsc.RootCAs == nil {
+				systemPool, err := tlsconfig.SystemCertPool()
+				if err != nil {
+					return errors.Wrap(err, "unable to get system cert pool")
+				}
+				tlsc.RootCAs = systemPool
+			}
+			tlsc.RootCAs.AppendCertsFromPEM(data)
+		}
+		if strings.HasSuffix(f.Name(), ".cert") {
+			certName := f.Name()
+			keyName := certName[:len(certName)-5] + ".key"
+			logrus.Debugf(" cert: %s", fullPath)
+			if !hasFile(fs, keyName) {
+				return errors.Errorf("missing key %s for client certificate %s. Note that CA certificates should use the extension .crt", keyName, certName)
+			}
+			cert, err := tls.LoadX509KeyPair(filepath.Join(dir, certName), filepath.Join(dir, keyName))
+			if err != nil {
+				return err
+			}
+			tlsc.Certificates = append(tlsc.Certificates, cert)
+		}
+		if strings.HasSuffix(f.Name(), ".key") {
+			keyName := f.Name()
+			certName := keyName[:len(keyName)-4] + ".cert"
+			logrus.Debugf(" key: %s", fullPath)
+			if !hasFile(fs, certName) {
+				return errors.Errorf("missing client certificate %s for key %s", certName, keyName)
+			}
+		}
+	}
+	return nil
+}
+
+func hasFile(files []os.FileInfo, name string) bool {
+	for _, f := range files {
+		if f.Name() == name {
+			return true
+		}
+	}
+	return false
+}
+
+// NewTransport Creates a default transport
+func NewTransport() *http.Transport {
+	direct := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		DualStack: true,
+	}
+	tr := &http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
+		DialContext:         direct.DialContext,
+		TLSHandshakeTimeout: 10 * time.Second,
+		// TODO(dmcgowan): Call close idle connections when complete and use keep alive
+		DisableKeepAlives: true,
+	}
+	if _, err := sockets.DialerFromEnvironment(direct); err != nil {
+		logrus.Debugf("Can't execute DialerFromEnvironment: %v", err)
+	}
+	return tr
+}

--- a/vendor/github.com/containers/image/v5/transports/stub.go
+++ b/vendor/github.com/containers/image/v5/transports/stub.go
@@ -1,0 +1,36 @@
+package transports
+
+import (
+	"fmt"
+
+	"github.com/containers/image/v5/types"
+)
+
+// stubTransport is an implementation of types.ImageTransport which has a name, but rejects any references with “the transport $name: is not supported in this build”.
+type stubTransport string
+
+// NewStubTransport returns an implementation of types.ImageTransport which has a name, but rejects any references with “the transport $name: is not supported in this build”.
+func NewStubTransport(name string) types.ImageTransport {
+	return stubTransport(name)
+}
+
+// Name returns the name of the transport, which must be unique among other transports.
+func (s stubTransport) Name() string {
+	return string(s)
+}
+
+// ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an ImageReference.
+func (s stubTransport) ParseReference(reference string) (types.ImageReference, error) {
+	return nil, fmt.Errorf(`The transport "%s:" is not supported in this build`, string(s))
+}
+
+// ValidatePolicyConfigurationScope checks that scope is a valid name for a signature.PolicyTransportScopes keys
+// (i.e. a valid PolicyConfigurationIdentity() or PolicyConfigurationNamespaces() return value).
+// It is acceptable to allow an invalid value which will never be matched, it can "only" cause user confusion.
+// scope passed to this function will not be "", that value is always allowed.
+func (s stubTransport) ValidatePolicyConfigurationScope(scope string) error {
+	// Allowing any reference in here allows tools with some transports stubbed-out to still
+	// use signature verification policies which refer to these stubbed-out transports.
+	// See also the treatment of unknown transports in policyTransportScopesWithTransport.UnmarshalJSON .
+	return nil
+}

--- a/vendor/github.com/containers/image/v5/transports/transports.go
+++ b/vendor/github.com/containers/image/v5/transports/transports.go
@@ -1,0 +1,90 @@
+package transports
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/containers/image/v5/types"
+)
+
+// knownTransports is a registry of known ImageTransport instances.
+type knownTransports struct {
+	transports map[string]types.ImageTransport
+	mu         sync.Mutex
+}
+
+func (kt *knownTransports) Get(k string) types.ImageTransport {
+	kt.mu.Lock()
+	t := kt.transports[k]
+	kt.mu.Unlock()
+	return t
+}
+
+func (kt *knownTransports) Remove(k string) {
+	kt.mu.Lock()
+	delete(kt.transports, k)
+	kt.mu.Unlock()
+}
+
+func (kt *knownTransports) Add(t types.ImageTransport) {
+	kt.mu.Lock()
+	defer kt.mu.Unlock()
+	name := t.Name()
+	if t := kt.transports[name]; t != nil {
+		panic(fmt.Sprintf("Duplicate image transport name %s", name))
+	}
+	kt.transports[name] = t
+}
+
+var kt *knownTransports
+
+func init() {
+	kt = &knownTransports{
+		transports: make(map[string]types.ImageTransport),
+	}
+}
+
+// Get returns the transport specified by name or nil when unavailable.
+func Get(name string) types.ImageTransport {
+	return kt.Get(name)
+}
+
+// Delete deletes a transport from the registered transports.
+func Delete(name string) {
+	kt.Remove(name)
+}
+
+// Register registers a transport.
+func Register(t types.ImageTransport) {
+	kt.Add(t)
+}
+
+// ImageName converts a types.ImageReference into an URL-like image name, which MUST be such that
+// ParseImageName(ImageName(reference)) returns an equivalent reference.
+//
+// This is the generally recommended way to refer to images in the UI.
+//
+// NOTE: The returned string is not promised to be equal to the original input to ParseImageName;
+// e.g. default attribute values omitted by the user may be filled in in the return value, or vice versa.
+func ImageName(ref types.ImageReference) string {
+	return ref.Transport().Name() + ":" + ref.StringWithinTransport()
+}
+
+// ListNames returns a list of non deprecated transport names.
+// Deprecated transports can be used, but are not presented to users.
+func ListNames() []string {
+	kt.mu.Lock()
+	defer kt.mu.Unlock()
+	deprecated := map[string]bool{
+		"atomic": true,
+	}
+	var names []string
+	for _, transport := range kt.transports {
+		if !deprecated[transport.Name()] {
+			names = append(names, transport.Name())
+		}
+	}
+	sort.Strings(names)
+	return names
+}

--- a/vendor/github.com/containers/storage/pkg/chunked/compressor/compressor.go
+++ b/vendor/github.com/containers/storage/pkg/chunked/compressor/compressor.go
@@ -1,0 +1,220 @@
+package compressor
+
+// NOTE: This is used from github.com/containers/image by callers that
+// don't otherwise use containers/storage, so don't make this depend on any
+// larger software like the graph drivers.
+
+import (
+	"encoding/base64"
+	"io"
+	"io/ioutil"
+
+	"github.com/containers/storage/pkg/chunked/internal"
+	"github.com/containers/storage/pkg/ioutils"
+	"github.com/opencontainers/go-digest"
+	"github.com/vbatts/tar-split/archive/tar"
+)
+
+func writeZstdChunkedStream(destFile io.Writer, outMetadata map[string]string, reader io.Reader, level int) error {
+	// total written so far.  Used to retrieve partial offsets in the file
+	dest := ioutils.NewWriteCounter(destFile)
+
+	tr := tar.NewReader(reader)
+	tr.RawAccounting = true
+
+	buf := make([]byte, 4096)
+
+	zstdWriter, err := internal.ZstdWriterWithLevel(dest, level)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if zstdWriter != nil {
+			zstdWriter.Close()
+			zstdWriter.Flush()
+		}
+	}()
+
+	restartCompression := func() (int64, error) {
+		var offset int64
+		if zstdWriter != nil {
+			if err := zstdWriter.Close(); err != nil {
+				return 0, err
+			}
+			if err := zstdWriter.Flush(); err != nil {
+				return 0, err
+			}
+			offset = dest.Count
+			zstdWriter.Reset(dest)
+		}
+		return offset, nil
+	}
+
+	var metadata []internal.ZstdFileMetadata
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+
+		rawBytes := tr.RawBytes()
+		if _, err := zstdWriter.Write(rawBytes); err != nil {
+			return err
+		}
+		payloadDigester := digest.Canonical.Digester()
+		payloadChecksum := payloadDigester.Hash()
+
+		payloadDest := io.MultiWriter(payloadChecksum, zstdWriter)
+
+		// Now handle the payload, if any
+		var startOffset, endOffset int64
+		checksum := ""
+		for {
+			read, errRead := tr.Read(buf)
+			if errRead != nil && errRead != io.EOF {
+				return err
+			}
+
+			// restart the compression only if there is
+			// a payload.
+			if read > 0 {
+				if startOffset == 0 {
+					startOffset, err = restartCompression()
+					if err != nil {
+						return err
+					}
+				}
+				_, err := payloadDest.Write(buf[:read])
+				if err != nil {
+					return err
+				}
+			}
+			if errRead == io.EOF {
+				if startOffset > 0 {
+					endOffset, err = restartCompression()
+					if err != nil {
+						return err
+					}
+					checksum = payloadDigester.Digest().String()
+				}
+				break
+			}
+		}
+
+		typ, err := internal.GetType(hdr.Typeflag)
+		if err != nil {
+			return err
+		}
+		xattrs := make(map[string]string)
+		for k, v := range hdr.Xattrs {
+			xattrs[k] = base64.StdEncoding.EncodeToString([]byte(v))
+		}
+		m := internal.ZstdFileMetadata{
+			Type:       typ,
+			Name:       hdr.Name,
+			Linkname:   hdr.Linkname,
+			Mode:       hdr.Mode,
+			Size:       hdr.Size,
+			UID:        hdr.Uid,
+			GID:        hdr.Gid,
+			ModTime:    hdr.ModTime,
+			AccessTime: hdr.AccessTime,
+			ChangeTime: hdr.ChangeTime,
+			Devmajor:   hdr.Devmajor,
+			Devminor:   hdr.Devminor,
+			Xattrs:     xattrs,
+			Digest:     checksum,
+			Offset:     startOffset,
+			EndOffset:  endOffset,
+
+			// ChunkSize is 0 for the last chunk
+			ChunkSize:   0,
+			ChunkOffset: 0,
+			ChunkDigest: checksum,
+		}
+		metadata = append(metadata, m)
+	}
+
+	rawBytes := tr.RawBytes()
+	if _, err := zstdWriter.Write(rawBytes); err != nil {
+		return err
+	}
+	if err := zstdWriter.Flush(); err != nil {
+		return err
+	}
+	if err := zstdWriter.Close(); err != nil {
+		return err
+	}
+	zstdWriter = nil
+
+	return internal.WriteZstdChunkedManifest(dest, outMetadata, uint64(dest.Count), metadata, level)
+}
+
+type zstdChunkedWriter struct {
+	tarSplitOut *io.PipeWriter
+	tarSplitErr chan error
+}
+
+func (w zstdChunkedWriter) Close() error {
+	err := <-w.tarSplitErr
+	if err != nil {
+		w.tarSplitOut.Close()
+		return err
+	}
+	return w.tarSplitOut.Close()
+}
+
+func (w zstdChunkedWriter) Write(p []byte) (int, error) {
+	select {
+	case err := <-w.tarSplitErr:
+		w.tarSplitOut.Close()
+		return 0, err
+	default:
+		return w.tarSplitOut.Write(p)
+	}
+}
+
+// zstdChunkedWriterWithLevel writes a zstd compressed tarball where each file is
+// compressed separately so it can be addressed separately.  Idea based on CRFS:
+// https://github.com/google/crfs
+// The difference with CRFS is that the zstd compression is used instead of gzip.
+// The reason for it is that zstd supports embedding metadata ignored by the decoder
+// as part of the compressed stream.
+// A manifest json file with all the metadata is appended at the end of the tarball
+// stream, using zstd skippable frames.
+// The final file will look like:
+// [FILE_1][FILE_2]..[FILE_N][SKIPPABLE FRAME 1][SKIPPABLE FRAME 2]
+// Where:
+// [FILE_N]: [ZSTD HEADER][TAR HEADER][PAYLOAD FILE_N][ZSTD FOOTER]
+// [SKIPPABLE FRAME 1]: [ZSTD SKIPPABLE FRAME, SIZE=MANIFEST LENGTH][MANIFEST]
+// [SKIPPABLE FRAME 2]: [ZSTD SKIPPABLE FRAME, SIZE=16][MANIFEST_OFFSET][MANIFEST_LENGTH][MANIFEST_LENGTH_UNCOMPRESSED][MANIFEST_TYPE][CHUNKED_ZSTD_MAGIC_NUMBER]
+// MANIFEST_OFFSET, MANIFEST_LENGTH, MANIFEST_LENGTH_UNCOMPRESSED and CHUNKED_ZSTD_MAGIC_NUMBER are 64 bits unsigned in little endian format.
+func zstdChunkedWriterWithLevel(out io.Writer, metadata map[string]string, level int) (io.WriteCloser, error) {
+	ch := make(chan error, 1)
+	r, w := io.Pipe()
+
+	go func() {
+		ch <- writeZstdChunkedStream(out, metadata, r, level)
+		io.Copy(ioutil.Discard, r)
+		r.Close()
+		close(ch)
+	}()
+
+	return zstdChunkedWriter{
+		tarSplitOut: w,
+		tarSplitErr: ch,
+	}, nil
+}
+
+// ZstdCompressor is a CompressorFunc for the zstd compression algorithm.
+func ZstdCompressor(r io.Writer, metadata map[string]string, level *int) (io.WriteCloser, error) {
+	if level == nil {
+		l := 3
+		level = &l
+	}
+
+	return zstdChunkedWriterWithLevel(r, metadata, *level)
+}

--- a/vendor/github.com/containers/storage/pkg/chunked/internal/compression.go
+++ b/vendor/github.com/containers/storage/pkg/chunked/internal/compression.go
@@ -1,0 +1,172 @@
+package internal
+
+// NOTE: This is used from github.com/containers/image by callers that
+// don't otherwise use containers/storage, so don't make this depend on any
+// larger software like the graph drivers.
+
+import (
+	"archive/tar"
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/opencontainers/go-digest"
+)
+
+type ZstdTOC struct {
+	Version int                `json:"version"`
+	Entries []ZstdFileMetadata `json:"entries"`
+}
+
+type ZstdFileMetadata struct {
+	Type       string            `json:"type"`
+	Name       string            `json:"name"`
+	Linkname   string            `json:"linkName,omitempty"`
+	Mode       int64             `json:"mode,omitempty"`
+	Size       int64             `json:"size"`
+	UID        int               `json:"uid"`
+	GID        int               `json:"gid"`
+	ModTime    time.Time         `json:"modtime"`
+	AccessTime time.Time         `json:"accesstime"`
+	ChangeTime time.Time         `json:"changetime"`
+	Devmajor   int64             `json:"devMajor"`
+	Devminor   int64             `json:"devMinor"`
+	Xattrs     map[string]string `json:"xattrs,omitempty"`
+	Digest     string            `json:"digest,omitempty"`
+	Offset     int64             `json:"offset,omitempty"`
+	EndOffset  int64             `json:"endOffset,omitempty"`
+
+	// Currently chunking is not supported.
+	ChunkSize   int64  `json:"chunkSize,omitempty"`
+	ChunkOffset int64  `json:"chunkOffset,omitempty"`
+	ChunkDigest string `json:"chunkDigest,omitempty"`
+}
+
+const (
+	TypeReg     = "reg"
+	TypeChunk   = "chunk"
+	TypeLink    = "hardlink"
+	TypeChar    = "char"
+	TypeBlock   = "block"
+	TypeDir     = "dir"
+	TypeFifo    = "fifo"
+	TypeSymlink = "symlink"
+)
+
+var TarTypes = map[byte]string{
+	tar.TypeReg:     TypeReg,
+	tar.TypeRegA:    TypeReg,
+	tar.TypeLink:    TypeLink,
+	tar.TypeChar:    TypeChar,
+	tar.TypeBlock:   TypeBlock,
+	tar.TypeDir:     TypeDir,
+	tar.TypeFifo:    TypeFifo,
+	tar.TypeSymlink: TypeSymlink,
+}
+
+func GetType(t byte) (string, error) {
+	r, found := TarTypes[t]
+	if !found {
+		return "", fmt.Errorf("unknown tarball type: %v", t)
+	}
+	return r, nil
+}
+
+const (
+	ManifestChecksumKey = "io.containers.zstd-chunked.manifest-checksum"
+	ManifestInfoKey     = "io.containers.zstd-chunked.manifest-position"
+
+	// ManifestTypeCRFS is a manifest file compatible with the CRFS TOC file.
+	ManifestTypeCRFS = 1
+
+	// FooterSizeSupported is the footer size supported by this implementation.
+	// Newer versions of the image format might increase this value, so reject
+	// any version that is not supported.
+	FooterSizeSupported = 40
+)
+
+var (
+	// when the zstd decoder encounters a skippable frame + 1 byte for the size, it
+	// will ignore it.
+	// https://tools.ietf.org/html/rfc8478#section-3.1.2
+	skippableFrameMagic = []byte{0x50, 0x2a, 0x4d, 0x18}
+
+	ZstdChunkedFrameMagic = []byte{0x47, 0x6e, 0x55, 0x6c, 0x49, 0x6e, 0x55, 0x78}
+)
+
+func appendZstdSkippableFrame(dest io.Writer, data []byte) error {
+	if _, err := dest.Write(skippableFrameMagic); err != nil {
+		return err
+	}
+
+	var size []byte = make([]byte, 4)
+	binary.LittleEndian.PutUint32(size, uint32(len(data)))
+	if _, err := dest.Write(size); err != nil {
+		return err
+	}
+	if _, err := dest.Write(data); err != nil {
+		return err
+	}
+	return nil
+}
+
+func WriteZstdChunkedManifest(dest io.Writer, outMetadata map[string]string, offset uint64, metadata []ZstdFileMetadata, level int) error {
+	// 8 is the size of the zstd skippable frame header + the frame size
+	manifestOffset := offset + 8
+
+	toc := ZstdTOC{
+		Version: 1,
+		Entries: metadata,
+	}
+
+	// Generate the manifest
+	manifest, err := json.Marshal(toc)
+	if err != nil {
+		return err
+	}
+
+	var compressedBuffer bytes.Buffer
+	zstdWriter, err := ZstdWriterWithLevel(&compressedBuffer, level)
+	if err != nil {
+		return err
+	}
+	if _, err := zstdWriter.Write(manifest); err != nil {
+		zstdWriter.Close()
+		return err
+	}
+	if err := zstdWriter.Close(); err != nil {
+		return err
+	}
+	compressedManifest := compressedBuffer.Bytes()
+
+	manifestDigester := digest.Canonical.Digester()
+	manifestChecksum := manifestDigester.Hash()
+	if _, err := manifestChecksum.Write(compressedManifest); err != nil {
+		return err
+	}
+
+	outMetadata[ManifestChecksumKey] = manifestDigester.Digest().String()
+	outMetadata[ManifestInfoKey] = fmt.Sprintf("%d:%d:%d:%d", manifestOffset, len(compressedManifest), len(manifest), ManifestTypeCRFS)
+	if err := appendZstdSkippableFrame(dest, compressedManifest); err != nil {
+		return err
+	}
+
+	// Store the offset to the manifest and its size in LE order
+	var manifestDataLE []byte = make([]byte, FooterSizeSupported)
+	binary.LittleEndian.PutUint64(manifestDataLE, manifestOffset)
+	binary.LittleEndian.PutUint64(manifestDataLE[8:], uint64(len(compressedManifest)))
+	binary.LittleEndian.PutUint64(manifestDataLE[16:], uint64(len(manifest)))
+	binary.LittleEndian.PutUint64(manifestDataLE[24:], uint64(ManifestTypeCRFS))
+	copy(manifestDataLE[32:], ZstdChunkedFrameMagic)
+
+	return appendZstdSkippableFrame(dest, manifestDataLE)
+}
+
+func ZstdWriterWithLevel(dest io.Writer, level int) (*zstd.Encoder, error) {
+	el := zstd.EncoderLevelFromZstd(level)
+	return zstd.NewWriter(dest, zstd.WithEncoderLevel(el))
+}

--- a/vendor/github.com/containers/storage/pkg/ioutils/buffer.go
+++ b/vendor/github.com/containers/storage/pkg/ioutils/buffer.go
@@ -1,0 +1,51 @@
+package ioutils
+
+import (
+	"errors"
+	"io"
+)
+
+var errBufferFull = errors.New("buffer is full")
+
+type fixedBuffer struct {
+	buf      []byte
+	pos      int
+	lastRead int
+}
+
+func (b *fixedBuffer) Write(p []byte) (int, error) {
+	n := copy(b.buf[b.pos:cap(b.buf)], p)
+	b.pos += n
+
+	if n < len(p) {
+		if b.pos == cap(b.buf) {
+			return n, errBufferFull
+		}
+		return n, io.ErrShortWrite
+	}
+	return n, nil
+}
+
+func (b *fixedBuffer) Read(p []byte) (int, error) {
+	n := copy(p, b.buf[b.lastRead:b.pos])
+	b.lastRead += n
+	return n, nil
+}
+
+func (b *fixedBuffer) Len() int {
+	return b.pos - b.lastRead
+}
+
+func (b *fixedBuffer) Cap() int {
+	return cap(b.buf)
+}
+
+func (b *fixedBuffer) Reset() {
+	b.pos = 0
+	b.lastRead = 0
+	b.buf = b.buf[:0]
+}
+
+func (b *fixedBuffer) String() string {
+	return string(b.buf[b.lastRead:b.pos])
+}

--- a/vendor/github.com/containers/storage/pkg/ioutils/bytespipe.go
+++ b/vendor/github.com/containers/storage/pkg/ioutils/bytespipe.go
@@ -1,0 +1,186 @@
+package ioutils
+
+import (
+	"errors"
+	"io"
+	"sync"
+)
+
+// maxCap is the highest capacity to use in byte slices that buffer data.
+const maxCap = 1e6
+
+// minCap is the lowest capacity to use in byte slices that buffer data
+const minCap = 64
+
+// blockThreshold is the minimum number of bytes in the buffer which will cause
+// a write to BytesPipe to block when allocating a new slice.
+const blockThreshold = 1e6
+
+var (
+	// ErrClosed is returned when Write is called on a closed BytesPipe.
+	ErrClosed = errors.New("write to closed BytesPipe")
+
+	bufPools     = make(map[int]*sync.Pool)
+	bufPoolsLock sync.Mutex
+)
+
+// BytesPipe is io.ReadWriteCloser which works similarly to pipe(queue).
+// All written data may be read at most once. Also, BytesPipe allocates
+// and releases new byte slices to adjust to current needs, so the buffer
+// won't be overgrown after peak loads.
+type BytesPipe struct {
+	mu       sync.Mutex
+	wait     *sync.Cond
+	buf      []*fixedBuffer
+	bufLen   int
+	closeErr error // error to return from next Read. set to nil if not closed.
+}
+
+// NewBytesPipe creates new BytesPipe, initialized by specified slice.
+// If buf is nil, then it will be initialized with slice which cap is 64.
+// buf will be adjusted in a way that len(buf) == 0, cap(buf) == cap(buf).
+func NewBytesPipe() *BytesPipe {
+	bp := &BytesPipe{}
+	bp.buf = append(bp.buf, getBuffer(minCap))
+	bp.wait = sync.NewCond(&bp.mu)
+	return bp
+}
+
+// Write writes p to BytesPipe.
+// It can allocate new []byte slices in a process of writing.
+func (bp *BytesPipe) Write(p []byte) (int, error) {
+	bp.mu.Lock()
+
+	written := 0
+loop0:
+	for {
+		if bp.closeErr != nil {
+			bp.mu.Unlock()
+			return written, ErrClosed
+		}
+
+		if len(bp.buf) == 0 {
+			bp.buf = append(bp.buf, getBuffer(64))
+		}
+		// get the last buffer
+		b := bp.buf[len(bp.buf)-1]
+
+		n, err := b.Write(p)
+		written += n
+		bp.bufLen += n
+
+		// errBufferFull is an error we expect to get if the buffer is full
+		if err != nil && err != errBufferFull {
+			bp.wait.Broadcast()
+			bp.mu.Unlock()
+			return written, err
+		}
+
+		// if there was enough room to write all then break
+		if len(p) == n {
+			break
+		}
+
+		// more data: write to the next slice
+		p = p[n:]
+
+		// make sure the buffer doesn't grow too big from this write
+		for bp.bufLen >= blockThreshold {
+			bp.wait.Wait()
+			if bp.closeErr != nil {
+				continue loop0
+			}
+		}
+
+		// add new byte slice to the buffers slice and continue writing
+		nextCap := b.Cap() * 2
+		if nextCap > maxCap {
+			nextCap = maxCap
+		}
+		bp.buf = append(bp.buf, getBuffer(nextCap))
+	}
+	bp.wait.Broadcast()
+	bp.mu.Unlock()
+	return written, nil
+}
+
+// CloseWithError causes further reads from a BytesPipe to return immediately.
+func (bp *BytesPipe) CloseWithError(err error) error {
+	bp.mu.Lock()
+	if err != nil {
+		bp.closeErr = err
+	} else {
+		bp.closeErr = io.EOF
+	}
+	bp.wait.Broadcast()
+	bp.mu.Unlock()
+	return nil
+}
+
+// Close causes further reads from a BytesPipe to return immediately.
+func (bp *BytesPipe) Close() error {
+	return bp.CloseWithError(nil)
+}
+
+// Read reads bytes from BytesPipe.
+// Data could be read only once.
+func (bp *BytesPipe) Read(p []byte) (n int, err error) {
+	bp.mu.Lock()
+	if bp.bufLen == 0 {
+		if bp.closeErr != nil {
+			bp.mu.Unlock()
+			return 0, bp.closeErr
+		}
+		bp.wait.Wait()
+		if bp.bufLen == 0 && bp.closeErr != nil {
+			err := bp.closeErr
+			bp.mu.Unlock()
+			return 0, err
+		}
+	}
+
+	for bp.bufLen > 0 {
+		b := bp.buf[0]
+		read, _ := b.Read(p) // ignore error since fixedBuffer doesn't really return an error
+		n += read
+		bp.bufLen -= read
+
+		if b.Len() == 0 {
+			// it's empty so return it to the pool and move to the next one
+			returnBuffer(b)
+			bp.buf[0] = nil
+			bp.buf = bp.buf[1:]
+		}
+
+		if len(p) == read {
+			break
+		}
+
+		p = p[read:]
+	}
+
+	bp.wait.Broadcast()
+	bp.mu.Unlock()
+	return
+}
+
+func returnBuffer(b *fixedBuffer) {
+	b.Reset()
+	bufPoolsLock.Lock()
+	pool := bufPools[b.Cap()]
+	bufPoolsLock.Unlock()
+	if pool != nil {
+		pool.Put(b)
+	}
+}
+
+func getBuffer(size int) *fixedBuffer {
+	bufPoolsLock.Lock()
+	pool, ok := bufPools[size]
+	if !ok {
+		pool = &sync.Pool{New: func() interface{} { return &fixedBuffer{buf: make([]byte, 0, size)} }}
+		bufPools[size] = pool
+	}
+	bufPoolsLock.Unlock()
+	return pool.Get().(*fixedBuffer)
+}

--- a/vendor/github.com/containers/storage/pkg/ioutils/fswriters.go
+++ b/vendor/github.com/containers/storage/pkg/ioutils/fswriters.go
@@ -1,0 +1,195 @@
+package ioutils
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// AtomicFileWriterOptions specifies options for creating the atomic file writer.
+type AtomicFileWriterOptions struct {
+	// NoSync specifies whether the sync call must be skipped for the file.
+	// If NoSync is not specified, the file is synced to the
+	// storage after it has been written and before it is moved to
+	// the specified path.
+	NoSync bool
+}
+
+var defaultWriterOptions AtomicFileWriterOptions = AtomicFileWriterOptions{}
+
+// SetDefaultOptions overrides the default options used when creating an
+// atomic file writer.
+func SetDefaultOptions(opts AtomicFileWriterOptions) {
+	defaultWriterOptions = opts
+}
+
+// NewAtomicFileWriterWithOpts returns WriteCloser so that writing to it writes to a
+// temporary file and closing it atomically changes the temporary file to
+// destination path. Writing and closing concurrently is not allowed.
+func NewAtomicFileWriterWithOpts(filename string, perm os.FileMode, opts *AtomicFileWriterOptions) (io.WriteCloser, error) {
+	f, err := ioutil.TempFile(filepath.Dir(filename), ".tmp-"+filepath.Base(filename))
+	if err != nil {
+		return nil, err
+	}
+	if opts == nil {
+		opts = &defaultWriterOptions
+	}
+	abspath, err := filepath.Abs(filename)
+	if err != nil {
+		return nil, err
+	}
+	return &atomicFileWriter{
+		f:      f,
+		fn:     abspath,
+		perm:   perm,
+		noSync: opts.NoSync,
+	}, nil
+}
+
+// NewAtomicFileWriter returns WriteCloser so that writing to it writes to a
+// temporary file and closing it atomically changes the temporary file to
+// destination path. Writing and closing concurrently is not allowed.
+func NewAtomicFileWriter(filename string, perm os.FileMode) (io.WriteCloser, error) {
+	return NewAtomicFileWriterWithOpts(filename, perm, nil)
+}
+
+// AtomicWriteFile atomically writes data to a file named by filename.
+func AtomicWriteFile(filename string, data []byte, perm os.FileMode) error {
+	f, err := NewAtomicFileWriter(filename, perm)
+	if err != nil {
+		return err
+	}
+	n, err := f.Write(data)
+	if err == nil && n < len(data) {
+		err = io.ErrShortWrite
+		f.(*atomicFileWriter).writeErr = err
+	}
+	if err1 := f.Close(); err == nil {
+		err = err1
+	}
+	return err
+}
+
+type atomicFileWriter struct {
+	f        *os.File
+	fn       string
+	writeErr error
+	perm     os.FileMode
+	noSync   bool
+}
+
+func (w *atomicFileWriter) Write(dt []byte) (int, error) {
+	n, err := w.f.Write(dt)
+	if err != nil {
+		w.writeErr = err
+	}
+	return n, err
+}
+
+func (w *atomicFileWriter) Close() (retErr error) {
+	defer func() {
+		if retErr != nil || w.writeErr != nil {
+			os.Remove(w.f.Name())
+		}
+	}()
+	if !w.noSync {
+		if err := fdatasync(w.f); err != nil {
+			w.f.Close()
+			return err
+		}
+	}
+	if err := w.f.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(w.f.Name(), w.perm); err != nil {
+		return err
+	}
+	if w.writeErr == nil {
+		return os.Rename(w.f.Name(), w.fn)
+	}
+	return nil
+}
+
+// AtomicWriteSet is used to atomically write a set
+// of files and ensure they are visible at the same time.
+// Must be committed to a new directory.
+type AtomicWriteSet struct {
+	root string
+}
+
+// NewAtomicWriteSet creates a new atomic write set to
+// atomically create a set of files. The given directory
+// is used as the base directory for storing files before
+// commit. If no temporary directory is given the system
+// default is used.
+func NewAtomicWriteSet(tmpDir string) (*AtomicWriteSet, error) {
+	td, err := ioutil.TempDir(tmpDir, "write-set-")
+	if err != nil {
+		return nil, err
+	}
+
+	return &AtomicWriteSet{
+		root: td,
+	}, nil
+}
+
+// WriteFile writes a file to the set, guaranteeing the file
+// has been synced.
+func (ws *AtomicWriteSet) WriteFile(filename string, data []byte, perm os.FileMode) error {
+	f, err := ws.FileWriter(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	n, err := f.Write(data)
+	if err == nil && n < len(data) {
+		err = io.ErrShortWrite
+	}
+	if err1 := f.Close(); err == nil {
+		err = err1
+	}
+	return err
+}
+
+type syncFileCloser struct {
+	*os.File
+}
+
+func (w syncFileCloser) Close() error {
+	if !defaultWriterOptions.NoSync {
+		return w.File.Close()
+	}
+	err := fdatasync(w.File)
+	if err1 := w.File.Close(); err == nil {
+		err = err1
+	}
+	return err
+}
+
+// FileWriter opens a file writer inside the set. The file
+// should be synced and closed before calling commit.
+func (ws *AtomicWriteSet) FileWriter(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+	f, err := os.OpenFile(filepath.Join(ws.root, name), flag, perm)
+	if err != nil {
+		return nil, err
+	}
+	return syncFileCloser{f}, nil
+}
+
+// Cancel cancels the set and removes all temporary data
+// created in the set.
+func (ws *AtomicWriteSet) Cancel() error {
+	return os.RemoveAll(ws.root)
+}
+
+// Commit moves all created files to the target directory. The
+// target directory must not exist and the parent of the target
+// directory must exist.
+func (ws *AtomicWriteSet) Commit(target string) error {
+	return os.Rename(ws.root, target)
+}
+
+// String returns the location the set is writing to.
+func (ws *AtomicWriteSet) String() string {
+	return ws.root
+}

--- a/vendor/github.com/containers/storage/pkg/ioutils/fswriters_linux.go
+++ b/vendor/github.com/containers/storage/pkg/ioutils/fswriters_linux.go
@@ -1,0 +1,11 @@
+package ioutils
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func fdatasync(f *os.File) error {
+	return unix.Fdatasync(int(f.Fd()))
+}

--- a/vendor/github.com/containers/storage/pkg/ioutils/fswriters_unsupported.go
+++ b/vendor/github.com/containers/storage/pkg/ioutils/fswriters_unsupported.go
@@ -1,0 +1,11 @@
+// +build !linux
+
+package ioutils
+
+import (
+	"os"
+)
+
+func fdatasync(f *os.File) error {
+	return f.Sync()
+}

--- a/vendor/github.com/containers/storage/pkg/ioutils/readers.go
+++ b/vendor/github.com/containers/storage/pkg/ioutils/readers.go
@@ -1,0 +1,171 @@
+package ioutils
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+
+	"golang.org/x/net/context"
+)
+
+type readCloserWrapper struct {
+	io.Reader
+	closer func() error
+}
+
+func (r *readCloserWrapper) Close() error {
+	return r.closer()
+}
+
+type readWriteToCloserWrapper struct {
+	io.Reader
+	io.WriterTo
+	closer func() error
+}
+
+func (r *readWriteToCloserWrapper) Close() error {
+	return r.closer()
+}
+
+// NewReadCloserWrapper returns a new io.ReadCloser.
+func NewReadCloserWrapper(r io.Reader, closer func() error) io.ReadCloser {
+	if wt, ok := r.(io.WriterTo); ok {
+		return &readWriteToCloserWrapper{
+			Reader:   r,
+			WriterTo: wt,
+			closer:   closer,
+		}
+	}
+	return &readCloserWrapper{
+		Reader: r,
+		closer: closer,
+	}
+}
+
+type readerErrWrapper struct {
+	reader io.Reader
+	closer func()
+}
+
+func (r *readerErrWrapper) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if err != nil {
+		r.closer()
+	}
+	return n, err
+}
+
+// NewReaderErrWrapper returns a new io.Reader.
+func NewReaderErrWrapper(r io.Reader, closer func()) io.Reader {
+	return &readerErrWrapper{
+		reader: r,
+		closer: closer,
+	}
+}
+
+// HashData returns the sha256 sum of src.
+func HashData(src io.Reader) (string, error) {
+	h := sha256.New()
+	if _, err := io.Copy(h, src); err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// OnEOFReader wraps an io.ReadCloser and a function
+// the function will run at the end of file or close the file.
+type OnEOFReader struct {
+	Rc io.ReadCloser
+	Fn func()
+}
+
+func (r *OnEOFReader) Read(p []byte) (n int, err error) {
+	n, err = r.Rc.Read(p)
+	if err == io.EOF {
+		r.runFunc()
+	}
+	return
+}
+
+// Close closes the file and run the function.
+func (r *OnEOFReader) Close() error {
+	err := r.Rc.Close()
+	r.runFunc()
+	return err
+}
+
+func (r *OnEOFReader) runFunc() {
+	if fn := r.Fn; fn != nil {
+		fn()
+		r.Fn = nil
+	}
+}
+
+// cancelReadCloser wraps an io.ReadCloser with a context for cancelling read
+// operations.
+type cancelReadCloser struct {
+	cancel func()
+	pR     *io.PipeReader // Stream to read from
+	pW     *io.PipeWriter
+}
+
+// NewCancelReadCloser creates a wrapper that closes the ReadCloser when the
+// context is cancelled. The returned io.ReadCloser must be closed when it is
+// no longer needed.
+func NewCancelReadCloser(ctx context.Context, in io.ReadCloser) io.ReadCloser {
+	pR, pW := io.Pipe()
+
+	// Create a context used to signal when the pipe is closed
+	doneCtx, cancel := context.WithCancel(context.Background())
+
+	p := &cancelReadCloser{
+		cancel: cancel,
+		pR:     pR,
+		pW:     pW,
+	}
+
+	go func() {
+		_, err := io.Copy(pW, in)
+		select {
+		case <-ctx.Done():
+			// If the context was closed, p.closeWithError
+			// was already called. Calling it again would
+			// change the error that Read returns.
+		default:
+			p.closeWithError(err)
+		}
+		in.Close()
+	}()
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				p.closeWithError(ctx.Err())
+			case <-doneCtx.Done():
+				return
+			}
+		}
+	}()
+
+	return p
+}
+
+// Read wraps the Read method of the pipe that provides data from the wrapped
+// ReadCloser.
+func (p *cancelReadCloser) Read(buf []byte) (n int, err error) {
+	return p.pR.Read(buf)
+}
+
+// closeWithError closes the wrapper and its underlying reader. It will
+// cause future calls to Read to return err.
+func (p *cancelReadCloser) closeWithError(err error) {
+	p.pW.CloseWithError(err)
+	p.cancel()
+}
+
+// Close closes the wrapper its underlying reader. It will cause
+// future calls to Read to return io.EOF.
+func (p *cancelReadCloser) Close() error {
+	p.closeWithError(io.EOF)
+	return nil
+}

--- a/vendor/github.com/containers/storage/pkg/ioutils/temp_unix.go
+++ b/vendor/github.com/containers/storage/pkg/ioutils/temp_unix.go
@@ -1,0 +1,10 @@
+// +build !windows
+
+package ioutils
+
+import "io/ioutil"
+
+// TempDir on Unix systems is equivalent to ioutil.TempDir.
+func TempDir(dir, prefix string) (string, error) {
+	return ioutil.TempDir(dir, prefix)
+}

--- a/vendor/github.com/containers/storage/pkg/ioutils/temp_windows.go
+++ b/vendor/github.com/containers/storage/pkg/ioutils/temp_windows.go
@@ -1,0 +1,18 @@
+// +build windows
+
+package ioutils
+
+import (
+	"io/ioutil"
+
+	"github.com/containers/storage/pkg/longpath"
+)
+
+// TempDir is the equivalent of ioutil.TempDir, except that the result is in Windows longpath format.
+func TempDir(dir, prefix string) (string, error) {
+	tempDir, err := ioutil.TempDir(dir, prefix)
+	if err != nil {
+		return "", err
+	}
+	return longpath.AddPrefix(tempDir), nil
+}

--- a/vendor/github.com/containers/storage/pkg/ioutils/writeflusher.go
+++ b/vendor/github.com/containers/storage/pkg/ioutils/writeflusher.go
@@ -1,0 +1,92 @@
+package ioutils
+
+import (
+	"io"
+	"sync"
+)
+
+// WriteFlusher wraps the Write and Flush operation ensuring that every write
+// is a flush. In addition, the Close method can be called to intercept
+// Read/Write calls if the targets lifecycle has already ended.
+type WriteFlusher struct {
+	w           io.Writer
+	flusher     flusher
+	flushed     chan struct{}
+	flushedOnce sync.Once
+	closed      chan struct{}
+	closeLock   sync.Mutex
+}
+
+type flusher interface {
+	Flush()
+}
+
+var errWriteFlusherClosed = io.EOF
+
+func (wf *WriteFlusher) Write(b []byte) (n int, err error) {
+	select {
+	case <-wf.closed:
+		return 0, errWriteFlusherClosed
+	default:
+	}
+
+	n, err = wf.w.Write(b)
+	wf.Flush() // every write is a flush.
+	return n, err
+}
+
+// Flush the stream immediately.
+func (wf *WriteFlusher) Flush() {
+	select {
+	case <-wf.closed:
+		return
+	default:
+	}
+
+	wf.flushedOnce.Do(func() {
+		close(wf.flushed)
+	})
+	wf.flusher.Flush()
+}
+
+// Flushed returns the state of flushed.
+// If it's flushed, return true, or else it return false.
+func (wf *WriteFlusher) Flushed() bool {
+	// BUG(stevvooe): Remove this method. Its use is inherently racy. Seems to
+	// be used to detect whether or a response code has been issued or not.
+	// Another hook should be used instead.
+	var flushed bool
+	select {
+	case <-wf.flushed:
+		flushed = true
+	default:
+	}
+	return flushed
+}
+
+// Close closes the write flusher, disallowing any further writes to the
+// target. After the flusher is closed, all calls to write or flush will
+// result in an error.
+func (wf *WriteFlusher) Close() error {
+	wf.closeLock.Lock()
+	defer wf.closeLock.Unlock()
+
+	select {
+	case <-wf.closed:
+		return errWriteFlusherClosed
+	default:
+		close(wf.closed)
+	}
+	return nil
+}
+
+// NewWriteFlusher returns a new WriteFlusher.
+func NewWriteFlusher(w io.Writer) *WriteFlusher {
+	var fl flusher
+	if f, ok := w.(flusher); ok {
+		fl = f
+	} else {
+		fl = &NopFlusher{}
+	}
+	return &WriteFlusher{w: w, flusher: fl, closed: make(chan struct{}), flushed: make(chan struct{})}
+}

--- a/vendor/github.com/containers/storage/pkg/ioutils/writers.go
+++ b/vendor/github.com/containers/storage/pkg/ioutils/writers.go
@@ -1,0 +1,66 @@
+package ioutils
+
+import "io"
+
+// NopWriter represents a type which write operation is nop.
+type NopWriter struct{}
+
+func (*NopWriter) Write(buf []byte) (int, error) {
+	return len(buf), nil
+}
+
+type nopWriteCloser struct {
+	io.Writer
+}
+
+func (w *nopWriteCloser) Close() error { return nil }
+
+// NopWriteCloser returns a nopWriteCloser.
+func NopWriteCloser(w io.Writer) io.WriteCloser {
+	return &nopWriteCloser{w}
+}
+
+// NopFlusher represents a type which flush operation is nop.
+type NopFlusher struct{}
+
+// Flush is a nop operation.
+func (f *NopFlusher) Flush() {}
+
+type writeCloserWrapper struct {
+	io.Writer
+	closer func() error
+}
+
+func (r *writeCloserWrapper) Close() error {
+	return r.closer()
+}
+
+// NewWriteCloserWrapper returns a new io.WriteCloser.
+func NewWriteCloserWrapper(r io.Writer, closer func() error) io.WriteCloser {
+	return &writeCloserWrapper{
+		Writer: r,
+		closer: closer,
+	}
+}
+
+// WriteCounter wraps a concrete io.Writer and hold a count of the number
+// of bytes written to the writer during a "session".
+// This can be convenient when write return is masked
+// (e.g., json.Encoder.Encode())
+type WriteCounter struct {
+	Count  int64
+	Writer io.Writer
+}
+
+// NewWriteCounter returns a new WriteCounter.
+func NewWriteCounter(w io.Writer) *WriteCounter {
+	return &WriteCounter{
+		Writer: w,
+	}
+}
+
+func (wc *WriteCounter) Write(p []byte) (count int, err error) {
+	count, err = wc.Writer.Write(p)
+	wc.Count += int64(count)
+	return
+}

--- a/vendor/github.com/containers/storage/pkg/longpath/longpath.go
+++ b/vendor/github.com/containers/storage/pkg/longpath/longpath.go
@@ -1,0 +1,26 @@
+// longpath introduces some constants and helper functions for handling long paths
+// in Windows, which are expected to be prepended with `\\?\` and followed by either
+// a drive letter, a UNC server\share, or a volume identifier.
+
+package longpath
+
+import (
+	"strings"
+)
+
+// Prefix is the longpath prefix for Windows file paths.
+const Prefix = `\\?\`
+
+// AddPrefix will add the Windows long path prefix to the path provided if
+// it does not already have it.
+func AddPrefix(path string) string {
+	if !strings.HasPrefix(path, Prefix) {
+		if strings.HasPrefix(path, `\\`) {
+			// This is a UNC path, so we need to add 'UNC' to the path as well.
+			path = Prefix + `UNC` + path[1:]
+		} else {
+			path = Prefix + path
+		}
+	}
+	return path
+}

--- a/vendor/github.com/docker/go-connections/sockets/inmem_socket.go
+++ b/vendor/github.com/docker/go-connections/sockets/inmem_socket.go
@@ -1,0 +1,81 @@
+package sockets
+
+import (
+	"errors"
+	"net"
+	"sync"
+)
+
+var errClosed = errors.New("use of closed network connection")
+
+// InmemSocket implements net.Listener using in-memory only connections.
+type InmemSocket struct {
+	chConn  chan net.Conn
+	chClose chan struct{}
+	addr    string
+	mu      sync.Mutex
+}
+
+// dummyAddr is used to satisfy net.Addr for the in-mem socket
+// it is just stored as a string and returns the string for all calls
+type dummyAddr string
+
+// NewInmemSocket creates an in-memory only net.Listener
+// The addr argument can be any string, but is used to satisfy the `Addr()` part
+// of the net.Listener interface
+func NewInmemSocket(addr string, bufSize int) *InmemSocket {
+	return &InmemSocket{
+		chConn:  make(chan net.Conn, bufSize),
+		chClose: make(chan struct{}),
+		addr:    addr,
+	}
+}
+
+// Addr returns the socket's addr string to satisfy net.Listener
+func (s *InmemSocket) Addr() net.Addr {
+	return dummyAddr(s.addr)
+}
+
+// Accept implements the Accept method in the Listener interface; it waits for the next call and returns a generic Conn.
+func (s *InmemSocket) Accept() (net.Conn, error) {
+	select {
+	case conn := <-s.chConn:
+		return conn, nil
+	case <-s.chClose:
+		return nil, errClosed
+	}
+}
+
+// Close closes the listener. It will be unavailable for use once closed.
+func (s *InmemSocket) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	select {
+	case <-s.chClose:
+	default:
+		close(s.chClose)
+	}
+	return nil
+}
+
+// Dial is used to establish a connection with the in-mem server
+func (s *InmemSocket) Dial(network, addr string) (net.Conn, error) {
+	srvConn, clientConn := net.Pipe()
+	select {
+	case s.chConn <- srvConn:
+	case <-s.chClose:
+		return nil, errClosed
+	}
+
+	return clientConn, nil
+}
+
+// Network returns the addr string, satisfies net.Addr
+func (a dummyAddr) Network() string {
+	return string(a)
+}
+
+// String returns the string form
+func (a dummyAddr) String() string {
+	return string(a)
+}

--- a/vendor/github.com/docker/go-connections/sockets/proxy.go
+++ b/vendor/github.com/docker/go-connections/sockets/proxy.go
@@ -1,0 +1,51 @@
+package sockets
+
+import (
+	"net"
+	"net/url"
+	"os"
+	"strings"
+
+	"golang.org/x/net/proxy"
+)
+
+// GetProxyEnv allows access to the uppercase and the lowercase forms of
+// proxy-related variables.  See the Go specification for details on these
+// variables. https://golang.org/pkg/net/http/
+func GetProxyEnv(key string) string {
+	proxyValue := os.Getenv(strings.ToUpper(key))
+	if proxyValue == "" {
+		return os.Getenv(strings.ToLower(key))
+	}
+	return proxyValue
+}
+
+// DialerFromEnvironment takes in a "direct" *net.Dialer and returns a
+// proxy.Dialer which will route the connections through the proxy using the
+// given dialer.
+func DialerFromEnvironment(direct *net.Dialer) (proxy.Dialer, error) {
+	allProxy := GetProxyEnv("all_proxy")
+	if len(allProxy) == 0 {
+		return direct, nil
+	}
+
+	proxyURL, err := url.Parse(allProxy)
+	if err != nil {
+		return direct, err
+	}
+
+	proxyFromURL, err := proxy.FromURL(proxyURL, direct)
+	if err != nil {
+		return direct, err
+	}
+
+	noProxy := GetProxyEnv("no_proxy")
+	if len(noProxy) == 0 {
+		return proxyFromURL, nil
+	}
+
+	perHost := proxy.NewPerHost(proxyFromURL, direct)
+	perHost.AddFromString(noProxy)
+
+	return perHost, nil
+}

--- a/vendor/github.com/docker/go-connections/sockets/sockets.go
+++ b/vendor/github.com/docker/go-connections/sockets/sockets.go
@@ -1,0 +1,38 @@
+// Package sockets provides helper functions to create and configure Unix or TCP sockets.
+package sockets
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"time"
+)
+
+// Why 32? See https://github.com/docker/docker/pull/8035.
+const defaultTimeout = 32 * time.Second
+
+// ErrProtocolNotAvailable is returned when a given transport protocol is not provided by the operating system.
+var ErrProtocolNotAvailable = errors.New("protocol not available")
+
+// ConfigureTransport configures the specified Transport according to the
+// specified proto and addr.
+// If the proto is unix (using a unix socket to communicate) or npipe the
+// compression is disabled.
+func ConfigureTransport(tr *http.Transport, proto, addr string) error {
+	switch proto {
+	case "unix":
+		return configureUnixTransport(tr, proto, addr)
+	case "npipe":
+		return configureNpipeTransport(tr, proto, addr)
+	default:
+		tr.Proxy = http.ProxyFromEnvironment
+		dialer, err := DialerFromEnvironment(&net.Dialer{
+			Timeout: defaultTimeout,
+		})
+		if err != nil {
+			return err
+		}
+		tr.Dial = dialer.Dial
+	}
+	return nil
+}

--- a/vendor/github.com/docker/go-connections/sockets/sockets_unix.go
+++ b/vendor/github.com/docker/go-connections/sockets/sockets_unix.go
@@ -1,0 +1,35 @@
+// +build !windows
+
+package sockets
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"syscall"
+	"time"
+)
+
+const maxUnixSocketPathSize = len(syscall.RawSockaddrUnix{}.Path)
+
+func configureUnixTransport(tr *http.Transport, proto, addr string) error {
+	if len(addr) > maxUnixSocketPathSize {
+		return fmt.Errorf("Unix socket path %q is too long", addr)
+	}
+	// No need for compression in local communications.
+	tr.DisableCompression = true
+	tr.Dial = func(_, _ string) (net.Conn, error) {
+		return net.DialTimeout(proto, addr, defaultTimeout)
+	}
+	return nil
+}
+
+func configureNpipeTransport(tr *http.Transport, proto, addr string) error {
+	return ErrProtocolNotAvailable
+}
+
+// DialPipe connects to a Windows named pipe.
+// This is not supported on other OSes.
+func DialPipe(_ string, _ time.Duration) (net.Conn, error) {
+	return nil, syscall.EAFNOSUPPORT
+}

--- a/vendor/github.com/docker/go-connections/sockets/sockets_windows.go
+++ b/vendor/github.com/docker/go-connections/sockets/sockets_windows.go
@@ -1,0 +1,27 @@
+package sockets
+
+import (
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func configureUnixTransport(tr *http.Transport, proto, addr string) error {
+	return ErrProtocolNotAvailable
+}
+
+func configureNpipeTransport(tr *http.Transport, proto, addr string) error {
+	// No need for compression in local communications.
+	tr.DisableCompression = true
+	tr.Dial = func(_, _ string) (net.Conn, error) {
+		return DialPipe(addr, defaultTimeout)
+	}
+	return nil
+}
+
+// DialPipe connects to a Windows named pipe.
+func DialPipe(addr string, timeout time.Duration) (net.Conn, error) {
+	return winio.DialPipe(addr, &timeout)
+}

--- a/vendor/github.com/docker/go-connections/sockets/tcp_socket.go
+++ b/vendor/github.com/docker/go-connections/sockets/tcp_socket.go
@@ -1,0 +1,22 @@
+// Package sockets provides helper functions to create and configure Unix or TCP sockets.
+package sockets
+
+import (
+	"crypto/tls"
+	"net"
+)
+
+// NewTCPSocket creates a TCP socket listener with the specified address and
+// the specified tls configuration. If TLSConfig is set, will encapsulate the
+// TCP listener inside a TLS one.
+func NewTCPSocket(addr string, tlsConfig *tls.Config) (net.Listener, error) {
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	if tlsConfig != nil {
+		tlsConfig.NextProtos = []string{"http/1.1"}
+		l = tls.NewListener(l, tlsConfig)
+	}
+	return l, nil
+}

--- a/vendor/github.com/docker/go-connections/sockets/unix_socket.go
+++ b/vendor/github.com/docker/go-connections/sockets/unix_socket.go
@@ -1,0 +1,32 @@
+// +build !windows
+
+package sockets
+
+import (
+	"net"
+	"os"
+	"syscall"
+)
+
+// NewUnixSocket creates a unix socket with the specified path and group.
+func NewUnixSocket(path string, gid int) (net.Listener, error) {
+	if err := syscall.Unlink(path); err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	mask := syscall.Umask(0777)
+	defer syscall.Umask(mask)
+
+	l, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chown(path, 0, gid); err != nil {
+		l.Close()
+		return nil, err
+	}
+	if err := os.Chmod(path, 0660); err != nil {
+		l.Close()
+		return nil, err
+	}
+	return l, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -194,16 +194,27 @@ github.com/containerd/stargz-snapshotter/estargz/errorutil
 github.com/containerd/ttrpc
 # github.com/containers/image/v5 v5.16.0
 ## explicit; go 1.13
+github.com/containers/image/v5/directory/explicitfilepath
 github.com/containers/image/v5/docker/reference
+github.com/containers/image/v5/image
+github.com/containers/image/v5/internal/blobinfocache
+github.com/containers/image/v5/internal/iolimits
 github.com/containers/image/v5/internal/pkg/keyctl
 github.com/containers/image/v5/internal/pkg/platform
+github.com/containers/image/v5/internal/putblobdigest
 github.com/containers/image/v5/internal/rootless
 github.com/containers/image/v5/manifest
+github.com/containers/image/v5/oci/internal
+github.com/containers/image/v5/oci/layout
+github.com/containers/image/v5/pkg/blobinfocache/none
+github.com/containers/image/v5/pkg/compression
 github.com/containers/image/v5/pkg/compression/internal
 github.com/containers/image/v5/pkg/compression/types
 github.com/containers/image/v5/pkg/docker/config
 github.com/containers/image/v5/pkg/strslice
 github.com/containers/image/v5/pkg/sysregistriesv2
+github.com/containers/image/v5/pkg/tlsclientconfig
+github.com/containers/image/v5/transports
 github.com/containers/image/v5/types
 # github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b
 ## explicit
@@ -213,9 +224,13 @@ github.com/containers/libtrust
 github.com/containers/ocicrypt/spec
 # github.com/containers/storage v1.35.0
 ## explicit; go 1.14
+github.com/containers/storage/pkg/chunked/compressor
+github.com/containers/storage/pkg/chunked/internal
 github.com/containers/storage/pkg/homedir
 github.com/containers/storage/pkg/idtools
+github.com/containers/storage/pkg/ioutils
 github.com/containers/storage/pkg/lockfile
+github.com/containers/storage/pkg/longpath
 github.com/containers/storage/pkg/mount
 github.com/containers/storage/pkg/reexec
 github.com/containers/storage/pkg/stringid
@@ -285,6 +300,7 @@ github.com/docker/docker-credential-helpers/credentials
 # github.com/docker/go-connections v0.4.0
 ## explicit
 github.com/docker/go-connections/nat
+github.com/docker/go-connections/sockets
 github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-metrics v0.0.1
 ## explicit; go 1.11


### PR DESCRIPTION
# Description

This PR is part of the work for Jira epic [CFE-538](https://issues.redhat.com//browse/CFE-538) and story [WRKLDS-456](https://issues.redhat.com//browse/WRKLDS-456).
* A new GetConfigDirFromOCICatalog function is added in [image.go](https://github.com/openshift/oc-mirror/pull/508/files#diff-bf24096fa40b3ad62a92fc00dff107293795641a6b871d6f39bb1068903d13ab). The purpose of this function is to extract (untar) the blob which contains the configs folder from the catalog OCI image.
* The PR illustrates how this function can be used in the usecase MirrorToMirror with the imageSetConfig and command shown below in the test section.

## TODOs: 
* defer cleanup of the tmp dir used for unpacking
* handle cases where OCI FBC path in imageSetConfig is relative
* Call the function also in `renderDCFull`, `renderDCDiff`, all cases

Fixes # [WRKLDS-517](https://issues.redhat.com//browse/WRKLDS-517)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This is a WIP PR. 
Its purpose is to show-case the solution to Workloads + Operator FW + Fields Eng teams (@jpower432 @ardaguclu , @deejross, @dinhxuanvu), and agree on it.
Further work (see TODOs) and unit test implementations are to come.

- [x] Manual test using command `  ./bin/oc-mirror -c imstcfg.yaml  docker://quay.io/skhoury/ocmir`

**Test Configuration**:
* ImageSetConfig:
  ```yaml
     kind: ImageSetConfiguration
     apiVersion: mirror.openshift.io/v1alpha2

     storageConfig:
       registry:
         imageURL: quay.io/skhoury/ocmir
         skipTLS: false
      mirror:
        operators:
       - catalog: oci:///home/skhoury/go/src/github.com/openshift/oc-mirror/rhop-ctlg-oci
     packages:
    - name: node-observability-operator
      channels:
      - name: alpha
  helm: {}
  ```


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules