### PR TITLE
CFE-768: Update to allow for incremental and pruning for oci feature

### DIFF
--- a/imstcfg.yaml
+++ b/imstcfg.yaml
@@ -1,0 +1,27 @@
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v1alpha2
+storageConfig:
+  local:
+    path: /tmp/storageBackend
+
+
+mirror:
+  # platform:
+  #   channels:
+  #   - name: stable-4.12
+  #     type: ocp
+  #   graph: false 
+  operators:
+  #rhop
+  #- catalog: registry.redhat.io/redhat/redhat-operator-index:v4.12
+  # now pushing from FBC catalog
+  - catalog: oci:///home/skhoury/oci-catalog2
+  # redhatgov
+  # - catalog: quay.io/redhatgov/oc-mirror-dev:test-catalog-latest
+  # now pushing from FBC catalog
+  # - catalog: oci:///tmp/oci-catalog/oc-mirror-dev
+  #   originalRef: quay.io/redhatgov/oc-mirror-dev:test-catalog-latest 
+    packages:
+    - name: aws-load-balancer-operator
+  # additionalImages:
+  # - name: registry.redhat.io/ubi8/ubi:latest

--- a/pkg/cli/mirror/additional.go
+++ b/pkg/cli/mirror/additional.go
@@ -32,7 +32,7 @@ func (o *AdditionalOptions) Plan(ctx context.Context, imageList []v1alpha2.Image
 	}
 	for _, img := range imageList {
 		// Get source image information
-		srcRef, err := imagesource.ParseReference(img.Name)
+		srcRef, err := image.ParseReference(img.Name)
 		if err != nil {
 			return mmappings, fmt.Errorf("error parsing source image %s: %v", img.Name, err)
 		}
@@ -53,7 +53,7 @@ func (o *AdditionalOptions) Plan(ctx context.Context, imageList []v1alpha2.Image
 				klog.Warning(err)
 				continue
 			}
-			pinnedRef, err := imagesource.ParseReference(srcImage)
+			pinnedRef, err := image.ParseReference(srcImage)
 			if err != nil {
 				return mmappings, fmt.Errorf("error parsing source image %s: %v", img.Name, err)
 			}

--- a/pkg/cli/mirror/additional_test.go
+++ b/pkg/cli/mirror/additional_test.go
@@ -39,7 +39,7 @@ func TestPlan_Additional(t *testing.T) {
 				},
 			},
 			wantImage: image.TypedImage{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Name:      "oc-mirror-dev",
 						ID:        "sha256:ee09cc8be7dd2b7a163e37f3e4dcdb7dbf474e15bbae557249cf648da0c7559f",
@@ -64,7 +64,7 @@ func TestPlan_Additional(t *testing.T) {
 				},
 			},
 			wantImage: image.TypedImage{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "quay.io",
 						Name:      "oc-mirror-dev",

--- a/pkg/cli/mirror/catalog_images.go
+++ b/pkg/cli/mirror/catalog_images.go
@@ -84,7 +84,7 @@ func (o *MirrorOptions) rebuildCatalogs(ctx context.Context, dstDir string) (ima
 			}
 			ctlgRef := image.TypedImage{}
 			ctlgRef.Type = imagesource.DestinationRegistry
-			sourceRef, err := imagesource.ParseReference(img)
+			sourceRef, err := image.ParseReference(img)
 			if err != nil {
 				return fmt.Errorf("error parsing index dir path %q as image %q: %v", fpath, img, err)
 			}

--- a/pkg/cli/mirror/cincinnati_graph_image.go
+++ b/pkg/cli/mirror/cincinnati_graph_image.go
@@ -112,8 +112,12 @@ func (o *MirrorOptions) buildGraphImage(ctx context.Context, dstDir string) (ima
 		return refs, nil
 	}
 
+	graphImgCvt := image.TypedImageReference{
+		Ref:  graphImage.Ref,
+		Type: graphImage.Type,
+	}
 	// Add to mapping for UpdateService manifest generation
-	refs.Add(graphImage, graphImage, v1alpha2.TypeCincinnatiGraph)
+	refs.Add(graphImgCvt, graphImgCvt, v1alpha2.TypeCincinnatiGraph)
 
 	resolver, err := containerdregistry.NewResolver("", o.DestSkipTLS, o.DestPlainHTTP, nil)
 	if err != nil {

--- a/pkg/cli/mirror/create_test.go
+++ b/pkg/cli/mirror/create_test.go
@@ -37,3 +37,109 @@ func TestCreate(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, mappings, 1)
 }
+
+func TestCreateOlmArtifactsForOCI(t *testing.T) {
+
+	type spec struct {
+		desc        string
+		cfg         v1alpha2.ImageSetConfiguration
+		expectedErr string
+	}
+
+	cases := []spec{
+		{
+			desc: "Success Scenario",
+			cfg: v1alpha2.ImageSetConfiguration{
+				TypeMeta: v1alpha2.NewMetadata().TypeMeta,
+				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+					Mirror: v1alpha2.Mirror{
+						Operators: []v1alpha2.Operator{
+							{
+								Catalog: "oci://" + testdata,
+								IncludeConfig: v1alpha2.IncludeConfig{
+									Packages: []v1alpha2.IncludePackage{
+										{
+											Name: "aws-load-balancer-operator",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "Success Scenario (no OCI catalog should be skipped) ",
+			cfg: v1alpha2.ImageSetConfiguration{
+				TypeMeta: v1alpha2.NewMetadata().TypeMeta,
+				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+					Mirror: v1alpha2.Mirror{
+						Operators: []v1alpha2.Operator{
+							{
+								Catalog: testdata,
+								IncludeConfig: v1alpha2.IncludeConfig{
+									Packages: []v1alpha2.IncludePackage{
+										{
+											Name: "aws-load-balancer-operator",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "Fail Scenario (invalid catalog) ",
+			cfg: v1alpha2.ImageSetConfiguration{
+				TypeMeta: v1alpha2.NewMetadata().TypeMeta,
+				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+					Mirror: v1alpha2.Mirror{
+						Operators: []v1alpha2.Operator{
+							{
+								Catalog: "oci:",
+								IncludeConfig: v1alpha2.IncludeConfig{
+									Packages: []v1alpha2.IncludePackage{
+										{
+											Name: "aws-load-balancer-operator",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: "unable to get OCI Image from oci:: open index.json: no such file or directory",
+		},
+	}
+
+	path := t.TempDir()
+	ctx := context.Background()
+
+	opts := MirrorOptions{
+		RootOptions: &cli.RootOptions{
+			Dir:      path,
+			LogLevel: 2,
+			IOStreams: genericclioptions.IOStreams{
+				In:     os.Stdin,
+				Out:    os.Stdout,
+				ErrOut: os.Stderr,
+			},
+		},
+		OutputDir: path,
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			err := opts.createOlmArtifactsForOCI(ctx, c.cfg)
+			if c.expectedErr != "" {
+				require.EqualError(t, err, c.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/cli/mirror/fbc_operators.go
+++ b/pkg/cli/mirror/fbc_operators.go
@@ -248,10 +248,8 @@ func addCatalogToMapping(catalogMapping image.TypedImageMapping, srcOperator v1a
 	if err != nil {
 		return err
 	}
-	if srcOperator.IsFBCOCI() {
-		if !strings.Contains(srcCtlgRef, v1alpha2.OCITransportPrefix) {
-			srcCtlgRef = v1alpha2.OCITransportPrefix + "//" + srcCtlgRef
-		}
+	if srcOperator.IsFBCOCI() && !strings.Contains(srcCtlgRef, v1alpha2.OCITransportPrefix) {
+		srcCtlgRef = v1alpha2.OCITransportPrefix + "//" + srcCtlgRef
 	}
 
 	ctlgSrcTIR, err := image.ParseReference(srcCtlgRef)

--- a/pkg/cli/mirror/manifests_test.go
+++ b/pkg/cli/mirror/manifests_test.go
@@ -28,7 +28,7 @@ func TestICSPGeneration(t *testing.T) {
 	}{{
 		name: "Valid/OperatorType",
 		sourceImages: []image.TypedImage{{
-			TypedImageReference: imagesource.TypedImageReference{
+			TypedImageReference: image.TypedImageReference{
 				Ref: reference.DockerImageReference{
 					Registry:  "some-registry",
 					Namespace: "namespace",
@@ -40,7 +40,7 @@ func TestICSPGeneration(t *testing.T) {
 			Category: v1alpha2.TypeOperatorBundle,
 		}},
 		destImages: []image.TypedImage{{
-			TypedImageReference: imagesource.TypedImageReference{
+			TypedImageReference: image.TypedImageReference{
 				Ref: reference.DockerImageReference{
 					Registry:  "disconn-registry",
 					Namespace: "namespace",
@@ -76,7 +76,7 @@ func TestICSPGeneration(t *testing.T) {
 		{
 			name: "Valid/GenericType",
 			sourceImages: []image.TypedImage{{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "some-registry",
 						Namespace: "namespace",
@@ -88,7 +88,7 @@ func TestICSPGeneration(t *testing.T) {
 				Category: v1alpha2.TypeGeneric,
 			}},
 			destImages: []image.TypedImage{{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "disconn-registry",
 						Namespace: "namespace",
@@ -122,7 +122,7 @@ func TestICSPGeneration(t *testing.T) {
 		}, {
 			name: "Valid/ReleaseType",
 			sourceImages: []image.TypedImage{{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "some-registry",
 						Namespace: "namespace",
@@ -134,7 +134,7 @@ func TestICSPGeneration(t *testing.T) {
 				Category: v1alpha2.TypeOCPRelease,
 			}},
 			destImages: []image.TypedImage{{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "disconn-registry",
 						Namespace: "namespace",
@@ -167,7 +167,7 @@ func TestICSPGeneration(t *testing.T) {
 		}, {
 			name: "Valid/NamespaceScope",
 			sourceImages: []image.TypedImage{{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "some-registry",
 						Namespace: "namespace",
@@ -179,7 +179,7 @@ func TestICSPGeneration(t *testing.T) {
 				Category: v1alpha2.TypeGeneric,
 			}},
 			destImages: []image.TypedImage{{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "disconn-registry",
 						Namespace: "namespace",
@@ -213,7 +213,7 @@ func TestICSPGeneration(t *testing.T) {
 		}, {
 			name: "Valid/RegistryScope",
 			sourceImages: []image.TypedImage{{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "some-registry",
 						Namespace: "namespace",
@@ -225,7 +225,7 @@ func TestICSPGeneration(t *testing.T) {
 				Category: v1alpha2.TypeGeneric,
 			}},
 			destImages: []image.TypedImage{{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "disconn-registry",
 						Namespace: "namespace",
@@ -259,7 +259,7 @@ func TestICSPGeneration(t *testing.T) {
 		}, {
 			name: "Valid/NamespaceScopeNoNamespace",
 			sourceImages: []image.TypedImage{{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "some-registry",
 						Namespace: "",
@@ -271,7 +271,7 @@ func TestICSPGeneration(t *testing.T) {
 				Category: v1alpha2.TypeGeneric,
 			}},
 			destImages: []image.TypedImage{{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "disconn-registry",
 						Namespace: "",
@@ -305,7 +305,7 @@ func TestICSPGeneration(t *testing.T) {
 		}, {
 			name: "Invalid/NoDigestMapping",
 			sourceImages: []image.TypedImage{{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "some-registry",
 						Namespace: "namespace",
@@ -320,7 +320,7 @@ func TestICSPGeneration(t *testing.T) {
 			icspSizeLimit: 250000,
 			typ:           &GenericBuilder{},
 			destImages: []image.TypedImage{{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "disconn-registry",
 						Namespace: "namespace",
@@ -335,7 +335,7 @@ func TestICSPGeneration(t *testing.T) {
 		}, {
 			name: "Invalid/InvalidICSPScope",
 			sourceImages: []image.TypedImage{{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "some-registry",
 						Namespace: "namespace",
@@ -350,7 +350,7 @@ func TestICSPGeneration(t *testing.T) {
 			icspSizeLimit: 250000,
 			typ:           &GenericBuilder{},
 			destImages: []image.TypedImage{{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "disconn-registry",
 						Namespace: "namespace",
@@ -368,7 +368,7 @@ func TestICSPGeneration(t *testing.T) {
 			name: "Valid/OperatorTypeWithRelatedImgs",
 			sourceImages: []image.TypedImage{
 				{
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: image.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry:  "some-registry-bundle",
 							Namespace: "namespace-bundle",
@@ -380,7 +380,7 @@ func TestICSPGeneration(t *testing.T) {
 					Category: v1alpha2.TypeOperatorBundle,
 				},
 				{
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: image.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry:  "some-registry-for-related",
 							Namespace: "namespace-related",
@@ -393,7 +393,7 @@ func TestICSPGeneration(t *testing.T) {
 				}},
 			destImages: []image.TypedImage{
 				{
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: image.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry:  "disconn-registry",
 							Namespace: "namespace-bundle",
@@ -405,7 +405,7 @@ func TestICSPGeneration(t *testing.T) {
 					Category: v1alpha2.TypeOperatorBundle,
 				},
 				{
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: image.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry:  "disconn-registry",
 							Namespace: "namespace-related",
@@ -478,7 +478,7 @@ func TestWriteCatalogSource(t *testing.T) {
 		{
 			name: "Success/UniqueCatalogNames",
 			images: image.TypedImageMapping{
-				{TypedImageReference: imagesource.TypedImageReference{
+				{TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry: "test-registry",
 						Name:     "dev",
@@ -487,7 +487,7 @@ func TestWriteCatalogSource(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 					Category: v1alpha2.TypeOperatorCatalog}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: image.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry: "test-registry",
 							Name:     "dev",
@@ -496,7 +496,7 @@ func TestWriteCatalogSource(t *testing.T) {
 						Type: imagesource.DestinationRegistry,
 					},
 					Category: v1alpha2.TypeOperatorCatalog},
-				{TypedImageReference: imagesource.TypedImageReference{
+				{TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry: "test-registry",
 						Name:     "staging",
@@ -505,7 +505,7 @@ func TestWriteCatalogSource(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 					Category: v1alpha2.TypeOperatorCatalog}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: image.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry: "test-registry",
 							Name:     "staging",
@@ -523,7 +523,7 @@ func TestWriteCatalogSource(t *testing.T) {
 		{
 			name: "Success/DuplicateCatalogName",
 			images: image.TypedImageMapping{
-				{TypedImageReference: imagesource.TypedImageReference{
+				{TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry: "test-registry",
 						Name:     "dev",
@@ -532,7 +532,7 @@ func TestWriteCatalogSource(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 					Category: v1alpha2.TypeOperatorCatalog}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: image.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry: "test-registry",
 							Name:     "dev",
@@ -541,7 +541,7 @@ func TestWriteCatalogSource(t *testing.T) {
 						Type: imagesource.DestinationRegistry,
 					},
 					Category: v1alpha2.TypeOperatorCatalog},
-				{TypedImageReference: imagesource.TypedImageReference{
+				{TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry: "test-registry",
 						Name:     "dev",
@@ -550,7 +550,7 @@ func TestWriteCatalogSource(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 					Category: v1alpha2.TypeOperatorCatalog}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: image.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry: "test-registry",
 							Name:     "dev",
@@ -559,7 +559,7 @@ func TestWriteCatalogSource(t *testing.T) {
 						Type: imagesource.DestinationRegistry,
 					},
 					Category: v1alpha2.TypeOperatorCatalog},
-				{TypedImageReference: imagesource.TypedImageReference{
+				{TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry: "test-registry",
 						Name:     "dev",
@@ -568,7 +568,7 @@ func TestWriteCatalogSource(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 					Category: v1alpha2.TypeOperatorCatalog}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: image.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry: "test-registry",
 							Name:     "dev",
@@ -591,7 +591,7 @@ func TestWriteCatalogSource(t *testing.T) {
 		{
 			name: "Success/CatalogNameContainingPathComponents",
 			images: image.TypedImageMapping{
-				{TypedImageReference: imagesource.TypedImageReference{
+				{TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "foo.com",
 						Namespace: "cp",
@@ -602,7 +602,7 @@ func TestWriteCatalogSource(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 					Category: v1alpha2.TypeOperatorCatalog}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: image.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry:  "localhost:5000",
 							Namespace: "cp",

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -280,6 +280,7 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 
 	cleanup := func() error {
 		if !o.SkipCleanup {
+			os.RemoveAll("olm_artifacts")
 			return os.RemoveAll(filepath.Join(o.Dir, config.SourceDir))
 		}
 		return nil
@@ -714,7 +715,7 @@ func (o *MirrorOptions) mirrorToMirrorWrapper(ctx context.Context, cfg v1alpha2.
 			return err
 		}
 	}
-	return nil
+	return cleanup()
 }
 
 // mirrorToDiskWrapper

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -9,12 +9,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containers/image/v5/copy"
-	"github.com/containers/image/v5/types"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/opencontainers/go-digest"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"github.com/openshift/oc/pkg/cli/image/imagesource"
 	imagemanifest "github.com/openshift/oc/pkg/cli/image/manifest"
@@ -38,11 +35,6 @@ import (
 	"github.com/openshift/oc-mirror/pkg/metadata/storage"
 )
 
-const (
-	OCIFeatureCopyAction   = "copy"
-	OCIFeatureMirrorAction = "mirror"
-)
-
 var (
 	mirrorlongDesc = templates.LongDesc(
 		` 
@@ -50,39 +42,29 @@ var (
 		Accepts an argument defining the destination for the mirrored images using the prefix file:// for a local mirror packed into a 
 		tar archive or docker:// for images to be streamed registry to registry without being stored locally. The default docker credentials are 
 		used for authenticating to the registries. The podman location for credentials is also supported as a secondary location.
-
 		When using file mirroring, the --from and --config flags control the location of the images to mirror. The --config flag accepts
 		an imageset configuration file and the --from flag accepts the location of the imageset on disk. The --from input can be passed as a 
 		file or directory, but must contain only one image sequence. The naming convention for an imageset is mirror\_seq<sequence number>\_<tar count>.tar.
-
 		The location of the directory used by oc-mirror as a workspace defaults to the name oc-mirror-workspace. The location of this directory
 		is outlined in the following: 
-
 		1. Destination prefix is docker:// - The current working directory will be used.
 		2. Destination prefix is file:// - The destination directory specified will be used.
-
 		`,
 	)
 	mirrorExamples = templates.Examples(
 		`
 		# Mirror to a directory
 		oc-mirror --config mirror-config.yaml file://mirror
-
 		# Mirror to a directory without layer and image differential operations
 		oc-mirror --config mirror-config.yaml file://mirror --ignore-history
-
 		# Mirror to mirror publish
 		oc-mirror --config mirror-config.yaml docker://localhost:5000
-
 		# Publish a previously created mirror archive
 		oc-mirror --from mirror_seq1_000000.tar docker://localhost:5000
-
 		# Publish to a registry and add a top-level namespace
 		oc-mirror --from mirror_seq1_000000.tar docker://localhost:5000/namespace
-
 		# Generate manifests for previously created mirror archive
 		oc-mirror --from mirror_seq1_000000.tar docker://localhost:5000/namespace --manifests-only
-
 		# Skip metadata check during imageset publishing. This example shows a two-step process.
 		# A differential imageset would have to be created with --ignore-history to be
 		# successfully published with --skip-metadata-check.
@@ -280,6 +262,9 @@ func (o *MirrorOptions) Validate() error {
 			}
 		}
 	}
+	if !o.UseOCIFeature && len(o.OCIRegistriesConfig) > 0 {
+		return fmt.Errorf("oci-registries-config flag can only be used with the --use-oci-feature flag")
+	}
 
 	return nil
 }
@@ -300,13 +285,6 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 		return nil
 	}
 
-	if o.UseOCIFeature {
-		return o.mirrorOCIImages(cmd.Context(), cleanup)
-	} else {
-		if len(o.OCIRegistriesConfig) > 0 {
-			return fmt.Errorf("this flag can only be used with the --use-oci-feature flag")
-		}
-	}
 	return o.mirrorImages(cmd.Context(), cleanup)
 }
 
@@ -363,38 +341,6 @@ func (o *MirrorOptions) mirrorImages(ctx context.Context, cleanup cleanupFunc) e
 		return o.mirrorToMirrorWrapper(ctx, cfg, cleanup)
 
 	}
-	if o.continuedOnError {
-		return fmt.Errorf("one or more errors occurred")
-	}
-
-	return cleanup()
-}
-func (o *MirrorOptions) mirrorOCIImages(ctx context.Context, cleanup cleanupFunc) error {
-	o.remoteRegFuncs = RemoteRegFuncs{
-		copy:           copy.Image,
-		mirrorMappings: o.mirrorMappings,
-		newImageSource: func(ctx context.Context, sys *types.SystemContext, imgRef types.ImageReference) (types.ImageSource, error) {
-			return imgRef.NewImageSource(ctx, sys)
-		},
-		getManifest: func(ctx context.Context, instanceDigest *digest.Digest, imgSrc types.ImageSource) ([]byte, string, error) {
-			return imgSrc.GetManifest(ctx, instanceDigest)
-		},
-		handleMetadata:     o.handleMetadata,
-		m2mWorkflowWrapper: o.mirrorToMirrorWrapper,
-	}
-
-	isc, err := o.getISConfig()
-	if err != nil {
-		return fmt.Errorf("reading imagesetconfig via command line %v", err)
-	}
-
-	klog.Infof("mirroring images to remote registry")
-	err = o.bulkImageMirror(ctx, isc, o.ToMirror, o.UserNamespace, cleanup)
-	if err != nil {
-		return fmt.Errorf("mirroring images %v", err)
-	}
-	klog.Infof("completed catalog mirror")
-
 	if o.continuedOnError {
 		return fmt.Errorf("one or more errors occurred")
 	}
@@ -464,9 +410,18 @@ func (o *MirrorOptions) mirrorMappings(cfg v1alpha2.ImageSetConfiguration, image
 			continue
 		}
 
+		srcTIR := imagesource.TypedImageReference{
+			Ref:  srcRef.Ref,
+			Type: srcRef.Type,
+		}
+
+		dstTIR := imagesource.TypedImageReference{
+			Ref:  dstRef.Ref,
+			Type: dstRef.Type,
+		}
 		mappings = append(mappings, mirror.Mapping{
-			Source:      srcRef.TypedImageReference,
-			Destination: dstRef.TypedImageReference,
+			Source:      srcTIR,
+			Destination: dstTIR,
 			Name:        srcRef.Ref.Name,
 		})
 	}
@@ -644,13 +599,15 @@ func (o *MirrorOptions) mirrorToMirrorWrapper(ctx context.Context, cfg v1alpha2.
 	}
 
 	targetBackend, err := storage.NewRegistryBackend(targetCfg, o.Dir)
-	if err != nil {
-		return err
-	}
-	var curr v1alpha2.Metadata
-	berr := targetBackend.ReadMetadata(ctx, &curr, config.MetadataBasePath)
-	if err := o.checkSequence(meta, curr, berr); err != nil {
-		return err
+	if !o.UseOCIFeature {
+		if err != nil {
+			return err
+		}
+		var curr v1alpha2.Metadata
+		berr := targetBackend.ReadMetadata(ctx, &curr, config.MetadataBasePath)
+		if err := o.checkSequence(meta, curr, berr); err != nil {
+			return err
+		}
 	}
 
 	// Change the destination to registry

--- a/pkg/cli/mirror/mirror_test.go
+++ b/pkg/cli/mirror/mirror_test.go
@@ -385,7 +385,7 @@ func TestRemovePreviouslyMirrored(t *testing.T) {
 				},
 			}},
 			images: image.TypedImageMapping{
-				{TypedImageReference: imagesource.TypedImageReference{
+				{TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry: "test-registry",
 						Name:     "imgname",
@@ -394,7 +394,7 @@ func TestRemovePreviouslyMirrored(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 					Category: v1alpha2.TypeOCPRelease}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: image.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry: "test-registry",
 							Name:     "imgname",
@@ -403,7 +403,7 @@ func TestRemovePreviouslyMirrored(t *testing.T) {
 						Type: imagesource.DestinationRegistry,
 					},
 					Category: v1alpha2.TypeOCPRelease},
-				{TypedImageReference: imagesource.TypedImageReference{
+				{TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry: "test-registry",
 						Name:     "imgname",
@@ -412,7 +412,7 @@ func TestRemovePreviouslyMirrored(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 					Category: v1alpha2.TypeOCPRelease}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: image.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry: "test-registry",
 							Name:     "imgname",
@@ -455,7 +455,7 @@ func TestRemovePreviouslyMirrored(t *testing.T) {
 			expSet:   image.AssociationSet{},
 			expError: ErrNoUpdatesExist.Error(),
 			images: image.TypedImageMapping{
-				{TypedImageReference: imagesource.TypedImageReference{
+				{TypedImageReference: image.TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry: "test-registry",
 						Name:     "imgname",
@@ -464,7 +464,7 @@ func TestRemovePreviouslyMirrored(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 					Category: v1alpha2.TypeOCPRelease}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: image.TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry: "test-registry",
 							Name:     "imgname",

--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -466,9 +466,17 @@ func (o *OperatorOptions) plan(ctx context.Context, dc *declcfg.DeclarativeConfi
 
 	// Remove the catalog image from mappings we are going to transfer this
 	// using an OCI layout.
-	ctlgImg, err := image.ParseTypedImage(ctlgRef.Ref.Exact(), v1alpha2.TypeOperatorBundle)
-	if err != nil {
-		return nil, err
+	var ctlgImg image.TypedImage
+	if ctlgRef.Type == "oci" {
+		ctlgImg, err = image.ParseTypedImage(ctlgRef.OCIFBCPath, v1alpha2.TypeOperatorBundle)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		ctlgImg, err = image.ParseTypedImage(ctlgRef.Ref.Exact(), v1alpha2.TypeOperatorBundle)
+		if err != nil {
+			return nil, err
+		}
 	}
 	mappings.Remove(ctlgImg)
 	// Write catalog OCI layout file to src so it is included in the archive

--- a/pkg/cli/mirror/publish.go
+++ b/pkg/cli/mirror/publish.go
@@ -292,12 +292,16 @@ func (o *MirrorOptions) processMirroredImages(ctx context.Context, assocs image.
 
 			// Add top level association to the ICSP mapping
 			if assoc.Name == imageName {
-				source, err := imagesource.ParseReference(imageName)
+				source, err := image.ParseReference(imageName)
 				if err != nil {
 					errs = append(errs, err)
 					continue
 				}
-				allMappings.Add(source, m.Destination, assoc.Type)
+				dst := image.TypedImageReference{
+					Ref:  m.Destination.Ref,
+					Type: m.Destination.Type,
+				}
+				allMappings.Add(source, dst, assoc.Type)
 			}
 
 			if len(missingLayers) != 0 {

--- a/pkg/image/association_builder_test.go
+++ b/pkg/image/association_builder_test.go
@@ -29,13 +29,13 @@ func TestAssociateLocalImageLayers(t *testing.T) {
 			imgTyp: v1alpha2.TypeGeneric,
 			imgMapping: map[TypedImage]TypedImage{
 				{
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name: "imgname",
 							Tag:  "latest",
 						}},
 					Category: v1alpha2.TypeGeneric}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name: "single_manifest",
 							Tag:  "latest",
@@ -67,13 +67,13 @@ func TestAssociateLocalImageLayers(t *testing.T) {
 			imgTyp: v1alpha2.TypeGeneric,
 			imgMapping: map[TypedImage]TypedImage{
 				{
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name: "imgname",
 							ID:   "sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
 						}},
 					Category: v1alpha2.TypeGeneric}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name: "single_manifest",
 							ID:   "sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
@@ -105,13 +105,13 @@ func TestAssociateLocalImageLayers(t *testing.T) {
 			imgTyp: v1alpha2.TypeGeneric,
 			imgMapping: map[TypedImage]TypedImage{
 				{
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name: "imgname",
 							Tag:  "latest",
 						}},
 					Category: v1alpha2.TypeGeneric}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name: "index_manifest",
 							Tag:  "latest",
@@ -209,12 +209,12 @@ func TestAssociateLocalImageLayers(t *testing.T) {
 			imgTyp: v1alpha2.TypeGeneric,
 			imgMapping: map[TypedImage]TypedImage{
 				{
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name: "imgname",
 						}},
 					Category: v1alpha2.TypeGeneric}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name: "single_manifest",
 						},
@@ -229,13 +229,13 @@ func TestAssociateLocalImageLayers(t *testing.T) {
 			imgTyp: v1alpha2.TypeGeneric,
 			imgMapping: map[TypedImage]TypedImage{
 				{
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name: "imgname",
 							Tag:  "latest",
 						}},
 					Category: v1alpha2.TypeGeneric}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name: "fake_manifest",
 							Tag:  "latest",
@@ -282,14 +282,14 @@ func TestAssociateRemoteImageLayers(t *testing.T) {
 			imgTyp: v1alpha2.TypeGeneric,
 			imgMapping: map[TypedImage]TypedImage{
 				{
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name:     "single_manifest",
 							Tag:      "latest",
 							Registry: u.Host,
 						}},
 					Category: v1alpha2.TypeGeneric}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name:     "single_manifest",
 							Tag:      "latest",
@@ -322,7 +322,7 @@ func TestAssociateRemoteImageLayers(t *testing.T) {
 			imgTyp: v1alpha2.TypeGeneric,
 			imgMapping: map[TypedImage]TypedImage{
 				{
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name:     "single_manifest",
 							ID:       "sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
@@ -330,7 +330,7 @@ func TestAssociateRemoteImageLayers(t *testing.T) {
 							Registry: u.Host,
 						}},
 					Category: v1alpha2.TypeGeneric}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name:     "single_manifest",
 							ID:       "sha256:d31c6ea5c50be93d6eb94d2b508f0208e84a308c011c6454ebf291d48b37df19",
@@ -363,7 +363,7 @@ func TestAssociateRemoteImageLayers(t *testing.T) {
 			imgTyp: v1alpha2.TypeGeneric,
 			imgMapping: map[TypedImage]TypedImage{
 				{
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name:     "index_manifest",
 							Tag:      "latest",
@@ -371,7 +371,7 @@ func TestAssociateRemoteImageLayers(t *testing.T) {
 							Registry: u.Host,
 						}},
 					Category: v1alpha2.TypeGeneric}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name:     "index_manifest",
 							Tag:      "latest",
@@ -470,12 +470,12 @@ func TestAssociateRemoteImageLayers(t *testing.T) {
 			imgTyp: v1alpha2.TypeGeneric,
 			imgMapping: map[TypedImage]TypedImage{
 				{
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name: "imgname",
 						}},
 					Category: v1alpha2.TypeGeneric}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name: "single_manifest",
 						},
@@ -490,13 +490,13 @@ func TestAssociateRemoteImageLayers(t *testing.T) {
 			imgTyp: v1alpha2.TypeGeneric,
 			imgMapping: map[TypedImage]TypedImage{
 				{
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name: "imgname",
 							Tag:  "fake",
 						}},
 					Category: v1alpha2.TypeGeneric}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name: "single_manifest",
 						},
@@ -511,14 +511,14 @@ func TestAssociateRemoteImageLayers(t *testing.T) {
 			imgTyp: v1alpha2.TypeGeneric,
 			imgMapping: map[TypedImage]TypedImage{
 				{
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name:     "fake_manifest",
 							Tag:      "latest",
 							Registry: u.Host,
 						}},
 					Category: v1alpha2.TypeGeneric}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Name:     "single_manifest",
 							Registry: "test-registry.com",

--- a/pkg/image/builder/image_builder.go
+++ b/pkg/image/builder/image_builder.go
@@ -133,6 +133,10 @@ func (b *ImageBuilder) Run(ctx context.Context, targetRef string, layoutPath lay
 		var layoutOpts []layout.Option
 		if manifest.Platform != nil {
 			layoutOpts = append(layoutOpts, layout.WithPlatform(*manifest.Platform))
+		} else {
+			//OCI workflow manifest.Platform is nil, to avoid failures in the OCI workflow the default amd64/linux is set here
+			pf := &v1.Platform{Architecture: "amd64", OS: "linux"}
+			layoutOpts = append(layoutOpts, layout.WithPlatform(*pf))
 		}
 		if err := layoutPath.ReplaceImage(img, match.Digests(manifest.Digest), layoutOpts...); err != nil {
 			return err

--- a/pkg/image/convert.go
+++ b/pkg/image/convert.go
@@ -3,7 +3,6 @@ package image
 import (
 	"fmt"
 
-	"github.com/openshift/oc/pkg/cli/image/imagesource"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 
@@ -99,7 +98,7 @@ func ConvertToTypedMapping(assocs []v1alpha2.Association) (TypedImageMapping, er
 		if _, ok := childManifest[a.Name]; ok {
 			continue
 		}
-		typedImg, err := imagesource.ParseReference(a.Name)
+		typedImg, err := ParseReference(a.Name)
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/pkg/image/convert_test.go
+++ b/pkg/image/convert_test.go
@@ -682,7 +682,7 @@ func TestConvertToTypedMapping(t *testing.T) {
 		{
 			desc: "Success/ImageManifestOnly",
 			expMapping: TypedImageMapping{
-				{TypedImageReference: imagesource.TypedImageReference{
+				{TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry: "test-registry.com",
 						Name:     "foo",
@@ -691,7 +691,7 @@ func TestConvertToTypedMapping(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 					Category: v1alpha2.TypeGeneric}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry: "test-registry.com",
 							Name:     "foo",
@@ -724,7 +724,7 @@ func TestConvertToTypedMapping(t *testing.T) {
 		{
 			desc: "Success/IndexManifestOnly",
 			expMapping: TypedImageMapping{
-				{TypedImageReference: imagesource.TypedImageReference{
+				{TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry: "test-registry.com",
 						Name:     "foo",
@@ -733,7 +733,7 @@ func TestConvertToTypedMapping(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 					Category: v1alpha2.TypeGeneric}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry: "test-registry.com",
 							Name:     "foo",
@@ -742,7 +742,7 @@ func TestConvertToTypedMapping(t *testing.T) {
 						Type: imagesource.DestinationRegistry,
 					},
 					Category: v1alpha2.TypeGeneric},
-				{TypedImageReference: imagesource.TypedImageReference{
+				{TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry: "test-registry.com",
 						Name:     "bar",
@@ -751,7 +751,7 @@ func TestConvertToTypedMapping(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 					Category: v1alpha2.TypeOperatorBundle}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry: "test-registry.com",
 							Name:     "bar",
@@ -928,7 +928,7 @@ func TestConvertToTypedMapping(t *testing.T) {
 		{
 			desc: "Success/BothManifestTypes",
 			expMapping: TypedImageMapping{
-				{TypedImageReference: imagesource.TypedImageReference{
+				{TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry: "test-registry.com",
 						Name:     "foo",
@@ -937,7 +937,7 @@ func TestConvertToTypedMapping(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 					Category: v1alpha2.TypeGeneric}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry: "test-registry.com",
 							Name:     "foo",
@@ -946,7 +946,7 @@ func TestConvertToTypedMapping(t *testing.T) {
 						Type: imagesource.DestinationRegistry,
 					},
 					Category: v1alpha2.TypeGeneric},
-				{TypedImageReference: imagesource.TypedImageReference{
+				{TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry: "test-registry.com",
 						Name:     "bar",
@@ -955,7 +955,7 @@ func TestConvertToTypedMapping(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 					Category: v1alpha2.TypeGeneric}: {
-					TypedImageReference: imagesource.TypedImageReference{
+					TypedImageReference: TypedImageReference{
 						Ref: reference.DockerImageReference{
 							Registry: "test-registry.com",
 							Name:     "bar",

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/openshift/library-go/pkg/image/reference"
+	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
 	"github.com/openshift/oc/pkg/cli/image/imagesource"
 	"github.com/stretchr/testify/require"
 )
@@ -51,7 +52,7 @@ func TestParseReference(t *testing.T) {
 			expImgRef: imagesource.TypedImageReference{
 				Type: DestinationOCI,
 				Ref: reference.DockerImageReference{
-					Registry:  "home/user",
+					Registry:  "oci://home/user",
 					Namespace: "catalogs",
 					Tag:       "v4.11",
 					Name:      "redhat-operator-index",
@@ -106,7 +107,7 @@ func TestParseImageName(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			registry, org, repo, tag, sha := ParseImageReference(c.imageName)
+			registry, org, repo, tag, sha := v1alpha2.ParseImageReference(c.imageName)
 			require.Equal(t, c.expReg, registry)
 			require.Equal(t, c.expOrg, org)
 			require.Equal(t, c.expRepo, repo)

--- a/pkg/image/mapping.go
+++ b/pkg/image/mapping.go
@@ -31,7 +31,7 @@ const (
 
 // TypedImage defines an a image with the destination and content type
 type TypedImage struct {
-	imagesource.TypedImageReference
+	TypedImageReference
 	ImageFormat Format
 	// Category adds image category type to TypedImageReference
 	Category v1alpha2.ImageType
@@ -39,7 +39,7 @@ type TypedImage struct {
 
 // ParseTypedImage will create a TypedImage from a string and type
 func ParseTypedImage(image string, typ v1alpha2.ImageType) (TypedImage, error) {
-	ref, err := imagesource.ParseReference(image)
+	ref, err := ParseReference(image)
 	if err != nil {
 		return TypedImage{}, err
 	}
@@ -52,7 +52,6 @@ func ParseTypedImage(image string, typ v1alpha2.ImageType) (TypedImage, error) {
 
 // SetDefaults sets the default values for TypedImage fields
 func (t TypedImage) SetDefaults() TypedImage {
-
 	if len(t.Ref.Tag) == 0 {
 		partial, err := getPartialDigest(t.Ref.ID)
 		// If unable to get a partial digest
@@ -95,7 +94,7 @@ func (m TypedImageMapping) Merge(in TypedImageMapping) {
 }
 
 // Add stores a key-value pair into image map
-func (m TypedImageMapping) Add(srcRef, dstRef imagesource.TypedImageReference, typ v1alpha2.ImageType) {
+func (m TypedImageMapping) Add(srcRef, dstRef TypedImageReference, typ v1alpha2.ImageType) {
 	srcTypedRef := TypedImage{
 		TypedImageReference: srcRef,
 		Category:            typ,

--- a/pkg/image/mapping_test.go
+++ b/pkg/image/mapping_test.go
@@ -20,7 +20,7 @@ func TestByCategory(t *testing.T) {
 	}{{
 		name: "Valid/OneType",
 		input: TypedImageMapping{
-			{TypedImageReference: imagesource.TypedImageReference{
+			{TypedImageReference: TypedImageReference{
 				Ref: reference.DockerImageReference{
 					Registry:  "some-registry",
 					Namespace: "namespace",
@@ -30,7 +30,7 @@ func TestByCategory(t *testing.T) {
 				Type: imagesource.DestinationRegistry,
 			},
 				Category: v1alpha2.TypeOperatorBundle}: {
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "disconn-registry",
 						Namespace: "namespace",
@@ -40,7 +40,7 @@ func TestByCategory(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 				Category: v1alpha2.TypeOperatorBundle},
-			{TypedImageReference: imagesource.TypedImageReference{
+			{TypedImageReference: TypedImageReference{
 				Ref: reference.DockerImageReference{
 					Registry:  "some-registry",
 					Namespace: "namespace",
@@ -50,7 +50,7 @@ func TestByCategory(t *testing.T) {
 				Type: imagesource.DestinationRegistry,
 			},
 				Category: v1alpha2.TypeOCPRelease}: {
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "disconn-registry",
 						Namespace: "namespace",
@@ -63,7 +63,7 @@ func TestByCategory(t *testing.T) {
 		},
 		typ: []v1alpha2.ImageType{v1alpha2.TypeOperatorBundle},
 		expected: TypedImageMapping{{
-			TypedImageReference: imagesource.TypedImageReference{
+			TypedImageReference: TypedImageReference{
 				Ref: reference.DockerImageReference{
 					Registry:  "some-registry",
 					Namespace: "namespace",
@@ -73,7 +73,7 @@ func TestByCategory(t *testing.T) {
 				Type: imagesource.DestinationRegistry,
 			},
 			Category: v1alpha2.TypeOperatorBundle}: {
-			TypedImageReference: imagesource.TypedImageReference{
+			TypedImageReference: TypedImageReference{
 				Ref: reference.DockerImageReference{
 					Registry:  "disconn-registry",
 					Namespace: "namespace",
@@ -87,7 +87,7 @@ func TestByCategory(t *testing.T) {
 	}, {
 		name: "Valid/PruneAllTypes",
 		input: TypedImageMapping{{
-			TypedImageReference: imagesource.TypedImageReference{
+			TypedImageReference: TypedImageReference{
 				Ref: reference.DockerImageReference{
 					Registry:  "some-registry",
 					Namespace: "namespace",
@@ -97,7 +97,7 @@ func TestByCategory(t *testing.T) {
 				Type: imagesource.DestinationRegistry,
 			},
 			Category: v1alpha2.TypeOperatorBundle}: {
-			TypedImageReference: imagesource.TypedImageReference{
+			TypedImageReference: TypedImageReference{
 				Ref: reference.DockerImageReference{
 					Registry:  "disconn-registry",
 					Namespace: "namespace",
@@ -113,7 +113,7 @@ func TestByCategory(t *testing.T) {
 	}, {
 		name: "Valid/MultipleTypes",
 		input: TypedImageMapping{
-			{TypedImageReference: imagesource.TypedImageReference{
+			{TypedImageReference: TypedImageReference{
 				Ref: reference.DockerImageReference{
 					Registry:  "some-registry",
 					Namespace: "namespace",
@@ -123,7 +123,7 @@ func TestByCategory(t *testing.T) {
 				Type: imagesource.DestinationRegistry,
 			},
 				Category: v1alpha2.TypeOperatorBundle}: {
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "disconn-registry",
 						Namespace: "namespace",
@@ -133,7 +133,7 @@ func TestByCategory(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 				Category: v1alpha2.TypeOperatorBundle},
-			{TypedImageReference: imagesource.TypedImageReference{
+			{TypedImageReference: TypedImageReference{
 				Ref: reference.DockerImageReference{
 					Registry:  "some-registry",
 					Namespace: "namespace",
@@ -143,7 +143,7 @@ func TestByCategory(t *testing.T) {
 				Type: imagesource.DestinationRegistry,
 			},
 				Category: v1alpha2.TypeOperatorCatalog}: {
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "disconn-registry",
 						Namespace: "namespace",
@@ -153,7 +153,7 @@ func TestByCategory(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 				Category: v1alpha2.TypeOperatorCatalog},
-			{TypedImageReference: imagesource.TypedImageReference{
+			{TypedImageReference: TypedImageReference{
 				Ref: reference.DockerImageReference{
 					Registry:  "some-registry",
 					Namespace: "namespace",
@@ -163,7 +163,7 @@ func TestByCategory(t *testing.T) {
 				Type: imagesource.DestinationRegistry,
 			},
 				Category: v1alpha2.TypeGeneric}: {
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "disconn-registry",
 						Namespace: "namespace",
@@ -176,7 +176,7 @@ func TestByCategory(t *testing.T) {
 		},
 		typ: []v1alpha2.ImageType{v1alpha2.TypeOperatorBundle, v1alpha2.TypeOperatorCatalog},
 		expected: TypedImageMapping{
-			{TypedImageReference: imagesource.TypedImageReference{
+			{TypedImageReference: TypedImageReference{
 				Ref: reference.DockerImageReference{
 					Registry:  "some-registry",
 					Namespace: "namespace",
@@ -186,7 +186,7 @@ func TestByCategory(t *testing.T) {
 				Type: imagesource.DestinationRegistry,
 			},
 				Category: v1alpha2.TypeOperatorBundle}: {
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "disconn-registry",
 						Namespace: "namespace",
@@ -196,7 +196,7 @@ func TestByCategory(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 				Category: v1alpha2.TypeOperatorBundle},
-			{TypedImageReference: imagesource.TypedImageReference{
+			{TypedImageReference: TypedImageReference{
 				Ref: reference.DockerImageReference{
 					Registry:  "some-registry",
 					Namespace: "namespace",
@@ -206,7 +206,7 @@ func TestByCategory(t *testing.T) {
 				Type: imagesource.DestinationRegistry,
 			},
 				Category: v1alpha2.TypeOperatorCatalog}: {
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "disconn-registry",
 						Namespace: "namespace",
@@ -240,7 +240,7 @@ func TestReadImageMapping(t *testing.T) {
 		seperator: "=",
 		typ:       v1alpha2.TypeOperatorBundle,
 		expected: TypedImageMapping{{
-			TypedImageReference: imagesource.TypedImageReference{
+			TypedImageReference: TypedImageReference{
 				Ref: reference.DockerImageReference{
 					Registry:  "some-registry.com",
 					Namespace: "namespace",
@@ -250,7 +250,7 @@ func TestReadImageMapping(t *testing.T) {
 				Type: imagesource.DestinationRegistry,
 			},
 			Category: v1alpha2.TypeOperatorBundle}: {
-			TypedImageReference: imagesource.TypedImageReference{
+			TypedImageReference: TypedImageReference{
 				Ref: reference.DockerImageReference{
 					Registry:  "disconn-registry.com",
 					Namespace: "namespace",
@@ -291,7 +291,7 @@ func TestWriteImageMapping(t *testing.T) {
 		{
 			name: "Valid/NoIDInDestination",
 			mapping: TypedImageMapping{{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "some-registry.com",
 						Namespace: "namespace",
@@ -301,7 +301,7 @@ func TestWriteImageMapping(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 				Category: v1alpha2.TypeOperatorBundle}: {
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "disconn-registry.com",
 						Namespace: "namespace",
@@ -317,7 +317,7 @@ func TestWriteImageMapping(t *testing.T) {
 		{
 			name: "Valid/PreferTagOverID",
 			mapping: TypedImageMapping{{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "some-registry.com",
 						Namespace: "namespace",
@@ -328,7 +328,7 @@ func TestWriteImageMapping(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 				Category: v1alpha2.TypeOperatorBundle}: {
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "disconn-registry.com",
 						Namespace: "namespace",
@@ -346,7 +346,7 @@ func TestWriteImageMapping(t *testing.T) {
 		{
 			name: "Valid/NoTags",
 			mapping: TypedImageMapping{{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "some-registry.com",
 						Namespace: "namespace",
@@ -356,7 +356,7 @@ func TestWriteImageMapping(t *testing.T) {
 					Type: imagesource.DestinationRegistry,
 				},
 				Category: v1alpha2.TypeOperatorBundle}: {
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "disconn-registry.com",
 						Namespace: "namespace",
@@ -395,7 +395,7 @@ func TestSetDefaults(t *testing.T) {
 		{
 			name: "Valid/NoChanges",
 			mapping: TypedImage{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "some-registry.com",
 						Namespace: "namespace",
@@ -407,7 +407,7 @@ func TestSetDefaults(t *testing.T) {
 				Category: v1alpha2.TypeOperatorBundle,
 			},
 			expected: TypedImage{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "some-registry.com",
 						Namespace: "namespace",
@@ -422,7 +422,7 @@ func TestSetDefaults(t *testing.T) {
 		{
 			name: "Valid/SetLatest",
 			mapping: TypedImage{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "some-registry.com",
 						Namespace: "namespace",
@@ -433,7 +433,7 @@ func TestSetDefaults(t *testing.T) {
 				Category: v1alpha2.TypeOperatorBundle,
 			},
 			expected: TypedImage{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "some-registry.com",
 						Namespace: "namespace",
@@ -448,7 +448,7 @@ func TestSetDefaults(t *testing.T) {
 		{
 			name: "Valid/SetWithPartialDigest",
 			mapping: TypedImage{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "some-registry.com",
 						Namespace: "namespace",
@@ -460,7 +460,7 @@ func TestSetDefaults(t *testing.T) {
 				Category: v1alpha2.TypeOperatorBundle,
 			},
 			expected: TypedImage{
-				TypedImageReference: imagesource.TypedImageReference{
+				TypedImageReference: TypedImageReference{
 					Ref: reference.DockerImageReference{
 						Registry:  "some-registry.com",
 						Namespace: "namespace",
@@ -485,7 +485,7 @@ func TestSetDefaults(t *testing.T) {
 func TestToRegistry(t *testing.T) {
 	toMirror := "test.registry"
 	inputMapping := TypedImageMapping{
-		{TypedImageReference: imagesource.TypedImageReference{
+		{TypedImageReference: TypedImageReference{
 			Ref: reference.DockerImageReference{
 				Registry:  "some-registry",
 				Namespace: "namespace",
@@ -495,7 +495,7 @@ func TestToRegistry(t *testing.T) {
 			Type: imagesource.DestinationRegistry,
 		},
 			Category: v1alpha2.TypeOperatorBundle}: {
-			TypedImageReference: imagesource.TypedImageReference{
+			TypedImageReference: TypedImageReference{
 				Ref: reference.DockerImageReference{
 					Registry:  "disconn-registry",
 					Namespace: "namespace",
@@ -507,7 +507,7 @@ func TestToRegistry(t *testing.T) {
 			Category: v1alpha2.TypeOperatorBundle}}
 
 	expMapping := TypedImageMapping{
-		{TypedImageReference: imagesource.TypedImageReference{
+		{TypedImageReference: TypedImageReference{
 			Ref: reference.DockerImageReference{
 				Registry:  "some-registry",
 				Namespace: "namespace",
@@ -517,7 +517,7 @@ func TestToRegistry(t *testing.T) {
 			Type: imagesource.DestinationRegistry,
 		},
 			Category: v1alpha2.TypeOperatorBundle}: {
-			TypedImageReference: imagesource.TypedImageReference{
+			TypedImageReference: TypedImageReference{
 				Ref: reference.DockerImageReference{
 					Registry:  "test.registry",
 					Namespace: "namespace",

--- a/test/e2e/artifacts/configs/index.yaml
+++ b/test/e2e/artifacts/configs/index.yaml
@@ -1,0 +1,589 @@
+---
+schema: olm.package
+name: foo
+description: 'foo
+
+  ===
+
+
+  The Foo operator reacts to Foos objects.
+
+  '
+icon:
+  base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJpY29uIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKICAgIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgogIC5zcXVpcmNsZSB7IGZpbGw6ICM3Qjg3OTQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDVweCwgMXB4KTsgfQogIC5uYW1lIHsgZm9udDogYm9sZCA0MDBweCBzYW5zIHNlcmlmOyBmaWxsOiByZWQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDEzMHB4LCA1MDBweCkgcm90YXRlKDIwZGVnKTsgfQo8L3N0eWxlPgo8Zz4KICA8cGF0aCBjbGFzcz0ic3F1aXJjbGUiIGQ9Ik0gMCwgNTAwCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBDIDAsIDUgNSwgMCA1MDAsIDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgIFMgMTAwMCwgNSAxMDAwLCA1MDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMTAwMCwgMTAwMCA1MDAsIDEwMDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMCwgMTAwMCAwLCA1MDAiLz4KICA8dGV4dCBjbGFzcz0ibmFtZSI+Zm9vPC90ZXh0Pgo8L2c+Cjwvc3ZnPgo=
+  mediatype: image/svg+xml
+defaultChannel: beta
+---
+schema: olm.channel
+package: foo
+name: beta
+entries:
+- name: foo.v0.1.0
+  skipRange: <0.1.0
+- name: foo.v0.2.0
+  skipRange: <0.2.0
+  skips:
+  - foo.v0.1.1
+  - foo.v0.1.2
+  replaces: foo.v0.1.0
+- name: foo.v0.3.0
+  skipRange: <0.3.0
+  replaces: foo.v0.2.0
+- name: foo.v0.3.1
+  skipRange: <0.3.1
+  skips:
+  - foo.v0.3.0
+  replaces: foo.v0.2.0
+---
+schema: olm.bundle
+package: foo
+name: foo.v0.1.0
+image: quay.io/redhatgov/oc-mirror-dev:foo-bundle-v0.1.0
+csvJson: '{"apiVersion": "operators.coreos.com/v1alpha1", "kind": "ClusterServiceVersion",
+  "metadata": {"annotations": {"capabilities": "BasicInstall", "certified": "false",
+  "containerImage": "quay.io/redhatgov/oc-mirror-dev@sha256:7d6bfc2e0450e0fe7a469884e5078b95c44ef84843e66bbf4ae0b3db17eeae84",
+  "description": "The Foo Operator does Foo things.", "olm.skipRange": "<0.1.0", "repository":
+  "https://github.com/openshift/oc-mirror"}, "name": "foo.v0.1.0"}, "spec": {"customresourcedefinitions":
+  {"owned": [{"group": "test.foo", "kind": "Foo", "name": "foos.test.foo", "version":
+  "v1"}]}, "description": "The Foo Operator does Foo things.", "displayName": "Foo
+  Operator", "icon": [{"base64data": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJpY29uIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKICAgIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgogIC5zcXVpcmNsZSB7IGZpbGw6ICM3Qjg3OTQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDVweCwgMXB4KTsgfQogIC5uYW1lIHsgZm9udDogYm9sZCA0MDBweCBzYW5zIHNlcmlmOyBmaWxsOiByZWQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDEzMHB4LCA1MDBweCkgcm90YXRlKDIwZGVnKTsgfQo8L3N0eWxlPgo8Zz4KICA8cGF0aCBjbGFzcz0ic3F1aXJjbGUiIGQ9Ik0gMCwgNTAwCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBDIDAsIDUgNSwgMCA1MDAsIDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgIFMgMTAwMCwgNSAxMDAwLCA1MDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMTAwMCwgMTAwMCA1MDAsIDEwMDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMCwgMTAwMCAwLCA1MDAiLz4KICA8dGV4dCBjbGFzcz0ibmFtZSI+Zm9vPC90ZXh0Pgo8L2c+Cjwvc3ZnPgo=",
+  "mediatype": "image/svg+xml"}], "install": {"spec": {"deployments": [{"name": "foo-operator",
+  "spec": {"replicas": 1, "selector": {"matchLabels": {"app": "foo-operator"}}, "template":
+  {"metadata": {"labels": {"app": "foo-operator", "version": "v0.1.0"}, "name": "foo-operator"},
+  "spec": {"containers": [{"command": ["/run.sh"], "image": "quay.io/redhatgov/oc-mirror-dev@sha256:7d6bfc2e0450e0fe7a469884e5078b95c44ef84843e66bbf4ae0b3db17eeae84",
+  "imagePullPolicy": "Always", "name": "foo"}]}}}}]}, "strategy": "deployment"}, "installModes":
+  [{"supported": true, "type": "OwnNamespace"}, {"supported": true, "type": "SingleNamespace"},
+  {"supported": false, "type": "MultiNamespace"}, {"supported": true, "type": "AllNamespaces"}],
+  "keywords": ["foo"], "labels": {"name": "foo-operator"}, "maintainers": [{"email":
+  "oc-mirror@openshift.org", "name": "oc-mirror developers"}], "maturity": "beta",
+  "provider": {"name": "Foo"}, "relatedImages": [{"image": "quay.io/redhatgov/oc-mirror-dev@sha256:7d6bfc2e0450e0fe7a469884e5078b95c44ef84843e66bbf4ae0b3db17eeae84",
+  "name": "operator"}], "version": "0.1.0"}}'
+properties:
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v1
+- type: olm.package
+  value:
+    packageName: foo
+    version: 0.1.0
+- type: olm.package.required
+  value:
+    packageName: bar
+    versionRange: <0.2.0
+- type: olm.gvk.required
+  value:
+    group: test.bar
+    version: v1alpha1
+    kind: Bar
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgImtpbmQiOiAiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwgIm1ldGFkYXRhIjogeyJhbm5vdGF0aW9ucyI6IHsiY2FwYWJpbGl0aWVzIjogIkJhc2ljSW5zdGFsbCIsICJjZXJ0aWZpZWQiOiAiZmFsc2UiLCAiY29udGFpbmVySW1hZ2UiOiAicXVheS5pby9yZWRoYXRnb3Yvb2MtbWlycm9yLWRldkBzaGEyNTY6N2Q2YmZjMmUwNDUwZTBmZTdhNDY5ODg0ZTUwNzhiOTVjNDRlZjg0ODQzZTY2YmJmNGFlMGIzZGIxN2VlYWU4NCIsICJkZXNjcmlwdGlvbiI6ICJUaGUgRm9vIE9wZXJhdG9yIGRvZXMgRm9vIHRoaW5ncy4iLCAib2xtLnNraXBSYW5nZSI6ICI8MC4xLjAiLCAicmVwb3NpdG9yeSI6ICJodHRwczovL2dpdGh1Yi5jb20vb3BlbnNoaWZ0L29jLW1pcnJvciJ9LCAibmFtZSI6ICJmb28udjAuMS4wIn0sICJzcGVjIjogeyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjogeyJvd25lZCI6IFt7Imdyb3VwIjogInRlc3QuZm9vIiwgImtpbmQiOiAiRm9vIiwgIm5hbWUiOiAiZm9vcy50ZXN0LmZvbyIsICJ2ZXJzaW9uIjogInYxIn1dfSwgImRlc2NyaXB0aW9uIjogIlRoZSBGb28gT3BlcmF0b3IgZG9lcyBGb28gdGhpbmdzLiIsICJkaXNwbGF5TmFtZSI6ICJGb28gT3BlcmF0b3IiLCAiaWNvbiI6IFt7ImJhc2U2NGRhdGEiOiAiUEQ5NGJXd2dkbVZ5YzJsdmJqMGlNUzR3SWlCbGJtTnZaR2x1WnowaWRYUm1MVGdpUHo0S1BITjJaeUIyWlhKemFXOXVQU0l4TGpFaUlHbGtQU0pwWTI5dUlpQjRiV3h1Y3owaWFIUjBjRG92TDNkM2R5NTNNeTV2Y21jdk1qQXdNQzl6ZG1jaUlIaHRiRzV6T25oc2FXNXJQU0pvZEhSd09pOHZkM2QzTG5jekxtOXlaeTh4T1RrNUwzaHNhVzVySWlCNFBTSXdjSGdpSUhrOUlqQndlQ0lLSUNBZ0lIWnBaWGRDYjNnOUlqQWdNQ0F4TWpnd0lERXlPREFpSUhOMGVXeGxQU0psYm1GaWJHVXRZbUZqYTJkeWIzVnVaRHB1WlhjZ01DQXdJREV5T0RBZ01USTRNRHNpSUhodGJEcHpjR0ZqWlQwaWNISmxjMlZ5ZG1VaVBnbzhjM1I1YkdVZ2RIbHdaVDBpZEdWNGRDOWpjM01pUGdvZ0lDNXpjWFZwY21Oc1pTQjdJR1pwYkd3NklDTTNRamczT1RRN0lIUnlZVzV6Wm05eWJUb2dkSEpoYm5Oc1lYUmxLRFZ3ZUN3Z01YQjRLVHNnZlFvZ0lDNXVZVzFsSUhzZ1ptOXVkRG9nWW05c1pDQTBNREJ3ZUNCellXNXpJSE5sY21sbU95Qm1hV3hzT2lCeVpXUTdJSFJ5WVc1elptOXliVG9nZEhKaGJuTnNZWFJsS0RFek1IQjRMQ0ExTURCd2VDa2djbTkwWVhSbEtESXdaR1ZuS1RzZ2ZRbzhMM04wZVd4bFBnbzhaejRLSUNBOGNHRjBhQ0JqYkdGemN6MGljM0YxYVhKamJHVWlJR1E5SWswZ01Dd2dOVEF3Q2lBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNCRElEQXNJRFVnTlN3Z01DQTFNREFzSURBS0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lGTWdNVEF3TUN3Z05TQXhNREF3TENBMU1EQUtJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnTVRBd01Dd2dNVEF3TUNBMU1EQXNJREV3TURBS0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdNQ3dnTVRBd01DQXdMQ0ExTURBaUx6NEtJQ0E4ZEdWNGRDQmpiR0Z6Y3owaWJtRnRaU0krWm05dlBDOTBaWGgwUGdvOEwyYytDand2YzNablBnbz0iLCAibWVkaWF0eXBlIjogImltYWdlL3N2Zyt4bWwifV0sICJpbnN0YWxsIjogeyJzcGVjIjogeyJkZXBsb3ltZW50cyI6IFt7Im5hbWUiOiAiZm9vLW9wZXJhdG9yIiwgInNwZWMiOiB7InJlcGxpY2FzIjogMSwgInNlbGVjdG9yIjogeyJtYXRjaExhYmVscyI6IHsiYXBwIjogImZvby1vcGVyYXRvciJ9fSwgInRlbXBsYXRlIjogeyJtZXRhZGF0YSI6IHsibGFiZWxzIjogeyJhcHAiOiAiZm9vLW9wZXJhdG9yIiwgInZlcnNpb24iOiAidjAuMS4wIn0sICJuYW1lIjogImZvby1vcGVyYXRvciJ9LCAic3BlYyI6IHsiY29udGFpbmVycyI6IFt7ImNvbW1hbmQiOiBbIi9ydW4uc2giXSwgImltYWdlIjogInF1YXkuaW8vcmVkaGF0Z292L29jLW1pcnJvci1kZXZAc2hhMjU2OjdkNmJmYzJlMDQ1MGUwZmU3YTQ2OTg4NGU1MDc4Yjk1YzQ0ZWY4NDg0M2U2NmJiZjRhZTBiM2RiMTdlZWFlODQiLCAiaW1hZ2VQdWxsUG9saWN5IjogIkFsd2F5cyIsICJuYW1lIjogImZvbyJ9XX19fX1dfSwgInN0cmF0ZWd5IjogImRlcGxveW1lbnQifSwgImluc3RhbGxNb2RlcyI6IFt7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIk93bk5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIlNpbmdsZU5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IGZhbHNlLCAidHlwZSI6ICJNdWx0aU5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIkFsbE5hbWVzcGFjZXMifV0sICJrZXl3b3JkcyI6IFsiZm9vIl0sICJsYWJlbHMiOiB7Im5hbWUiOiAiZm9vLW9wZXJhdG9yIn0sICJtYWludGFpbmVycyI6IFt7ImVtYWlsIjogIm9jLW1pcnJvckBvcGVuc2hpZnQub3JnIiwgIm5hbWUiOiAib2MtbWlycm9yIGRldmVsb3BlcnMifV0sICJtYXR1cml0eSI6ICJiZXRhIiwgInByb3ZpZGVyIjogeyJuYW1lIjogIkZvbyJ9LCAicmVsYXRlZEltYWdlcyI6IFt7ImltYWdlIjogInF1YXkuaW8vcmVkaGF0Z292L29jLW1pcnJvci1kZXZAc2hhMjU2OjdkNmJmYzJlMDQ1MGUwZmU3YTQ2OTg4NGU1MDc4Yjk1YzQ0ZWY4NDg0M2U2NmJiZjRhZTBiM2RiMTdlZWFlODQiLCAibmFtZSI6ICJvcGVyYXRvciJ9XSwgInZlcnNpb24iOiAiMC4xLjAifX0=
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogImFwaWV4dGVuc2lvbnMuazhzLmlvL3YxIiwgImtpbmQiOiAiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwgIm1ldGFkYXRhIjogeyJuYW1lIjogImZvb3MudGVzdC5mb28ifSwgInNwZWMiOiB7Imdyb3VwIjogInRlc3QuZm9vIiwgInNjb3BlIjogIk5hbWVzcGFjZWQiLCAibmFtZXMiOiB7ImtpbmQiOiAiRm9vIiwgInBsdXJhbCI6ICJmb29zIn0sICJ2ZXJzaW9ucyI6IFt7Im5hbWUiOiAidjEiLCAic2VydmVkIjogdHJ1ZSwgInN0b3JhZ2UiOiB0cnVlLCAic2NoZW1hIjogeyJvcGVuQVBJVjNTY2hlbWEiOiB7InR5cGUiOiAib2JqZWN0IiwgIngta3ViZXJuZXRlcy1wcmVzZXJ2ZS11bmtub3duLWZpZWxkcyI6IHRydWV9fX1dfX0=
+relatedImages:
+- name: operator
+  image: quay.io/redhatgov/oc-mirror-dev@sha256:7d6bfc2e0450e0fe7a469884e5078b95c44ef84843e66bbf4ae0b3db17eeae84
+---
+schema: olm.bundle
+package: foo
+name: foo.v0.2.0
+image: quay.io/redhatgov/oc-mirror-dev:foo-bundle-v0.2.0
+csvJson: '{"apiVersion": "operators.coreos.com/v1alpha1", "kind": "ClusterServiceVersion",
+  "metadata": {"annotations": {"capabilities": "BasicInstall", "certified": "false",
+  "containerImage": "quay.io/redhatgov/oc-mirror-dev@sha256:4daee43355c22f037602e266f012c158fd567050ad6c9dc36e49a45012196d62",
+  "description": "The Foo Operator does Foo things.", "olm.skipRange": "<0.2.0", "repository":
+  "https://github.com/openshift/oc-mirror"}, "name": "foo.v0.2.0"}, "spec": {"customresourcedefinitions":
+  {"owned": [{"group": "test.foo", "kind": "Foo", "name": "foos.test.foo", "version":
+  "v1"}]}, "description": "The Foo Operator does Foo things.", "displayName": "Foo
+  Operator", "icon": [{"base64data": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJpY29uIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKICAgIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgogIC5zcXVpcmNsZSB7IGZpbGw6ICM3Qjg3OTQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDVweCwgMXB4KTsgfQogIC5uYW1lIHsgZm9udDogYm9sZCA0MDBweCBzYW5zIHNlcmlmOyBmaWxsOiByZWQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDEzMHB4LCA1MDBweCkgcm90YXRlKDIwZGVnKTsgfQo8L3N0eWxlPgo8Zz4KICA8cGF0aCBjbGFzcz0ic3F1aXJjbGUiIGQ9Ik0gMCwgNTAwCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBDIDAsIDUgNSwgMCA1MDAsIDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgIFMgMTAwMCwgNSAxMDAwLCA1MDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMTAwMCwgMTAwMCA1MDAsIDEwMDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMCwgMTAwMCAwLCA1MDAiLz4KICA8dGV4dCBjbGFzcz0ibmFtZSI+Zm9vPC90ZXh0Pgo8L2c+Cjwvc3ZnPgo=",
+  "mediatype": "image/svg+xml"}], "install": {"spec": {"deployments": [{"name": "foo-operator",
+  "spec": {"replicas": 1, "selector": {"matchLabels": {"app": "foo-operator"}}, "template":
+  {"metadata": {"labels": {"app": "foo-operator", "version": "v0.2.0"}, "name": "foo-operator"},
+  "spec": {"containers": [{"command": ["/run.sh"], "image": "quay.io/redhatgov/oc-mirror-dev@sha256:4daee43355c22f037602e266f012c158fd567050ad6c9dc36e49a45012196d62",
+  "imagePullPolicy": "Always", "name": "foo"}]}}}}]}, "strategy": "deployment"}, "installModes":
+  [{"supported": true, "type": "OwnNamespace"}, {"supported": true, "type": "SingleNamespace"},
+  {"supported": false, "type": "MultiNamespace"}, {"supported": true, "type": "AllNamespaces"}],
+  "keywords": ["foo"], "labels": {"name": "foo-operator"}, "maintainers": [{"email":
+  "oc-mirror@openshift.org", "name": "oc-mirror developers"}], "maturity": "beta",
+  "provider": {"name": "Foo"}, "relatedImages": [{"image": "quay.io/redhatgov/oc-mirror-dev@sha256:4daee43355c22f037602e266f012c158fd567050ad6c9dc36e49a45012196d62",
+  "name": "operator"}], "replaces": "foo.v0.1.0", "skips": ["foo.v0.1.1", "foo.v0.1.2"],
+  "version": "0.2.0"}}'
+properties:
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v1
+- type: olm.package
+  value:
+    packageName: foo
+    version: 0.2.0
+- type: olm.package.required
+  value:
+    packageName: bar
+    versionRange: <0.2.0
+- type: olm.gvk.required
+  value:
+    group: test.bar
+    version: v1alpha1
+    kind: Bar
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgImtpbmQiOiAiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwgIm1ldGFkYXRhIjogeyJhbm5vdGF0aW9ucyI6IHsiY2FwYWJpbGl0aWVzIjogIkJhc2ljSW5zdGFsbCIsICJjZXJ0aWZpZWQiOiAiZmFsc2UiLCAiY29udGFpbmVySW1hZ2UiOiAicXVheS5pby9yZWRoYXRnb3Yvb2MtbWlycm9yLWRldkBzaGEyNTY6NGRhZWU0MzM1NWMyMmYwMzc2MDJlMjY2ZjAxMmMxNThmZDU2NzA1MGFkNmM5ZGMzNmU0OWE0NTAxMjE5NmQ2MiIsICJkZXNjcmlwdGlvbiI6ICJUaGUgRm9vIE9wZXJhdG9yIGRvZXMgRm9vIHRoaW5ncy4iLCAib2xtLnNraXBSYW5nZSI6ICI8MC4yLjAiLCAicmVwb3NpdG9yeSI6ICJodHRwczovL2dpdGh1Yi5jb20vb3BlbnNoaWZ0L29jLW1pcnJvciJ9LCAibmFtZSI6ICJmb28udjAuMi4wIn0sICJzcGVjIjogeyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjogeyJvd25lZCI6IFt7Imdyb3VwIjogInRlc3QuZm9vIiwgImtpbmQiOiAiRm9vIiwgIm5hbWUiOiAiZm9vcy50ZXN0LmZvbyIsICJ2ZXJzaW9uIjogInYxIn1dfSwgImRlc2NyaXB0aW9uIjogIlRoZSBGb28gT3BlcmF0b3IgZG9lcyBGb28gdGhpbmdzLiIsICJkaXNwbGF5TmFtZSI6ICJGb28gT3BlcmF0b3IiLCAiaWNvbiI6IFt7ImJhc2U2NGRhdGEiOiAiUEQ5NGJXd2dkbVZ5YzJsdmJqMGlNUzR3SWlCbGJtTnZaR2x1WnowaWRYUm1MVGdpUHo0S1BITjJaeUIyWlhKemFXOXVQU0l4TGpFaUlHbGtQU0pwWTI5dUlpQjRiV3h1Y3owaWFIUjBjRG92TDNkM2R5NTNNeTV2Y21jdk1qQXdNQzl6ZG1jaUlIaHRiRzV6T25oc2FXNXJQU0pvZEhSd09pOHZkM2QzTG5jekxtOXlaeTh4T1RrNUwzaHNhVzVySWlCNFBTSXdjSGdpSUhrOUlqQndlQ0lLSUNBZ0lIWnBaWGRDYjNnOUlqQWdNQ0F4TWpnd0lERXlPREFpSUhOMGVXeGxQU0psYm1GaWJHVXRZbUZqYTJkeWIzVnVaRHB1WlhjZ01DQXdJREV5T0RBZ01USTRNRHNpSUhodGJEcHpjR0ZqWlQwaWNISmxjMlZ5ZG1VaVBnbzhjM1I1YkdVZ2RIbHdaVDBpZEdWNGRDOWpjM01pUGdvZ0lDNXpjWFZwY21Oc1pTQjdJR1pwYkd3NklDTTNRamczT1RRN0lIUnlZVzV6Wm05eWJUb2dkSEpoYm5Oc1lYUmxLRFZ3ZUN3Z01YQjRLVHNnZlFvZ0lDNXVZVzFsSUhzZ1ptOXVkRG9nWW05c1pDQTBNREJ3ZUNCellXNXpJSE5sY21sbU95Qm1hV3hzT2lCeVpXUTdJSFJ5WVc1elptOXliVG9nZEhKaGJuTnNZWFJsS0RFek1IQjRMQ0ExTURCd2VDa2djbTkwWVhSbEtESXdaR1ZuS1RzZ2ZRbzhMM04wZVd4bFBnbzhaejRLSUNBOGNHRjBhQ0JqYkdGemN6MGljM0YxYVhKamJHVWlJR1E5SWswZ01Dd2dOVEF3Q2lBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNCRElEQXNJRFVnTlN3Z01DQTFNREFzSURBS0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lGTWdNVEF3TUN3Z05TQXhNREF3TENBMU1EQUtJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnTVRBd01Dd2dNVEF3TUNBMU1EQXNJREV3TURBS0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdNQ3dnTVRBd01DQXdMQ0ExTURBaUx6NEtJQ0E4ZEdWNGRDQmpiR0Z6Y3owaWJtRnRaU0krWm05dlBDOTBaWGgwUGdvOEwyYytDand2YzNablBnbz0iLCAibWVkaWF0eXBlIjogImltYWdlL3N2Zyt4bWwifV0sICJpbnN0YWxsIjogeyJzcGVjIjogeyJkZXBsb3ltZW50cyI6IFt7Im5hbWUiOiAiZm9vLW9wZXJhdG9yIiwgInNwZWMiOiB7InJlcGxpY2FzIjogMSwgInNlbGVjdG9yIjogeyJtYXRjaExhYmVscyI6IHsiYXBwIjogImZvby1vcGVyYXRvciJ9fSwgInRlbXBsYXRlIjogeyJtZXRhZGF0YSI6IHsibGFiZWxzIjogeyJhcHAiOiAiZm9vLW9wZXJhdG9yIiwgInZlcnNpb24iOiAidjAuMi4wIn0sICJuYW1lIjogImZvby1vcGVyYXRvciJ9LCAic3BlYyI6IHsiY29udGFpbmVycyI6IFt7ImNvbW1hbmQiOiBbIi9ydW4uc2giXSwgImltYWdlIjogInF1YXkuaW8vcmVkaGF0Z292L29jLW1pcnJvci1kZXZAc2hhMjU2OjRkYWVlNDMzNTVjMjJmMDM3NjAyZTI2NmYwMTJjMTU4ZmQ1NjcwNTBhZDZjOWRjMzZlNDlhNDUwMTIxOTZkNjIiLCAiaW1hZ2VQdWxsUG9saWN5IjogIkFsd2F5cyIsICJuYW1lIjogImZvbyJ9XX19fX1dfSwgInN0cmF0ZWd5IjogImRlcGxveW1lbnQifSwgImluc3RhbGxNb2RlcyI6IFt7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIk93bk5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIlNpbmdsZU5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IGZhbHNlLCAidHlwZSI6ICJNdWx0aU5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIkFsbE5hbWVzcGFjZXMifV0sICJrZXl3b3JkcyI6IFsiZm9vIl0sICJsYWJlbHMiOiB7Im5hbWUiOiAiZm9vLW9wZXJhdG9yIn0sICJtYWludGFpbmVycyI6IFt7ImVtYWlsIjogIm9jLW1pcnJvckBvcGVuc2hpZnQub3JnIiwgIm5hbWUiOiAib2MtbWlycm9yIGRldmVsb3BlcnMifV0sICJtYXR1cml0eSI6ICJiZXRhIiwgInByb3ZpZGVyIjogeyJuYW1lIjogIkZvbyJ9LCAicmVsYXRlZEltYWdlcyI6IFt7ImltYWdlIjogInF1YXkuaW8vcmVkaGF0Z292L29jLW1pcnJvci1kZXZAc2hhMjU2OjRkYWVlNDMzNTVjMjJmMDM3NjAyZTI2NmYwMTJjMTU4ZmQ1NjcwNTBhZDZjOWRjMzZlNDlhNDUwMTIxOTZkNjIiLCAibmFtZSI6ICJvcGVyYXRvciJ9XSwgInJlcGxhY2VzIjogImZvby52MC4xLjAiLCAic2tpcHMiOiBbImZvby52MC4xLjEiLCAiZm9vLnYwLjEuMiJdLCAidmVyc2lvbiI6ICIwLjIuMCJ9fQ==
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogImFwaWV4dGVuc2lvbnMuazhzLmlvL3YxIiwgImtpbmQiOiAiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwgIm1ldGFkYXRhIjogeyJuYW1lIjogImZvb3MudGVzdC5mb28ifSwgInNwZWMiOiB7Imdyb3VwIjogInRlc3QuZm9vIiwgInNjb3BlIjogIk5hbWVzcGFjZWQiLCAibmFtZXMiOiB7ImtpbmQiOiAiRm9vIiwgInBsdXJhbCI6ICJmb29zIn0sICJ2ZXJzaW9ucyI6IFt7Im5hbWUiOiAidjEiLCAic2VydmVkIjogdHJ1ZSwgInN0b3JhZ2UiOiB0cnVlLCAic2NoZW1hIjogeyJvcGVuQVBJVjNTY2hlbWEiOiB7InR5cGUiOiAib2JqZWN0IiwgIngta3ViZXJuZXRlcy1wcmVzZXJ2ZS11bmtub3duLWZpZWxkcyI6IHRydWV9fX1dfX0=
+relatedImages:
+- name: operator
+  image: quay.io/redhatgov/oc-mirror-dev@sha256:4daee43355c22f037602e266f012c158fd567050ad6c9dc36e49a45012196d62
+---
+schema: olm.bundle
+package: foo
+name: foo.v0.3.0
+image: quay.io/redhatgov/oc-mirror-dev:foo-bundle-v0.3.0
+csvJson: '{"apiVersion": "operators.coreos.com/v1alpha1", "kind": "ClusterServiceVersion",
+  "metadata": {"annotations": {"capabilities": "BasicInstall", "certified": "false",
+  "containerImage": "quay.io/redhatgov/oc-mirror-dev@sha256:7e1e74b87a503e95db5203334917856f61aece90a72e8d53a9fd903344eb78a5",
+  "description": "The Foo Operator does Foo things.", "olm.skipRange": "<0.3.0", "repository":
+  "https://github.com/openshift/oc-mirror"}, "name": "foo.v0.3.0"}, "spec": {"customresourcedefinitions":
+  {"owned": [{"group": "test.foo", "kind": "Foo", "name": "foos.test.foo", "version":
+  "v1"}, {"group": "test.foo", "kind": "Foo", "name": "foos.test.foo", "version":
+  "v2"}]}, "description": "The Foo Operator does Foo things.", "displayName": "Foo
+  Operator", "icon": [{"base64data": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJpY29uIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKICAgIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgogIC5zcXVpcmNsZSB7IGZpbGw6ICM3Qjg3OTQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDVweCwgMXB4KTsgfQogIC5uYW1lIHsgZm9udDogYm9sZCA0MDBweCBzYW5zIHNlcmlmOyBmaWxsOiByZWQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDEzMHB4LCA1MDBweCkgcm90YXRlKDIwZGVnKTsgfQo8L3N0eWxlPgo8Zz4KICA8cGF0aCBjbGFzcz0ic3F1aXJjbGUiIGQ9Ik0gMCwgNTAwCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBDIDAsIDUgNSwgMCA1MDAsIDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgIFMgMTAwMCwgNSAxMDAwLCA1MDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMTAwMCwgMTAwMCA1MDAsIDEwMDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMCwgMTAwMCAwLCA1MDAiLz4KICA8dGV4dCBjbGFzcz0ibmFtZSI+Zm9vPC90ZXh0Pgo8L2c+Cjwvc3ZnPgo=",
+  "mediatype": "image/svg+xml"}], "install": {"spec": {"deployments": [{"name": "foo-operator",
+  "spec": {"replicas": 1, "selector": {"matchLabels": {"app": "foo-operator"}}, "template":
+  {"metadata": {"labels": {"app": "foo-operator", "version": "v0.3.0"}, "name": "foo-operator"},
+  "spec": {"containers": [{"command": ["/run.sh"], "image": "quay.io/redhatgov/oc-mirror-dev@sha256:7e1e74b87a503e95db5203334917856f61aece90a72e8d53a9fd903344eb78a5",
+  "imagePullPolicy": "Always", "name": "foo"}]}}}}]}, "strategy": "deployment"}, "installModes":
+  [{"supported": true, "type": "OwnNamespace"}, {"supported": true, "type": "SingleNamespace"},
+  {"supported": false, "type": "MultiNamespace"}, {"supported": true, "type": "AllNamespaces"}],
+  "keywords": ["foo"], "labels": {"name": "foo-operator"}, "maintainers": [{"email":
+  "oc-mirror@openshift.org", "name": "oc-mirror developers"}], "maturity": "beta",
+  "provider": {"name": "Foo"}, "relatedImages": [{"image": "quay.io/redhatgov/oc-mirror-dev@sha256:7e1e74b87a503e95db5203334917856f61aece90a72e8d53a9fd903344eb78a5",
+  "name": "operator"}], "replaces": "foo.v0.2.0", "version": "0.3.0"}}'
+properties:
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v1
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v2
+- type: olm.package
+  value:
+    packageName: foo
+    version: 0.3.0
+- type: olm.package.required
+  value:
+    packageName: bar
+    versionRange: <0.3.0
+- type: olm.gvk.required
+  value:
+    group: test.bar
+    version: v1alpha1
+    kind: Bar
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgImtpbmQiOiAiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwgIm1ldGFkYXRhIjogeyJhbm5vdGF0aW9ucyI6IHsiY2FwYWJpbGl0aWVzIjogIkJhc2ljSW5zdGFsbCIsICJjZXJ0aWZpZWQiOiAiZmFsc2UiLCAiY29udGFpbmVySW1hZ2UiOiAicXVheS5pby9yZWRoYXRnb3Yvb2MtbWlycm9yLWRldkBzaGEyNTY6N2UxZTc0Yjg3YTUwM2U5NWRiNTIwMzMzNDkxNzg1NmY2MWFlY2U5MGE3MmU4ZDUzYTlmZDkwMzM0NGViNzhhNSIsICJkZXNjcmlwdGlvbiI6ICJUaGUgRm9vIE9wZXJhdG9yIGRvZXMgRm9vIHRoaW5ncy4iLCAib2xtLnNraXBSYW5nZSI6ICI8MC4zLjAiLCAicmVwb3NpdG9yeSI6ICJodHRwczovL2dpdGh1Yi5jb20vb3BlbnNoaWZ0L29jLW1pcnJvciJ9LCAibmFtZSI6ICJmb28udjAuMy4wIn0sICJzcGVjIjogeyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjogeyJvd25lZCI6IFt7Imdyb3VwIjogInRlc3QuZm9vIiwgImtpbmQiOiAiRm9vIiwgIm5hbWUiOiAiZm9vcy50ZXN0LmZvbyIsICJ2ZXJzaW9uIjogInYxIn0sIHsiZ3JvdXAiOiAidGVzdC5mb28iLCAia2luZCI6ICJGb28iLCAibmFtZSI6ICJmb29zLnRlc3QuZm9vIiwgInZlcnNpb24iOiAidjIifV19LCAiZGVzY3JpcHRpb24iOiAiVGhlIEZvbyBPcGVyYXRvciBkb2VzIEZvbyB0aGluZ3MuIiwgImRpc3BsYXlOYW1lIjogIkZvbyBPcGVyYXRvciIsICJpY29uIjogW3siYmFzZTY0ZGF0YSI6ICJQRDk0Yld3Z2RtVnljMmx2YmowaU1TNHdJaUJsYm1OdlpHbHVaejBpZFhSbUxUZ2lQejRLUEhOMlp5QjJaWEp6YVc5dVBTSXhMakVpSUdsa1BTSnBZMjl1SWlCNGJXeHVjejBpYUhSMGNEb3ZMM2QzZHk1M015NXZjbWN2TWpBd01DOXpkbWNpSUhodGJHNXpPbmhzYVc1clBTSm9kSFJ3T2k4dmQzZDNMbmN6TG05eVp5OHhPVGs1TDNoc2FXNXJJaUI0UFNJd2NIZ2lJSGs5SWpCd2VDSUtJQ0FnSUhacFpYZENiM2c5SWpBZ01DQXhNamd3SURFeU9EQWlJSE4wZVd4bFBTSmxibUZpYkdVdFltRmphMmR5YjNWdVpEcHVaWGNnTUNBd0lERXlPREFnTVRJNE1Ec2lJSGh0YkRwemNHRmpaVDBpY0hKbGMyVnlkbVVpUGdvOGMzUjViR1VnZEhsd1pUMGlkR1Y0ZEM5amMzTWlQZ29nSUM1emNYVnBjbU5zWlNCN0lHWnBiR3c2SUNNM1FqZzNPVFE3SUhSeVlXNXpabTl5YlRvZ2RISmhibk5zWVhSbEtEVndlQ3dnTVhCNEtUc2dmUW9nSUM1dVlXMWxJSHNnWm05dWREb2dZbTlzWkNBME1EQndlQ0J6WVc1eklITmxjbWxtT3lCbWFXeHNPaUJ5WldRN0lIUnlZVzV6Wm05eWJUb2dkSEpoYm5Oc1lYUmxLREV6TUhCNExDQTFNREJ3ZUNrZ2NtOTBZWFJsS0RJd1pHVm5LVHNnZlFvOEwzTjBlV3hsUGdvOFp6NEtJQ0E4Y0dGMGFDQmpiR0Z6Y3owaWMzRjFhWEpqYkdVaUlHUTlJazBnTUN3Z05UQXdDaUFnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0JESURBc0lEVWdOU3dnTUNBMU1EQXNJREFLSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUZNZ01UQXdNQ3dnTlNBeE1EQXdMQ0ExTURBS0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdNVEF3TUN3Z01UQXdNQ0ExTURBc0lERXdNREFLSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ01Dd2dNVEF3TUNBd0xDQTFNREFpTHo0S0lDQThkR1Y0ZENCamJHRnpjejBpYm1GdFpTSStabTl2UEM5MFpYaDBQZ284TDJjK0Nqd3ZjM1puUGdvPSIsICJtZWRpYXR5cGUiOiAiaW1hZ2Uvc3ZnK3htbCJ9XSwgImluc3RhbGwiOiB7InNwZWMiOiB7ImRlcGxveW1lbnRzIjogW3sibmFtZSI6ICJmb28tb3BlcmF0b3IiLCAic3BlYyI6IHsicmVwbGljYXMiOiAxLCAic2VsZWN0b3IiOiB7Im1hdGNoTGFiZWxzIjogeyJhcHAiOiAiZm9vLW9wZXJhdG9yIn19LCAidGVtcGxhdGUiOiB7Im1ldGFkYXRhIjogeyJsYWJlbHMiOiB7ImFwcCI6ICJmb28tb3BlcmF0b3IiLCAidmVyc2lvbiI6ICJ2MC4zLjAifSwgIm5hbWUiOiAiZm9vLW9wZXJhdG9yIn0sICJzcGVjIjogeyJjb250YWluZXJzIjogW3siY29tbWFuZCI6IFsiL3J1bi5zaCJdLCAiaW1hZ2UiOiAicXVheS5pby9yZWRoYXRnb3Yvb2MtbWlycm9yLWRldkBzaGEyNTY6N2UxZTc0Yjg3YTUwM2U5NWRiNTIwMzMzNDkxNzg1NmY2MWFlY2U5MGE3MmU4ZDUzYTlmZDkwMzM0NGViNzhhNSIsICJpbWFnZVB1bGxQb2xpY3kiOiAiQWx3YXlzIiwgIm5hbWUiOiAiZm9vIn1dfX19fV19LCAic3RyYXRlZ3kiOiAiZGVwbG95bWVudCJ9LCAiaW5zdGFsbE1vZGVzIjogW3sic3VwcG9ydGVkIjogdHJ1ZSwgInR5cGUiOiAiT3duTmFtZXNwYWNlIn0sIHsic3VwcG9ydGVkIjogdHJ1ZSwgInR5cGUiOiAiU2luZ2xlTmFtZXNwYWNlIn0sIHsic3VwcG9ydGVkIjogZmFsc2UsICJ0eXBlIjogIk11bHRpTmFtZXNwYWNlIn0sIHsic3VwcG9ydGVkIjogdHJ1ZSwgInR5cGUiOiAiQWxsTmFtZXNwYWNlcyJ9XSwgImtleXdvcmRzIjogWyJmb28iXSwgImxhYmVscyI6IHsibmFtZSI6ICJmb28tb3BlcmF0b3IifSwgIm1haW50YWluZXJzIjogW3siZW1haWwiOiAib2MtbWlycm9yQG9wZW5zaGlmdC5vcmciLCAibmFtZSI6ICJvYy1taXJyb3IgZGV2ZWxvcGVycyJ9XSwgIm1hdHVyaXR5IjogImJldGEiLCAicHJvdmlkZXIiOiB7Im5hbWUiOiAiRm9vIn0sICJyZWxhdGVkSW1hZ2VzIjogW3siaW1hZ2UiOiAicXVheS5pby9yZWRoYXRnb3Yvb2MtbWlycm9yLWRldkBzaGEyNTY6N2UxZTc0Yjg3YTUwM2U5NWRiNTIwMzMzNDkxNzg1NmY2MWFlY2U5MGE3MmU4ZDUzYTlmZDkwMzM0NGViNzhhNSIsICJuYW1lIjogIm9wZXJhdG9yIn1dLCAicmVwbGFjZXMiOiAiZm9vLnYwLjIuMCIsICJ2ZXJzaW9uIjogIjAuMy4wIn19
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogImFwaWV4dGVuc2lvbnMuazhzLmlvL3YxIiwgImtpbmQiOiAiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwgIm1ldGFkYXRhIjogeyJuYW1lIjogImZvb3MudGVzdC5mb28ifSwgInNwZWMiOiB7Imdyb3VwIjogInRlc3QuZm9vIiwgInNjb3BlIjogIk5hbWVzcGFjZWQiLCAibmFtZXMiOiB7ImtpbmQiOiAiRm9vIiwgInBsdXJhbCI6ICJmb29zIn0sICJ2ZXJzaW9ucyI6IFt7Im5hbWUiOiAidjEiLCAic2VydmVkIjogdHJ1ZSwgInN0b3JhZ2UiOiBmYWxzZSwgInNjaGVtYSI6IHsib3BlbkFQSVYzU2NoZW1hIjogeyJ0eXBlIjogIm9iamVjdCIsICJ4LWt1YmVybmV0ZXMtcHJlc2VydmUtdW5rbm93bi1maWVsZHMiOiB0cnVlfX19LCB7Im5hbWUiOiAidjIiLCAic2VydmVkIjogdHJ1ZSwgInN0b3JhZ2UiOiB0cnVlLCAic2NoZW1hIjogeyJvcGVuQVBJVjNTY2hlbWEiOiB7InR5cGUiOiAib2JqZWN0IiwgIngta3ViZXJuZXRlcy1wcmVzZXJ2ZS11bmtub3duLWZpZWxkcyI6IHRydWV9fX1dfX0=
+relatedImages:
+- name: operator
+  image: quay.io/redhatgov/oc-mirror-dev@sha256:7e1e74b87a503e95db5203334917856f61aece90a72e8d53a9fd903344eb78a5
+---
+schema: olm.bundle
+package: foo
+name: foo.v0.3.1
+image: quay.io/redhatgov/oc-mirror-dev:foo-bundle-v0.3.1
+csvJson: '{"apiVersion": "operators.coreos.com/v1alpha1", "kind": "ClusterServiceVersion",
+  "metadata": {"annotations": {"capabilities": "BasicInstall", "certified": "false",
+  "containerImage": "quay.io/redhatgov/oc-mirror-dev@sha256:00aef3f7bd9bea8f627dbf46d2d062010ed7d8b208a98da389b701c3cae90026",
+  "description": "The Foo Operator does Foo things.", "olm.skipRange": "<0.3.1", "repository":
+  "https://github.com/openshift/oc-mirror"}, "name": "foo.v0.3.1"}, "spec": {"customresourcedefinitions":
+  {"owned": [{"group": "test.foo", "kind": "Foo", "name": "foos.test.foo", "version":
+  "v1"}, {"group": "test.foo", "kind": "Foo", "name": "foos.test.foo", "version":
+  "v2"}]}, "description": "The Foo Operator does Foo things.", "displayName": "Foo
+  Operator", "icon": [{"base64data": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJpY29uIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKICAgIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgogIC5zcXVpcmNsZSB7IGZpbGw6ICM3Qjg3OTQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDVweCwgMXB4KTsgfQogIC5uYW1lIHsgZm9udDogYm9sZCA0MDBweCBzYW5zIHNlcmlmOyBmaWxsOiByZWQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDEzMHB4LCA1MDBweCkgcm90YXRlKDIwZGVnKTsgfQo8L3N0eWxlPgo8Zz4KICA8cGF0aCBjbGFzcz0ic3F1aXJjbGUiIGQ9Ik0gMCwgNTAwCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBDIDAsIDUgNSwgMCA1MDAsIDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgIFMgMTAwMCwgNSAxMDAwLCA1MDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMTAwMCwgMTAwMCA1MDAsIDEwMDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMCwgMTAwMCAwLCA1MDAiLz4KICA8dGV4dCBjbGFzcz0ibmFtZSI+Zm9vPC90ZXh0Pgo8L2c+Cjwvc3ZnPgo=",
+  "mediatype": "image/svg+xml"}], "install": {"spec": {"deployments": [{"name": "foo-operator",
+  "spec": {"replicas": 1, "selector": {"matchLabels": {"app": "foo-operator"}}, "template":
+  {"metadata": {"labels": {"app": "foo-operator", "version": "v0.3.1"}, "name": "foo-operator"},
+  "spec": {"containers": [{"command": ["/run.sh"], "image": "quay.io/redhatgov/oc-mirror-dev@sha256:00aef3f7bd9bea8f627dbf46d2d062010ed7d8b208a98da389b701c3cae90026",
+  "imagePullPolicy": "Always", "name": "foo"}]}}}}]}, "strategy": "deployment"}, "installModes":
+  [{"supported": true, "type": "OwnNamespace"}, {"supported": true, "type": "SingleNamespace"},
+  {"supported": false, "type": "MultiNamespace"}, {"supported": true, "type": "AllNamespaces"}],
+  "keywords": ["foo"], "labels": {"name": "foo-operator"}, "maintainers": [{"email":
+  "oc-mirror@openshift.org", "name": "oc-mirror developers"}], "maturity": "beta",
+  "provider": {"name": "Foo"}, "relatedImages": [{"image": "quay.io/redhatgov/oc-mirror-dev@sha256:00aef3f7bd9bea8f627dbf46d2d062010ed7d8b208a98da389b701c3cae90026",
+  "name": "operator"}], "replaces": "foo.v0.2.0", "skips": ["foo.v0.3.0"], "version":
+  "0.3.1"}}'
+properties:
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v1
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v2
+- type: olm.package
+  value:
+    packageName: foo
+    version: 0.3.1
+- type: olm.package.required
+  value:
+    packageName: bar
+    versionRange: <0.2.0
+- type: olm.gvk.required
+  value:
+    group: test.bar
+    version: v1alpha1
+    kind: Bar
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgImtpbmQiOiAiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwgIm1ldGFkYXRhIjogeyJhbm5vdGF0aW9ucyI6IHsiY2FwYWJpbGl0aWVzIjogIkJhc2ljSW5zdGFsbCIsICJjZXJ0aWZpZWQiOiAiZmFsc2UiLCAiY29udGFpbmVySW1hZ2UiOiAicXVheS5pby9yZWRoYXRnb3Yvb2MtbWlycm9yLWRldkBzaGEyNTY6MDBhZWYzZjdiZDliZWE4ZjYyN2RiZjQ2ZDJkMDYyMDEwZWQ3ZDhiMjA4YTk4ZGEzODliNzAxYzNjYWU5MDAyNiIsICJkZXNjcmlwdGlvbiI6ICJUaGUgRm9vIE9wZXJhdG9yIGRvZXMgRm9vIHRoaW5ncy4iLCAib2xtLnNraXBSYW5nZSI6ICI8MC4zLjEiLCAicmVwb3NpdG9yeSI6ICJodHRwczovL2dpdGh1Yi5jb20vb3BlbnNoaWZ0L29jLW1pcnJvciJ9LCAibmFtZSI6ICJmb28udjAuMy4xIn0sICJzcGVjIjogeyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjogeyJvd25lZCI6IFt7Imdyb3VwIjogInRlc3QuZm9vIiwgImtpbmQiOiAiRm9vIiwgIm5hbWUiOiAiZm9vcy50ZXN0LmZvbyIsICJ2ZXJzaW9uIjogInYxIn0sIHsiZ3JvdXAiOiAidGVzdC5mb28iLCAia2luZCI6ICJGb28iLCAibmFtZSI6ICJmb29zLnRlc3QuZm9vIiwgInZlcnNpb24iOiAidjIifV19LCAiZGVzY3JpcHRpb24iOiAiVGhlIEZvbyBPcGVyYXRvciBkb2VzIEZvbyB0aGluZ3MuIiwgImRpc3BsYXlOYW1lIjogIkZvbyBPcGVyYXRvciIsICJpY29uIjogW3siYmFzZTY0ZGF0YSI6ICJQRDk0Yld3Z2RtVnljMmx2YmowaU1TNHdJaUJsYm1OdlpHbHVaejBpZFhSbUxUZ2lQejRLUEhOMlp5QjJaWEp6YVc5dVBTSXhMakVpSUdsa1BTSnBZMjl1SWlCNGJXeHVjejBpYUhSMGNEb3ZMM2QzZHk1M015NXZjbWN2TWpBd01DOXpkbWNpSUhodGJHNXpPbmhzYVc1clBTSm9kSFJ3T2k4dmQzZDNMbmN6TG05eVp5OHhPVGs1TDNoc2FXNXJJaUI0UFNJd2NIZ2lJSGs5SWpCd2VDSUtJQ0FnSUhacFpYZENiM2c5SWpBZ01DQXhNamd3SURFeU9EQWlJSE4wZVd4bFBTSmxibUZpYkdVdFltRmphMmR5YjNWdVpEcHVaWGNnTUNBd0lERXlPREFnTVRJNE1Ec2lJSGh0YkRwemNHRmpaVDBpY0hKbGMyVnlkbVVpUGdvOGMzUjViR1VnZEhsd1pUMGlkR1Y0ZEM5amMzTWlQZ29nSUM1emNYVnBjbU5zWlNCN0lHWnBiR3c2SUNNM1FqZzNPVFE3SUhSeVlXNXpabTl5YlRvZ2RISmhibk5zWVhSbEtEVndlQ3dnTVhCNEtUc2dmUW9nSUM1dVlXMWxJSHNnWm05dWREb2dZbTlzWkNBME1EQndlQ0J6WVc1eklITmxjbWxtT3lCbWFXeHNPaUJ5WldRN0lIUnlZVzV6Wm05eWJUb2dkSEpoYm5Oc1lYUmxLREV6TUhCNExDQTFNREJ3ZUNrZ2NtOTBZWFJsS0RJd1pHVm5LVHNnZlFvOEwzTjBlV3hsUGdvOFp6NEtJQ0E4Y0dGMGFDQmpiR0Z6Y3owaWMzRjFhWEpqYkdVaUlHUTlJazBnTUN3Z05UQXdDaUFnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0JESURBc0lEVWdOU3dnTUNBMU1EQXNJREFLSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUZNZ01UQXdNQ3dnTlNBeE1EQXdMQ0ExTURBS0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdNVEF3TUN3Z01UQXdNQ0ExTURBc0lERXdNREFLSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ01Dd2dNVEF3TUNBd0xDQTFNREFpTHo0S0lDQThkR1Y0ZENCamJHRnpjejBpYm1GdFpTSStabTl2UEM5MFpYaDBQZ284TDJjK0Nqd3ZjM1puUGdvPSIsICJtZWRpYXR5cGUiOiAiaW1hZ2Uvc3ZnK3htbCJ9XSwgImluc3RhbGwiOiB7InNwZWMiOiB7ImRlcGxveW1lbnRzIjogW3sibmFtZSI6ICJmb28tb3BlcmF0b3IiLCAic3BlYyI6IHsicmVwbGljYXMiOiAxLCAic2VsZWN0b3IiOiB7Im1hdGNoTGFiZWxzIjogeyJhcHAiOiAiZm9vLW9wZXJhdG9yIn19LCAidGVtcGxhdGUiOiB7Im1ldGFkYXRhIjogeyJsYWJlbHMiOiB7ImFwcCI6ICJmb28tb3BlcmF0b3IiLCAidmVyc2lvbiI6ICJ2MC4zLjEifSwgIm5hbWUiOiAiZm9vLW9wZXJhdG9yIn0sICJzcGVjIjogeyJjb250YWluZXJzIjogW3siY29tbWFuZCI6IFsiL3J1bi5zaCJdLCAiaW1hZ2UiOiAicXVheS5pby9yZWRoYXRnb3Yvb2MtbWlycm9yLWRldkBzaGEyNTY6MDBhZWYzZjdiZDliZWE4ZjYyN2RiZjQ2ZDJkMDYyMDEwZWQ3ZDhiMjA4YTk4ZGEzODliNzAxYzNjYWU5MDAyNiIsICJpbWFnZVB1bGxQb2xpY3kiOiAiQWx3YXlzIiwgIm5hbWUiOiAiZm9vIn1dfX19fV19LCAic3RyYXRlZ3kiOiAiZGVwbG95bWVudCJ9LCAiaW5zdGFsbE1vZGVzIjogW3sic3VwcG9ydGVkIjogdHJ1ZSwgInR5cGUiOiAiT3duTmFtZXNwYWNlIn0sIHsic3VwcG9ydGVkIjogdHJ1ZSwgInR5cGUiOiAiU2luZ2xlTmFtZXNwYWNlIn0sIHsic3VwcG9ydGVkIjogZmFsc2UsICJ0eXBlIjogIk11bHRpTmFtZXNwYWNlIn0sIHsic3VwcG9ydGVkIjogdHJ1ZSwgInR5cGUiOiAiQWxsTmFtZXNwYWNlcyJ9XSwgImtleXdvcmRzIjogWyJmb28iXSwgImxhYmVscyI6IHsibmFtZSI6ICJmb28tb3BlcmF0b3IifSwgIm1haW50YWluZXJzIjogW3siZW1haWwiOiAib2MtbWlycm9yQG9wZW5zaGlmdC5vcmciLCAibmFtZSI6ICJvYy1taXJyb3IgZGV2ZWxvcGVycyJ9XSwgIm1hdHVyaXR5IjogImJldGEiLCAicHJvdmlkZXIiOiB7Im5hbWUiOiAiRm9vIn0sICJyZWxhdGVkSW1hZ2VzIjogW3siaW1hZ2UiOiAicXVheS5pby9yZWRoYXRnb3Yvb2MtbWlycm9yLWRldkBzaGEyNTY6MDBhZWYzZjdiZDliZWE4ZjYyN2RiZjQ2ZDJkMDYyMDEwZWQ3ZDhiMjA4YTk4ZGEzODliNzAxYzNjYWU5MDAyNiIsICJuYW1lIjogIm9wZXJhdG9yIn1dLCAicmVwbGFjZXMiOiAiZm9vLnYwLjIuMCIsICJza2lwcyI6IFsiZm9vLnYwLjMuMCJdLCAidmVyc2lvbiI6ICIwLjMuMSJ9fQ==
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogImFwaWV4dGVuc2lvbnMuazhzLmlvL3YxIiwgImtpbmQiOiAiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwgIm1ldGFkYXRhIjogeyJuYW1lIjogImZvb3MudGVzdC5mb28ifSwgInNwZWMiOiB7Imdyb3VwIjogInRlc3QuZm9vIiwgInNjb3BlIjogIk5hbWVzcGFjZWQiLCAibmFtZXMiOiB7ImtpbmQiOiAiRm9vIiwgInBsdXJhbCI6ICJmb29zIn0sICJ2ZXJzaW9ucyI6IFt7Im5hbWUiOiAidjEiLCAic2VydmVkIjogdHJ1ZSwgInN0b3JhZ2UiOiBmYWxzZSwgInNjaGVtYSI6IHsib3BlbkFQSVYzU2NoZW1hIjogeyJ0eXBlIjogIm9iamVjdCIsICJ4LWt1YmVybmV0ZXMtcHJlc2VydmUtdW5rbm93bi1maWVsZHMiOiB0cnVlfX19LCB7Im5hbWUiOiAidjIiLCAic2VydmVkIjogdHJ1ZSwgInN0b3JhZ2UiOiB0cnVlLCAic2NoZW1hIjogeyJvcGVuQVBJVjNTY2hlbWEiOiB7InR5cGUiOiAib2JqZWN0IiwgIngta3ViZXJuZXRlcy1wcmVzZXJ2ZS11bmtub3duLWZpZWxkcyI6IHRydWV9fX1dfX0=
+relatedImages:
+- name: operator
+  image: quay.io/redhatgov/oc-mirror-dev@sha256:00aef3f7bd9bea8f627dbf46d2d062010ed7d8b208a98da389b701c3cae90026
+---
+schema: olm.package
+name: bar
+description: 'bar
+
+  ===
+
+
+  The Bar operator reacts to Bars objects.
+
+  '
+icon:
+  base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJpY29uIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKICAgIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgogIC5zcXVpcmNsZSB7IGZpbGw6ICM3Qjg3OTQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDVweCwgMXB4KTsgfQogIC5uYW1lIHsgZm9udDogYm9sZCA0MDBweCBzYW5zIHNlcmlmOyBmaWxsOiByZWQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDEzMHB4LCA1MDBweCkgcm90YXRlKDIwZGVnKTsgfQo8L3N0eWxlPgo8Zz4KICA8cGF0aCBjbGFzcz0ic3F1aXJjbGUiIGQ9Ik0gMCwgNTAwCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBDIDAsIDUgNSwgMCA1MDAsIDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgIFMgMTAwMCwgNSAxMDAwLCA1MDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMTAwMCwgMTAwMCA1MDAsIDEwMDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMCwgMTAwMCAwLCA1MDAiLz4KICA8dGV4dCBjbGFzcz0ibmFtZSI+YmFyPC90ZXh0Pgo8L2c+Cjwvc3ZnPgo=
+  mediatype: image/svg+xml
+defaultChannel: stable
+---
+schema: olm.channel
+package: bar
+name: alpha
+entries:
+- name: bar.v0.1.0
+  skipRange: <0.1.0
+- name: bar.v0.2.0
+  skipRange: <0.2.0
+  skips:
+  - bar.v0.1.0
+  replaces: bar.v0.1.0
+- name: bar.v1.0.0
+  skipRange: <1.0.0
+  replaces: bar.v0.2.0
+---
+schema: olm.bundle
+package: bar
+name: bar.v0.1.0
+image: quay.io/redhatgov/oc-mirror-dev:bar-bundle-v0.1.0
+csvJson: '{"apiVersion": "operators.coreos.com/v1alpha1", "kind": "ClusterServiceVersion",
+  "metadata": {"annotations": {"capabilities": "BasicInstall", "certified": "false",
+  "containerImage": "quay.io/redhatgov/oc-mirror-dev@sha256:efd4f2dcc69f843fb0f02252e2e982999d29d4d31d272731cf2e0342bac23c61",
+  "description": "The Bar Operator does Bar things.", "olm.skipRange": "<0.1.0", "repository":
+  "https://github.com/openshift/oc-mirror"}, "name": "bar.v0.1.0"}, "spec": {"customresourcedefinitions":
+  {"owned": [{"group": "test.bar", "kind": "Bar", "name": "bars.test.bar", "version":
+  "v1alpha1"}]}, "description": "The Bar Operator does Bar things.", "displayName":
+  "Bar Operator", "icon": [{"base64data": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJpY29uIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKICAgIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgogIC5zcXVpcmNsZSB7IGZpbGw6ICM3Qjg3OTQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDVweCwgMXB4KTsgfQogIC5uYW1lIHsgZm9udDogYm9sZCA0MDBweCBzYW5zIHNlcmlmOyBmaWxsOiByZWQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDEzMHB4LCA1MDBweCkgcm90YXRlKDIwZGVnKTsgfQo8L3N0eWxlPgo8Zz4KICA8cGF0aCBjbGFzcz0ic3F1aXJjbGUiIGQ9Ik0gMCwgNTAwCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBDIDAsIDUgNSwgMCA1MDAsIDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgIFMgMTAwMCwgNSAxMDAwLCA1MDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMTAwMCwgMTAwMCA1MDAsIDEwMDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMCwgMTAwMCAwLCA1MDAiLz4KICA8dGV4dCBjbGFzcz0ibmFtZSI+YmFyPC90ZXh0Pgo8L2c+Cjwvc3ZnPgo=",
+  "mediatype": "image/svg+xml"}], "install": {"spec": {"deployments": [{"name": "bar-operator",
+  "spec": {"replicas": 1, "selector": {"matchLabels": {"app": "bar-operator"}}, "template":
+  {"metadata": {"labels": {"app": "bar-operator", "version": "v0.1.0"}, "name": "bar-operator"},
+  "spec": {"containers": [{"command": ["/run.sh"], "image": "quay.io/redhatgov/oc-mirror-dev@sha256:efd4f2dcc69f843fb0f02252e2e982999d29d4d31d272731cf2e0342bac23c61",
+  "imagePullPolicy": "Always", "name": "bar"}]}}}}]}, "strategy": "deployment"}, "installModes":
+  [{"supported": true, "type": "OwnNamespace"}, {"supported": true, "type": "SingleNamespace"},
+  {"supported": false, "type": "MultiNamespace"}, {"supported": true, "type": "AllNamespaces"}],
+  "keywords": ["bar"], "labels": {"name": "bar-operator"}, "maintainers": [{"email":
+  "oc-mirror@openshift.org", "name": "oc-mirror developers"}], "maturity": "beta",
+  "provider": {"name": "Bar"}, "relatedImages": [{"image": "quay.io/redhatgov/oc-mirror-dev@sha256:efd4f2dcc69f843fb0f02252e2e982999d29d4d31d272731cf2e0342bac23c61",
+  "name": "operator"}], "version": "0.1.0"}}'
+properties:
+- type: olm.gvk
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: bar
+    version: 0.1.0
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgImtpbmQiOiAiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwgIm1ldGFkYXRhIjogeyJhbm5vdGF0aW9ucyI6IHsiY2FwYWJpbGl0aWVzIjogIkJhc2ljSW5zdGFsbCIsICJjZXJ0aWZpZWQiOiAiZmFsc2UiLCAiY29udGFpbmVySW1hZ2UiOiAicXVheS5pby9yZWRoYXRnb3Yvb2MtbWlycm9yLWRldkBzaGEyNTY6ZWZkNGYyZGNjNjlmODQzZmIwZjAyMjUyZTJlOTgyOTk5ZDI5ZDRkMzFkMjcyNzMxY2YyZTAzNDJiYWMyM2M2MSIsICJkZXNjcmlwdGlvbiI6ICJUaGUgQmFyIE9wZXJhdG9yIGRvZXMgQmFyIHRoaW5ncy4iLCAib2xtLnNraXBSYW5nZSI6ICI8MC4xLjAiLCAicmVwb3NpdG9yeSI6ICJodHRwczovL2dpdGh1Yi5jb20vb3BlbnNoaWZ0L29jLW1pcnJvciJ9LCAibmFtZSI6ICJiYXIudjAuMS4wIn0sICJzcGVjIjogeyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjogeyJvd25lZCI6IFt7Imdyb3VwIjogInRlc3QuYmFyIiwgImtpbmQiOiAiQmFyIiwgIm5hbWUiOiAiYmFycy50ZXN0LmJhciIsICJ2ZXJzaW9uIjogInYxYWxwaGExIn1dfSwgImRlc2NyaXB0aW9uIjogIlRoZSBCYXIgT3BlcmF0b3IgZG9lcyBCYXIgdGhpbmdzLiIsICJkaXNwbGF5TmFtZSI6ICJCYXIgT3BlcmF0b3IiLCAiaWNvbiI6IFt7ImJhc2U2NGRhdGEiOiAiUEQ5NGJXd2dkbVZ5YzJsdmJqMGlNUzR3SWlCbGJtTnZaR2x1WnowaWRYUm1MVGdpUHo0S1BITjJaeUIyWlhKemFXOXVQU0l4TGpFaUlHbGtQU0pwWTI5dUlpQjRiV3h1Y3owaWFIUjBjRG92TDNkM2R5NTNNeTV2Y21jdk1qQXdNQzl6ZG1jaUlIaHRiRzV6T25oc2FXNXJQU0pvZEhSd09pOHZkM2QzTG5jekxtOXlaeTh4T1RrNUwzaHNhVzVySWlCNFBTSXdjSGdpSUhrOUlqQndlQ0lLSUNBZ0lIWnBaWGRDYjNnOUlqQWdNQ0F4TWpnd0lERXlPREFpSUhOMGVXeGxQU0psYm1GaWJHVXRZbUZqYTJkeWIzVnVaRHB1WlhjZ01DQXdJREV5T0RBZ01USTRNRHNpSUhodGJEcHpjR0ZqWlQwaWNISmxjMlZ5ZG1VaVBnbzhjM1I1YkdVZ2RIbHdaVDBpZEdWNGRDOWpjM01pUGdvZ0lDNXpjWFZwY21Oc1pTQjdJR1pwYkd3NklDTTNRamczT1RRN0lIUnlZVzV6Wm05eWJUb2dkSEpoYm5Oc1lYUmxLRFZ3ZUN3Z01YQjRLVHNnZlFvZ0lDNXVZVzFsSUhzZ1ptOXVkRG9nWW05c1pDQTBNREJ3ZUNCellXNXpJSE5sY21sbU95Qm1hV3hzT2lCeVpXUTdJSFJ5WVc1elptOXliVG9nZEhKaGJuTnNZWFJsS0RFek1IQjRMQ0ExTURCd2VDa2djbTkwWVhSbEtESXdaR1ZuS1RzZ2ZRbzhMM04wZVd4bFBnbzhaejRLSUNBOGNHRjBhQ0JqYkdGemN6MGljM0YxYVhKamJHVWlJR1E5SWswZ01Dd2dOVEF3Q2lBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNCRElEQXNJRFVnTlN3Z01DQTFNREFzSURBS0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lGTWdNVEF3TUN3Z05TQXhNREF3TENBMU1EQUtJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnTVRBd01Dd2dNVEF3TUNBMU1EQXNJREV3TURBS0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdNQ3dnTVRBd01DQXdMQ0ExTURBaUx6NEtJQ0E4ZEdWNGRDQmpiR0Z6Y3owaWJtRnRaU0krWW1GeVBDOTBaWGgwUGdvOEwyYytDand2YzNablBnbz0iLCAibWVkaWF0eXBlIjogImltYWdlL3N2Zyt4bWwifV0sICJpbnN0YWxsIjogeyJzcGVjIjogeyJkZXBsb3ltZW50cyI6IFt7Im5hbWUiOiAiYmFyLW9wZXJhdG9yIiwgInNwZWMiOiB7InJlcGxpY2FzIjogMSwgInNlbGVjdG9yIjogeyJtYXRjaExhYmVscyI6IHsiYXBwIjogImJhci1vcGVyYXRvciJ9fSwgInRlbXBsYXRlIjogeyJtZXRhZGF0YSI6IHsibGFiZWxzIjogeyJhcHAiOiAiYmFyLW9wZXJhdG9yIiwgInZlcnNpb24iOiAidjAuMS4wIn0sICJuYW1lIjogImJhci1vcGVyYXRvciJ9LCAic3BlYyI6IHsiY29udGFpbmVycyI6IFt7ImNvbW1hbmQiOiBbIi9ydW4uc2giXSwgImltYWdlIjogInF1YXkuaW8vcmVkaGF0Z292L29jLW1pcnJvci1kZXZAc2hhMjU2OmVmZDRmMmRjYzY5Zjg0M2ZiMGYwMjI1MmUyZTk4Mjk5OWQyOWQ0ZDMxZDI3MjczMWNmMmUwMzQyYmFjMjNjNjEiLCAiaW1hZ2VQdWxsUG9saWN5IjogIkFsd2F5cyIsICJuYW1lIjogImJhciJ9XX19fX1dfSwgInN0cmF0ZWd5IjogImRlcGxveW1lbnQifSwgImluc3RhbGxNb2RlcyI6IFt7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIk93bk5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIlNpbmdsZU5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IGZhbHNlLCAidHlwZSI6ICJNdWx0aU5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIkFsbE5hbWVzcGFjZXMifV0sICJrZXl3b3JkcyI6IFsiYmFyIl0sICJsYWJlbHMiOiB7Im5hbWUiOiAiYmFyLW9wZXJhdG9yIn0sICJtYWludGFpbmVycyI6IFt7ImVtYWlsIjogIm9jLW1pcnJvckBvcGVuc2hpZnQub3JnIiwgIm5hbWUiOiAib2MtbWlycm9yIGRldmVsb3BlcnMifV0sICJtYXR1cml0eSI6ICJiZXRhIiwgInByb3ZpZGVyIjogeyJuYW1lIjogIkJhciJ9LCAicmVsYXRlZEltYWdlcyI6IFt7ImltYWdlIjogInF1YXkuaW8vcmVkaGF0Z292L29jLW1pcnJvci1kZXZAc2hhMjU2OmVmZDRmMmRjYzY5Zjg0M2ZiMGYwMjI1MmUyZTk4Mjk5OWQyOWQ0ZDMxZDI3MjczMWNmMmUwMzQyYmFjMjNjNjEiLCAibmFtZSI6ICJvcGVyYXRvciJ9XSwgInZlcnNpb24iOiAiMC4xLjAifX0=
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogImFwaWV4dGVuc2lvbnMuazhzLmlvL3YxIiwgImtpbmQiOiAiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwgIm1ldGFkYXRhIjogeyJuYW1lIjogImJhcnMudGVzdC5iYXIifSwgInNwZWMiOiB7Imdyb3VwIjogInRlc3QuYmFyIiwgInNjb3BlIjogIk5hbWVzcGFjZWQiLCAibmFtZXMiOiB7ImtpbmQiOiAiQmFyIiwgInBsdXJhbCI6ICJiYXJzIn0sICJ2ZXJzaW9ucyI6IFt7Im5hbWUiOiAidjFhbHBoYTEiLCAic2VydmVkIjogdHJ1ZSwgInN0b3JhZ2UiOiB0cnVlLCAic2NoZW1hIjogeyJvcGVuQVBJVjNTY2hlbWEiOiB7InR5cGUiOiAib2JqZWN0IiwgIngta3ViZXJuZXRlcy1wcmVzZXJ2ZS11bmtub3duLWZpZWxkcyI6IHRydWV9fX1dfX0=
+relatedImages:
+- name: operator
+  image: quay.io/redhatgov/oc-mirror-dev@sha256:efd4f2dcc69f843fb0f02252e2e982999d29d4d31d272731cf2e0342bac23c61
+---
+schema: olm.bundle
+package: bar
+name: bar.v0.2.0
+image: quay.io/redhatgov/oc-mirror-dev:bar-bundle-v0.2.0
+csvJson: '{"apiVersion": "operators.coreos.com/v1alpha1", "kind": "ClusterServiceVersion",
+  "metadata": {"annotations": {"capabilities": "BasicInstall", "certified": "false",
+  "containerImage": "quay.io/redhatgov/oc-mirror-dev@sha256:3f8e127e9f6c785b420e95c50e5f5c011363384e62895a6a34b327f0e3c526a2",
+  "description": "The Bar Operator does Bar things.", "olm.skipRange": "<0.2.0", "repository":
+  "https://github.com/openshift/oc-mirror"}, "name": "bar.v0.2.0"}, "spec": {"customresourcedefinitions":
+  {"owned": [{"group": "test.bar", "kind": "Bar", "name": "bars.test.bar", "version":
+  "v1alpha1"}]}, "description": "The Bar Operator does Bar things.", "displayName":
+  "Bar Operator", "icon": [{"base64data": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJpY29uIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKICAgIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgogIC5zcXVpcmNsZSB7IGZpbGw6ICM3Qjg3OTQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDVweCwgMXB4KTsgfQogIC5uYW1lIHsgZm9udDogYm9sZCA0MDBweCBzYW5zIHNlcmlmOyBmaWxsOiByZWQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDEzMHB4LCA1MDBweCkgcm90YXRlKDIwZGVnKTsgfQo8L3N0eWxlPgo8Zz4KICA8cGF0aCBjbGFzcz0ic3F1aXJjbGUiIGQ9Ik0gMCwgNTAwCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBDIDAsIDUgNSwgMCA1MDAsIDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgIFMgMTAwMCwgNSAxMDAwLCA1MDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMTAwMCwgMTAwMCA1MDAsIDEwMDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMCwgMTAwMCAwLCA1MDAiLz4KICA8dGV4dCBjbGFzcz0ibmFtZSI+YmFyPC90ZXh0Pgo8L2c+Cjwvc3ZnPgo=",
+  "mediatype": "image/svg+xml"}], "install": {"spec": {"deployments": [{"name": "bar-operator",
+  "spec": {"replicas": 1, "selector": {"matchLabels": {"app": "bar-operator"}}, "template":
+  {"metadata": {"labels": {"app": "bar-operator", "version": "v0.2.0"}, "name": "bar-operator"},
+  "spec": {"containers": [{"command": ["/run.sh"], "image": "quay.io/redhatgov/oc-mirror-dev@sha256:3f8e127e9f6c785b420e95c50e5f5c011363384e62895a6a34b327f0e3c526a2",
+  "imagePullPolicy": "Always", "name": "bar"}]}}}}]}, "strategy": "deployment"}, "installModes":
+  [{"supported": true, "type": "OwnNamespace"}, {"supported": true, "type": "SingleNamespace"},
+  {"supported": false, "type": "MultiNamespace"}, {"supported": true, "type": "AllNamespaces"}],
+  "keywords": ["bar"], "labels": {"name": "bar-operator"}, "maintainers": [{"email":
+  "oc-mirror@openshift.org", "name": "oc-mirror developers"}], "maturity": "beta",
+  "provider": {"name": "Bar"}, "relatedImages": [{"image": "quay.io/redhatgov/oc-mirror-dev@sha256:3f8e127e9f6c785b420e95c50e5f5c011363384e62895a6a34b327f0e3c526a2",
+  "name": "operator"}], "replaces": "bar.v0.1.0", "skips": ["bar.v0.1.0"], "version":
+  "0.2.0"}}'
+properties:
+- type: olm.gvk
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: bar
+    version: 0.2.0
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgImtpbmQiOiAiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwgIm1ldGFkYXRhIjogeyJhbm5vdGF0aW9ucyI6IHsiY2FwYWJpbGl0aWVzIjogIkJhc2ljSW5zdGFsbCIsICJjZXJ0aWZpZWQiOiAiZmFsc2UiLCAiY29udGFpbmVySW1hZ2UiOiAicXVheS5pby9yZWRoYXRnb3Yvb2MtbWlycm9yLWRldkBzaGEyNTY6M2Y4ZTEyN2U5ZjZjNzg1YjQyMGU5NWM1MGU1ZjVjMDExMzYzMzg0ZTYyODk1YTZhMzRiMzI3ZjBlM2M1MjZhMiIsICJkZXNjcmlwdGlvbiI6ICJUaGUgQmFyIE9wZXJhdG9yIGRvZXMgQmFyIHRoaW5ncy4iLCAib2xtLnNraXBSYW5nZSI6ICI8MC4yLjAiLCAicmVwb3NpdG9yeSI6ICJodHRwczovL2dpdGh1Yi5jb20vb3BlbnNoaWZ0L29jLW1pcnJvciJ9LCAibmFtZSI6ICJiYXIudjAuMi4wIn0sICJzcGVjIjogeyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjogeyJvd25lZCI6IFt7Imdyb3VwIjogInRlc3QuYmFyIiwgImtpbmQiOiAiQmFyIiwgIm5hbWUiOiAiYmFycy50ZXN0LmJhciIsICJ2ZXJzaW9uIjogInYxYWxwaGExIn1dfSwgImRlc2NyaXB0aW9uIjogIlRoZSBCYXIgT3BlcmF0b3IgZG9lcyBCYXIgdGhpbmdzLiIsICJkaXNwbGF5TmFtZSI6ICJCYXIgT3BlcmF0b3IiLCAiaWNvbiI6IFt7ImJhc2U2NGRhdGEiOiAiUEQ5NGJXd2dkbVZ5YzJsdmJqMGlNUzR3SWlCbGJtTnZaR2x1WnowaWRYUm1MVGdpUHo0S1BITjJaeUIyWlhKemFXOXVQU0l4TGpFaUlHbGtQU0pwWTI5dUlpQjRiV3h1Y3owaWFIUjBjRG92TDNkM2R5NTNNeTV2Y21jdk1qQXdNQzl6ZG1jaUlIaHRiRzV6T25oc2FXNXJQU0pvZEhSd09pOHZkM2QzTG5jekxtOXlaeTh4T1RrNUwzaHNhVzVySWlCNFBTSXdjSGdpSUhrOUlqQndlQ0lLSUNBZ0lIWnBaWGRDYjNnOUlqQWdNQ0F4TWpnd0lERXlPREFpSUhOMGVXeGxQU0psYm1GaWJHVXRZbUZqYTJkeWIzVnVaRHB1WlhjZ01DQXdJREV5T0RBZ01USTRNRHNpSUhodGJEcHpjR0ZqWlQwaWNISmxjMlZ5ZG1VaVBnbzhjM1I1YkdVZ2RIbHdaVDBpZEdWNGRDOWpjM01pUGdvZ0lDNXpjWFZwY21Oc1pTQjdJR1pwYkd3NklDTTNRamczT1RRN0lIUnlZVzV6Wm05eWJUb2dkSEpoYm5Oc1lYUmxLRFZ3ZUN3Z01YQjRLVHNnZlFvZ0lDNXVZVzFsSUhzZ1ptOXVkRG9nWW05c1pDQTBNREJ3ZUNCellXNXpJSE5sY21sbU95Qm1hV3hzT2lCeVpXUTdJSFJ5WVc1elptOXliVG9nZEhKaGJuTnNZWFJsS0RFek1IQjRMQ0ExTURCd2VDa2djbTkwWVhSbEtESXdaR1ZuS1RzZ2ZRbzhMM04wZVd4bFBnbzhaejRLSUNBOGNHRjBhQ0JqYkdGemN6MGljM0YxYVhKamJHVWlJR1E5SWswZ01Dd2dOVEF3Q2lBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNCRElEQXNJRFVnTlN3Z01DQTFNREFzSURBS0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lGTWdNVEF3TUN3Z05TQXhNREF3TENBMU1EQUtJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnTVRBd01Dd2dNVEF3TUNBMU1EQXNJREV3TURBS0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdNQ3dnTVRBd01DQXdMQ0ExTURBaUx6NEtJQ0E4ZEdWNGRDQmpiR0Z6Y3owaWJtRnRaU0krWW1GeVBDOTBaWGgwUGdvOEwyYytDand2YzNablBnbz0iLCAibWVkaWF0eXBlIjogImltYWdlL3N2Zyt4bWwifV0sICJpbnN0YWxsIjogeyJzcGVjIjogeyJkZXBsb3ltZW50cyI6IFt7Im5hbWUiOiAiYmFyLW9wZXJhdG9yIiwgInNwZWMiOiB7InJlcGxpY2FzIjogMSwgInNlbGVjdG9yIjogeyJtYXRjaExhYmVscyI6IHsiYXBwIjogImJhci1vcGVyYXRvciJ9fSwgInRlbXBsYXRlIjogeyJtZXRhZGF0YSI6IHsibGFiZWxzIjogeyJhcHAiOiAiYmFyLW9wZXJhdG9yIiwgInZlcnNpb24iOiAidjAuMi4wIn0sICJuYW1lIjogImJhci1vcGVyYXRvciJ9LCAic3BlYyI6IHsiY29udGFpbmVycyI6IFt7ImNvbW1hbmQiOiBbIi9ydW4uc2giXSwgImltYWdlIjogInF1YXkuaW8vcmVkaGF0Z292L29jLW1pcnJvci1kZXZAc2hhMjU2OjNmOGUxMjdlOWY2Yzc4NWI0MjBlOTVjNTBlNWY1YzAxMTM2MzM4NGU2Mjg5NWE2YTM0YjMyN2YwZTNjNTI2YTIiLCAiaW1hZ2VQdWxsUG9saWN5IjogIkFsd2F5cyIsICJuYW1lIjogImJhciJ9XX19fX1dfSwgInN0cmF0ZWd5IjogImRlcGxveW1lbnQifSwgImluc3RhbGxNb2RlcyI6IFt7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIk93bk5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIlNpbmdsZU5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IGZhbHNlLCAidHlwZSI6ICJNdWx0aU5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIkFsbE5hbWVzcGFjZXMifV0sICJrZXl3b3JkcyI6IFsiYmFyIl0sICJsYWJlbHMiOiB7Im5hbWUiOiAiYmFyLW9wZXJhdG9yIn0sICJtYWludGFpbmVycyI6IFt7ImVtYWlsIjogIm9jLW1pcnJvckBvcGVuc2hpZnQub3JnIiwgIm5hbWUiOiAib2MtbWlycm9yIGRldmVsb3BlcnMifV0sICJtYXR1cml0eSI6ICJiZXRhIiwgInByb3ZpZGVyIjogeyJuYW1lIjogIkJhciJ9LCAicmVsYXRlZEltYWdlcyI6IFt7ImltYWdlIjogInF1YXkuaW8vcmVkaGF0Z292L29jLW1pcnJvci1kZXZAc2hhMjU2OjNmOGUxMjdlOWY2Yzc4NWI0MjBlOTVjNTBlNWY1YzAxMTM2MzM4NGU2Mjg5NWE2YTM0YjMyN2YwZTNjNTI2YTIiLCAibmFtZSI6ICJvcGVyYXRvciJ9XSwgInJlcGxhY2VzIjogImJhci52MC4xLjAiLCAic2tpcHMiOiBbImJhci52MC4xLjAiXSwgInZlcnNpb24iOiAiMC4yLjAifX0=
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogImFwaWV4dGVuc2lvbnMuazhzLmlvL3YxIiwgImtpbmQiOiAiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwgIm1ldGFkYXRhIjogeyJuYW1lIjogImJhcnMudGVzdC5iYXIifSwgInNwZWMiOiB7Imdyb3VwIjogInRlc3QuYmFyIiwgInNjb3BlIjogIk5hbWVzcGFjZWQiLCAibmFtZXMiOiB7ImtpbmQiOiAiQmFyIiwgInBsdXJhbCI6ICJiYXJzIn0sICJ2ZXJzaW9ucyI6IFt7Im5hbWUiOiAidjFhbHBoYTEiLCAic2VydmVkIjogdHJ1ZSwgInN0b3JhZ2UiOiB0cnVlLCAic2NoZW1hIjogeyJvcGVuQVBJVjNTY2hlbWEiOiB7InR5cGUiOiAib2JqZWN0IiwgIngta3ViZXJuZXRlcy1wcmVzZXJ2ZS11bmtub3duLWZpZWxkcyI6IHRydWV9fX1dfX0=
+relatedImages:
+- name: operator
+  image: quay.io/redhatgov/oc-mirror-dev@sha256:3f8e127e9f6c785b420e95c50e5f5c011363384e62895a6a34b327f0e3c526a2
+---
+schema: olm.bundle
+package: bar
+name: bar.v1.0.0
+image: quay.io/redhatgov/oc-mirror-dev:bar-bundle-v1.0.0
+csvJson: '{"apiVersion": "operators.coreos.com/v1alpha1", "kind": "ClusterServiceVersion",
+  "metadata": {"annotations": {"capabilities": "BasicInstall", "certified": "false",
+  "containerImage": "quay.io/redhatgov/oc-mirror-dev@sha256:2d17d26c8595a749d418525cbc75cec638fa57b4a1bf529f351e47a73675102a",
+  "description": "The Bar Operator does Bar things.", "olm.skipRange": "<1.0.0", "repository":
+  "https://github.com/openshift/oc-mirror"}, "name": "bar.v1.0.0"}, "spec": {"customresourcedefinitions":
+  {"owned": [{"group": "test.bar", "kind": "Bar", "name": "bars.test.bar", "version":
+  "v1alpha1"}, {"group": "test.bar", "kind": "Bar", "name": "bars.test.bar", "version":
+  "v1"}]}, "description": "The Bar Operator does Bar things.", "displayName": "Bar
+  Operator", "icon": [{"base64data": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJpY29uIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKICAgIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgogIC5zcXVpcmNsZSB7IGZpbGw6ICM3Qjg3OTQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDVweCwgMXB4KTsgfQogIC5uYW1lIHsgZm9udDogYm9sZCA0MDBweCBzYW5zIHNlcmlmOyBmaWxsOiByZWQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDEzMHB4LCA1MDBweCkgcm90YXRlKDIwZGVnKTsgfQo8L3N0eWxlPgo8Zz4KICA8cGF0aCBjbGFzcz0ic3F1aXJjbGUiIGQ9Ik0gMCwgNTAwCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBDIDAsIDUgNSwgMCA1MDAsIDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgIFMgMTAwMCwgNSAxMDAwLCA1MDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMTAwMCwgMTAwMCA1MDAsIDEwMDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMCwgMTAwMCAwLCA1MDAiLz4KICA8dGV4dCBjbGFzcz0ibmFtZSI+YmFyPC90ZXh0Pgo8L2c+Cjwvc3ZnPgo=",
+  "mediatype": "image/svg+xml"}], "install": {"spec": {"deployments": [{"name": "bar-operator",
+  "spec": {"replicas": 1, "selector": {"matchLabels": {"app": "bar-operator"}}, "template":
+  {"metadata": {"labels": {"app": "bar-operator", "version": "v1.0.0"}, "name": "bar-operator"},
+  "spec": {"containers": [{"command": ["/run.sh"], "image": "quay.io/redhatgov/oc-mirror-dev@sha256:2d17d26c8595a749d418525cbc75cec638fa57b4a1bf529f351e47a73675102a",
+  "imagePullPolicy": "Always", "name": "bar"}]}}}}]}, "strategy": "deployment"}, "installModes":
+  [{"supported": true, "type": "OwnNamespace"}, {"supported": true, "type": "SingleNamespace"},
+  {"supported": false, "type": "MultiNamespace"}, {"supported": true, "type": "AllNamespaces"}],
+  "keywords": ["bar"], "labels": {"name": "bar-operator"}, "maintainers": [{"email":
+  "oc-mirror@openshift.org", "name": "oc-mirror developers"}], "maturity": "beta",
+  "provider": {"name": "Bar"}, "relatedImages": [{"image": "quay.io/redhatgov/oc-mirror-dev@sha256:2d17d26c8595a749d418525cbc75cec638fa57b4a1bf529f351e47a73675102a",
+  "name": "operator"}], "replaces": "bar.v0.2.0", "version": "1.0.0"}}'
+properties:
+- type: olm.gvk
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1
+- type: olm.package
+  value:
+    packageName: bar
+    version: 1.0.0
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgImtpbmQiOiAiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwgIm1ldGFkYXRhIjogeyJhbm5vdGF0aW9ucyI6IHsiY2FwYWJpbGl0aWVzIjogIkJhc2ljSW5zdGFsbCIsICJjZXJ0aWZpZWQiOiAiZmFsc2UiLCAiY29udGFpbmVySW1hZ2UiOiAicXVheS5pby9yZWRoYXRnb3Yvb2MtbWlycm9yLWRldkBzaGEyNTY6MmQxN2QyNmM4NTk1YTc0OWQ0MTg1MjVjYmM3NWNlYzYzOGZhNTdiNGExYmY1MjlmMzUxZTQ3YTczNjc1MTAyYSIsICJkZXNjcmlwdGlvbiI6ICJUaGUgQmFyIE9wZXJhdG9yIGRvZXMgQmFyIHRoaW5ncy4iLCAib2xtLnNraXBSYW5nZSI6ICI8MS4wLjAiLCAicmVwb3NpdG9yeSI6ICJodHRwczovL2dpdGh1Yi5jb20vb3BlbnNoaWZ0L29jLW1pcnJvciJ9LCAibmFtZSI6ICJiYXIudjEuMC4wIn0sICJzcGVjIjogeyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjogeyJvd25lZCI6IFt7Imdyb3VwIjogInRlc3QuYmFyIiwgImtpbmQiOiAiQmFyIiwgIm5hbWUiOiAiYmFycy50ZXN0LmJhciIsICJ2ZXJzaW9uIjogInYxYWxwaGExIn0sIHsiZ3JvdXAiOiAidGVzdC5iYXIiLCAia2luZCI6ICJCYXIiLCAibmFtZSI6ICJiYXJzLnRlc3QuYmFyIiwgInZlcnNpb24iOiAidjEifV19LCAiZGVzY3JpcHRpb24iOiAiVGhlIEJhciBPcGVyYXRvciBkb2VzIEJhciB0aGluZ3MuIiwgImRpc3BsYXlOYW1lIjogIkJhciBPcGVyYXRvciIsICJpY29uIjogW3siYmFzZTY0ZGF0YSI6ICJQRDk0Yld3Z2RtVnljMmx2YmowaU1TNHdJaUJsYm1OdlpHbHVaejBpZFhSbUxUZ2lQejRLUEhOMlp5QjJaWEp6YVc5dVBTSXhMakVpSUdsa1BTSnBZMjl1SWlCNGJXeHVjejBpYUhSMGNEb3ZMM2QzZHk1M015NXZjbWN2TWpBd01DOXpkbWNpSUhodGJHNXpPbmhzYVc1clBTSm9kSFJ3T2k4dmQzZDNMbmN6TG05eVp5OHhPVGs1TDNoc2FXNXJJaUI0UFNJd2NIZ2lJSGs5SWpCd2VDSUtJQ0FnSUhacFpYZENiM2c5SWpBZ01DQXhNamd3SURFeU9EQWlJSE4wZVd4bFBTSmxibUZpYkdVdFltRmphMmR5YjNWdVpEcHVaWGNnTUNBd0lERXlPREFnTVRJNE1Ec2lJSGh0YkRwemNHRmpaVDBpY0hKbGMyVnlkbVVpUGdvOGMzUjViR1VnZEhsd1pUMGlkR1Y0ZEM5amMzTWlQZ29nSUM1emNYVnBjbU5zWlNCN0lHWnBiR3c2SUNNM1FqZzNPVFE3SUhSeVlXNXpabTl5YlRvZ2RISmhibk5zWVhSbEtEVndlQ3dnTVhCNEtUc2dmUW9nSUM1dVlXMWxJSHNnWm05dWREb2dZbTlzWkNBME1EQndlQ0J6WVc1eklITmxjbWxtT3lCbWFXeHNPaUJ5WldRN0lIUnlZVzV6Wm05eWJUb2dkSEpoYm5Oc1lYUmxLREV6TUhCNExDQTFNREJ3ZUNrZ2NtOTBZWFJsS0RJd1pHVm5LVHNnZlFvOEwzTjBlV3hsUGdvOFp6NEtJQ0E4Y0dGMGFDQmpiR0Z6Y3owaWMzRjFhWEpqYkdVaUlHUTlJazBnTUN3Z05UQXdDaUFnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0JESURBc0lEVWdOU3dnTUNBMU1EQXNJREFLSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUZNZ01UQXdNQ3dnTlNBeE1EQXdMQ0ExTURBS0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdNVEF3TUN3Z01UQXdNQ0ExTURBc0lERXdNREFLSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ01Dd2dNVEF3TUNBd0xDQTFNREFpTHo0S0lDQThkR1Y0ZENCamJHRnpjejBpYm1GdFpTSStZbUZ5UEM5MFpYaDBQZ284TDJjK0Nqd3ZjM1puUGdvPSIsICJtZWRpYXR5cGUiOiAiaW1hZ2Uvc3ZnK3htbCJ9XSwgImluc3RhbGwiOiB7InNwZWMiOiB7ImRlcGxveW1lbnRzIjogW3sibmFtZSI6ICJiYXItb3BlcmF0b3IiLCAic3BlYyI6IHsicmVwbGljYXMiOiAxLCAic2VsZWN0b3IiOiB7Im1hdGNoTGFiZWxzIjogeyJhcHAiOiAiYmFyLW9wZXJhdG9yIn19LCAidGVtcGxhdGUiOiB7Im1ldGFkYXRhIjogeyJsYWJlbHMiOiB7ImFwcCI6ICJiYXItb3BlcmF0b3IiLCAidmVyc2lvbiI6ICJ2MS4wLjAifSwgIm5hbWUiOiAiYmFyLW9wZXJhdG9yIn0sICJzcGVjIjogeyJjb250YWluZXJzIjogW3siY29tbWFuZCI6IFsiL3J1bi5zaCJdLCAiaW1hZ2UiOiAicXVheS5pby9yZWRoYXRnb3Yvb2MtbWlycm9yLWRldkBzaGEyNTY6MmQxN2QyNmM4NTk1YTc0OWQ0MTg1MjVjYmM3NWNlYzYzOGZhNTdiNGExYmY1MjlmMzUxZTQ3YTczNjc1MTAyYSIsICJpbWFnZVB1bGxQb2xpY3kiOiAiQWx3YXlzIiwgIm5hbWUiOiAiYmFyIn1dfX19fV19LCAic3RyYXRlZ3kiOiAiZGVwbG95bWVudCJ9LCAiaW5zdGFsbE1vZGVzIjogW3sic3VwcG9ydGVkIjogdHJ1ZSwgInR5cGUiOiAiT3duTmFtZXNwYWNlIn0sIHsic3VwcG9ydGVkIjogdHJ1ZSwgInR5cGUiOiAiU2luZ2xlTmFtZXNwYWNlIn0sIHsic3VwcG9ydGVkIjogZmFsc2UsICJ0eXBlIjogIk11bHRpTmFtZXNwYWNlIn0sIHsic3VwcG9ydGVkIjogdHJ1ZSwgInR5cGUiOiAiQWxsTmFtZXNwYWNlcyJ9XSwgImtleXdvcmRzIjogWyJiYXIiXSwgImxhYmVscyI6IHsibmFtZSI6ICJiYXItb3BlcmF0b3IifSwgIm1haW50YWluZXJzIjogW3siZW1haWwiOiAib2MtbWlycm9yQG9wZW5zaGlmdC5vcmciLCAibmFtZSI6ICJvYy1taXJyb3IgZGV2ZWxvcGVycyJ9XSwgIm1hdHVyaXR5IjogImJldGEiLCAicHJvdmlkZXIiOiB7Im5hbWUiOiAiQmFyIn0sICJyZWxhdGVkSW1hZ2VzIjogW3siaW1hZ2UiOiAicXVheS5pby9yZWRoYXRnb3Yvb2MtbWlycm9yLWRldkBzaGEyNTY6MmQxN2QyNmM4NTk1YTc0OWQ0MTg1MjVjYmM3NWNlYzYzOGZhNTdiNGExYmY1MjlmMzUxZTQ3YTczNjc1MTAyYSIsICJuYW1lIjogIm9wZXJhdG9yIn1dLCAicmVwbGFjZXMiOiAiYmFyLnYwLjIuMCIsICJ2ZXJzaW9uIjogIjEuMC4wIn19
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogImFwaWV4dGVuc2lvbnMuazhzLmlvL3YxIiwgImtpbmQiOiAiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwgIm1ldGFkYXRhIjogeyJuYW1lIjogImJhcnMudGVzdC5iYXIifSwgInNwZWMiOiB7Imdyb3VwIjogInRlc3QuYmFyIiwgInNjb3BlIjogIk5hbWVzcGFjZWQiLCAibmFtZXMiOiB7ImtpbmQiOiAiQmFyIiwgInBsdXJhbCI6ICJiYXJzIn0sICJ2ZXJzaW9ucyI6IFt7Im5hbWUiOiAidjFhbHBoYTEiLCAic2VydmVkIjogdHJ1ZSwgInN0b3JhZ2UiOiBmYWxzZSwgInNjaGVtYSI6IHsib3BlbkFQSVYzU2NoZW1hIjogeyJ0eXBlIjogIm9iamVjdCIsICJ4LWt1YmVybmV0ZXMtcHJlc2VydmUtdW5rbm93bi1maWVsZHMiOiB0cnVlfX19LCB7Im5hbWUiOiAidjEiLCAic2VydmVkIjogdHJ1ZSwgInN0b3JhZ2UiOiB0cnVlLCAic2NoZW1hIjogeyJvcGVuQVBJVjNTY2hlbWEiOiB7InR5cGUiOiAib2JqZWN0IiwgIngta3ViZXJuZXRlcy1wcmVzZXJ2ZS11bmtub3duLWZpZWxkcyI6IHRydWV9fX1dfX0=
+relatedImages:
+- name: operator
+  image: quay.io/redhatgov/oc-mirror-dev@sha256:2d17d26c8595a749d418525cbc75cec638fa57b4a1bf529f351e47a73675102a
+---
+schema: olm.channel
+package: bar
+name: stable
+entries:
+- name: bar.v1.0.0
+  skipRange: <1.0.0
+---
+schema: olm.package
+name: baz
+description: 'baz
+
+  ===
+
+
+  The Baz operator reacts to Bazs objects.
+
+  '
+icon:
+  base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJpY29uIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKICAgIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgogIC5zcXVpcmNsZSB7IGZpbGw6ICM3Qjg3OTQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDVweCwgMXB4KTsgfQogIC5uYW1lIHsgZm9udDogYm9sZCA0MDBweCBzYW5zIHNlcmlmOyBmaWxsOiByZWQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDEzMHB4LCA1MDBweCkgcm90YXRlKDIwZGVnKTsgfQo8L3N0eWxlPgo8Zz4KICA8cGF0aCBjbGFzcz0ic3F1aXJjbGUiIGQ9Ik0gMCwgNTAwCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBDIDAsIDUgNSwgMCA1MDAsIDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgIFMgMTAwMCwgNSAxMDAwLCA1MDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMTAwMCwgMTAwMCA1MDAsIDEwMDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMCwgMTAwMCAwLCA1MDAiLz4KICA8dGV4dCBjbGFzcz0ibmFtZSI+YmF6PC90ZXh0Pgo8L2c+Cjwvc3ZnPgo=
+  mediatype: image/svg+xml
+defaultChannel: stable
+---
+schema: olm.channel
+package: baz
+name: stable
+entries:
+- name: baz.v1.0.0
+  skipRange: <1.0.0
+- name: baz.v1.0.1
+  skipRange: <1.0.1
+  skips:
+  - baz.v1.0.0
+- name: baz.v1.1.0
+  skipRange: <1.1.0
+  replaces: baz.v1.0.1
+---
+schema: olm.bundle
+package: baz
+name: baz.v1.0.0
+image: quay.io/redhatgov/oc-mirror-dev:baz-bundle-v1.0.0
+csvJson: '{"apiVersion": "operators.coreos.com/v1alpha1", "kind": "ClusterServiceVersion",
+  "metadata": {"annotations": {"capabilities": "BasicInstall", "certified": "false",
+  "containerImage": "quay.io/redhatgov/oc-mirror-dev@sha256:1d7dac32c4a5d44344f2861e56f4928899c53e20548c488b78d3fe8e04a6afd0",
+  "description": "The Baz Operator does Baz things.", "olm.skipRange": "<1.0.0", "repository":
+  "https://github.com/openshift/oc-mirror"}, "name": "baz.v1.0.0"}, "spec": {"customresourcedefinitions":
+  {"owned": [{"group": "test.baz", "kind": "Baz", "name": "bazs.test.baz", "version":
+  "v1"}]}, "description": "The Baz Operator does Baz things.", "displayName": "Baz
+  Operator", "icon": [{"base64data": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJpY29uIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKICAgIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgogIC5zcXVpcmNsZSB7IGZpbGw6ICM3Qjg3OTQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDVweCwgMXB4KTsgfQogIC5uYW1lIHsgZm9udDogYm9sZCA0MDBweCBzYW5zIHNlcmlmOyBmaWxsOiByZWQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDEzMHB4LCA1MDBweCkgcm90YXRlKDIwZGVnKTsgfQo8L3N0eWxlPgo8Zz4KICA8cGF0aCBjbGFzcz0ic3F1aXJjbGUiIGQ9Ik0gMCwgNTAwCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBDIDAsIDUgNSwgMCA1MDAsIDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgIFMgMTAwMCwgNSAxMDAwLCA1MDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMTAwMCwgMTAwMCA1MDAsIDEwMDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMCwgMTAwMCAwLCA1MDAiLz4KICA8dGV4dCBjbGFzcz0ibmFtZSI+YmF6PC90ZXh0Pgo8L2c+Cjwvc3ZnPgo=",
+  "mediatype": "image/svg+xml"}], "install": {"spec": {"deployments": [{"name": "baz-operator",
+  "spec": {"replicas": 1, "selector": {"matchLabels": {"app": "baz-operator"}}, "template":
+  {"metadata": {"labels": {"app": "baz-operator", "version": "v1.0.0"}, "name": "baz-operator"},
+  "spec": {"containers": [{"command": ["/run.sh"], "image": "quay.io/redhatgov/oc-mirror-dev@sha256:1d7dac32c4a5d44344f2861e56f4928899c53e20548c488b78d3fe8e04a6afd0",
+  "imagePullPolicy": "Always", "name": "baz"}]}}}}]}, "strategy": "deployment"}, "installModes":
+  [{"supported": true, "type": "OwnNamespace"}, {"supported": true, "type": "SingleNamespace"},
+  {"supported": false, "type": "MultiNamespace"}, {"supported": true, "type": "AllNamespaces"}],
+  "keywords": ["baz"], "labels": {"name": "baz-operator"}, "maintainers": [{"email":
+  "oc-mirror@openshift.org", "name": "oc-mirror developers"}], "maturity": "beta",
+  "provider": {"name": "Baz"}, "relatedImages": [{"image": "quay.io/redhatgov/oc-mirror-dev@sha256:1d7dac32c4a5d44344f2861e56f4928899c53e20548c488b78d3fe8e04a6afd0",
+  "name": "operator"}], "version": "1.0.0"}}'
+properties:
+- type: olm.gvk
+  value:
+    group: test.baz
+    kind: Baz
+    version: v1
+- type: olm.package
+  value:
+    packageName: baz
+    version: 1.0.0
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgImtpbmQiOiAiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwgIm1ldGFkYXRhIjogeyJhbm5vdGF0aW9ucyI6IHsiY2FwYWJpbGl0aWVzIjogIkJhc2ljSW5zdGFsbCIsICJjZXJ0aWZpZWQiOiAiZmFsc2UiLCAiY29udGFpbmVySW1hZ2UiOiAicXVheS5pby9yZWRoYXRnb3Yvb2MtbWlycm9yLWRldkBzaGEyNTY6MWQ3ZGFjMzJjNGE1ZDQ0MzQ0ZjI4NjFlNTZmNDkyODg5OWM1M2UyMDU0OGM0ODhiNzhkM2ZlOGUwNGE2YWZkMCIsICJkZXNjcmlwdGlvbiI6ICJUaGUgQmF6IE9wZXJhdG9yIGRvZXMgQmF6IHRoaW5ncy4iLCAib2xtLnNraXBSYW5nZSI6ICI8MS4wLjAiLCAicmVwb3NpdG9yeSI6ICJodHRwczovL2dpdGh1Yi5jb20vb3BlbnNoaWZ0L29jLW1pcnJvciJ9LCAibmFtZSI6ICJiYXoudjEuMC4wIn0sICJzcGVjIjogeyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjogeyJvd25lZCI6IFt7Imdyb3VwIjogInRlc3QuYmF6IiwgImtpbmQiOiAiQmF6IiwgIm5hbWUiOiAiYmF6cy50ZXN0LmJheiIsICJ2ZXJzaW9uIjogInYxIn1dfSwgImRlc2NyaXB0aW9uIjogIlRoZSBCYXogT3BlcmF0b3IgZG9lcyBCYXogdGhpbmdzLiIsICJkaXNwbGF5TmFtZSI6ICJCYXogT3BlcmF0b3IiLCAiaWNvbiI6IFt7ImJhc2U2NGRhdGEiOiAiUEQ5NGJXd2dkbVZ5YzJsdmJqMGlNUzR3SWlCbGJtTnZaR2x1WnowaWRYUm1MVGdpUHo0S1BITjJaeUIyWlhKemFXOXVQU0l4TGpFaUlHbGtQU0pwWTI5dUlpQjRiV3h1Y3owaWFIUjBjRG92TDNkM2R5NTNNeTV2Y21jdk1qQXdNQzl6ZG1jaUlIaHRiRzV6T25oc2FXNXJQU0pvZEhSd09pOHZkM2QzTG5jekxtOXlaeTh4T1RrNUwzaHNhVzVySWlCNFBTSXdjSGdpSUhrOUlqQndlQ0lLSUNBZ0lIWnBaWGRDYjNnOUlqQWdNQ0F4TWpnd0lERXlPREFpSUhOMGVXeGxQU0psYm1GaWJHVXRZbUZqYTJkeWIzVnVaRHB1WlhjZ01DQXdJREV5T0RBZ01USTRNRHNpSUhodGJEcHpjR0ZqWlQwaWNISmxjMlZ5ZG1VaVBnbzhjM1I1YkdVZ2RIbHdaVDBpZEdWNGRDOWpjM01pUGdvZ0lDNXpjWFZwY21Oc1pTQjdJR1pwYkd3NklDTTNRamczT1RRN0lIUnlZVzV6Wm05eWJUb2dkSEpoYm5Oc1lYUmxLRFZ3ZUN3Z01YQjRLVHNnZlFvZ0lDNXVZVzFsSUhzZ1ptOXVkRG9nWW05c1pDQTBNREJ3ZUNCellXNXpJSE5sY21sbU95Qm1hV3hzT2lCeVpXUTdJSFJ5WVc1elptOXliVG9nZEhKaGJuTnNZWFJsS0RFek1IQjRMQ0ExTURCd2VDa2djbTkwWVhSbEtESXdaR1ZuS1RzZ2ZRbzhMM04wZVd4bFBnbzhaejRLSUNBOGNHRjBhQ0JqYkdGemN6MGljM0YxYVhKamJHVWlJR1E5SWswZ01Dd2dOVEF3Q2lBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNCRElEQXNJRFVnTlN3Z01DQTFNREFzSURBS0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lGTWdNVEF3TUN3Z05TQXhNREF3TENBMU1EQUtJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnTVRBd01Dd2dNVEF3TUNBMU1EQXNJREV3TURBS0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdNQ3dnTVRBd01DQXdMQ0ExTURBaUx6NEtJQ0E4ZEdWNGRDQmpiR0Z6Y3owaWJtRnRaU0krWW1GNlBDOTBaWGgwUGdvOEwyYytDand2YzNablBnbz0iLCAibWVkaWF0eXBlIjogImltYWdlL3N2Zyt4bWwifV0sICJpbnN0YWxsIjogeyJzcGVjIjogeyJkZXBsb3ltZW50cyI6IFt7Im5hbWUiOiAiYmF6LW9wZXJhdG9yIiwgInNwZWMiOiB7InJlcGxpY2FzIjogMSwgInNlbGVjdG9yIjogeyJtYXRjaExhYmVscyI6IHsiYXBwIjogImJhei1vcGVyYXRvciJ9fSwgInRlbXBsYXRlIjogeyJtZXRhZGF0YSI6IHsibGFiZWxzIjogeyJhcHAiOiAiYmF6LW9wZXJhdG9yIiwgInZlcnNpb24iOiAidjEuMC4wIn0sICJuYW1lIjogImJhei1vcGVyYXRvciJ9LCAic3BlYyI6IHsiY29udGFpbmVycyI6IFt7ImNvbW1hbmQiOiBbIi9ydW4uc2giXSwgImltYWdlIjogInF1YXkuaW8vcmVkaGF0Z292L29jLW1pcnJvci1kZXZAc2hhMjU2OjFkN2RhYzMyYzRhNWQ0NDM0NGYyODYxZTU2ZjQ5Mjg4OTljNTNlMjA1NDhjNDg4Yjc4ZDNmZThlMDRhNmFmZDAiLCAiaW1hZ2VQdWxsUG9saWN5IjogIkFsd2F5cyIsICJuYW1lIjogImJheiJ9XX19fX1dfSwgInN0cmF0ZWd5IjogImRlcGxveW1lbnQifSwgImluc3RhbGxNb2RlcyI6IFt7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIk93bk5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIlNpbmdsZU5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IGZhbHNlLCAidHlwZSI6ICJNdWx0aU5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIkFsbE5hbWVzcGFjZXMifV0sICJrZXl3b3JkcyI6IFsiYmF6Il0sICJsYWJlbHMiOiB7Im5hbWUiOiAiYmF6LW9wZXJhdG9yIn0sICJtYWludGFpbmVycyI6IFt7ImVtYWlsIjogIm9jLW1pcnJvckBvcGVuc2hpZnQub3JnIiwgIm5hbWUiOiAib2MtbWlycm9yIGRldmVsb3BlcnMifV0sICJtYXR1cml0eSI6ICJiZXRhIiwgInByb3ZpZGVyIjogeyJuYW1lIjogIkJheiJ9LCAicmVsYXRlZEltYWdlcyI6IFt7ImltYWdlIjogInF1YXkuaW8vcmVkaGF0Z292L29jLW1pcnJvci1kZXZAc2hhMjU2OjFkN2RhYzMyYzRhNWQ0NDM0NGYyODYxZTU2ZjQ5Mjg4OTljNTNlMjA1NDhjNDg4Yjc4ZDNmZThlMDRhNmFmZDAiLCAibmFtZSI6ICJvcGVyYXRvciJ9XSwgInZlcnNpb24iOiAiMS4wLjAifX0=
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogImFwaWV4dGVuc2lvbnMuazhzLmlvL3YxIiwgImtpbmQiOiAiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwgIm1ldGFkYXRhIjogeyJuYW1lIjogImJhenMudGVzdC5iYXoifSwgInNwZWMiOiB7Imdyb3VwIjogInRlc3QuYmF6IiwgInNjb3BlIjogIk5hbWVzcGFjZWQiLCAibmFtZXMiOiB7ImtpbmQiOiAiQmF6IiwgInBsdXJhbCI6ICJiYXpzIn0sICJ2ZXJzaW9ucyI6IFt7Im5hbWUiOiAidjEiLCAic2VydmVkIjogdHJ1ZSwgInN0b3JhZ2UiOiB0cnVlLCAic2NoZW1hIjogeyJvcGVuQVBJVjNTY2hlbWEiOiB7InR5cGUiOiAib2JqZWN0IiwgIngta3ViZXJuZXRlcy1wcmVzZXJ2ZS11bmtub3duLWZpZWxkcyI6IHRydWV9fX1dfX0=
+relatedImages:
+- name: operator
+  image: quay.io/redhatgov/oc-mirror-dev@sha256:1d7dac32c4a5d44344f2861e56f4928899c53e20548c488b78d3fe8e04a6afd0
+---
+schema: olm.bundle
+package: baz
+name: baz.v1.0.1
+image: quay.io/redhatgov/oc-mirror-dev:baz-bundle-v1.0.1
+csvJson: '{"apiVersion": "operators.coreos.com/v1alpha1", "kind": "ClusterServiceVersion",
+  "metadata": {"annotations": {"capabilities": "BasicInstall", "certified": "false",
+  "containerImage": "quay.io/redhatgov/oc-mirror-dev@sha256:f1f6dabc6d05ae1d6e1b729d8ed80edb6b99fce8a6459c60a595945479e6f4ce",
+  "description": "The Baz Operator does Baz things.", "olm.skipRange": "<1.0.1", "repository":
+  "https://github.com/openshift/oc-mirror"}, "name": "baz.v1.0.1"}, "spec": {"customresourcedefinitions":
+  {"owned": [{"group": "test.baz", "kind": "Baz", "name": "bazs.test.baz", "version":
+  "v1"}]}, "description": "The Baz Operator does Baz things.", "displayName": "Baz
+  Operator", "icon": [{"base64data": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJpY29uIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKICAgIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgogIC5zcXVpcmNsZSB7IGZpbGw6ICM3Qjg3OTQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDVweCwgMXB4KTsgfQogIC5uYW1lIHsgZm9udDogYm9sZCA0MDBweCBzYW5zIHNlcmlmOyBmaWxsOiByZWQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDEzMHB4LCA1MDBweCkgcm90YXRlKDIwZGVnKTsgfQo8L3N0eWxlPgo8Zz4KICA8cGF0aCBjbGFzcz0ic3F1aXJjbGUiIGQ9Ik0gMCwgNTAwCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBDIDAsIDUgNSwgMCA1MDAsIDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgIFMgMTAwMCwgNSAxMDAwLCA1MDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMTAwMCwgMTAwMCA1MDAsIDEwMDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMCwgMTAwMCAwLCA1MDAiLz4KICA8dGV4dCBjbGFzcz0ibmFtZSI+YmF6PC90ZXh0Pgo8L2c+Cjwvc3ZnPgo=",
+  "mediatype": "image/svg+xml"}], "install": {"spec": {"deployments": [{"name": "baz-operator",
+  "spec": {"replicas": 1, "selector": {"matchLabels": {"app": "baz-operator"}}, "template":
+  {"metadata": {"labels": {"app": "baz-operator", "version": "v1.0.1"}, "name": "baz-operator"},
+  "spec": {"containers": [{"command": ["/run.sh"], "image": "quay.io/redhatgov/oc-mirror-dev@sha256:f1f6dabc6d05ae1d6e1b729d8ed80edb6b99fce8a6459c60a595945479e6f4ce",
+  "imagePullPolicy": "Always", "name": "baz"}]}}}}]}, "strategy": "deployment"}, "installModes":
+  [{"supported": true, "type": "OwnNamespace"}, {"supported": true, "type": "SingleNamespace"},
+  {"supported": false, "type": "MultiNamespace"}, {"supported": true, "type": "AllNamespaces"}],
+  "keywords": ["baz"], "labels": {"name": "baz-operator"}, "maintainers": [{"email":
+  "oc-mirror@openshift.org", "name": "oc-mirror developers"}], "maturity": "beta",
+  "provider": {"name": "Baz"}, "relatedImages": [{"image": "quay.io/redhatgov/oc-mirror-dev@sha256:f1f6dabc6d05ae1d6e1b729d8ed80edb6b99fce8a6459c60a595945479e6f4ce",
+  "name": "operator"}], "skips": ["baz.v1.0.0"], "version": "1.0.1"}}'
+properties:
+- type: olm.gvk
+  value:
+    group: test.baz
+    kind: Baz
+    version: v1
+- type: olm.package
+  value:
+    packageName: baz
+    version: 1.0.1
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgImtpbmQiOiAiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwgIm1ldGFkYXRhIjogeyJhbm5vdGF0aW9ucyI6IHsiY2FwYWJpbGl0aWVzIjogIkJhc2ljSW5zdGFsbCIsICJjZXJ0aWZpZWQiOiAiZmFsc2UiLCAiY29udGFpbmVySW1hZ2UiOiAicXVheS5pby9yZWRoYXRnb3Yvb2MtbWlycm9yLWRldkBzaGEyNTY6ZjFmNmRhYmM2ZDA1YWUxZDZlMWI3MjlkOGVkODBlZGI2Yjk5ZmNlOGE2NDU5YzYwYTU5NTk0NTQ3OWU2ZjRjZSIsICJkZXNjcmlwdGlvbiI6ICJUaGUgQmF6IE9wZXJhdG9yIGRvZXMgQmF6IHRoaW5ncy4iLCAib2xtLnNraXBSYW5nZSI6ICI8MS4wLjEiLCAicmVwb3NpdG9yeSI6ICJodHRwczovL2dpdGh1Yi5jb20vb3BlbnNoaWZ0L29jLW1pcnJvciJ9LCAibmFtZSI6ICJiYXoudjEuMC4xIn0sICJzcGVjIjogeyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjogeyJvd25lZCI6IFt7Imdyb3VwIjogInRlc3QuYmF6IiwgImtpbmQiOiAiQmF6IiwgIm5hbWUiOiAiYmF6cy50ZXN0LmJheiIsICJ2ZXJzaW9uIjogInYxIn1dfSwgImRlc2NyaXB0aW9uIjogIlRoZSBCYXogT3BlcmF0b3IgZG9lcyBCYXogdGhpbmdzLiIsICJkaXNwbGF5TmFtZSI6ICJCYXogT3BlcmF0b3IiLCAiaWNvbiI6IFt7ImJhc2U2NGRhdGEiOiAiUEQ5NGJXd2dkbVZ5YzJsdmJqMGlNUzR3SWlCbGJtTnZaR2x1WnowaWRYUm1MVGdpUHo0S1BITjJaeUIyWlhKemFXOXVQU0l4TGpFaUlHbGtQU0pwWTI5dUlpQjRiV3h1Y3owaWFIUjBjRG92TDNkM2R5NTNNeTV2Y21jdk1qQXdNQzl6ZG1jaUlIaHRiRzV6T25oc2FXNXJQU0pvZEhSd09pOHZkM2QzTG5jekxtOXlaeTh4T1RrNUwzaHNhVzVySWlCNFBTSXdjSGdpSUhrOUlqQndlQ0lLSUNBZ0lIWnBaWGRDYjNnOUlqQWdNQ0F4TWpnd0lERXlPREFpSUhOMGVXeGxQU0psYm1GaWJHVXRZbUZqYTJkeWIzVnVaRHB1WlhjZ01DQXdJREV5T0RBZ01USTRNRHNpSUhodGJEcHpjR0ZqWlQwaWNISmxjMlZ5ZG1VaVBnbzhjM1I1YkdVZ2RIbHdaVDBpZEdWNGRDOWpjM01pUGdvZ0lDNXpjWFZwY21Oc1pTQjdJR1pwYkd3NklDTTNRamczT1RRN0lIUnlZVzV6Wm05eWJUb2dkSEpoYm5Oc1lYUmxLRFZ3ZUN3Z01YQjRLVHNnZlFvZ0lDNXVZVzFsSUhzZ1ptOXVkRG9nWW05c1pDQTBNREJ3ZUNCellXNXpJSE5sY21sbU95Qm1hV3hzT2lCeVpXUTdJSFJ5WVc1elptOXliVG9nZEhKaGJuTnNZWFJsS0RFek1IQjRMQ0ExTURCd2VDa2djbTkwWVhSbEtESXdaR1ZuS1RzZ2ZRbzhMM04wZVd4bFBnbzhaejRLSUNBOGNHRjBhQ0JqYkdGemN6MGljM0YxYVhKamJHVWlJR1E5SWswZ01Dd2dOVEF3Q2lBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNCRElEQXNJRFVnTlN3Z01DQTFNREFzSURBS0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lGTWdNVEF3TUN3Z05TQXhNREF3TENBMU1EQUtJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnTVRBd01Dd2dNVEF3TUNBMU1EQXNJREV3TURBS0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdNQ3dnTVRBd01DQXdMQ0ExTURBaUx6NEtJQ0E4ZEdWNGRDQmpiR0Z6Y3owaWJtRnRaU0krWW1GNlBDOTBaWGgwUGdvOEwyYytDand2YzNablBnbz0iLCAibWVkaWF0eXBlIjogImltYWdlL3N2Zyt4bWwifV0sICJpbnN0YWxsIjogeyJzcGVjIjogeyJkZXBsb3ltZW50cyI6IFt7Im5hbWUiOiAiYmF6LW9wZXJhdG9yIiwgInNwZWMiOiB7InJlcGxpY2FzIjogMSwgInNlbGVjdG9yIjogeyJtYXRjaExhYmVscyI6IHsiYXBwIjogImJhei1vcGVyYXRvciJ9fSwgInRlbXBsYXRlIjogeyJtZXRhZGF0YSI6IHsibGFiZWxzIjogeyJhcHAiOiAiYmF6LW9wZXJhdG9yIiwgInZlcnNpb24iOiAidjEuMC4xIn0sICJuYW1lIjogImJhei1vcGVyYXRvciJ9LCAic3BlYyI6IHsiY29udGFpbmVycyI6IFt7ImNvbW1hbmQiOiBbIi9ydW4uc2giXSwgImltYWdlIjogInF1YXkuaW8vcmVkaGF0Z292L29jLW1pcnJvci1kZXZAc2hhMjU2OmYxZjZkYWJjNmQwNWFlMWQ2ZTFiNzI5ZDhlZDgwZWRiNmI5OWZjZThhNjQ1OWM2MGE1OTU5NDU0NzllNmY0Y2UiLCAiaW1hZ2VQdWxsUG9saWN5IjogIkFsd2F5cyIsICJuYW1lIjogImJheiJ9XX19fX1dfSwgInN0cmF0ZWd5IjogImRlcGxveW1lbnQifSwgImluc3RhbGxNb2RlcyI6IFt7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIk93bk5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIlNpbmdsZU5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IGZhbHNlLCAidHlwZSI6ICJNdWx0aU5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIkFsbE5hbWVzcGFjZXMifV0sICJrZXl3b3JkcyI6IFsiYmF6Il0sICJsYWJlbHMiOiB7Im5hbWUiOiAiYmF6LW9wZXJhdG9yIn0sICJtYWludGFpbmVycyI6IFt7ImVtYWlsIjogIm9jLW1pcnJvckBvcGVuc2hpZnQub3JnIiwgIm5hbWUiOiAib2MtbWlycm9yIGRldmVsb3BlcnMifV0sICJtYXR1cml0eSI6ICJiZXRhIiwgInByb3ZpZGVyIjogeyJuYW1lIjogIkJheiJ9LCAicmVsYXRlZEltYWdlcyI6IFt7ImltYWdlIjogInF1YXkuaW8vcmVkaGF0Z292L29jLW1pcnJvci1kZXZAc2hhMjU2OmYxZjZkYWJjNmQwNWFlMWQ2ZTFiNzI5ZDhlZDgwZWRiNmI5OWZjZThhNjQ1OWM2MGE1OTU5NDU0NzllNmY0Y2UiLCAibmFtZSI6ICJvcGVyYXRvciJ9XSwgInNraXBzIjogWyJiYXoudjEuMC4wIl0sICJ2ZXJzaW9uIjogIjEuMC4xIn19
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogImFwaWV4dGVuc2lvbnMuazhzLmlvL3YxIiwgImtpbmQiOiAiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwgIm1ldGFkYXRhIjogeyJuYW1lIjogImJhenMudGVzdC5iYXoifSwgInNwZWMiOiB7Imdyb3VwIjogInRlc3QuYmF6IiwgInNjb3BlIjogIk5hbWVzcGFjZWQiLCAibmFtZXMiOiB7ImtpbmQiOiAiQmF6IiwgInBsdXJhbCI6ICJiYXpzIn0sICJ2ZXJzaW9ucyI6IFt7Im5hbWUiOiAidjEiLCAic2VydmVkIjogdHJ1ZSwgInN0b3JhZ2UiOiB0cnVlLCAic2NoZW1hIjogeyJvcGVuQVBJVjNTY2hlbWEiOiB7InR5cGUiOiAib2JqZWN0IiwgIngta3ViZXJuZXRlcy1wcmVzZXJ2ZS11bmtub3duLWZpZWxkcyI6IHRydWV9fX1dfX0=
+relatedImages:
+- name: operator
+  image: quay.io/redhatgov/oc-mirror-dev@sha256:f1f6dabc6d05ae1d6e1b729d8ed80edb6b99fce8a6459c60a595945479e6f4ce
+---
+schema: olm.bundle
+package: baz
+name: baz.v1.1.0
+image: quay.io/redhatgov/oc-mirror-dev:baz-bundle-v1.1.0
+csvJson: '{"apiVersion": "operators.coreos.com/v1alpha1", "kind": "ClusterServiceVersion",
+  "metadata": {"annotations": {"capabilities": "BasicInstall", "certified": "false",
+  "containerImage": "quay.io/redhatgov/oc-mirror-dev@sha256:73afbdf22427d0aef8e610f2cfd4abab408a626a6f97c526744bd42395514099",
+  "description": "The Baz Operator does Baz things.", "olm.skipRange": "<1.1.0", "repository":
+  "https://github.com/openshift/oc-mirror"}, "name": "baz.v1.1.0"}, "spec": {"customresourcedefinitions":
+  {"owned": [{"group": "test.baz", "kind": "Baz", "name": "bazs.test.baz", "version":
+  "v1"}]}, "description": "The Baz Operator does Baz things.", "displayName": "Baz
+  Operator", "icon": [{"base64data": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJpY29uIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKICAgIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgogIC5zcXVpcmNsZSB7IGZpbGw6ICM3Qjg3OTQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDVweCwgMXB4KTsgfQogIC5uYW1lIHsgZm9udDogYm9sZCA0MDBweCBzYW5zIHNlcmlmOyBmaWxsOiByZWQ7IHRyYW5zZm9ybTogdHJhbnNsYXRlKDEzMHB4LCA1MDBweCkgcm90YXRlKDIwZGVnKTsgfQo8L3N0eWxlPgo8Zz4KICA8cGF0aCBjbGFzcz0ic3F1aXJjbGUiIGQ9Ik0gMCwgNTAwCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBDIDAsIDUgNSwgMCA1MDAsIDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgIFMgMTAwMCwgNSAxMDAwLCA1MDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMTAwMCwgMTAwMCA1MDAsIDEwMDAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMCwgMTAwMCAwLCA1MDAiLz4KICA8dGV4dCBjbGFzcz0ibmFtZSI+YmF6PC90ZXh0Pgo8L2c+Cjwvc3ZnPgo=",
+  "mediatype": "image/svg+xml"}], "install": {"spec": {"deployments": [{"name": "baz-operator",
+  "spec": {"replicas": 1, "selector": {"matchLabels": {"app": "baz-operator"}}, "template":
+  {"metadata": {"labels": {"app": "baz-operator", "version": "v1.1.0"}, "name": "baz-operator"},
+  "spec": {"containers": [{"command": ["/run.sh"], "image": "quay.io/redhatgov/oc-mirror-dev@sha256:73afbdf22427d0aef8e610f2cfd4abab408a626a6f97c526744bd42395514099",
+  "imagePullPolicy": "Always", "name": "baz"}]}}}}]}, "strategy": "deployment"}, "installModes":
+  [{"supported": true, "type": "OwnNamespace"}, {"supported": true, "type": "SingleNamespace"},
+  {"supported": false, "type": "MultiNamespace"}, {"supported": true, "type": "AllNamespaces"}],
+  "keywords": ["baz"], "labels": {"name": "baz-operator"}, "maintainers": [{"email":
+  "oc-mirror@openshift.org", "name": "oc-mirror developers"}], "maturity": "beta",
+  "provider": {"name": "Baz"}, "relatedImages": [{"image": "quay.io/redhatgov/oc-mirror-dev@sha256:73afbdf22427d0aef8e610f2cfd4abab408a626a6f97c526744bd42395514099",
+  "name": "operator"}], "replaces": "baz.v1.0.1", "version": "1.1.0"}}'
+properties:
+- type: olm.gvk
+  value:
+    group: test.baz
+    kind: Baz
+    version: v1
+- type: olm.package
+  value:
+    packageName: baz
+    version: 1.1.0
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgImtpbmQiOiAiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwgIm1ldGFkYXRhIjogeyJhbm5vdGF0aW9ucyI6IHsiY2FwYWJpbGl0aWVzIjogIkJhc2ljSW5zdGFsbCIsICJjZXJ0aWZpZWQiOiAiZmFsc2UiLCAiY29udGFpbmVySW1hZ2UiOiAicXVheS5pby9yZWRoYXRnb3Yvb2MtbWlycm9yLWRldkBzaGEyNTY6NzNhZmJkZjIyNDI3ZDBhZWY4ZTYxMGYyY2ZkNGFiYWI0MDhhNjI2YTZmOTdjNTI2NzQ0YmQ0MjM5NTUxNDA5OSIsICJkZXNjcmlwdGlvbiI6ICJUaGUgQmF6IE9wZXJhdG9yIGRvZXMgQmF6IHRoaW5ncy4iLCAib2xtLnNraXBSYW5nZSI6ICI8MS4xLjAiLCAicmVwb3NpdG9yeSI6ICJodHRwczovL2dpdGh1Yi5jb20vb3BlbnNoaWZ0L29jLW1pcnJvciJ9LCAibmFtZSI6ICJiYXoudjEuMS4wIn0sICJzcGVjIjogeyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjogeyJvd25lZCI6IFt7Imdyb3VwIjogInRlc3QuYmF6IiwgImtpbmQiOiAiQmF6IiwgIm5hbWUiOiAiYmF6cy50ZXN0LmJheiIsICJ2ZXJzaW9uIjogInYxIn1dfSwgImRlc2NyaXB0aW9uIjogIlRoZSBCYXogT3BlcmF0b3IgZG9lcyBCYXogdGhpbmdzLiIsICJkaXNwbGF5TmFtZSI6ICJCYXogT3BlcmF0b3IiLCAiaWNvbiI6IFt7ImJhc2U2NGRhdGEiOiAiUEQ5NGJXd2dkbVZ5YzJsdmJqMGlNUzR3SWlCbGJtTnZaR2x1WnowaWRYUm1MVGdpUHo0S1BITjJaeUIyWlhKemFXOXVQU0l4TGpFaUlHbGtQU0pwWTI5dUlpQjRiV3h1Y3owaWFIUjBjRG92TDNkM2R5NTNNeTV2Y21jdk1qQXdNQzl6ZG1jaUlIaHRiRzV6T25oc2FXNXJQU0pvZEhSd09pOHZkM2QzTG5jekxtOXlaeTh4T1RrNUwzaHNhVzVySWlCNFBTSXdjSGdpSUhrOUlqQndlQ0lLSUNBZ0lIWnBaWGRDYjNnOUlqQWdNQ0F4TWpnd0lERXlPREFpSUhOMGVXeGxQU0psYm1GaWJHVXRZbUZqYTJkeWIzVnVaRHB1WlhjZ01DQXdJREV5T0RBZ01USTRNRHNpSUhodGJEcHpjR0ZqWlQwaWNISmxjMlZ5ZG1VaVBnbzhjM1I1YkdVZ2RIbHdaVDBpZEdWNGRDOWpjM01pUGdvZ0lDNXpjWFZwY21Oc1pTQjdJR1pwYkd3NklDTTNRamczT1RRN0lIUnlZVzV6Wm05eWJUb2dkSEpoYm5Oc1lYUmxLRFZ3ZUN3Z01YQjRLVHNnZlFvZ0lDNXVZVzFsSUhzZ1ptOXVkRG9nWW05c1pDQTBNREJ3ZUNCellXNXpJSE5sY21sbU95Qm1hV3hzT2lCeVpXUTdJSFJ5WVc1elptOXliVG9nZEhKaGJuTnNZWFJsS0RFek1IQjRMQ0ExTURCd2VDa2djbTkwWVhSbEtESXdaR1ZuS1RzZ2ZRbzhMM04wZVd4bFBnbzhaejRLSUNBOGNHRjBhQ0JqYkdGemN6MGljM0YxYVhKamJHVWlJR1E5SWswZ01Dd2dOVEF3Q2lBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNCRElEQXNJRFVnTlN3Z01DQTFNREFzSURBS0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lGTWdNVEF3TUN3Z05TQXhNREF3TENBMU1EQUtJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnTVRBd01Dd2dNVEF3TUNBMU1EQXNJREV3TURBS0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZ0lDQWdNQ3dnTVRBd01DQXdMQ0ExTURBaUx6NEtJQ0E4ZEdWNGRDQmpiR0Z6Y3owaWJtRnRaU0krWW1GNlBDOTBaWGgwUGdvOEwyYytDand2YzNablBnbz0iLCAibWVkaWF0eXBlIjogImltYWdlL3N2Zyt4bWwifV0sICJpbnN0YWxsIjogeyJzcGVjIjogeyJkZXBsb3ltZW50cyI6IFt7Im5hbWUiOiAiYmF6LW9wZXJhdG9yIiwgInNwZWMiOiB7InJlcGxpY2FzIjogMSwgInNlbGVjdG9yIjogeyJtYXRjaExhYmVscyI6IHsiYXBwIjogImJhei1vcGVyYXRvciJ9fSwgInRlbXBsYXRlIjogeyJtZXRhZGF0YSI6IHsibGFiZWxzIjogeyJhcHAiOiAiYmF6LW9wZXJhdG9yIiwgInZlcnNpb24iOiAidjEuMS4wIn0sICJuYW1lIjogImJhei1vcGVyYXRvciJ9LCAic3BlYyI6IHsiY29udGFpbmVycyI6IFt7ImNvbW1hbmQiOiBbIi9ydW4uc2giXSwgImltYWdlIjogInF1YXkuaW8vcmVkaGF0Z292L29jLW1pcnJvci1kZXZAc2hhMjU2OjczYWZiZGYyMjQyN2QwYWVmOGU2MTBmMmNmZDRhYmFiNDA4YTYyNmE2Zjk3YzUyNjc0NGJkNDIzOTU1MTQwOTkiLCAiaW1hZ2VQdWxsUG9saWN5IjogIkFsd2F5cyIsICJuYW1lIjogImJheiJ9XX19fX1dfSwgInN0cmF0ZWd5IjogImRlcGxveW1lbnQifSwgImluc3RhbGxNb2RlcyI6IFt7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIk93bk5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIlNpbmdsZU5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IGZhbHNlLCAidHlwZSI6ICJNdWx0aU5hbWVzcGFjZSJ9LCB7InN1cHBvcnRlZCI6IHRydWUsICJ0eXBlIjogIkFsbE5hbWVzcGFjZXMifV0sICJrZXl3b3JkcyI6IFsiYmF6Il0sICJsYWJlbHMiOiB7Im5hbWUiOiAiYmF6LW9wZXJhdG9yIn0sICJtYWludGFpbmVycyI6IFt7ImVtYWlsIjogIm9jLW1pcnJvckBvcGVuc2hpZnQub3JnIiwgIm5hbWUiOiAib2MtbWlycm9yIGRldmVsb3BlcnMifV0sICJtYXR1cml0eSI6ICJiZXRhIiwgInByb3ZpZGVyIjogeyJuYW1lIjogIkJheiJ9LCAicmVsYXRlZEltYWdlcyI6IFt7ImltYWdlIjogInF1YXkuaW8vcmVkaGF0Z292L29jLW1pcnJvci1kZXZAc2hhMjU2OjczYWZiZGYyMjQyN2QwYWVmOGU2MTBmMmNmZDRhYmFiNDA4YTYyNmE2Zjk3YzUyNjc0NGJkNDIzOTU1MTQwOTkiLCAibmFtZSI6ICJvcGVyYXRvciJ9XSwgInJlcGxhY2VzIjogImJhei52MS4wLjEiLCAidmVyc2lvbiI6ICIxLjEuMCJ9fQ==
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjogImFwaWV4dGVuc2lvbnMuazhzLmlvL3YxIiwgImtpbmQiOiAiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwgIm1ldGFkYXRhIjogeyJuYW1lIjogImJhenMudGVzdC5iYXoifSwgInNwZWMiOiB7Imdyb3VwIjogInRlc3QuYmF6IiwgInNjb3BlIjogIk5hbWVzcGFjZWQiLCAibmFtZXMiOiB7ImtpbmQiOiAiQmF6IiwgInBsdXJhbCI6ICJiYXpzIn0sICJ2ZXJzaW9ucyI6IFt7Im5hbWUiOiAidjEiLCAic2VydmVkIjogdHJ1ZSwgInN0b3JhZ2UiOiB0cnVlLCAic2NoZW1hIjogeyJvcGVuQVBJVjNTY2hlbWEiOiB7InR5cGUiOiAib2JqZWN0IiwgIngta3ViZXJuZXRlcy1wcmVzZXJ2ZS11bmtub3duLWZpZWxkcyI6IHRydWV9fX1dfX0=
+relatedImages:
+- name: operator
+  image: quay.io/redhatgov/oc-mirror-dev@sha256:73afbdf22427d0aef8e610f2cfd4abab408a626a6f97c526744bd42395514099

--- a/test/e2e/lib/util.sh
+++ b/test/e2e/lib/util.sh
@@ -175,4 +175,6 @@ function prepare_oci_testdata() {
   local DATA_DIR="${1:?DATA_DIR required}"
   mkdir -p "${DATA_DIR}/mirror_oci"
   tar xfz "${DIR}/artifacts/${OCI_CTLG_PATH}" -C "${DATA_DIR}/mirror_oci"
+  mkdir -p  "olm_artifacts/oc-mirror-dev"
+  cp -r "${DIR}/artifacts/configs"  "olm_artifacts/oc-mirror-dev/"
 }

--- a/test/e2e/lib/workflow.sh
+++ b/test/e2e/lib/workflow.sh
@@ -105,7 +105,7 @@ function workflow_oci_mirror() {
   local remote_image="${2:?remote_image required}"
   prepare_oci_testdata "${DATA_TMP}"
   prepare_mirror_testdata "${DATA_TMP}" "${MIRROR_OCI_DIR}" "${config}" false 
-  
+ 
   # call oc-mirror
   run_cmd --config "${MIRROR_OCI_DIR}/${config}" $CREATE_FLAGS "${remote_image}"
 }


### PR DESCRIPTION
# Description

This change allows for the the incremental and pruning functionality to work for the oci feature

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The update was tested as follows 

- Add an oci catalog in the imagesetconfig (i.e cincinnati-operator) and mirror to remote registry
- Update oci catalog in the imagesetconfig (remove cincinbati-operator and add openshift-logging) and mirror
- Verfiy the mapping.txt had correct entry
- Verify the .metatadat.json file sequence was bumped
- Verify the console logs for both oc-mirror and remote registry (see below)

```
Pruning 6 manifest(s) from repository test-lmz/openshift-update-service/openshift-update-service-rhel8-operator
Pruning 3 manifest(s) from repository test-lmz/openshift-update-service/cincinnati-operator-bundle
Pruning 6 manifest(s) from repository test-lmz/openshift-update-service/openshift-update-service-rhel8
Deleting manifest sha256:1d3bde7bc3ce4f6acb79307e67aa0342b91fca5ff69bf38e2b0a1884c5cd7db6 from repo test-lmz/openshift-update-service/openshift-update-service-rhel8-operator
Deleting manifest sha256:2743f74cc102c059d7c1dc6698eb947cca75a3cc4230905f09703666ae7a4dbf from repo test-lmz/openshift-update-service/cincinnati-operator-bundle
Deleting manifest sha256:21e32b201bba902cc730dc43943d9cb6c4bab40afc5a148613ae51176c21cd85 from repo test-lmz/openshift-update-service/openshift-update-service-rhel8
Deleting manifest sha256:50566d6670315bc3a4526644404c8e8ab5bd1e1709c1fd9fcde5a37abcb7cb04 from repo test-lmz/openshift-update-service/openshift-update-service-rhel8-operator
Deleting manifest sha256:389c339253271477440c5f470c08a3b149f1795647b1df7b104ae95fc63af22c from repo test-lmz/openshift-update-service/openshift-update-service-rhel8
Deleting manifest sha256:3feccb95e912f2d710958e701a1b52acf16a676fde9a8219491ad9381e6284ea from repo test-lmz/openshift-update-service/cincinnati-operator-bundle
Deleting manifest sha256:66db743f2d61dddab7363ab36252812ffb63653510124c3b32d26f0ddfeb5def from repo test-lmz/openshift-update-service/openshift-update-service-rhel8-operator
Deleting manifest sha256:4bbed256e300088500ae3eb8475b3457d7a6765999e1102dc482e086e2cc0b43 from repo test-lmz/openshift-update-service/openshift-update-service-rhel8
Deleting manifest sha256:71b8f7816a01503a4af5d6f93b9b3a057f6c011aef3b560b408ee4d7abf02165 from repo test-lmz/openshift-update-service/cincinnati-operator-bundle
Deleting manifest sha256:c8f156f73bb3e5fd92c024513c9446ed30d5231e33ef0d0952b365a1fbd69db4 from repo test-lmz/openshift-update-service/openshift-update-service-rhel8-operator
Deleting manifest sha256:6e65da919ed05274e4a0101f67a149188801b715cf073dd517d0dd311a4572a4 from repo test-lmz/openshift-update-service/openshift-update-service-rhel8
Deleting manifest sha256:ce77a27ae4b7b219e44111b6322a3387f75c23fa39ecd94017d2d4bc68bf4a5c from repo test-lmz/openshift-update-service/openshift-update-service-rhel8-operator
Deleting manifest sha256:a2cc2f9d3acd147ced68d8657cf8dd6189be242b4e82852ea8ef002d5f55b31e from repo test-lmz/openshift-update-service/openshift-update-service-rhel8
Deleting manifest sha256:ce7b16803bb2bd058014a3783ed1f0a8a93819dd5769fcd8772228cf96814bf9 from repo test-lmz/openshift-update-service/openshift-update-service-rhel8-operator
Deleting manifest sha256:aea49b2145d59912757f2e371db2e23a9ba20cfa54d0c7132931e16d35655e40 from repo test-lmz/openshift-update-service/openshift-update-service-rhel8
Rendering catalog image "localhost:5000/lmz-test/home/lzuccarelli/go/src/github.com/openshift/oc-mirror/rhopi-412:2cde02" with file-based catalog 
```

Registry log (top entry)

```
[16/Feb/2023:15:10:57 +0100] "DELETE /v2/test-lmz/openshift-update-service/openshift-update-service-rhel8-operator/manifests/sha256:ce7b16803bb2bd058014a3783ed1f0a8a93819dd5769fcd8772228cf96814bf9 HTTP/1.1" 202 0 "" "go-containerregistry/v0.10.0"
INFO[13249] response completed                            go.version=go1.19.5 http.request.host="localhost:5000" http.request.id=3d7cf0cd-7f03-438e-a9fc-0fb7431add9a http.request.method=DELETE http.request.remoteaddr="[::1]:33704" http.request.uri="/v2/test-lmz/openshift-update-service/openshift-update-service-rhel8/manifests/sha256:aea49b2145d59912757f2e371db2e23a9ba20cfa54d0c7132931e16d35655e40" http.request.useragent=go-containerregistry/v0.10.0 http.response.duration="259.493µs" http.response.status=202 http.response.written=0 instance.id=18c670a9-9bee-4d1b-9f24-2765bebb6c74 service=registry version=v3.0.0+unknown
::1 - - [16/Feb/2023:15:10:57 +0100] "DELETE /v2/test-lmz/openshift-update-service/openshift-update-service-rhel8/manifests/sha256:aea49b2145d59912757f2e371db2e23a9ba20cfa54d0c7132931e16d35655e40 HTTP/1.1" 202 0 "" "go-containerregistry/v0.10.0"
```


- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules