### PR TITLE
[graph-data] use new cincinnati endpoint to download tarball

### DIFF
--- a/pkg/cli/mirror/cincinnati_graph_image.go
+++ b/pkg/cli/mirror/cincinnati_graph_image.go
@@ -30,7 +30,7 @@ const (
 	// Base image to use when build graph image
 	graphBaseImage = "registry.access.redhat.com/ubi8/ubi:latest"
 	// URL where graph archive is stored
-	graphURL       = "https://github.com/openshift/cincinnati-graph-data/archive/master.tar.gz"
+	graphURL       = "https://api.openshift.com/api/upgrades_info/graph-data"
 	outputFile     = "cincinnati-graph-data.tar.gz"
 	getDataTimeout = time.Minute * 60
 )


### PR DESCRIPTION
# Description

move to the new endpoin hosted on redhat domain api.openshift.com 
to download the tarball for openshift update service (cincinnati) graph-data.

Also changes the existing logic and extracts the tarball before creating the 
container image.

As this is an init container or will be used with cincinnati plugin, we're using 
a stripped down ubi image (ubi-micro)

Fixes [OTA-831](https://issues.redhat.com//browse/OTA-831)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules