### PR TITLE
WIP: CFE-659 - additionalImages for oc-mirror oci copy and mirror workflows

### DIFF
--- a/pkg/api/v1alpha2/types_config.go
+++ b/pkg/api/v1alpha2/types_config.go
@@ -186,7 +186,8 @@ type Chart struct {
 type Image struct {
 	// Name of the image. This should be an exact image pin (registry/namespace/name@sha256:<hash>)
 	// but is not required to be.
-	Name string `json:"name"`
+	Name   string `json:"name"`
+	Source string `json:"source,omitempty"`
 }
 
 // SampleImages define the configuration

--- a/pkg/cli/mirror/additional_test.go
+++ b/pkg/cli/mirror/additional_test.go
@@ -92,7 +92,7 @@ func TestPlan_Additional(t *testing.T) {
 			}
 			opts := NewAdditionalOptions(&mo)
 
-			mappings, err := opts.Plan(context.TODO(), test.cfg.Mirror.AdditionalImages)
+			mappings, err := opts.Plan(context.TODO(), test.cfg.Mirror.AdditionalImages, MirrorToDiskScenario)
 			if test.wantErr {
 				testErr := test.want
 				require.ErrorAs(t, err, &testErr)

--- a/pkg/cli/mirror/create.go
+++ b/pkg/cli/mirror/create.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Create will plan a mirroring operation based on provided configuration
-func (o *MirrorOptions) Create(ctx context.Context, cfg v1alpha2.ImageSetConfiguration) (v1alpha2.Metadata, image.TypedImageMapping, error) {
+func (o *MirrorOptions) Create(ctx context.Context, cfg v1alpha2.ImageSetConfiguration, scn scenario) (v1alpha2.Metadata, image.TypedImageMapping, error) {
 	// Determine stateless or stateful mode.
 	// Empty storage configuration will trigger a metadata cleanup
 	// action and labels metadata as single use
@@ -70,7 +70,7 @@ func (o *MirrorOptions) Create(ctx context.Context, cfg v1alpha2.ImageSetConfigu
 			}
 			return image.TypedImageMapping{}, nil
 		}
-		mmapping, err := o.run(ctx, &cfg, meta, f)
+		mmapping, err := o.run(ctx, &cfg, meta, f, scn)
 		meta.PastMirror = thisRun
 		return meta, mmapping, err
 	default:
@@ -85,13 +85,13 @@ func (o *MirrorOptions) Create(ctx context.Context, cfg v1alpha2.ImageSetConfigu
 			}
 			return image.TypedImageMapping{}, nil
 		}
-		mmapping, err := o.run(ctx, &cfg, meta, f)
+		mmapping, err := o.run(ctx, &cfg, meta, f, scn)
 		meta.PastMirror = thisRun
 		return meta, mmapping, err
 	}
 }
 
-func (o *MirrorOptions) run(ctx context.Context, cfg *v1alpha2.ImageSetConfiguration, meta v1alpha2.Metadata, operatorPlan operatorFunc) (image.TypedImageMapping, error) {
+func (o *MirrorOptions) run(ctx context.Context, cfg *v1alpha2.ImageSetConfiguration, meta v1alpha2.Metadata, operatorPlan operatorFunc, scn scenario) (image.TypedImageMapping, error) {
 
 	mmappings := image.TypedImageMapping{}
 
@@ -127,7 +127,7 @@ func (o *MirrorOptions) run(ctx context.Context, cfg *v1alpha2.ImageSetConfigura
 
 	if len(cfg.Mirror.AdditionalImages) != 0 {
 		additional := NewAdditionalOptions(o)
-		mappings, err := additional.Plan(ctx, cfg.Mirror.AdditionalImages)
+		mappings, err := additional.Plan(ctx, cfg.Mirror.AdditionalImages, scn)
 		if err != nil {
 			return mmappings, err
 		}

--- a/pkg/cli/mirror/create_test.go
+++ b/pkg/cli/mirror/create_test.go
@@ -33,7 +33,7 @@ func TestCreate(t *testing.T) {
 		},
 		OutputDir: path,
 	}
-	_, mappings, err := opts.Create(ctx, cfg)
+	_, mappings, err := opts.Create(ctx, cfg, MirrorToDiskScenario)
 	require.NoError(t, err)
 	require.Len(t, mappings, 1)
 }

--- a/pkg/cli/mirror/helm.go
+++ b/pkg/cli/mirror/helm.go
@@ -112,7 +112,7 @@ func (h *HelmOptions) PullCharts(ctx context.Context, cfg v1alpha2.ImageSetConfi
 
 	// Image download planning
 	additional := NewAdditionalOptions(h.MirrorOptions)
-	return additional.Plan(ctx, images)
+	return additional.Plan(ctx, images, MirrorToDiskScenario)
 }
 
 // FindImages will download images found in a Helm chart on disk

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -39,9 +39,14 @@ import (
 	"github.com/openshift/oc-mirror/pkg/metadata/storage"
 )
 
+type scenario string
+
 const (
 	OCIFeatureCopyAction   = "copy"
 	OCIFeatureMirrorAction = "mirror"
+	MirrorToMirrorScenario = scenario("M2M")
+	MirrorToDiskScenario   = scenario("M2D")
+	DiskToMirrorScenario   = scenario("D2M")
 )
 
 var (
@@ -323,6 +328,7 @@ func (o *MirrorOptions) mirrorImages(ctx context.Context, cleanup cleanupFunc) e
 		}
 		return o.generateResults(mapping, results)
 	case mirrorToDisk:
+		scn := MirrorToDiskScenario
 		cfg, err := config.ReadConfig(o.ConfigPath)
 		if err != nil {
 			return err
@@ -332,7 +338,7 @@ func (o *MirrorOptions) mirrorImages(ctx context.Context, cleanup cleanupFunc) e
 			return err
 		}
 
-		meta, mapping, err = o.Create(ctx, cfg)
+		meta, mapping, err = o.Create(ctx, cfg, scn)
 		if err != nil {
 			return err
 		}
@@ -416,6 +422,7 @@ func (o *MirrorOptions) mirrorImages(ctx context.Context, cleanup cleanupFunc) e
 			return err
 		}
 	case mirrorToMirror:
+		scn := MirrorToMirrorScenario
 		cfg, err := config.ReadConfig(o.ConfigPath)
 		if err != nil {
 			return err
@@ -423,7 +430,7 @@ func (o *MirrorOptions) mirrorImages(ctx context.Context, cleanup cleanupFunc) e
 		if err := bundle.MakeWorkspaceDirs(o.Dir); err != nil {
 			return err
 		}
-		meta, mapping, err = o.Create(ctx, cfg)
+		meta, mapping, err = o.Create(ctx, cfg, scn)
 		if err != nil {
 			return err
 		}

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -46,6 +46,9 @@ ParseReference is a wrapper function of imagesource.ParseReference
 	It provides support for oci: prefixes
 */
 func ParseReference(ref string) (imagesource.TypedImageReference, error) {
+
+	ref = strings.TrimPrefix(ref, "docker://")
+
 	if !strings.HasPrefix(ref, "oci:") {
 		return imagesource.ParseReference(ref)
 	}
@@ -60,4 +63,16 @@ func ParseReference(ref string) (imagesource.TypedImageReference, error) {
 		return imagesource.TypedImageReference{Ref: dst, Type: dstType}, fmt.Errorf("%q is not a valid image reference: %v", ref, err)
 	}
 	return imagesource.TypedImageReference{Ref: dst, Type: dstType}, nil
+}
+
+func IsDocker(ref string) bool {
+	return strings.HasPrefix(ref, "docker")
+}
+
+func IsOCI(ref string) bool {
+	return strings.HasPrefix(ref, "oci")
+}
+
+func IsFile(ref string) bool {
+	return strings.HasPrefix(ref, "file")
 }


### PR DESCRIPTION


# Description

oc-mirror oci copy and mirror workflow take into account additionalImages in ImageSetConfig on docker transport

**Status of the PR:**
- [x] takes remote additionalImages (docker://) into account for the ConnectedMirroring scenario (MirrorToMirror)
- [ ] support FBC OCI additionalImages (oci://) for the ConnectedMirroring scenario (MirrorToMirror)
- [x] takes remote additionalImages (docker://) into account for the oci feature copy scenario (--oci-feature-action=copy)
- [x] takes remote additionalImages (docker://) into account for the oci feature copy scenario (--oci-feature-action=mirror)
- [ ] takes FBC OCI additionalImages (oci://) into account for the oci feature copy scenario (--oci-feature-action=copy)
- [ ] takes FBC OCI additionalImages (oci://) into account for the oci feature copy scenario (--oci-feature-action=mirror)

For the moment, this design - if accepted - will have an impact on the ImageSetConfig schema:
It becomes necessary to always set a prefix for additionalImages:
* `docker://` for remote images
* `file://` for on disk dockerv2 images
* `oci://` for on disk oci format images
For some cases, it is already implemented to add docker:// if no prefix was found. And this solution can be generalized for backwards compatibility. 

**TODOs**
- [ ] Ability to use registries.conf, when available
- [ ] Can mirror images in OCI format : for now, mirrorMappings relies on oc code, which doesn't understand OCI format
- [ ] Can mirror file based images (even dockerv2? or maybe out of scope?): oc's mirror always assumes images are on docker registry

Fixes # [CFE-659](https://issues.redhat.com//browse/CFE-659)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [?] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

The tests done on this PR involve:
* `./bin/oc-mirror --config /home/skhoury/go/src/github.com/openshift/oc-mirror/imstcfg.yaml --use-oci-feature --oci-feature-action=mirror docker://localhost:5000 --dest-use-http --dest-skip-tls`
* `./bin/oc-mirror --config /home/skhoury/go/src/github.com/openshift/oc-mirror/imstcfg.yaml --use-oci-feature --oci-feature-action=copy oci:///tmp/scos-content-out --dest-use-http`
* `./bin/oc-mirror --config /home/skhoury/go/src/github.com/openshift/oc-mirror/imstcfg.yaml docker://localhost:5000 --dest-use-http` (standard M2M scneraio)

All 3 tests using same imagesSetConfig file:
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
storageConfig:
  local:
    path: /tmp/storageBackend                                                    
mirror:
  additionalImages:
  - name: docker://quay.io/okd/scos-content:4.12.0-0.okd-scos-2022-10-22-232744-branding
```

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules