### PR TITLE
OCPBUGS-8111: Bugfix for destination registry nested paths length

### DIFF
--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -163,7 +163,7 @@ func (o *MirrorOptions) Complete(cmd *cobra.Command, args []string) error {
 		}
 		o.ToMirror = mirror.Ref.Registry
 		o.UserNamespace = mirror.Ref.AsRepository().RepositoryName()
-		err = checkDockerReference(mirror)
+		err = checkDockerReference(mirror, o.MaxNestedPaths)
 		if err != nil {
 			return err
 		}
@@ -175,7 +175,7 @@ func (o *MirrorOptions) Complete(cmd *cobra.Command, args []string) error {
 }
 
 // checkDockerReference prints warnings or returns an error if applicable.
-func checkDockerReference(mirror imagesource.TypedImageReference) error {
+func checkDockerReference(mirror imagesource.TypedImageReference, nested int) error {
 	switch {
 	case mirror.Ref.Registry == "" && mirror.Ref.Namespace != "" && strings.Count(mirror.Ref.Name, "/") >= 1:
 		klog.V(0).Info("The docker reference was parsed as a namespace and a repository name, not including a registry.")
@@ -196,6 +196,12 @@ func checkDockerReference(mirror imagesource.TypedImageReference) error {
 	}
 	if mirror.Ref.Registry == "" || mirror.Ref.Tag != "" || mirror.Ref.ID != "" {
 		return fmt.Errorf("destination registry must consist of registry host and namespace(s) only, and must not include an image tag or ID")
+	}
+
+	depth := strings.Split(strings.Join([]string{mirror.Ref.Namespace, mirror.Ref.Name}, "/"), "/")
+	if len(depth) > nested {
+		destination := strings.Join([]string{mirror.Ref.Registry, mirror.Ref.Namespace, mirror.Ref.Name}, "/")
+		return fmt.Errorf("the max-nested-paths value (%d) for %s exceeds the registry mirror paths setting (some registries limit the nested paths)", len(depth), destination)
 	}
 	return nil
 }

--- a/pkg/cli/mirror/mirror_test.go
+++ b/pkg/cli/mirror/mirror_test.go
@@ -75,69 +75,77 @@ func TestMirrorComplete(t *testing.T) {
 		{
 			name: "Valid/RegDest",
 			args: []string{"docker://reg.com"},
-			opts: &MirrorOptions{},
+			opts: &MirrorOptions{MaxNestedPaths: 3},
 			expOpts: &MirrorOptions{
-				ToMirror: "reg.com",
+				ToMirror:       "reg.com",
+				MaxNestedPaths: 3,
 			},
 		},
 		{
 			name: "Valid/LocalhostRegDest",
 			args: []string{"docker://localhost"},
-			opts: &MirrorOptions{},
+			opts: &MirrorOptions{MaxNestedPaths: 3},
 			expOpts: &MirrorOptions{
-				ToMirror: "localhost",
+				ToMirror:       "localhost",
+				MaxNestedPaths: 3,
 			},
 		},
 		{
 			name: "Valid/FqdnRegPortDest",
 			args: []string{"docker://reg.com:5000"},
-			opts: &MirrorOptions{},
+			opts: &MirrorOptions{MaxNestedPaths: 3},
 			expOpts: &MirrorOptions{
-				ToMirror: "reg.com:5000",
+				ToMirror:       "reg.com:5000",
+				MaxNestedPaths: 3,
 			},
 		},
 		{
 			name: "Valid/LocalhostRegPortDest",
 			args: []string{"docker://localhost:5000"},
-			opts: &MirrorOptions{},
+			opts: &MirrorOptions{MaxNestedPaths: 3},
 			expOpts: &MirrorOptions{
-				ToMirror: "localhost:5000",
+				ToMirror:       "localhost:5000",
+				MaxNestedPaths: 3,
 			},
 		},
 		{
 			name: "Valid/RegNamespace",
 			args: []string{"docker://reg.com/foo/bar"},
-			opts: &MirrorOptions{},
+			opts: &MirrorOptions{MaxNestedPaths: 3},
 			expOpts: &MirrorOptions{
-				ToMirror:      "reg.com",
-				UserNamespace: "foo/bar",
+				ToMirror:       "reg.com",
+				UserNamespace:  "foo/bar",
+				MaxNestedPaths: 3,
 			},
 		},
 		{
 			name: "Valid/LocalhostRegNamespace",
 			args: []string{"docker://localhost/foo/bar"},
-			opts: &MirrorOptions{},
+			opts: &MirrorOptions{MaxNestedPaths: 3},
 			expOpts: &MirrorOptions{
-				ToMirror:      "localhost",
-				UserNamespace: "foo/bar",
+				ToMirror:       "localhost",
+				UserNamespace:  "foo/bar",
+				MaxNestedPaths: 3,
 			},
 		},
 		{
 			name: "Valid/NonFqdnRegPortNamespace",
 			args: []string{"docker://reg:5000/foo"},
-			opts: &MirrorOptions{},
+			opts: &MirrorOptions{MaxNestedPaths: 3},
 			expOpts: &MirrorOptions{
-				ToMirror:      "reg:5000",
-				UserNamespace: "foo",
+				ToMirror:       "reg:5000",
+				UserNamespace:  "foo",
+				MaxNestedPaths: 3,
 			},
 		},
 		{
 			name: "Valid/NonFqdnRegPortNamespaceName",
 			args: []string{"docker://reg:5000/foo/bar"},
-			opts: &MirrorOptions{},
+			opts: &MirrorOptions{MaxNestedPaths: 3},
 			expOpts: &MirrorOptions{
-				ToMirror:      "reg:5000",
-				UserNamespace: "foo/bar",
+				ToMirror:       "reg:5000",
+				UserNamespace:  "foo/bar",
+				MaxNestedPaths: 3,
 			},
 		},
 		{
@@ -214,6 +222,12 @@ func TestMirrorComplete(t *testing.T) {
 			args:     []string{"foo"},
 			opts:     &MirrorOptions{},
 			expError: "no scheme delimiter in destination argument",
+		},
+		{
+			name:     "Invalid/ExceedsNestedPathsLength",
+			args:     []string{"docker://reg.com/foo/bar/baz"},
+			opts:     &MirrorOptions{MaxNestedPaths: 2},
+			expError: "the max-nested-paths value (3) for reg.com/foo/bar/baz exceeds the registry mirror paths setting (some registries limit the nested paths)",
 		},
 	}
 

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -37,6 +37,7 @@ type MirrorOptions struct {
 	UseOCIFeature              bool
 	OCIRegistriesConfig        string
 	OCIInsecureSignaturePolicy bool
+	MaxNestedPaths             int
 	// cancelCh is a channel listening for command cancellations
 	cancelCh         <-chan struct{}
 	once             sync.Once
@@ -71,6 +72,7 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.OCIRegistriesConfig, "oci-registries-config", o.OCIRegistriesConfig, "Registries config file location (used only with --use-oci-feature flag)")
 	fs.BoolVar(&o.OCIInsecureSignaturePolicy, "oci-insecure-signature-policy", o.OCIInsecureSignaturePolicy, "If set, OCI catalog push will not try to push signatures")
 	fs.BoolVar(&o.SkipPruning, "skip-pruning", o.SkipPruning, "If set, will disable pruning globally")
+	fs.IntVar(&o.MaxNestedPaths, "max-nested-paths", 2, "Number of nested paths, for destination registries that limit nested paths")
 
 }
 


### PR DESCRIPTION
# Description

This bug fix addresses the issue of nested path length in some registries that limit this.

A flag `--max-nested-paths` can be used to set the value (default is 2) 

As an example 
docker://registry.gitlab.com/xxx/yyy would be allowed
docker://registry.gitlab.com/xxx/yyy/zzz would not be allowed

However if the flag --max-nested-paths is used (default is set to 2) with the second example 

docker://registry.gitlab.com/xxx/yyy/zzz 

An error message would be shown before the main execution of oc-mirror (preventing time waste) in the form :

`the max-nested-paths value (2) for registry.gitlab.com/xxx/yyy/zzz exceeds the registry mirror paths setting (some registries limit the nested paths)`


Fixes # (OCPBUGS-8111)

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added unit test to verify 

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules