### PR TITLE
OCPBUGS-4516: fix: oc-mirror does not work as expected relative path …

### DIFF
--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -165,7 +165,6 @@ func (o *MirrorOptions) Complete(cmd *cobra.Command, args []string) error {
 		if cmd.Flags().Changed("dir") {
 			return fmt.Errorf("--dir cannot be specified with oci destination scheme")
 		}
-		ref = strings.Replace(ref, "oci", "file", 1)
 		ref = filepath.Clean(ref)
 		if ref == "" {
 			ref = "."

--- a/test/e2e/configs/imageset-config-oci-mirror.yaml
+++ b/test/e2e/configs/imageset-config-oci-mirror.yaml
@@ -6,7 +6,7 @@ storageConfig:
     path: DATA_TMP
 mirror:
   operators:
-  - catalog: oci://DATA_TMP/mirror_file/oc-mirror-dev
+  - catalog: oci://DATA_TMP/mirror_oci/oc-mirror-dev
     packages:
       - name: baz
         minVersion: 1.0.1


### PR DESCRIPTION
…for OCI format copy

# Description

Fixes issue: `oc-mirror` does not work as expected relative path for OCI format copy

Fixes # OCPBUGS-4516

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Copy the operator image with OCI format to localhost with relative path my-oci-catalog;
cat imageset-copy.yaml
```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
operators:
    catalog: registry.redhat.io/redhat/redhat-operator-index:v4.12
    packages:
    name: aws-load-balancer-operator
```
```
$ ./bin/oc-mirror --config imageset-copy.yaml --use-oci-feature --oci-feature-action=copy oci://my-oci-catalog
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules