### PR TITLE
CFE-764 : Introduce v1alpha2.Operator.TargetCatalog 

### DIFF
--- a/pkg/api/v1alpha2/types_config.go
+++ b/pkg/api/v1alpha2/types_config.go
@@ -1,10 +1,8 @@
 package v1alpha2
 
 import (
-	"fmt"
 	"strings"
 
-	"github.com/openshift/library-go/pkg/image/reference"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -107,7 +105,22 @@ type Operator struct {
 	// TargetName is the target image name the catalog will be built with. If unset,
 	// the catalog will be published with the provided name in the Catalog
 	// field.
+	// Deprecated in oc-mirror 4.13, to be replaced with TargetCatalog.
 	TargetName string `json:"targetName,omitempty"`
+	// TargetCatalog replaces TargetName and allows for specifying the exact URL of the target
+	// catalog, including any path-components (organization, namespace) of the target catalog's location
+	// on the disconnected registry.
+	// This answer some customers requests regarding restrictions on where images can be placed.
+	// The targetCatalog field consists of an optional namespace followed by the target image name,
+	// described in extended Backus–Naur form below:
+	//     target-catalog = [namespace '/'] target-name
+	//     target-name    = path-component
+	//     namespace      = path-component ['/' path-component]*
+	//     path-component = alpha-numeric [separator alpha-numeric]*
+	//     alpha-numeric  = /[a-z0-9]+/
+	//     separator      = /[_.]|__|[-]*/
+	// TargetCatalog will be preferred over TargetName if both are specified in te ImageSetConfig.
+	TargetCatalog string `json:"targetCatalog,omitempty"`
 	// TargetTag is the tag the catalog image will be built with. If unset,
 	// the catalog will be publish with the provided tag in the Catalog
 	// field or a tag calculated from the partial digest.
@@ -126,52 +139,54 @@ type Operator struct {
 
 // GetUniqueName determines the catalog name that will
 // be tracked in the metadata and built. This depends on what fields
-// are set between Catalog, TargetName, and TargetTag.
+// are set between Catalog, TargetCatalog (and soon deprecated
+// TargetName), and TargetTag.
 func (o Operator) GetUniqueName() (string, error) {
 	ctlgRef := o.Catalog
-	if o.TargetName == "" && o.TargetTag == "" {
-		return ctlgRef, nil
+	if o.TargetCatalog == "" && o.TargetName == "" && o.TargetTag == "" {
+		return TrimProtocol(ctlgRef), nil
 	}
-	if o.IsFBCOCI() {
-		reg, ns, name, tag, id := ParseImageReference(ctlgRef)
-		if o.TargetName != "" {
-			name = o.TargetName
+
+	reg, ns, name, tag, id := ParseImageReference(ctlgRef)
+
+	if o.TargetTag != "" {
+		tag = o.TargetTag
+		id = ""
+	}
+	uniqueName := ""
+
+	if o.TargetCatalog != "" {
+		// TargetCatalog takes precedence over TargetName, and replaces the catalog component-paths (URL)
+		if !o.IsFBCOCI() && reg != "" {
+			// reg is included in the name only in case of registry based catalogs.
+			// the parsed reg is not relevant in case of OCI, because the parsed ref is simply a filesystem path here
+			uniqueName += reg + "/"
 		}
-		if o.TargetTag != "" {
-			tag = o.TargetTag
-			id = ""
-		}
-		uniqueName := "oci://"
+		uniqueName += o.TargetCatalog
+	} else {
 		if reg != "" {
-			uniqueName = reg
+			uniqueName += reg
 		}
 		if ns != "" {
 			uniqueName = strings.Join([]string{uniqueName, ns}, "/")
 		}
-
-		uniqueName = strings.Join([]string{uniqueName, name}, "/")
-		if tag != "" {
-			uniqueName = uniqueName + ":" + tag
+		if o.TargetName != "" {
+			name = o.TargetName
+		}
+		if uniqueName != "" {
+			uniqueName = strings.Join([]string{uniqueName, name}, "/")
 		} else {
+			uniqueName = name
+		}
+	}
+	if tag != "" {
+		uniqueName = uniqueName + ":" + tag
+	} else {
+		if id != "" {
 			uniqueName = uniqueName + "@sha256:" + id
 		}
-		return uniqueName, nil
-	} else {
-		catalogRef, err := reference.Parse(ctlgRef)
-		if err != nil {
-			return "", fmt.Errorf("error parsing source catalog %s: %v", catalogRef, err)
-		}
-		if o.TargetName != "" {
-			catalogRef.Name = o.TargetName
-		}
-		if o.TargetTag != "" {
-			catalogRef.ID = ""
-			catalogRef.Tag = o.TargetTag
-		}
-
-		return catalogRef.Exact(), nil
 	}
-
+	return uniqueName, nil
 }
 
 // parseImageName returns the registry, organisation, repository, tag and digest
@@ -184,7 +199,10 @@ func ParseImageReference(imageName string) (string, string, string, string, stri
 	imageName = strings.TrimSuffix(imageName, "/")
 	tmp := strings.Split(imageName, "/")
 
-	registry = tmp[0]
+	if len(tmp) > 1 {
+		registry = tmp[0]
+	}
+
 	img := strings.Split(tmp[len(tmp)-1], ":")
 	if len(tmp) > 2 {
 		org = strings.Join(tmp[1:len(tmp)-1], "/")
@@ -208,7 +226,7 @@ func ParseImageReference(imageName string) (string, string, string, string, stri
 // trimProtocol removes oci://, file:// or docker:// from
 // the parameter imageName
 func TrimProtocol(imageName string) string {
-	imageName = strings.TrimPrefix(imageName, "oci:")
+	imageName = strings.TrimPrefix(imageName, OCITransportPrefix)
 	imageName = strings.TrimPrefix(imageName, "file:")
 	imageName = strings.TrimPrefix(imageName, "docker:")
 	imageName = strings.TrimPrefix(imageName, "//")

--- a/pkg/api/v1alpha2/types_config.go
+++ b/pkg/api/v1alpha2/types_config.go
@@ -1,6 +1,7 @@
 package v1alpha2
 
 import (
+	"path"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -160,24 +161,16 @@ func (o Operator) GetUniqueName() (string, error) {
 		if !o.IsFBCOCI() && reg != "" {
 			// reg is included in the name only in case of registry based catalogs.
 			// the parsed reg is not relevant in case of OCI, because the parsed ref is simply a filesystem path here
-			uniqueName += reg + "/"
-		}
-		uniqueName += o.TargetCatalog
-	} else {
-		if reg != "" {
 			uniqueName += reg
 		}
-		if ns != "" {
-			uniqueName = strings.Join([]string{uniqueName, ns}, "/")
-		}
+		uniqueName = path.Join(uniqueName, o.TargetCatalog)
+	} else {
+		uniqueName = path.Join(uniqueName, reg, ns)
+
 		if o.TargetName != "" {
 			name = o.TargetName
 		}
-		if uniqueName != "" {
-			uniqueName = strings.Join([]string{uniqueName, name}, "/")
-		} else {
-			uniqueName = name
-		}
+		uniqueName = path.Join(uniqueName, name)
 	}
 	if tag != "" {
 		uniqueName = uniqueName + ":" + tag

--- a/pkg/api/v1alpha2/types_config_test.go
+++ b/pkg/api/v1alpha2/types_config_test.go
@@ -1,0 +1,78 @@
+package v1alpha2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUniqueName(t *testing.T) {
+	type spec struct {
+		desc     string
+		ref      Operator
+		exp      string
+		expError string
+	}
+
+	specs := []spec{
+		{
+			desc: "simple flow",
+			ref: Operator{
+				Catalog: "registry.redhat.io/redhat/redhat-operator-index:v4.12",
+				IncludeConfig: IncludeConfig{
+					Packages: []IncludePackage{
+						{
+							Name: "aws-load-balancer-operator",
+						},
+					},
+				},
+			},
+			exp:      "registry.redhat.io/redhat/redhat-operator-index:v4.12",
+			expError: "",
+		},
+		{
+			desc: "simple flow with targetCatalog",
+			ref: Operator{
+				Catalog:       "registry.redhat.io/redhat/redhat-operator-index:v4.12",
+				TargetCatalog: "def/redhat-operator-index",
+				IncludeConfig: IncludeConfig{
+					Packages: []IncludePackage{
+						{
+							Name: "aws-load-balancer-operator",
+						},
+					},
+				},
+			},
+			exp:      "registry.redhat.io/def/redhat-operator-index:v4.12",
+			expError: "",
+		},
+		{
+			desc: "OCI FBC flow",
+			ref: Operator{
+				Catalog:       "oci:///home/myuser/random/folder/redhat-operator-index:v4.12",
+				TargetCatalog: "def/redhat-operator-index",
+				IncludeConfig: IncludeConfig{
+					Packages: []IncludePackage{
+						{
+							Name: "aws-load-balancer-operator",
+						},
+					},
+				},
+			},
+			exp:      "def/redhat-operator-index:v4.12",
+			expError: "",
+		},
+	}
+
+	for _, s := range specs {
+		t.Run(s.desc, func(t *testing.T) {
+			un, err := s.ref.GetUniqueName()
+			if s.expError != "" {
+				require.EqualError(t, err, s.expError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, s.exp, un)
+			}
+		})
+	}
+}

--- a/pkg/cli/mirror/fbc_operators.go
+++ b/pkg/cli/mirror/fbc_operators.go
@@ -210,30 +210,30 @@ func prepareDestCatalogRef(operator v1alpha2.Operator, destReg, namespace string
 	if destReg == "" {
 		return "", errors.New("destination registry may not be empty")
 	}
-	_, subNamespace, repo, tag, _ := v1alpha2.ParseImageReference(operator.Catalog)
+	uniqueName, err := operator.GetUniqueName()
+	if err != nil {
+		return "", err
+	}
+	notAReg, subNamespace, repo, tag, _ := v1alpha2.ParseImageReference(uniqueName)
 
 	to := dockerPrefix + destReg
+
 	if namespace != "" {
 		to = strings.Join([]string{to, namespace}, "/")
+	}
+	if notAReg != "" {
+		to = strings.Join([]string{to, notAReg}, "/")
 	}
 	if subNamespace != "" {
 		to = strings.Join([]string{to, subNamespace}, "/")
 	}
 
-	klog.Infof("pushing catalog %s to %s \n", operator.Catalog, to)
-
-	if operator.TargetName != "" {
-		to = strings.Join([]string{to, operator.TargetName}, "/")
-	} else {
-		to = strings.Join([]string{to, repo}, "/")
-	}
-	if operator.TargetTag != "" {
-		to += ":" + operator.TargetTag
-	} else if tag != "" {
+	to = strings.Join([]string{to, repo}, "/")
+	if tag != "" {
 		to += ":" + tag
 	}
 	//check if this is a valid reference
-	_, err := image.ParseReference(v1alpha2.TrimProtocol(to))
+	_, err = image.ParseReference(v1alpha2.TrimProtocol(to))
 	return to, err
 }
 

--- a/pkg/cli/mirror/fbc_operators_test.go
+++ b/pkg/cli/mirror/fbc_operators_test.go
@@ -1092,7 +1092,7 @@ func TestPrepareDestCatalogRef(t *testing.T) {
 			},
 			destReg:     "localhost:5000",
 			namespace:   "disconnected_ocp",
-			expectedRef: "docker://localhost:5000/disconnected_ocp/artifacts/rhop-ctlg-oci",
+			expectedRef: "docker://localhost:5000/disconnected_ocp/testdata/artifacts/rhop-ctlg-oci",
 			expectedErr: "",
 		},
 		{
@@ -1103,7 +1103,7 @@ func TestPrepareDestCatalogRef(t *testing.T) {
 			},
 			destReg:     "localhost:5000",
 			namespace:   "disconnected_ocp",
-			expectedRef: "docker://localhost:5000/disconnected_ocp/artifacts/rhopi",
+			expectedRef: "docker://localhost:5000/disconnected_ocp/testdata/artifacts/rhopi",
 			expectedErr: "",
 		},
 		{
@@ -1114,7 +1114,7 @@ func TestPrepareDestCatalogRef(t *testing.T) {
 			},
 			destReg:     "localhost:5000",
 			namespace:   "disconnected_ocp",
-			expectedRef: "docker://localhost:5000/disconnected_ocp/artifacts/rhop-ctlg-oci:v12",
+			expectedRef: "docker://localhost:5000/disconnected_ocp/testdata/artifacts/rhop-ctlg-oci:v12",
 			expectedErr: "",
 		},
 		{
@@ -1126,7 +1126,19 @@ func TestPrepareDestCatalogRef(t *testing.T) {
 			},
 			destReg:     "localhost:5000",
 			namespace:   "disconnected_ocp",
-			expectedRef: "docker://localhost:5000/disconnected_ocp/artifacts/rhopi:v12",
+			expectedRef: "docker://localhost:5000/disconnected_ocp/testdata/artifacts/rhopi:v12",
+			expectedErr: "",
+		},
+		{
+			desc: "with targetCatalog",
+			operator: v1alpha2.Operator{
+				Catalog:       "oci://" + testdata,
+				TargetTag:     "v12",
+				TargetCatalog: "chosen_ns/rhopi",
+			},
+			destReg:     "localhost:5000",
+			namespace:   "disconnected_ocp",
+			expectedRef: "docker://localhost:5000/disconnected_ocp/chosen_ns/rhopi:v12",
 			expectedErr: "",
 		},
 		{
@@ -1146,7 +1158,7 @@ func TestPrepareDestCatalogRef(t *testing.T) {
 			},
 			destReg:     "localhost:5000",
 			namespace:   "",
-			expectedRef: "docker://localhost:5000/artifacts/rhop-ctlg-oci",
+			expectedRef: "docker://localhost:5000/testdata/artifacts/rhop-ctlg-oci",
 			expectedErr: "",
 		},
 	}

--- a/pkg/cli/mirror/manifests.go
+++ b/pkg/cli/mirror/manifests.go
@@ -13,6 +13,7 @@ import (
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	cincinnativ1 "github.com/openshift/cincinnati-operator/api/v1"
 	"github.com/openshift/library-go/pkg/image/reference"
+	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
 	"github.com/openshift/oc-mirror/pkg/image"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -179,7 +180,8 @@ func getRegistryMapping(icspScope string, mapping image.TypedImageMapping) (map[
 			registryMapping[k.Ref.AsRepository().String()] = v.Ref.AsRepository().String()
 		case icspScope == namespaceICSPScope:
 			source := path.Join(imgRegistry, imgNamespace)
-			dest := path.Join(v.Ref.Registry, v.Ref.Namespace)
+			reg, org, _, _, _ := v1alpha2.ParseImageReference(v.Ref.AsRepository().Exact())
+			dest := path.Join(reg, org)
 			registryMapping[source] = dest
 		default:
 			return registryMapping, fmt.Errorf("invalid ICSP scope %s", icspScope)

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -600,10 +600,10 @@ func (o *MirrorOptions) mirrorToMirrorWrapper(ctx context.Context, cfg v1alpha2.
 	}
 
 	targetBackend, err := storage.NewRegistryBackend(targetCfg, o.Dir)
+	if err != nil {
+		return err
+	}
 	if !o.UseOCIFeature {
-		if err != nil {
-			return err
-		}
 		var curr v1alpha2.Metadata
 		berr := targetBackend.ReadMetadata(ctx, &curr, config.MetadataBasePath)
 		if err := o.checkSequence(meta, curr, berr); err != nil {

--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -111,6 +111,9 @@ func (o *OperatorOptions) run(ctx context.Context, cfg v1alpha2.ImageSetConfigur
 		if err != nil {
 			return nil, err
 		}
+		if ctlg.IsFBCOCI() {
+			targetName = v1alpha2.OCITransportPrefix + "//" + targetName
+		}
 		targetCtlg, err := image.ParseReference(targetName)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing catalog: %v", err)
@@ -379,7 +382,6 @@ func (o *OperatorOptions) plan(ctx context.Context, dc *declcfg.DeclarativeConfi
 			return nil, fmt.Errorf("error pinning images in catalog %s: %v", ctlgRef, err)
 		}
 	}
-
 	indexDir, err := o.writeConfigs(dc, ic, targetCtlg.Ref)
 	if err != nil {
 		return nil, err

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -145,8 +145,7 @@ func resolveOperatorMetadata(ctx context.Context, ctlg v1alpha2.Operator, reg *c
 			if err != nil {
 				return v1alpha2.OperatorMetadata{}, fmt.Errorf("error resolving catalog image %q: %v", ctlg.Catalog, err)
 			}
-			operatorMeta.ImagePin = ctlgPin // registry.redhat.io/redhat/redhat-operator-registry@sha256:sdfhgsdfsdhfgd
-
+			operatorMeta.ImagePin = ctlgPin
 		}
 
 	}
@@ -157,6 +156,9 @@ func resolveOperatorMetadata(ctx context.Context, ctlg v1alpha2.Operator, reg *c
 	// or full catalogs to heads only.
 	if ctlg.IsHeadsOnly() {
 
+		if ctlg.IsFBCOCI() {
+			ctlgName = v1alpha2.OCITransportPrefix + "//" + ctlgName
+		}
 		// Determine the location of the created FBC
 		tir, err := image.ParseReference(ctlgName)
 		if err != nil {


### PR DESCRIPTION
TargetCatalog can contain several component-paths, allowing the user to set the namespace to which the catalog will be copied. 

It will later replace TargetName.

 Changes to be committed:
	modified:   pkg/api/v1alpha2/types_config.go
	new file:   pkg/api/v1alpha2/types_config_test.go
	modified:   pkg/cli/mirror/fbc_operators.go
	modified:   pkg/cli/mirror/fbc_operators_test.go
	modified:   pkg/cli/mirror/manifests.go

# Description

See https://issues.redhat.com/browse/CFE-764?filter=-1 for relevant motivation and context. 

Fixes # [CFE-764](https://issues.redhat.com//browse/CFE-764)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Changes in GetUniqueName and ICSP generation (determining namespace scope of mirrored images) have been changed for catalogs. This might have impacts on the way images are mirrored or contents of ICSP.

# How Has This Been Tested?

- [x] Simple flow - cmd1, IMSTCFG=imstcfg1.yaml
- [x] Simple flow with namespace - cmd2, IMSTCFG=imstcfg1.yaml
- [x] Simple flow with TargetCatalog - cmd1, IMSTCFG=imstcfg2.yaml
- [x] OCI FBC flow - cmd1, IMSTCFG=imstcfg3.yaml
- [x] OCI FBC flow with namespace - cmd2, IMSTCFG=imstcfg3.yaml 

PS: /tmp/storageBackend was cleaned after each test. Otherwise, an issue was found reading the metadata. This didn't seem related to the PR, and we think will be fixed with https://github.com/openshift/oc-mirror/pull/564 

**Test Configuration**:
* command lines

| Name    | Command |
| ----------- | --------------- | 
| cmd1     | ./bin/oc-mirror -c $IMSTCFG docker://localhost:5000 --dest-skip-tls --dest-use-http --use-oci-feature  |
| cmd2     | ./bin/oc-mirror -c $IMSTCFG docker://localhost:5000/test-namespace --dest-skip-tls --dest-use-http --use-oci-feature       |
* imstcfg1.yaml:
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
storageConfig:
  local:
    path: /tmp/storageBackend
mirror:
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.12
    packages:
    - name: aws-load-balancer-operator
```
* imstcfg2.yaml:
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
storageConfig:
  local:
    path: /tmp/storageBackend
mirror:
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.12
    targetCatalog: abc/redhat-operator-index
    packages:
    - name: aws-load-balancer-operator
```
* imstcfg3.yaml:
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
storageConfig:
  local:
    path: /tmp/storageBackend
mirror:
  operators:
  - catalog: oci:///home/skhoury/oci-catalog2
    targetCatalog: mno/redhat-operator-index
    targetTag: v4.12
     packages:
    - name: aws-load-balancer-operator
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules