### PR TITLE
[release-4.12] OCPBUGS-863: Add skip pruning flag and logic 

### DIFF
--- a/pkg/cli/mirror/manifests_test.go
+++ b/pkg/cli/mirror/manifests_test.go
@@ -458,7 +458,7 @@ func TestICSPGeneration(t *testing.T) {
 				// for loop replaces require.Equal(test.expected, icsps): order elements in Spec.RepositoryDigestMirrors
 				// was making the test fail
 				for ind, icsp := range test.expected {
-					require.Equal(t, icsp.Spec.RepositoryDigestMirrors, icsps[ind].Spec.RepositoryDigestMirrors)
+					require.ElementsMatch(t, icsp.Spec.RepositoryDigestMirrors, icsps[ind].Spec.RepositoryDigestMirrors)
 					require.Equal(t, icsp.Labels, icsps[ind].Labels)
 					require.Equal(t, icsp.Name, icsps[ind].Name)
 				}

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -266,6 +266,10 @@ func (o *MirrorOptions) Validate() error {
 		klog.Infof("using --skip-pruning flag - pruning will be skipped")
 	}
 
+	if o.SkipPruning {
+		klog.Infof("Skip pruning - N.B. this feature is unsupported")
+	}
+
 	return nil
 }
 

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -262,6 +262,10 @@ func (o *MirrorOptions) Validate() error {
 		}
 	}
 
+	if o.SkipPruning {
+		klog.Infof("using --skip-pruning flag - pruning will be skipped")
+	}
+
 	return nil
 }
 

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -266,10 +266,6 @@ func (o *MirrorOptions) Validate() error {
 		klog.Infof("using --skip-pruning flag - pruning will be skipped")
 	}
 
-	if o.SkipPruning {
-		klog.Infof("Skip pruning - N.B. this feature is unsupported")
-	}
-
 	return nil
 }
 

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -30,6 +30,7 @@ type MirrorOptions struct {
 	SkipCleanup                bool
 	SkipMissing                bool
 	SkipMetadataCheck          bool
+	SkipPruning                bool
 	ContinueOnError            bool
 	IgnoreHistory              bool
 	MaxPerRegistry             int
@@ -73,6 +74,7 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.OCIRegistriesConfig, "oci-registries-config", o.OCIRegistriesConfig, "Registries config file location (used only with --use-oci-feature flag)")
 	fs.BoolVar(&o.OCIInsecureSignaturePolicy, "oci-insecure-signature-policy", o.OCIInsecureSignaturePolicy, "If set, OCI catalog push will not try to push signatures")
 	fs.IntVar(&o.MaxNestedPaths, "max-nested-paths", 2, "Number of nested paths, for destination registries that limit nested paths")
+	fs.BoolVar(&o.SkipPruning, "skip-pruning", o.SkipPruning, "If set, will disable pruning globally")
 }
 
 func (o *MirrorOptions) init() {

--- a/pkg/cli/mirror/prune.go
+++ b/pkg/cli/mirror/prune.go
@@ -26,13 +26,18 @@ import (
 
 // pruneRegistry plans and executes registry pruning based on current and previous Associations.
 func (o *MirrorOptions) pruneRegistry(ctx context.Context, prev, curr image.AssociationSet) error {
-	deleter, toRemove, err := o.planImagePruning(ctx, curr, prev)
-	if err != nil {
-		return err
+	//CFE-739
+	if !o.SkipPruning {
+		deleter, toRemove, err := o.planImagePruning(ctx, curr, prev)
+		if err != nil {
+			return err
+		}
+		// We can use MaxPerRegistry for maxWorkers because
+		// we only prune from one registry
+		return o.pruneImages(deleter, toRemove, o.MaxPerRegistry)
 	}
-	// We can use MaxPerRegistry for maxWorkers because
-	// we only prune from one registry
-	return o.pruneImages(deleter, toRemove, o.MaxPerRegistry)
+	klog.Info("skipped pruning")
+	return nil
 }
 
 // planImagePruning creates a ManifestDeleter and map of manifests scheduled for deletion.


### PR DESCRIPTION
# Description
Add skip pruning flag that will globally skip all pruning functionality in oc-mirror

Fixes # (ocpbugs-863)

## Type of change
[x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally on docker server registry

Mirrored an additional image registry.redhat.io/ubi8/ubi:latest (with so flag set i.e --skip-pruning)
Update image set config with a registry.redhat.io/ubi9/ubi:latest and removed previous image
Verified that the logs for both oc-mirror and registry showed that the ubi8 image was pruned/deleted
Clean the registry and started the same process as aboved but with --skip-pruning flag set
Verified message displayed that this feature is not supported
Verified that no images were pruned or deleted


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules