### PR TITLE
OCPBUGS-4959: oc-mirror error on second synchronisation with no change

### DIFF
--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -813,8 +813,16 @@ func (o *MirrorOptions) diskToMirrorWrapper(ctx context.Context, cleanup cleanup
 	// Publish from disk to registry
 	// this takes care of syncing the metadata to the
 	// registry backends.
+
 	mapping, err := o.Publish(ctx)
 	if err != nil {
+		// OCPBUGS-4959 for automation processes to end gracefully
+		// when we have the same sequence - i.e nothing to do
+		msqErr := &ErrMirrorSequence{}
+		if errors.As(err, &msqErr) {
+			klog.Info("No diff from previous mirror (sequence is the same), nothing to do")
+			return cleanup()
+		}
 		serr := &ErrInvalidSequence{}
 		if errors.As(err, &serr) {
 			return fmt.Errorf("error during publishing, expecting imageset with prefix mirror_seq%d: %v", serr.wantSeq, err)


### PR DESCRIPTION
# Description

This bug fix addresses the issue for automation (i.e when running oc-mirror in a ci/cd pipeline or cronjob etc).
If the  mirror sequence has not changed from a previous run end gracefully with no error i.e exit 0 and print a releavnt message 

Fixes # OCPBUGS-4959

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ensures that the process ends without an error and print an appropriate message e.g _"No diff from previous run (seqeunce is the same), nothing to do"_ 

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules