### PR TITLE
generate metadata results

### DIFF
--- a/pkg/cli/mirror/copy.go
+++ b/pkg/cli/mirror/copy.go
@@ -804,7 +804,7 @@ func pushImage(from, to string, dstSkipTLS bool, insecurePolicy bool, funcs Remo
 	if !strings.HasPrefix(fromPath, "/") {
 		absolutePath, err := filepath.Abs(fromPath)
 		if err != nil {
-			return "", fmt.Errorf("unable to get absolute path of oci image %s: %v", from, err)
+			return digest.Digest(""), fmt.Errorf("unable to get absolute path of oci image %s: %v", from, err)
 		}
 		from = "oci://" + absolutePath
 	}
@@ -820,22 +820,22 @@ func pushImage(from, to string, dstSkipTLS bool, insecurePolicy bool, funcs Remo
 	} else {
 		sigPolicy, err = signature.DefaultPolicy(nil)
 		if err != nil {
-			return "", err
+			return digest.Digest(""), err
 		}
 	}
 	policyContext, err := signature.NewPolicyContext(sigPolicy)
 	if err != nil {
-		return "", err
+		return digest.Digest(""), err
 	}
 	// define the source context
 	srcRef, err := alltransports.ParseImageName(from)
 	if err != nil {
-		return "", err
+		return digest.Digest(""), err
 	}
 	// define the destination context
 	destRef, err := alltransports.ParseImageName(to)
 	if err != nil {
-		return "", err
+		return digest.Digest(""), err
 	}
 
 	// call the copy.Image function with the set options
@@ -852,7 +852,7 @@ func pushImage(from, to string, dstSkipTLS bool, insecurePolicy bool, funcs Remo
 		OciEncryptConfig:      nil,
 	})
 	if err != nil {
-		return "", err
+		return digest.Digest(""), err
 	}
 
 	return manifest.Digest(manifestBytes)

--- a/pkg/cli/mirror/copy_test.go
+++ b/pkg/cli/mirror/copy_test.go
@@ -695,7 +695,7 @@ func TestPushImage(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			err := pushImage(c.from, c.to, true, true, c.funcs)
+			_, err := pushImage(c.from, c.to, true, true, c.funcs)
 			if c.expectedErr != "" {
 				require.EqualError(t, err, c.expectedErr)
 			} else {


### PR DESCRIPTION
- keep track of src -> dst mapping for catalogs separately
- use digest that comes from catalog push
- after mirroring, add catalog to mapping and generate the results

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes https://issues.redhat.com/browse/OCPBUGS-3414

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules