### PR TITLE
OCPBUGS-3414: Fix: fixes issues encountered by QE

### DIFF
--- a/pkg/cli/mirror/copy.go
+++ b/pkg/cli/mirror/copy.go
@@ -381,9 +381,15 @@ func prepareDestCatalogRef(operator v1alpha2.Operator, destReg, namespace string
 	if destReg == "" {
 		return "", errors.New("destination registry may not be empty")
 	}
+	_, subNamespace, _, tag, _ := image.ParseImageReference(operator.OriginalRef)
+	_, _, repo, _, _ := image.ParseImageReference(operator.Catalog)
+
 	to := "docker://" + destReg
 	if namespace != "" {
 		to = strings.Join([]string{to, namespace}, "/")
+	}
+	if subNamespace != "" {
+		to = strings.Join([]string{to, subNamespace}, "/")
 	}
 
 	klog.Infof("pushing catalog %s to %s \n", operator.Catalog, to)
@@ -391,11 +397,12 @@ func prepareDestCatalogRef(operator v1alpha2.Operator, destReg, namespace string
 	if operator.TargetName != "" {
 		to = strings.Join([]string{to, operator.TargetName}, "/")
 	} else {
-		_, _, repo, _, _ := image.ParseImageReference(operator.Catalog)
 		to = strings.Join([]string{to, repo}, "/")
 	}
 	if operator.TargetTag != "" {
 		to += ":" + operator.TargetTag
+	} else if tag != "" {
+		to += ":" + tag
 	}
 	//check if this is a valid reference
 	_, err := image.ParseReference(image.TrimProtocol(to))

--- a/pkg/cli/mirror/copy_test.go
+++ b/pkg/cli/mirror/copy_test.go
@@ -1393,7 +1393,7 @@ func TestPrepareDestCatalogRef(t *testing.T) {
 			},
 			destReg:     "localhost:5000",
 			namespace:   "disconnected_ocp",
-			expectedRef: "docker://localhost:5000/disconnected_ocp/rhop-ctlg-oci",
+			expectedRef: "docker://localhost:5000/disconnected_ocp/redhat/rhop-ctlg-oci:v4.12",
 			expectedErr: "",
 		},
 		{
@@ -1405,7 +1405,7 @@ func TestPrepareDestCatalogRef(t *testing.T) {
 			},
 			destReg:     "localhost:5000",
 			namespace:   "disconnected_ocp",
-			expectedRef: "docker://localhost:5000/disconnected_ocp/rhopi",
+			expectedRef: "docker://localhost:5000/disconnected_ocp/redhat/rhopi:v4.12",
 			expectedErr: "",
 		},
 		{
@@ -1417,7 +1417,7 @@ func TestPrepareDestCatalogRef(t *testing.T) {
 			},
 			destReg:     "localhost:5000",
 			namespace:   "disconnected_ocp",
-			expectedRef: "docker://localhost:5000/disconnected_ocp/rhop-ctlg-oci:v12",
+			expectedRef: "docker://localhost:5000/disconnected_ocp/redhat/rhop-ctlg-oci:v12",
 			expectedErr: "",
 		},
 		{
@@ -1430,7 +1430,7 @@ func TestPrepareDestCatalogRef(t *testing.T) {
 			},
 			destReg:     "localhost:5000",
 			namespace:   "disconnected_ocp",
-			expectedRef: "docker://localhost:5000/disconnected_ocp/rhopi:v12",
+			expectedRef: "docker://localhost:5000/disconnected_ocp/redhat/rhopi:v12",
 			expectedErr: "",
 		},
 		{
@@ -1452,7 +1452,7 @@ func TestPrepareDestCatalogRef(t *testing.T) {
 			},
 			destReg:     "localhost:5000",
 			namespace:   "",
-			expectedRef: "docker://localhost:5000/rhop-ctlg-oci",
+			expectedRef: "docker://localhost:5000/redhat/rhop-ctlg-oci:v4.12",
 			expectedErr: "",
 		},
 	}
@@ -1722,7 +1722,7 @@ func TestAddRelatedImageToMapping(t *testing.T) {
 						},
 					},
 					OriginalRef: "quay.io/okd/scos-content:4.12.0-0.okd-scos-2022-10-22-232744-branding",
-					Category: v1alpha2.TypeOperatorRelatedImage,
+					Category:    v1alpha2.TypeOperatorRelatedImage,
 				},
 			},
 			img: declcfg.RelatedImage{
@@ -1761,7 +1761,7 @@ func TestAddRelatedImageToMapping(t *testing.T) {
 						},
 					},
 					OriginalRef: "quay.io/okd/scos-content:4.12.0-0.okd-scos-2022-10-22-232744-branding",
-					Category: v1alpha2.TypeOperatorRelatedImage,
+					Category:    v1alpha2.TypeOperatorRelatedImage,
 				},
 			},
 			img: declcfg.RelatedImage{
@@ -1800,7 +1800,7 @@ func TestAddRelatedImageToMapping(t *testing.T) {
 						},
 					},
 					OriginalRef: "quay.io/scos-content:4.12.0-0.okd-scos-2022-10-22-232744-branding",
-					Category: v1alpha2.TypeOperatorRelatedImage,
+					Category:    v1alpha2.TypeOperatorRelatedImage,
 				},
 			},
 			img: declcfg.RelatedImage{

--- a/pkg/cli/mirror/copy_test.go
+++ b/pkg/cli/mirror/copy_test.go
@@ -1088,48 +1088,6 @@ func TestUntarLayers(t *testing.T) {
 	}
 }
 
-func TestParseImageName(t *testing.T) {
-	type spec struct {
-		desc      string
-		imageName string
-		expReg    string
-		expOrg    string
-		expRepo   string
-		expTag    string
-		expDigest string
-	}
-	cases := []spec{
-		{
-			desc:      "remote image with tag",
-			imageName: "quay.io/redhatgov/oc-mirror-dev:foo-bundle-v0.3.1",
-			expReg:    "quay.io",
-			expOrg:    "redhatgov",
-			expRepo:   "oc-mirror-dev",
-			expDigest: "",
-			expTag:    "foo-bundle-v0.3.1",
-		},
-		{
-			desc:      "remote image with digest",
-			imageName: "quay.io/redhatgov/oc-mirror-dev@sha256:7e1e74b87a503e95db5203334917856f61aece90a72e8d53a9fd903344eb78a5",
-			expReg:    "quay.io",
-			expOrg:    "redhatgov",
-			expRepo:   "oc-mirror-dev",
-			expDigest: "7e1e74b87a503e95db5203334917856f61aece90a72e8d53a9fd903344eb78a5",
-			expTag:    "",
-		},
-	}
-	for _, c := range cases {
-		t.Run(c.desc, func(t *testing.T) {
-			registry, org, repo, tag, sha := parseImageName(c.imageName)
-			require.Equal(t, c.expReg, registry)
-			require.Equal(t, c.expOrg, org)
-			require.Equal(t, c.expRepo, repo)
-			require.Equal(t, c.expDigest, sha)
-			require.Equal(t, c.expTag, tag)
-		})
-	}
-}
-
 func TestFirstAvailableMirror(t *testing.T) {
 	type spec struct {
 		desc      string
@@ -1192,24 +1150,6 @@ func TestFirstAvailableMirror(t *testing.T) {
 			expMirror: "",
 			regFuncs:  createMockFunctions(2),
 		},
-		// {
-		// 	desc:      "1/2 mirrors reachable, returns a mirror",
-		// 	imageName: "docker://quay.io/redhatgov/oc-mirror-dev:foo-bundle-v0.3.1",
-		// 	prefix:    "quay.io/redhatgov/",
-		// 	mirrors: []sysregistriesv2.Endpoint{
-		// 		{
-		// 			Location: "my.mirror.io/redhatgov",
-		// 			Insecure: true,
-		// 		},
-		// 		{
-		// 			Location: "quay.io/redhatgov",
-		// 			Insecure: false,
-		// 		},
-		// 	},
-		// 	expErr:    "",
-		// 	expMirror: "quay.io/redhatgov/oc-mirror-dev:foo-bundle-v0.3.1",
-		// 	regFuncs:  createMockFunctions(),
-		// },
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {

--- a/pkg/cli/mirror/copy_test.go
+++ b/pkg/cli/mirror/copy_test.go
@@ -1214,10 +1214,10 @@ func TestGenerateSrcToFileMapping(t *testing.T) {
 						Type: "file",
 						Ref: reference.DockerImageReference{
 							Registry:  "",
-							Namespace: "operator",
-							Name:      "7e1e74b87a503e95db5203334917856f61aece90a72e8d53a9fd903344eb78a5",
+							Namespace: "redhatgov",
+							Name:      "oc-mirror-dev/7e1e74b87a503e95db5203334917856f61aece90a72e8d53a9fd903344eb78a5",
 							Tag:       "",
-							ID:        "",
+							ID:        "", // is this correct??
 						},
 					},
 					OriginalRef: "quay.io/redhatgov/oc-mirror-dev@sha256:7e1e74b87a503e95db5203334917856f61aece90a72e8d53a9fd903344eb78a5",
@@ -1242,8 +1242,8 @@ func TestGenerateSrcToFileMapping(t *testing.T) {
 						Type: "file",
 						Ref: reference.DockerImageReference{
 							Registry:  "",
-							Namespace: "foo",
-							Name:      fmt.Sprintf("%x", sha256.Sum256([]byte("foo-bundle-v0.3.0")))[0:6],
+							Namespace: "redhatgov",
+							Name:      "oc-mirror-dev/" + fmt.Sprintf("%x", sha256.Sum256([]byte("foo-bundle-v0.3.0")))[0:6],
 							Tag:       "foo-bundle-v0.3.0",
 							ID:        "",
 						},
@@ -1270,8 +1270,8 @@ func TestGenerateSrcToFileMapping(t *testing.T) {
 						Type: "file",
 						Ref: reference.DockerImageReference{
 							Registry:  "",
-							Namespace: fmt.Sprintf("%x", sha256.Sum256([]byte("quay.io/redhatgov/oc-mirror-dev:no-name-v0.3.0")))[0:6],
-							Name:      fmt.Sprintf("%x", sha256.Sum256([]byte("no-name-v0.3.0")))[0:6],
+							Namespace: "redhatgov",
+							Name:      "oc-mirror-dev/" + fmt.Sprintf("%x", sha256.Sum256([]byte("no-name-v0.3.0")))[0:6],
 							Tag:       "no-name-v0.3.0",
 							ID:        "",
 						},
@@ -1329,8 +1329,8 @@ func TestGenerateSrcToFileMapping(t *testing.T) {
 						Type: "file",
 						Ref: reference.DockerImageReference{
 							Registry:  "",
-							Namespace: "operator",
-							Name:      "7e1e74b87a503e95db5203334917856f61aece90a72e8d53a9fd903344eb78a5",
+							Namespace: "test",
+							Name:      "oc-mirror-dev/7e1e74b87a503e95db5203334917856f61aece90a72e8d53a9fd903344eb78a5",
 							Tag:       "",
 							ID:        "",
 						},
@@ -1703,8 +1703,8 @@ func TestAddRelatedImageToMapping(t *testing.T) {
 						Type: "file",
 						Ref: reference.DockerImageReference{
 							Registry:  "",
-							Namespace: "scos-content",
-							Name:       fmt.Sprintf("%x", sha256.Sum256([]byte("4.12.0-0.okd-scos-2022-10-22-232744-branding")))[0:6],
+							Namespace: "okd",
+							Name:      "scos-content/" + fmt.Sprintf("%x", sha256.Sum256([]byte("4.12.0-0.okd-scos-2022-10-22-232744-branding")))[0:6],
 							Tag:       "4.12.0-0.okd-scos-2022-10-22-232744-branding",
 							ID:        ""},
 					},
@@ -1742,8 +1742,8 @@ func TestAddRelatedImageToMapping(t *testing.T) {
 						Type: "file",
 						Ref: reference.DockerImageReference{
 							Registry:  "",
-							Namespace: "scos-content",
-							Name:      "0aa078",
+							Namespace: "okd",
+							Name:      "scos-content/" + fmt.Sprintf("%x", sha256.Sum256([]byte("4.12.0-0.okd-scos-2022-10-22-232744-branding")))[0:6],
 							Tag:       "4.12.0-0.okd-scos-2022-10-22-232744-branding",
 							ID:        ""},
 					},
@@ -1782,7 +1782,7 @@ func TestAddRelatedImageToMapping(t *testing.T) {
 						Ref: reference.DockerImageReference{
 							Registry:  "",
 							Namespace: "scos-content",
-							Name:      "0aa078",
+							Name:      fmt.Sprintf("%x", sha256.Sum256([]byte("4.12.0-0.okd-scos-2022-10-22-232744-branding")))[0:6],
 							Tag:       "4.12.0-0.okd-scos-2022-10-22-232744-branding",
 							ID:        ""},
 					},

--- a/pkg/cli/mirror/copy_test.go
+++ b/pkg/cli/mirror/copy_test.go
@@ -1207,7 +1207,8 @@ func TestGenerateSrcToFileMapping(t *testing.T) {
 							ID:        "sha256:7e1e74b87a503e95db5203334917856f61aece90a72e8d53a9fd903344eb78a5",
 						},
 					},
-					Category: v1alpha2.TypeOperatorRelatedImage,
+					OriginalRef: "",
+					Category:    v1alpha2.TypeOperatorRelatedImage,
 				}: image.TypedImage{
 					TypedImageReference: imagesource.TypedImageReference{
 						Type: "file",
@@ -1219,7 +1220,8 @@ func TestGenerateSrcToFileMapping(t *testing.T) {
 							ID:        "",
 						},
 					},
-					Category: v1alpha2.TypeOperatorRelatedImage,
+					OriginalRef: "quay.io/redhatgov/oc-mirror-dev@sha256:7e1e74b87a503e95db5203334917856f61aece90a72e8d53a9fd903344eb78a5",
+					Category:    v1alpha2.TypeOperatorRelatedImage,
 				},
 
 				image.TypedImage{
@@ -1233,7 +1235,8 @@ func TestGenerateSrcToFileMapping(t *testing.T) {
 							ID:        "",
 						},
 					},
-					Category: v1alpha2.TypeOperatorRelatedImage,
+					OriginalRef: "",
+					Category:    v1alpha2.TypeOperatorRelatedImage,
 				}: image.TypedImage{
 					TypedImageReference: imagesource.TypedImageReference{
 						Type: "file",
@@ -1244,7 +1247,9 @@ func TestGenerateSrcToFileMapping(t *testing.T) {
 							Tag:       "foo-bundle-v0.3.0",
 							ID:        "",
 						},
-					}, Category: v1alpha2.TypeOperatorRelatedImage,
+					},
+					Category:    v1alpha2.TypeOperatorRelatedImage,
+					OriginalRef: "quay.io/redhatgov/oc-mirror-dev:foo-bundle-v0.3.0",
 				},
 
 				image.TypedImage{
@@ -1258,7 +1263,8 @@ func TestGenerateSrcToFileMapping(t *testing.T) {
 							ID:        "",
 						},
 					},
-					Category: v1alpha2.TypeOperatorRelatedImage,
+					Category:    v1alpha2.TypeOperatorRelatedImage,
+					OriginalRef: "",
 				}: image.TypedImage{
 					TypedImageReference: imagesource.TypedImageReference{
 						Type: "file",
@@ -1270,7 +1276,8 @@ func TestGenerateSrcToFileMapping(t *testing.T) {
 							ID:        "",
 						},
 					},
-					Category: v1alpha2.TypeOperatorRelatedImage,
+					Category:    v1alpha2.TypeOperatorRelatedImage,
+					OriginalRef: "quay.io/redhatgov/oc-mirror-dev:no-name-v0.3.0",
 				},
 			},
 
@@ -1315,7 +1322,8 @@ func TestGenerateSrcToFileMapping(t *testing.T) {
 							ID:        "sha256:7e1e74b87a503e95db5203334917856f61aece90a72e8d53a9fd903344eb78a5",
 						},
 					},
-					Category: v1alpha2.TypeOperatorRelatedImage,
+					Category:    v1alpha2.TypeOperatorRelatedImage,
+					OriginalRef: "",
 				}: image.TypedImage{
 					TypedImageReference: imagesource.TypedImageReference{
 						Type: "file",
@@ -1327,7 +1335,8 @@ func TestGenerateSrcToFileMapping(t *testing.T) {
 							ID:        "",
 						},
 					},
-					Category: v1alpha2.TypeOperatorRelatedImage,
+					Category:    v1alpha2.TypeOperatorRelatedImage,
+					OriginalRef: "quay.io/redhatgov/oc-mirror-dev@sha256:7e1e74b87a503e95db5203334917856f61aece90a72e8d53a9fd903344eb78a5",
 				},
 			},
 
@@ -1491,7 +1500,8 @@ func TestAddCatalogToMapping(t *testing.T) {
 							ID:        digest.FromString("just for testing").String(),
 						},
 					},
-					Category: v1alpha2.TypeOperatorCatalog,
+					OriginalRef: "registry.redhat.io/redhat/redhat-operator-index:v4.12",
+					Category:    v1alpha2.TypeOperatorCatalog,
 				}: image.TypedImage{
 					TypedImageReference: imagesource.TypedImageReference{
 						Type: "docker",
@@ -1503,7 +1513,8 @@ func TestAddCatalogToMapping(t *testing.T) {
 							ID:        digest.FromString("just for testing").String(),
 						},
 					},
-					Category: v1alpha2.TypeOperatorCatalog,
+					OriginalRef: "registry.redhat.io/redhat/redhat-operator-index:v4.12",
+					Category:    v1alpha2.TypeOperatorCatalog,
 				},
 			},
 			expectedErr: "",
@@ -1528,7 +1539,8 @@ func TestAddCatalogToMapping(t *testing.T) {
 							Tag:       "",
 							ID:        "sha256:d7bc364512178c36671d8a4b5a76cf7cb10f8e56997106187b0fe1f032670ece"},
 					},
-					Category: v1alpha2.TypeOperatorCatalog,
+					Category:    v1alpha2.TypeOperatorCatalog,
+					OriginalRef: "registry.redhat.io/redhat/redhat-operator-index@sha256:d7bc364512178c36671d8a4b5a76cf7cb10f8e56997106187b0fe1f032670ece",
 				}: image.TypedImage{
 					TypedImageReference: imagesource.TypedImageReference{
 						Type: "docker",
@@ -1540,7 +1552,8 @@ func TestAddCatalogToMapping(t *testing.T) {
 							ID:        "sha256:d7bc364512178c36671d8a4b5a76cf7cb10f8e56997106187b0fe1f032670ece",
 						},
 					},
-					Category: v1alpha2.TypeOperatorCatalog,
+					OriginalRef: "registry.redhat.io/redhat/redhat-operator-index@sha256:d7bc364512178c36671d8a4b5a76cf7cb10f8e56997106187b0fe1f032670ece",
+					Category:    v1alpha2.TypeOperatorCatalog,
 				},
 			},
 			expectedErr: "",
@@ -1565,7 +1578,8 @@ func TestAddCatalogToMapping(t *testing.T) {
 							Tag:       "v4.12",
 							ID:        ""},
 					},
-					Category: v1alpha2.TypeOperatorCatalog,
+					OriginalRef: "registry.redhat.io/redhat/redhat-operator-index:v4.12",
+					Category:    v1alpha2.TypeOperatorCatalog,
 				}: image.TypedImage{
 					TypedImageReference: imagesource.TypedImageReference{
 						Type: "docker",
@@ -1577,7 +1591,8 @@ func TestAddCatalogToMapping(t *testing.T) {
 							ID:        "",
 						},
 					},
-					Category: v1alpha2.TypeOperatorCatalog,
+					OriginalRef: "registry.redhat.io/redhat/redhat-operator-index:v4.12",
+					Category:    v1alpha2.TypeOperatorCatalog,
 				},
 			},
 			expectedErr: "",
@@ -1613,7 +1628,8 @@ func TestAddCatalogToMapping(t *testing.T) {
 							ID:        digest.FromString("just for testing").String(),
 						},
 					},
-					Category: v1alpha2.TypeOperatorCatalog,
+					Category:    v1alpha2.TypeOperatorCatalog,
+					OriginalRef: "",
 				}: image.TypedImage{
 					TypedImageReference: imagesource.TypedImageReference{
 						Type: "docker",
@@ -1625,7 +1641,8 @@ func TestAddCatalogToMapping(t *testing.T) {
 							ID:        digest.FromString("just for testing").String(),
 						},
 					},
-					Category: v1alpha2.TypeOperatorCatalog,
+					Category:    v1alpha2.TypeOperatorCatalog,
+					OriginalRef: "",
 				},
 			},
 			expectedErr: "",
@@ -1677,43 +1694,6 @@ func TestAddRelatedImageToMapping(t *testing.T) {
 			namespace: "disconnectedOCP",
 		},
 		{
-			desc:   "relatedImage name empty uses a sha as source folder",
-			expErr: "",
-			expMapping: image.TypedImageMapping{
-
-				image.TypedImage{
-					TypedImageReference: imagesource.TypedImageReference{
-						Type: "file",
-						Ref: reference.DockerImageReference{
-							Registry:  "",
-							Namespace: "6234aa",
-							Name:      "0aa078",
-							Tag:       "4.12.0-0.okd-scos-2022-10-22-232744-branding",
-							ID:        ""},
-					},
-					Category: v1alpha2.TypeOperatorRelatedImage,
-				}: image.TypedImage{
-					TypedImageReference: imagesource.TypedImageReference{
-						Type: "docker",
-						Ref: reference.DockerImageReference{
-							Registry:  "localhost:5000",
-							Namespace: "disconnected-ocp",
-							Name:      "okd/scos-content",
-							Tag:       "4.12.0-0.okd-scos-2022-10-22-232744-branding",
-							ID:        "",
-						},
-					},
-					Category: v1alpha2.TypeOperatorRelatedImage,
-				},
-			},
-			img: declcfg.RelatedImage{
-				Name:  "",
-				Image: "quay.io/okd/scos-content:4.12.0-0.okd-scos-2022-10-22-232744-branding",
-			},
-			destReg:   "localhost:5000",
-			namespace: "disconnected-ocp",
-		},
-		{
 			desc:   "nominal case passes",
 			expErr: "",
 			expMapping: image.TypedImageMapping{
@@ -1724,11 +1704,12 @@ func TestAddRelatedImageToMapping(t *testing.T) {
 						Ref: reference.DockerImageReference{
 							Registry:  "",
 							Namespace: "scos-content",
-							Name:      "0aa078",
+							Name:       fmt.Sprintf("%x", sha256.Sum256([]byte("4.12.0-0.okd-scos-2022-10-22-232744-branding")))[0:6],
 							Tag:       "4.12.0-0.okd-scos-2022-10-22-232744-branding",
 							ID:        ""},
 					},
-					Category: v1alpha2.TypeOperatorRelatedImage,
+					OriginalRef: "quay.io/okd/scos-content:4.12.0-0.okd-scos-2022-10-22-232744-branding",
+					Category:    v1alpha2.TypeOperatorRelatedImage,
 				}: image.TypedImage{
 					TypedImageReference: imagesource.TypedImageReference{
 						Type: "docker",
@@ -1740,6 +1721,7 @@ func TestAddRelatedImageToMapping(t *testing.T) {
 							ID:        "",
 						},
 					},
+					OriginalRef: "quay.io/okd/scos-content:4.12.0-0.okd-scos-2022-10-22-232744-branding",
 					Category: v1alpha2.TypeOperatorRelatedImage,
 				},
 			},
@@ -1765,7 +1747,8 @@ func TestAddRelatedImageToMapping(t *testing.T) {
 							Tag:       "4.12.0-0.okd-scos-2022-10-22-232744-branding",
 							ID:        ""},
 					},
-					Category: v1alpha2.TypeOperatorRelatedImage,
+					OriginalRef: "quay.io/okd/scos-content:4.12.0-0.okd-scos-2022-10-22-232744-branding",
+					Category:    v1alpha2.TypeOperatorRelatedImage,
 				}: image.TypedImage{
 					TypedImageReference: imagesource.TypedImageReference{
 						Type: "docker",
@@ -1777,6 +1760,7 @@ func TestAddRelatedImageToMapping(t *testing.T) {
 							ID:        "",
 						},
 					},
+					OriginalRef: "quay.io/okd/scos-content:4.12.0-0.okd-scos-2022-10-22-232744-branding",
 					Category: v1alpha2.TypeOperatorRelatedImage,
 				},
 			},
@@ -1802,7 +1786,8 @@ func TestAddRelatedImageToMapping(t *testing.T) {
 							Tag:       "4.12.0-0.okd-scos-2022-10-22-232744-branding",
 							ID:        ""},
 					},
-					Category: v1alpha2.TypeOperatorRelatedImage,
+					OriginalRef: "quay.io/scos-content:4.12.0-0.okd-scos-2022-10-22-232744-branding",
+					Category:    v1alpha2.TypeOperatorRelatedImage,
 				}: image.TypedImage{
 					TypedImageReference: imagesource.TypedImageReference{
 						Type: "docker",
@@ -1814,6 +1799,7 @@ func TestAddRelatedImageToMapping(t *testing.T) {
 							ID:        "",
 						},
 					},
+					OriginalRef: "quay.io/scos-content:4.12.0-0.okd-scos-2022-10-22-232744-branding",
 					Category: v1alpha2.TypeOperatorRelatedImage,
 				},
 			},

--- a/pkg/cli/mirror/manifests.go
+++ b/pkg/cli/mirror/manifests.go
@@ -192,6 +192,12 @@ func getRegistryMapping(icspScope string, mapping image.TypedImageMapping) (map[
 		case icspScope == namespaceICSPScope:
 			source := path.Join(imgRegistry, imgNamespace)
 			dest := path.Join(v.Ref.Registry, v.Ref.Namespace)
+			if k.OriginalRef != "" { //do this only for TypedImages that have a OriginalRef
+				// Keeping risks at minimum for other functions using this function
+				reg, namespace, _, _, _ := image.ParseImageReference(path.Join(v.Ref.Registry, v.Ref.Namespace, v.Ref.Name))
+				dest = path.Join(reg, namespace)
+			}
+
 			registryMapping[source] = dest
 		default:
 			return registryMapping, fmt.Errorf("invalid ICSP scope %s", icspScope)

--- a/pkg/cli/mirror/manifests_test.go
+++ b/pkg/cli/mirror/manifests_test.go
@@ -366,18 +366,19 @@ func TestICSPGeneration(t *testing.T) {
 		},
 		{
 			name: "Valid/OperatorTypeWithRelatedImgs",
-			sourceImages: []image.TypedImage{{
-				TypedImageReference: imagesource.TypedImageReference{
-					Ref: reference.DockerImageReference{
-						Registry:  "some-registry-bundle",
-						Namespace: "namespace-bundle",
-						Name:      "image-bundle",
-						ID:        "digest-bundle",
+			sourceImages: []image.TypedImage{
+				{
+					TypedImageReference: imagesource.TypedImageReference{
+						Ref: reference.DockerImageReference{
+							Registry:  "some-registry-bundle",
+							Namespace: "namespace-bundle",
+							Name:      "image-bundle",
+							ID:        "digest-bundle",
+						},
+						Type: imagesource.DestinationRegistry,
 					},
-					Type: imagesource.DestinationRegistry,
+					Category: v1alpha2.TypeOperatorBundle,
 				},
-				Category: v1alpha2.TypeOperatorBundle,
-			},
 				{
 					TypedImageReference: imagesource.TypedImageReference{
 						Ref: reference.DockerImageReference{
@@ -390,18 +391,19 @@ func TestICSPGeneration(t *testing.T) {
 					},
 					Category: v1alpha2.TypeOperatorRelatedImage,
 				}},
-			destImages: []image.TypedImage{{
-				TypedImageReference: imagesource.TypedImageReference{
-					Ref: reference.DockerImageReference{
-						Registry:  "disconn-registry",
-						Namespace: "namespace-bundle",
-						Name:      "image-bundle",
-						ID:        "digest-bundle",
+			destImages: []image.TypedImage{
+				{
+					TypedImageReference: imagesource.TypedImageReference{
+						Ref: reference.DockerImageReference{
+							Registry:  "disconn-registry",
+							Namespace: "namespace-bundle",
+							Name:      "image-bundle",
+							ID:        "digest-bundle",
+						},
+						Type: imagesource.DestinationRegistry,
 					},
-					Type: imagesource.DestinationRegistry,
+					Category: v1alpha2.TypeOperatorBundle,
 				},
-				Category: v1alpha2.TypeOperatorBundle,
-			},
 				{
 					TypedImageReference: imagesource.TypedImageReference{
 						Ref: reference.DockerImageReference{

--- a/pkg/cli/mirror/manifests_test.go
+++ b/pkg/cli/mirror/manifests_test.go
@@ -369,10 +369,10 @@ func TestICSPGeneration(t *testing.T) {
 			sourceImages: []image.TypedImage{{
 				TypedImageReference: imagesource.TypedImageReference{
 					Ref: reference.DockerImageReference{
-						Registry:  "some-registry",
-						Namespace: "namespace",
-						Name:      "image",
-						ID:        "digest",
+						Registry:  "some-registry-bundle",
+						Namespace: "namespace-bundle",
+						Name:      "image-bundle",
+						ID:        "digest-bundle",
 					},
 					Type: imagesource.DestinationRegistry,
 				},
@@ -382,9 +382,9 @@ func TestICSPGeneration(t *testing.T) {
 					TypedImageReference: imagesource.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry:  "some-registry-for-related",
-							Namespace: "namespace",
-							Name:      "related-image",
-							ID:        "digest",
+							Namespace: "namespace-related",
+							Name:      "image-related",
+							ID:        "digest-related",
 						},
 						Type: imagesource.DestinationRegistry,
 					},
@@ -394,9 +394,9 @@ func TestICSPGeneration(t *testing.T) {
 				TypedImageReference: imagesource.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "disconn-registry",
-						Namespace: "namespace",
-						Name:      "image",
-						ID:        "digest",
+						Namespace: "namespace-bundle",
+						Name:      "image-bundle",
+						ID:        "digest-bundle",
 					},
 					Type: imagesource.DestinationRegistry,
 				},
@@ -406,9 +406,9 @@ func TestICSPGeneration(t *testing.T) {
 					TypedImageReference: imagesource.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry:  "disconn-registry",
-							Namespace: "namespace",
-							Name:      "related-image",
-							ID:        "digest",
+							Namespace: "namespace-related",
+							Name:      "image-related",
+							ID:        "digest-related",
 						},
 						Type: imagesource.DestinationRegistry,
 					},
@@ -428,12 +428,12 @@ func TestICSPGeneration(t *testing.T) {
 				Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
 					RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
 						{
-							Source:  "some-registry/namespace",
-							Mirrors: []string{"disconn-registry/namespace"},
+							Source:  "some-registry-bundle/namespace-bundle",
+							Mirrors: []string{"disconn-registry/namespace-bundle"},
 						},
 						{
-							Source:  "some-registry-for-related/namespace",
-							Mirrors: []string{"disconn-registry/namespace"},
+							Source:  "some-registry-for-related/namespace-related",
+							Mirrors: []string{"disconn-registry/namespace-related"},
 						},
 					},
 				},

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -61,3 +61,45 @@ func ParseReference(ref string) (imagesource.TypedImageReference, error) {
 	}
 	return imagesource.TypedImageReference{Ref: dst, Type: dstType}, nil
 }
+
+// parseImageName returns the registry, organisation, repository, tag and digest
+// from the imageName.
+// It can handle both remote and local images.
+func ParseImageReference(imageName string) (string, string, string, string, string) {
+	registry, org, repo, tag, sha := "", "", "", "", ""
+	imageName = TrimProtocol(imageName)
+	imageName = strings.TrimPrefix(imageName, "/")
+	imageName = strings.TrimSuffix(imageName, "/")
+	tmp := strings.Split(imageName, "/")
+
+	registry = tmp[0]
+	img := strings.Split(tmp[len(tmp)-1], ":")
+	if len(tmp) > 2 {
+		org = strings.Join(tmp[1:len(tmp)-1], "/")
+	}
+	if len(img) > 1 {
+		if strings.Contains(img[0], "@") {
+			nm := strings.Split(img[0], "@")
+			repo = nm[0]
+			sha = img[1]
+		} else {
+			repo = img[0]
+			tag = img[1]
+		}
+	} else {
+		repo = img[0]
+	}
+
+	return registry, org, repo, tag, sha
+}
+
+// trimProtocol removes oci://, file:// or docker:// from
+// the parameter imageName
+func TrimProtocol(imageName string) string {
+	imageName = strings.TrimPrefix(imageName, "oci:")
+	imageName = strings.TrimPrefix(imageName, "file:")
+	imageName = strings.TrimPrefix(imageName, "docker:")
+	imageName = strings.TrimPrefix(imageName, "//")
+
+	return imageName
+}

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -73,3 +73,45 @@ func TestParseReference(t *testing.T) {
 		})
 	}
 }
+
+func TestParseImageName(t *testing.T) {
+	type spec struct {
+		desc      string
+		imageName string
+		expReg    string
+		expOrg    string
+		expRepo   string
+		expTag    string
+		expDigest string
+	}
+	cases := []spec{
+		{
+			desc:      "remote image with tag",
+			imageName: "quay.io/redhatgov/oc-mirror-dev:foo-bundle-v0.3.1",
+			expReg:    "quay.io",
+			expOrg:    "redhatgov",
+			expRepo:   "oc-mirror-dev",
+			expDigest: "",
+			expTag:    "foo-bundle-v0.3.1",
+		},
+		{
+			desc:      "remote image with digest",
+			imageName: "quay.io/redhatgov/oc-mirror-dev@sha256:7e1e74b87a503e95db5203334917856f61aece90a72e8d53a9fd903344eb78a5",
+			expReg:    "quay.io",
+			expOrg:    "redhatgov",
+			expRepo:   "oc-mirror-dev",
+			expDigest: "7e1e74b87a503e95db5203334917856f61aece90a72e8d53a9fd903344eb78a5",
+			expTag:    "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			registry, org, repo, tag, sha := ParseImageReference(c.imageName)
+			require.Equal(t, c.expReg, registry)
+			require.Equal(t, c.expOrg, org)
+			require.Equal(t, c.expRepo, repo)
+			require.Equal(t, c.expDigest, sha)
+			require.Equal(t, c.expTag, tag)
+		})
+	}
+}

--- a/pkg/image/mapping.go
+++ b/pkg/image/mapping.go
@@ -17,6 +17,7 @@ import (
 // TypedImage defines an a image with the destination and content type
 type TypedImage struct {
 	imagesource.TypedImageReference
+	OriginalRef string
 	// Category adds image category type to TypedImageReference
 	Category v1alpha2.ImageType
 }
@@ -27,7 +28,7 @@ func ParseTypedImage(image string, typ v1alpha2.ImageType) (TypedImage, error) {
 	if err != nil {
 		return TypedImage{}, err
 	}
-	t := TypedImage{ref, typ}
+	t := TypedImage{ref, image, typ}
 	return t.SetDefaults(), nil
 }
 

--- a/pkg/image/mapping_test.go
+++ b/pkg/image/mapping_test.go
@@ -249,7 +249,8 @@ func TestReadImageMapping(t *testing.T) {
 				},
 				Type: imagesource.DestinationRegistry,
 			},
-			Category: v1alpha2.TypeOperatorBundle}: {
+			OriginalRef: "some-registry.com/namespace/image:latest",
+			Category:    v1alpha2.TypeOperatorBundle}: {
 			TypedImageReference: imagesource.TypedImageReference{
 				Ref: reference.DockerImageReference{
 					Registry:  "disconn-registry.com",
@@ -259,7 +260,8 @@ func TestReadImageMapping(t *testing.T) {
 				},
 				Type: imagesource.DestinationRegistry,
 			},
-			Category: v1alpha2.TypeOperatorBundle},
+			OriginalRef: "disconn-registry.com/namespace/image:latest",
+			Category:    v1alpha2.TypeOperatorBundle},
 		},
 	}, {
 		name:      "Invalid/NoSeparator",


### PR DESCRIPTION
# Description
This PR contains fixes to multiple issues encountered by QE:
* ICSP generation: Fix the mirror destination of the catalog: The URL should contain the original namespace
* ICSP generation: Fix the source for relatedImages: the URL should contain the original image reference as found in the catalog
  * This uses OriginalRef, which was added to TypedImage 
* Move parseImageName and trimProtocol to image package

Fixes # OCPBUGS-3414

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests

## Manual test 1a
* ImageSetConfig:

```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
  #rhop
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.12
    originalRef: registry.redhat.io/redhat/redhat-operator-index:v4.12
    packages:
    - name: node-observability-operator
```
* Command

```bash
 ./bin/oc-mirror -c imstcfg.yaml --use-oci-feature --oci-feature-action=copy oci://sc-copy-rhop
```
- [x] command finishes successfully
- [x] sc-copy-rhop contains catalog image and blobs
- [x] olm_artifacts contains catalog contents (csv files)
- [x] oc-mirror-workspace contains all related images of node-observability-operator   

## Manual test 1b
* ImageSetConfig

```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
  #rhop
  - catalog: oci:///home/skhoury/go/src/github.com/openshift/oc-mirror/sc-copy-rhop/redhat-operator-index
    originalRef: registry.redhat.io/redhat/redhat-operator-index:v4.12
    packages:
    - name: node-observability-operator
```
* Command

```shell
./bin/oc-mirror -c imstcfg.yaml --use-oci-feature --oci-feature-action=mirror docker://localhost:5000/ocmir --dest-skip-tls
```
- [x] command finishes successfully
- [x] `skopeo  inspect docker://localhost:5000/ocmir/noo/node-observability-operator-bundle-rhel8@sha256:25b8e1c8ed635364d4dcba7814ad504570b1c6053d287ab7e26c8d6a97ae3f6a --tls-verify=false` returns OK
- [x] `skopeo  inspect docker://localhost:5000/ocmir/redhat/redhat-operator-index:v4.12 --tls-verify=false` returns OK
- [x] oc-mirror-workspace contains results folder with both CatalogSource and ICSP
- [x] ICSP content correct for both sources and mirrors
- [x] CatalogSource content correct
     
## Manual test 2
* delete all folders (oc-mirror-workspace, sc-copy-rhop, olm_artifacts)
* `skopeo copy docker://registry.redhat.io/redhat/redhat-operator-index:v4.12 oci://sc-copy-rhop`
* ImageSetConfig
 
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
  #rhop
  - catalog: oci:///home/skhoury/go/src/github.com/openshift/oc-mirror/sc-copy-rhop/redhat-operator-index
    originalRef: registry.redhat.io/redhat/redhat-operator-index:v4.12
    packages:
    - name: node-observability-operator
```
* Command

```shell
./bin/oc-mirror -c imstcfg.yaml --use-oci-feature --oci-feature-action=mirror docker://localhost:5000/ocmir --dest-skip-tls
```
- [x] command finishes successfully
- [x] `skopeo  inspect docker://localhost:5000/ocmir/noo/node-observability-operator-bundle-rhel8@sha256:25b8e1c8ed635364d4dcba7814ad504570b1c6053d287ab7e26c8d6a97ae3f6a --tls-verify=false` returns OK
- [x] `skopeo  inspect docker://localhost:5000/ocmir/redhat/redhat-operator-index:v4.12 --tls-verify=false` returns OK
- [x] oc-mirror-workspace contains results folder with both CatalogSource and ICSP
- [x] ICSP content correct for both sources and mirrors
- [x] CatalogSource content correct

## Manual test 3a
* ImageSetConfig

```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
  #redhatgov
  - catalog: quay.io/redhatgov/oc-mirror-dev:test-catalog-latest 
    originalRef: quay.io/redhatgov/oc-mirror-dev:test-catalog-latest 
    packages:
    - name: foo
```
* Command

```shell
./bin/oc-mirror -c imstcfg.yaml --use-oci-feature --oci-feature-action=copy oci://sc-copy-gov 
```
- [x] command finishes successfully
- [x] sc-copy-gov  contains catalog image and blobs
- [x] olm_artifacts contains catalog contents (csv files)
- [x] oc-mirror-workspace contains all related images of node-observability-operator   

## Manual test 3b
* ImageSetConfig

```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
  #redhatgov
  - catalog: oci:///home/skhoury/go/src/github.com/openshift/oc-mirror/sc-copy-gov/oc-mirror-dev
    originalRef: quay.io/redhatgov/oc-mirror-dev:test-catalog-latest 
    packages:
    - name: foo
```
* Command

```shell
./bin/oc-mirror -c imstcfg.yaml --use-oci-feature --oci-feature-action=mirror docker://localhost:5000/ocmirgov  --dest-skip-tls
```
- [x] command finishes successfully
- [x] `skopeo inspect docker://localhost:5000/ocmirgov/redhatgov/oc-mirror-dev:foo-bundle-v0.3.1 --tls-verify=false` returns OK
- [x] `skopeo  inspect docker://localhost:5000/ocmirgov/redhatgov/oc-mirror-dev:test-catalog-latest  --tls-verify=false` returns OK
- [x] oc-mirror-workspace contains results folder with both CatalogSource and ICSP
- [x] ICSP content correct for both sources and mirrors
- [x] CatalogSource content correct

## Manual test 4
* delete all folders (oc-mirror-workspace, sc-copy-rhop, olm_artifacts)
* `skopeo copy docker://registry.redhat.io/redhat/redhat-operator-index:v4.12 oci://sc-copy-rhop`
* ImageSetConfig
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
  #redhatgov
  - catalog: oci:///home/skhoury/go/src/github.com/openshift/oc-mirror/sc-copy-gov/oc-mirror-dev
    originalRef: quay.io/redhatgov/oc-mirror-dev:test-catalog-latest 
    packages:
    - name: foo
```
* Command

```shell
./bin/oc-mirror -c imstcfg.yaml --use-oci-feature --oci-feature-action=mirror docker://localhost:5000/ocmirgov  --dest-skip-tls
```
- [x] command finishes successfully
- [x] `skopeo inspect docker://localhost:5000/ocmirgov/redhatgov/oc-mirror-dev:foo-bundle-v0.3.1 --tls-verify=false` returns OK
- [x] `skopeo  inspect docker://localhost:5000/ocmirgov/redhatgov/oc-mirror-dev:test-catalog-latest  --tls-verify=false` returns OK
- [x] oc-mirror-workspace contains results folder with both CatalogSource and ICSP
- [x] ICSP content correct for both sources and mirrors
- [x] CatalogSource content correct

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules