### PR TITLE
OCPBUGS-10348 fix: changes to include the registry path

### DIFF
--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -10,11 +10,6 @@ import (
 
 // ResolveToPin returns unresolvedImage's digest-pinned string representation.
 func ResolveToPin(ctx context.Context, resolver remotes.Resolver, unresolvedImage string) (string, error) {
-	// Get the image's registry-specific digest.
-	_, desc, err := resolver.Resolve(ctx, unresolvedImage)
-	if err != nil {
-		return "", err
-	}
 
 	// Add the digest to the Reference to use it's Stringer implementation
 	// to get the full image pin.
@@ -23,6 +18,13 @@ func ResolveToPin(ctx context.Context, resolver remotes.Resolver, unresolvedImag
 		return "", err
 	}
 	ref = ref.DockerClientDefaults()
+
+	// Get the image's registry-specific digest.
+	_, desc, err := resolver.Resolve(ctx, ref.String())
+	if err != nil {
+		return "", err
+	}
+
 	ref.ID = desc.Digest.String()
 
 	return ref.String(), nil


### PR DESCRIPTION
# Description

Some related images does not include the registry path (as the example below). 

```
"relatedImages": [
    {
      "name": "",
      "image": "devopstales/trivy-operator:2.4.1"
    }
]
``` 

For scenarios like that docker.io should be the default registry. The code was changed to make sure this default is applied.

Fixes OCPBUGS-10348

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

ImageSetConfig

```
apiVersion: mirror.openshift.io/v1alpha2
kind: ImageSetConfiguration
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/community-operator-index:v4.11
      packages:
        - name: community-trivy-operator
          channels:
            - name: stable
```

Command: 

```
oc-mirror --config /home/aguidi/go/src/github.com/aguidirh/oc-mirror/ocpbugs-10348.yaml file://ocpbugs10348
```

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules