### PR TITLE
OCPBUGS-11552: work around OCPBUGS-6741 by explicitly setting --cache-dir on opm in catalog images

### DIFF
--- a/pkg/cli/mirror/catalog_images.go
+++ b/pkg/cli/mirror/catalog_images.go
@@ -176,7 +176,7 @@ func (o *MirrorOptions) processCatalogRefs(ctx context.Context, catalogsByImage 
 				containertools.ConfigsLocationLabel: "/configs",
 			}
 			cfg.Config.Labels = labels
-			cfg.Config.Cmd = []string{"serve", "/configs"}
+			cfg.Config.Cmd = []string{"serve", "/configs", "--cache-dir", "/tmp/cache"}
 			cfg.Config.Entrypoint = []string{"/bin/opm"}
 		}
 		if err := imgBuilder.Run(ctx, refExact, layoutPath, update, layers...); err != nil {


### PR DESCRIPTION
This temporary workaround will be required for versions of OPM, and catalogs based on them, until that longer term fix is cherry-picked and catalogs with the update are published.

# Description

Applied the relevant workaround from OCPBUGS-6741 to catalog images generated by oc-mirror

Fixes # OCPBUGS-11552

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `make hack-build` (tidy, test-unit, and build targets)

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules