### PR TITLE
OCPBUGS-7845 fix: changes the way the version is shown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,17 +13,6 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 
 GO_BUILD_PACKAGES := ./cmd/...
 
-GO_LD_EXTRAFLAGS :=-X k8s.io/component-base/version.gitMajor="1" \
-                   -X k8s.io/component-base/version.gitMinor="22" \
-                   -X k8s.io/component-base/version.gitVersion="v0.22.4" \
-                   -X k8s.io/component-base/version.gitCommit="$(SOURCE_GIT_COMMIT)" \
-                   -X k8s.io/component-base/version.buildDate="$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-                   -X k8s.io/component-base/version.gitTreeState="clean" \
-                   -X k8s.io/client-go/pkg/version.gitVersion="$(SOURCE_GIT_TAG)" \
-                   -X k8s.io/client-go/pkg/version.gitCommit="$(SOURCE_GIT_COMMIT)" \
-                   -X k8s.io/client-go/pkg/version.buildDate="$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-                   -X k8s.io/client-go/pkg/version.gitTreeState="$(SOURCE_GIT_TREE_STATE)"
-
 LIBDM_BUILD_TAG = $(shell hack/libdm_tag.sh)
 LIBSUBID_BUILD_TAG = $(shell hack/libsubid_tag.sh)
 BTRFS_BUILD_TAG = $(shell hack/btrfs_tag.sh) $(shell hack/btrfs_installed_tag.sh)

--- a/pkg/cli/mirror/version/version.go
+++ b/pkg/cli/mirror/version/version.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
@@ -19,6 +20,7 @@ type VersionOptions struct {
 	*cli.RootOptions
 	Output string
 	Short  bool
+	Info   bool
 }
 
 // Version is a struct for version information
@@ -46,6 +48,7 @@ func NewVersionCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command {
 
 	fs := cmd.Flags()
 	fs.BoolVar(&o.Short, "short", o.Short, "Print just the version number")
+	fs.BoolVar(&o.Info, "info", o.Info, "Print the complete information about the version")
 	fs.StringVar(&o.Output, "output", o.Output, "One of 'yaml' or 'json'.")
 	o.BindFlags(cmd.PersistentFlags())
 
@@ -71,9 +74,11 @@ func (o *VersionOptions) Run() error {
 	switch o.Output {
 	case "":
 		if o.Short {
-			fmt.Fprintf(o.Out, "Client Version: %s\n", clientVersion.GitVersion)
-		} else {
+			fmt.Fprintf(o.Out, "Client Version: %s\n", clientVersion.GitVersion[0:strings.Index(clientVersion.GitVersion, "-")])
+		} else if o.Info {
 			fmt.Fprintf(o.Out, "Client Version: %#v\n", clientVersion)
+		} else {
+			fmt.Fprintf(o.Out, "Client Version: %s\n", clientVersion.GitVersion)
 		}
 	case "yaml":
 		marshalled, err := yaml.Marshal(&versionInfo)


### PR DESCRIPTION
# Description

This issue fix OCPBUGS-7845 by changing the way version is shown in oc-mirror. 

A new flag --info was added to keep the old mechanism responsible to show the entire version schema.

Fixes OCPBUGS-7845

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

To show the long version:

```
./bin/oc-mirror version
Client Version: v0.2.0-alpha.1-103-g6943ced
```

To show the short version:

```
./bin/oc-mirror version --short
Client Version: v0.2.0
```

To show the entire version schema:

```
./bin/oc-mirror version --info
Client Version: version.Info{Major:"", Minor:"", GitVersion:"v0.2.0-alpha.1-103-g6943ced", GitCommit:"6943ced8", GitTreeState:"dirty", BuildDate:"2023-04-04T11:52:15Z", GoVersion:"go1.20.2", Compiler:"gc", Platform:"linux/amd64"}
```

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules