### PR TITLE
docs: add information about unsupported scenario

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -14,3 +14,8 @@ To troubleshoot issues with the created file-based catalog, use the following co
 
 ## Destination Registry parsing
 For docker registry destinations, to preserve the same docker reference format across the ecosystem, `docker://registry` is not parsed as a registry hostname, but as an image or repository name. In order to specify a registry, qualify the hostname, or use an IP address. For example, use `docker://registry.localdomain`. `docker://localhost` works as expected, because localhost is generally treated as a special exception, not requiring a qualified domain to be parsed as a registry host.
+
+## Error Examples
+```unable to get OCI Image from oci:///$LOCATION_FOR_OCI_CATALOG: more than one image in oci, choose an image```
+- It means that $LOCATION_FOR_OCI_CATALOG contains an OCI catalog with more than one manifest, and oc-mirror cannot choose which of them should be used.
+- This usually happens if you copy a catalog to the same location more than once.

--- a/pkg/cli/mirror/fbc_operators.go
+++ b/pkg/cli/mirror/fbc_operators.go
@@ -15,6 +15,7 @@ import (
 
 	semver "github.com/blang/semver/v4"
 	imagecopy "github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/opencontainers/go-digest"
 
@@ -561,6 +562,9 @@ func getOCIImgSrcFromPath(ctx context.Context, path string) (types.ImageSource, 
 	}
 	imgsrc, err := ociImgRef.NewImageSource(ctx, nil)
 	if err != nil {
+		if err == layout.ErrMoreThanOneImage {
+			return nil, errors.New("multiple catalogs in the same location is not supported: https://github.com/openshift/oc-mirror/blob/main/TROUBLESHOOTING.md#error-examples")
+		}
 		return nil, fmt.Errorf("unable to get OCI Image from %s: %w", path, err)
 	}
 	return imgsrc, nil

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -2,10 +2,12 @@ package image
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -130,6 +132,9 @@ func getManifest(ctx context.Context, imgPath string) (manifest.Manifest, error)
 		}
 	}()
 	if err != nil {
+		if err == layout.ErrMoreThanOneImage {
+			return nil, errors.New("multiple catalogs in the same location is not supported: https://github.com/openshift/oc-mirror/blob/main/TROUBLESHOOTING.md#error-examples")
+		}
 		return nil, fmt.Errorf("unable to create ImageSource for %s: %v", err, imgPath)
 	}
 	manifestBlob, manifestType, err := imgsrc.GetManifest(ctx, nil)


### PR DESCRIPTION
# Description

OCPBUGS-9903 - docs: add information about unsupported scenario
    
The scenario is when a user copied a catalog to the same location more than once and try to mirror it.
## Type of change

- [X] This change requires a documentation update

# How Has This Been Tested?

The following commands were executed:

```skopeo copy docker://registry.redhat.io/redhat/redhat-operator-index:v4.11 oci:///home/aguidi/rhoc-ying  --remove-signatures ```

and 

```skopeo copy docker://registry.redhat.io/redhat/redhat-operator-index:v4.12 oci:///home/aguidi/rhoc-ying  --remove-signatures```

then I tried to mirror using the following command:

```./bin/oc-mirror --config ying.yaml  docker://localhost:5000  --use-oci-feature --dest-use-http --dest-skip-tls --dry-run ```

and the following ImageSetConfiguration:

```
apiVersion: mirror.openshift.io/v1alpha2
kind: ImageSetConfiguration
storageConfig:
  registry:
    imageURL: localhost:5000/metadata:latest
    skipTLS: true
mirror:
  operators:
    - catalog: oci:///home/aguidi/rhoc-ying
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules