### PR TITLE
OCPBUGS-588: minVersion in ImageSetConfiguration seems to be ignored

### DIFF
--- a/pkg/operator/diff/internal/diff_include.go
+++ b/pkg/operator/diff/internal/diff_include.go
@@ -277,9 +277,15 @@ func getBundlesForVersions(ch *model.Channel, vers []semver.Version, names []str
 		namesToInclude[name] = struct{}{}
 	}
 	for _, b := range ch.Bundles {
+		// OCPBUGS-588 - the postfix i.e '-0' causes a miss in the lookup
+		// as an  example we have this in the 'vers' variable 2.2.0
+		// however the b.Version.String() could return 2.2.0-0
+		// the fix is to remove the -0 postfix to ensure the bundle is included
+		trimVer := strings.Split(b.Version.String(), "-")[0]
+		_, trimmedVersionedBundle := versionsToInclude[trimVer]
 		_, includeVersionedBundle := versionsToInclude[b.Version.String()]
 		_, includeNamedBundle := namesToInclude[b.Name]
-		if includeVersionedBundle || includeNamedBundle {
+		if includeVersionedBundle || includeNamedBundle || trimmedVersionedBundle {
 			bundles = append(bundles, b)
 		}
 	}


### PR DESCRIPTION
# Description

This PR addresses the problem with minVersion being ignored in the ImageSetConfiguration (for catalogs)

Fixes # OCPBUGS-588

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

ImageSetConfig used to verify

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
storageConfig:
  local:
    path: /tmp/lmz-images
mirror:
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.11
    packages:
    - name: servicemeshoperator
      channels:
      - name: stable
        minVersion: '2.3.1'
    - name: rhsso-operator
      channels:
      - name: stable
        minVersion: '7.6.1-opr-005'
 
```
Before the fix an error message would be displayed 
```
error: error generating diff: error including items:
[package="servicemeshoperator" channel="stable"] bundles do not exist in channel: versions=["2.3.1"]
```

After this fix (using debug output we get this) - output is truncated !!!

```
(dlv) print bundles[1] ...
Version: github.com/blang/semver/v4.Version {
		Major: 2,
		Minor: 3,
		Patch: 1,
		Pre: []github.com/blang/semver/v4.PRVersion len: 1, cap: 1, [
			(*"github.com/blang/semver/v4.PRVersion")(0xc00605af60),
		],
		Build: []string len: 0, cap: 0, nil,},}

(dlv) print bundles[2] ...
Version: github.com/blang/semver/v4.Version {
		Major: 2,
		Minor: 3,
		Patch: 2,
		Pre: []github.com/blang/semver/v4.PRVersion len: 1, cap: 1, [
			(*"github.com/blang/semver/v4.PRVersion")(0xc00605b000),
		],
		Build: []string len: 0, cap: 0, nil,},}
```

The diff logic executes correctly now (as it included bundles from version 2.3.1 to 2.3.2 (maxVersion)

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules