### PR TITLE
Replacing the hard coded path with graphDataMountPath

### DIFF
--- a/pkg/cli/mirror/cincinnati_graph_image.go
+++ b/pkg/cli/mirror/cincinnati_graph_image.go
@@ -31,10 +31,11 @@ const (
 	// Base image to use when build graph image
 	graphBaseImage = "registry.access.redhat.com/ubi8/ubi-micro:latest"
 	// URL where graph archive is stored
-	graphURL       = "https://api.openshift.com/api/upgrades_info/graph-data"
-	outputFile     = "cincinnati-graph-data.tar.gz"
-	graphDataDir   = "/var/lib/cincinnati-graph-data/"
-	getDataTimeout = time.Minute * 60
+	graphURL           = "https://api.openshift.com/api/upgrades_info/graph-data"
+	outputFile         = "cincinnati-graph-data.tar.gz"
+	graphDataDir       = "/var/lib/cincinnati-graph-data/"
+	graphDataMountPath = "/var/lib/cincinnati/graph-data"
+	getDataTimeout     = time.Minute * 60
 )
 
 // unpackRelease will unpack Cincinnati graph data if it exists in the archive
@@ -101,7 +102,7 @@ func (o *MirrorOptions) buildGraphImage(ctx context.Context, dstDir string) (ima
 		return refs, fmt.Errorf("error creating add layer: %v", err)
 	}
 
-	cpCmd := fmt.Sprintf("cp -rp %s/* /var/lib/cincinnati/graph-data", graphDataDir)
+	cpCmd := fmt.Sprintf("cp -rp %s/* %s", graphDataDir, graphDataMountPath)
 
 	update := func(cfg *v1.ConfigFile) {
 		cfg.Config.Cmd = []string{"/bin/bash", "-c", cpCmd}


### PR DESCRIPTION
Adding graphDataMountPath varibale for "/var/lib/cincinnati/graph-data"

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules