### PR TITLE
OCPBUGS-12236: Revert adding '--cache-dir /tmp/cache' to catalog images

### DIFF
--- a/pkg/cli/mirror/catalog_images.go
+++ b/pkg/cli/mirror/catalog_images.go
@@ -176,7 +176,7 @@ func (o *MirrorOptions) processCatalogRefs(ctx context.Context, catalogsByImage 
 				containertools.ConfigsLocationLabel: "/configs",
 			}
 			cfg.Config.Labels = labels
-			cfg.Config.Cmd = []string{"serve", "/configs", "--cache-dir", "/tmp/cache"}
+			cfg.Config.Cmd = []string{"serve", "/configs"}
 			cfg.Config.Entrypoint = []string{"/bin/opm"}
 		}
 		if err := imgBuilder.Run(ctx, refExact, layoutPath, update, layers...); err != nil {


### PR DESCRIPTION
This PR reverts the change introduced in #604 . 
Since merge of https://github.com/openshift/operator-framework-olm/pull/435, public catalogs have --cache-dir and precomputed caches. Therefore adding --cache-dir to the cmd of operators later mirrored by oc-mirror causes a CrashLoopBackOff in clusters.

This was due to cache digest not matching the contents of the catalog.

Without the flag, oc-mirror writes catalog without --cache-dir in CMD
oc-mirror catalogs recompute cache, presumably in some other directory than the precomputed (you can tell this because the time to get to serving registry is much longer)
oc-mirror catalogs work .
