### PR TITLE
updateURL: Allow overriding for CI builds

### DIFF
--- a/pkg/cincinnati/client.go
+++ b/pkg/cincinnati/client.go
@@ -5,8 +5,10 @@ import (
 	"crypto/x509"
 	"net/http"
 	"net/url"
+	"os"
 
 	"github.com/google/uuid"
+	"k8s.io/klog/v2"
 )
 
 // Client is a Cincinnati client which can be used to fetch update graphs from
@@ -28,7 +30,14 @@ type ocpClient struct {
 
 // NewOCPClient creates a new OCP Cincinnati client with the given client identifier.
 func NewOCPClient(id uuid.UUID) (Client, error) {
-	upstream, err := url.Parse(UpdateURL)
+	var updateGraphURL string
+	if updateURLOverride := os.Getenv("UPDATE_URL_OVERRIDE"); len(updateURLOverride) != 0 {
+		klog.Info("Usage of the UPDATE_URL_OVERRIDE environment variable is unsupported")
+		updateGraphURL = updateURLOverride
+	} else {
+		updateGraphURL = UpdateURL
+	}
+	upstream, err := url.Parse(updateGraphURL)
 	if err != nil {
 		return &ocpClient{}, err
 	}


### PR DESCRIPTION
# Description

    In order to be able to mirror 4.next builds and the latest nightly
    releases, it is handy to have an environment variable for CI/devs to
    mirror from development registry graphs.
    
    The two env variables that this defines are:
    UPDATE_URL_OVERRIDE: URL to a release graph
    VERSION_FILTER: A golang regular expression to filter out disconnected
    graphs that are provided by the aforementioned URL.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally:
UPDATE_URL_OVERRIDE=https://{redacted}/graph oc-mirror -c imageset.yaml --dest-skip-tls docker://${HOSTNAME}:5000/

imageset:
```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
archiveSize: 4
storageConfig:
  registry:
    imageURL: toni.openshift-agent.cloud:5000/mirror/cicandidate-oc-mirror-metadata
    skipTLS: true
mirror:
  platform:
    architectures:
      - "amd64"
    channels:
      - name: stable-4.12
        type: ocp
  additionalImages:
    - name: registry.redhat.io/ubi8/ubi:latest
```

sample image retrieved:
sha256:323e7d72b8bd127ece7ef25e602ab924977f37c4d3516cf327b7ab6b1b88b669 toni.openshift-agent.cloud:5000/openshift/release:4.12.0-ec.3-x86_64-installer       

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules