### PR TITLE
OCPBUGS-8216: fix: remove an unecessary error message

### DIFF
--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -107,9 +107,7 @@ func ParseReference(ref string) (TypedImageReference, error) {
 	// in case of TargetName and TargetTag replacing the original name ,
 	// the returned path will not exist on disk
 	manifest, err := getManifest(context.Background(), ref)
-	if err != nil {
-		fmt.Printf("%v", err)
-	} else {
+	if err == nil {
 		dst.ID = string(manifest.ConfigInfo().Digest)
 	}
 	return TypedImageReference{Ref: dst, Type: dstType, OCIFBCPath: ref}, nil


### PR DESCRIPTION
# Description

There are some scenarios where an error is expected so it should not print the error message otherwise it will confuse the user.

fixes #576 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Using the command and image set config below:

```./bin/oc-mirror --config ocpbugs-8216.yaml  docker://localhost:5000  --use-oci-feature  --dest-use-http  --dest-skip-tls```

``` kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
storageConfig:
  local:
    path: /home/aguidi/go/src/github.com/aguidirh/oc-mirror/ocpbugs-8216
mirror:
  operators:
  - catalog: oci:///home/aguidi/dev/catalogs/rhoc4.12
    targetCatalog: mno/redhat-operator-index
    targetTag: v4.12
    packages:
    - name: aws-load-balancer-operator 
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules