### PR TITLE
OCPBUGS-8276: Bugfix check imagesetconfig for valid oci protocol when oci feature i…

### DIFF
--- a/pkg/cli/mirror/mirror_test.go
+++ b/pkg/cli/mirror/mirror_test.go
@@ -302,6 +302,15 @@ func TestMirrorValidate(t *testing.T) {
 			expError: "use of OCI FBC catalogs (prefix oci://) in configuration file is authorized only with flag --use-oci-feature",
 		},
 		{
+			name: "Invalid/MirrorToMirror/ImageSetConfigWithoutOCI",
+			opts: &MirrorOptions{
+				ConfigPath:    "testdata/configs/iscfg.yaml",
+				ToMirror:      u.Host,
+				UseOCIFeature: true,
+			},
+			expError: "no operator found with OCI FBC catalog prefix (oci://) in configuration file, please execute without the --use-oci-feature flag",
+		},
+		{
 			name: "Valid/ManifestOnlyWithFakeMirror",
 			opts: &MirrorOptions{
 				ManifestsOnly: true,


### PR DESCRIPTION
…s used

# Description

This fixes the bug when using the --use-oci-feature flag and no oci protocol is used in the imagesetconfig.

Fixes OCPBUGS-8276

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added unit test to verify this bug is addressed.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules