### PR TITLE
OCPBUGS-10051: fix: remove catalog from ImageContentSourcePolicy.yaml

### DIFF
--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -480,7 +480,7 @@ func (o *MirrorOptions) generateResults(mapping image.TypedImageMapping, dir str
 	releases := image.ByCategory(mapping, v1alpha2.TypeOCPRelease, v1alpha2.TypeOCPReleaseContent)
 	graphs := image.ByCategory(mapping, v1alpha2.TypeCincinnatiGraph)
 	generic := image.ByCategory(mapping, v1alpha2.TypeGeneric)
-	operator := image.ByCategory(mapping, v1alpha2.TypeOperatorBundle, v1alpha2.TypeOperatorCatalog, v1alpha2.TypeOperatorRelatedImage)
+	operator := image.ByCategory(mapping, v1alpha2.TypeOperatorBundle, v1alpha2.TypeOperatorRelatedImage)
 
 	getICSP := func(mapping image.TypedImageMapping, name string, builder ICSPBuilder) error {
 		icsps, err := GenerateICSP(name, namespaceICSPScope, icspSizeLimit, mapping, builder)
@@ -511,7 +511,7 @@ func (o *MirrorOptions) generateResults(mapping image.TypedImageMapping, dir str
 
 	}
 
-	ctlgRefs := image.ByCategory(operator, v1alpha2.TypeOperatorCatalog)
+	ctlgRefs := image.ByCategory(mapping, v1alpha2.TypeOperatorCatalog)
 	if len(ctlgRefs) != 0 {
 		if err := WriteCatalogSource(ctlgRefs, dir); err != nil {
 			return err


### PR DESCRIPTION
# Description

ImageContentSourcePolicy.yaml should not include catalog reference since the CatalogSource.yaml already contains this information. 

Fixes #OCPBUGS-10051:

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Using the following ImageSetConfig:

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
storageConfig:
  local:
    path: /home/aguidi/go/src/github.com/aguidirh/oc-mirror/ocpbugs-8216
mirror:
  operators:
  - catalog: oci:///home/aguidi/dev/catalogs/rhoc4.12
    targetCatalog: mno/redhat-operator-index
    targetTag: v4.12
    packages:
    - name: aws-load-balancer-operator
```

And the following command:

```
./bin/oc-mirror --config /home/aguidi/go/src/github.com/aguidirh/oc-mirror/imstcfg.yaml --use-oci-feature docker://quay.io/rh_ee_aguidi
```

The following artifacts were generated:

```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: redhat-operator-index
  namespace: openshift-marketplace
spec:
  image: quay.io/rh_ee_aguidi/mno/redhat-operator-index:v4.12
  sourceType: grpc

```

```
---
apiVersion: operator.openshift.io/v1alpha1
kind: ImageContentSourcePolicy
metadata:
  labels:
    operators.openshift.org/catalog: "true"
  name: operator-0
spec:
  repositoryDigestMirrors:
  - mirrors:
    - quay.io/rh_ee_aguidi/albo
    source: registry.redhat.io/albo
  - mirrors:
    - quay.io/rh_ee_aguidi/openshift4
    source: registry.redhat.io/openshift4

```

After applying both ImageContentSourcePolicy and CatalogSource to a running openshift cluster we were able to validate that everything worked fine.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules