### PR TITLE
OCPBUGS-1060 fix: changes confusing error message

### DIFF
--- a/pkg/cli/mirror/publish.go
+++ b/pkg/cli/mirror/publish.go
@@ -402,6 +402,7 @@ func (o *MirrorOptions) fetchBlobs(ctx context.Context, meta v1alpha2.Metadata, 
 		imgRef, err := o.findBlobRepo(pathsByLayer, layerDigest)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("error finding remote layer %q: %v", layerDigest, err))
+			continue
 		}
 		if err := o.fetchBlob(ctx, regctx, imgRef.Ref, layerDigest, dstBlobPaths); err != nil {
 			errs = append(errs, fmt.Errorf("layer %s: %v", layerDigest, err))
@@ -514,7 +515,7 @@ func (o *MirrorOptions) findBlobRepo(assocPathsByLayer map[string]string, layerD
 
 	srcRef, ok := assocPathsByLayer[layerDigest]
 	if !ok {
-		return imagesource.TypedImageReference{}, fmt.Errorf("layer %q is not present in previous metadata", layerDigest)
+		return imagesource.TypedImageReference{}, fmt.Errorf("layer %q is not present in the archive", layerDigest)
 	}
 
 	dstRef, err := imagesource.ParseReference(srcRef)

--- a/pkg/cli/mirror/publish_test.go
+++ b/pkg/cli/mirror/publish_test.go
@@ -199,7 +199,7 @@ func TestFindBlobRepo(t *testing.T) {
 			options: &MirrorOptions{
 				ToMirror: "registry.com",
 			},
-			err: "layer \"notfound\" is not present in previous metadata",
+			err: "layer \"notfound\" is not present in the archive",
 		}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
# Description

The previous error message was not telling the customer what was the real error so it was changed to be clear why the error happened.

The real error was that when the flag --continue-on-error is used, a tar file can be generated with missing layers. The mirroring of a tar file with missing layers will fail.

It is recommended to avoid using the --continue-on-error flag on production environments. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

A container image was pulled and then a layer was manually removed from the archive (.tar file). After that a new mirror process was triggered and it failed with the following message:

```
error: error occurred during image processing: error finding remote layer "sha256:c3036aa2b3e5e076041b8c1d2a239dd04d408306db78491177541c843bf538f4": layer "sha256:c3036aa2b3e5e076041b8c1d2a239dd04d408306db78491177541c843bf538f4" is not present in previous metadata
```

Since the layer is missing in the archive file and not in the 'previous metadata' the error message was changed.

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules