### PR TITLE
OCPBUGS-5891: fix: adds logic that searches for the correct name when using a heads…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ sha256sum.txt
 **/.metadata.json
 oc-mirror-workspace/
 pkg/image/testdata/v2/single_manifest/manifests/oc-mirror
+olm_artifacts/
 
 # Logs.
 **/.oc-mirror.log

--- a/test/e2e/testcases.sh
+++ b/test/e2e/testcases.sh
@@ -22,6 +22,7 @@ TESTCASES[16]="skip_deps"
 TESTCASES[17]="helm_local"
 TESTCASES[18]="no_updates_exist"
 TESTCASES[19]="oci_local"
+TESTCASES[20]="headsonly_diff_with_target"
 
 # Test full catalog mode.
 function full_catalog() {
@@ -53,6 +54,20 @@ function headsonly_diff () {
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
+}
+
+# Test heads-only mode with target
+function headsonly_diff_with_target () {
+    workflow_full imageset-config-headsonly-newtarget.yaml "test-catalog-latest" --diff -c="--source-use-http"
+    # shellcheck disable=SC2086
+    check_bundles localhost.localdomain:"${REGISTRY_DISCONN_PORT}"/"${CATALOGORG}"/${TARGET_CATALOG_NAME}:${TARGET_CATALOG_TAG} \
+    "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
+    localhost.localdomain:${REGISTRY_DISCONN_PORT}
+
+    workflow_diff imageset-config-headsonly-newtarget.yaml "test-catalog-diff" -c="--source-use-http"
+    check_bundles localhost.localdomain:"${REGISTRY_DISCONN_PORT}"/"${CATALOGORG}"/"${TARGET_CATALOG_NAME}":"${TARGET_CATALOG_TAG}" \
+    "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
+    localhost.localdomain:"${REGISTRY_DISCONN_PORT}"
 }
 
 # Test heads-only mode with catalogs that prune bundles


### PR DESCRIPTION
…-only workflow with target name

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

# Description

This change fixes a bug in the event that target name is used with heads-only mode. The previous catalog information was being searched for with the source catalog name. However, catalog names are stored [uniquely](https://github.com/openshift/oc-mirror/blob/96c3cab5052cdb993eafdab7be93f7b80aaffb31/pkg/metadata/store.go#L128) in the metadata to allow for different configurations of the same source catalog. With this change, the minimum bundles versions will be managed and stored in the metadata and will be able to be located on subsequent runs.

Fixes # OCPBUGS-5891

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] E2E test case added (the added E2E test case fails on main)

**Test Configuration**:

Toolchain: go version go1.18.3 linux/amd64

# Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules