### PR TITLE
OCPBUGS-7888: fix extract dir for cincinnati-graph-data container

### DIFF
--- a/pkg/cli/mirror/cincinnati_graph_image.go
+++ b/pkg/cli/mirror/cincinnati_graph_image.go
@@ -33,7 +33,7 @@ const (
 	// URL where graph archive is stored
 	graphURL       = "https://api.openshift.com/api/upgrades_info/graph-data"
 	outputFile     = "cincinnati-graph-data.tar.gz"
-	graphDataDir   = "/var/lib/cincinnati/graph-data/"
+	graphDataDir   = "/var/lib/cincinnati-graph-data/"
 	getDataTimeout = time.Minute * 60
 )
 
@@ -101,7 +101,10 @@ func (o *MirrorOptions) buildGraphImage(ctx context.Context, dstDir string) (ima
 		return refs, fmt.Errorf("error creating add layer: %v", err)
 	}
 
+	cpCmd := fmt.Sprintf("cp -rp %s/* /var/lib/cincinnati/graph-data", graphDataDir)
+
 	update := func(cfg *v1.ConfigFile) {
+		cfg.Config.Cmd = []string{"/bin/bash", "-c", cpCmd}
 		cfg.Author = "oc-mirror"
 	}
 	layoutPath, err := imgBuilder.CreateLayout(ubiImage.Ref.Exact(), layoutDir)


### PR DESCRIPTION
# Description
we're changing the dir for extracting cincinnati-graph-data as we're mounting an empty volume to /var/lib/cincinnati/graph-data on the operator. this results in the dir getting overrided with an empty dir.

Solution:
Extract cincinnati-graph-data to a different directory and copy the contents to the required directory after the container is mounted by introducing an init command for the container.

Fixes [OCPBUGS-7888](https://issues.redhat.com/browse/OCPBUGS-7888)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

use the graph-data created by this PR with OSUS operator v5.0.1

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules