### PR TITLE
OCPBUGS-12458: Deprecate --use-oci-feature in favor of --include-local-oci-catalogs

### DIFF
--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -255,11 +255,11 @@ func (o *MirrorOptions) Validate() error {
 	mirrorToMirror := len(o.ToMirror) > 0 && len(o.ConfigPath) > 0
 
 	// mirrorToDisk workflow is not supported with the oci feature
-	if o.UseOCIFeature && mirrorToDisk {
+	if o.IncludeLocalOCICatalogs && mirrorToDisk {
 		return fmt.Errorf("oci feature cannot be used when mirroring to local archive")
 	}
 	// diskToMirror workflow is not supported with the oci feature
-	if o.UseOCIFeature && diskToMirror {
+	if o.IncludeLocalOCICatalogs && diskToMirror {
 		return fmt.Errorf("oci feature cannot be used when publishing from a local archive to a registry")
 	}
 	// mirrorToMirror workflow using the oci feature must have at least on operator set with oci:// prefix
@@ -274,15 +274,15 @@ func (o *MirrorOptions) Validate() error {
 				bIsFBOCI = true
 			}
 		}
-		if o.UseOCIFeature && !bIsFBOCI {
-			return fmt.Errorf("no operator found with OCI FBC catalog prefix (oci://) in configuration file, please execute without the --use-oci-feature flag")
+		if o.IncludeLocalOCICatalogs && !bIsFBOCI {
+			return fmt.Errorf("no operator found with OCI FBC catalog prefix (oci://) in configuration file, please execute without the --include-local-oci-catalogs flag")
 		}
-		if !o.UseOCIFeature && bIsFBOCI {
-			return fmt.Errorf("use of OCI FBC catalogs (prefix oci://) in configuration file is authorized only with flag --use-oci-feature")
+		if !o.IncludeLocalOCICatalogs && bIsFBOCI {
+			return fmt.Errorf("use of OCI FBC catalogs (prefix oci://) in configuration file is authorized only with flag --include-local-oci-catalogs")
 		}
 	}
-	if !o.UseOCIFeature && len(o.OCIRegistriesConfig) > 0 {
-		return fmt.Errorf("oci-registries-config flag can only be used with the --use-oci-feature flag")
+	if !o.IncludeLocalOCICatalogs && len(o.OCIRegistriesConfig) > 0 {
+		return fmt.Errorf("oci-registries-config flag can only be used with the --include-local-oci-catalog flag")
 	}
 
 	if o.SkipPruning {
@@ -632,7 +632,7 @@ func (o *MirrorOptions) mirrorToMirrorWrapper(ctx context.Context, cfg v1alpha2.
 	if err != nil {
 		return err
 	}
-	if !o.UseOCIFeature {
+	if !o.IncludeLocalOCICatalogs {
 		var curr v1alpha2.Metadata
 		berr := targetBackend.ReadMetadata(ctx, &curr, config.MetadataBasePath)
 		if err := o.checkSequence(meta, curr, berr); err != nil {

--- a/pkg/cli/mirror/mirror_test.go
+++ b/pkg/cli/mirror/mirror_test.go
@@ -291,38 +291,38 @@ func TestMirrorValidate(t *testing.T) {
 		{
 			name: "Invalid/MirrortoDisk/OCIFlag",
 			opts: &MirrorOptions{
-				OutputDir:     t.TempDir(),
-				ConfigPath:    "foo",
-				UseOCIFeature: true,
+				OutputDir:               t.TempDir(),
+				ConfigPath:              "foo",
+				IncludeLocalOCICatalogs: true,
 			},
 			expError: "oci feature cannot be used when mirroring to local archive",
 		},
 		{
 			name: "Invalid/DisktoMirror/OCIFlag",
 			opts: &MirrorOptions{
-				From:          t.TempDir(),
-				ToMirror:      u.Host,
-				UseOCIFeature: true,
+				From:                    t.TempDir(),
+				ToMirror:                u.Host,
+				IncludeLocalOCICatalogs: true,
 			},
 			expError: "oci feature cannot be used when publishing from a local archive to a registry",
 		},
 		{
 			name: "Invalid/MirrorToMirror/ImageSetConfigWithOCI",
 			opts: &MirrorOptions{
-				ConfigPath:    "testdata/configs/iscfg_oci_ops.yaml",
-				ToMirror:      u.Host,
-				UseOCIFeature: false,
+				ConfigPath:              "testdata/configs/iscfg_oci_ops.yaml",
+				ToMirror:                u.Host,
+				IncludeLocalOCICatalogs: false,
 			},
-			expError: "use of OCI FBC catalogs (prefix oci://) in configuration file is authorized only with flag --use-oci-feature",
+			expError: "use of OCI FBC catalogs (prefix oci://) in configuration file is authorized only with flag --include-local-oci-catalogs",
 		},
 		{
 			name: "Invalid/MirrorToMirror/ImageSetConfigWithoutOCI",
 			opts: &MirrorOptions{
-				ConfigPath:    "testdata/configs/iscfg.yaml",
-				ToMirror:      u.Host,
-				UseOCIFeature: true,
+				ConfigPath:              "testdata/configs/iscfg.yaml",
+				ToMirror:                u.Host,
+				IncludeLocalOCICatalogs: true,
 			},
-			expError: "no operator found with OCI FBC catalog prefix (oci://) in configuration file, please execute without the --use-oci-feature flag",
+			expError: "no operator found with OCI FBC catalog prefix (oci://) in configuration file, please execute without the --include-local-oci-catalogs flag",
 		},
 		{
 			name: "Valid/ManifestOnlyWithFakeMirror",

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -34,7 +34,7 @@ type MirrorOptions struct {
 	ContinueOnError            bool
 	IgnoreHistory              bool
 	MaxPerRegistry             int
-	UseOCIFeature              bool
+	IncludeLocalOCICatalogs    bool
 	OCIRegistriesConfig        string
 	OCIInsecureSignaturePolicy bool
 	MaxNestedPaths             int
@@ -68,12 +68,13 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 		"404/NotFound errors encountered while pulling images explicitly specified in the config "+
 		"will not be skipped")
 	fs.IntVar(&o.MaxPerRegistry, "max-per-registry", 6, "Number of concurrent requests allowed per registry")
-	fs.BoolVar(&o.UseOCIFeature, "use-oci-feature", o.UseOCIFeature, "Use the new oci feature for oc mirror (oci formatted copy")
+	fs.BoolVar(&o.IncludeLocalOCICatalogs, "use-oci-feature", o.IncludeLocalOCICatalogs, "Deprecated, use --include-local-oci-catalog instead")
+	fs.BoolVar(&o.IncludeLocalOCICatalogs, "include-local-oci-catalogs", o.IncludeLocalOCICatalogs, "If set, enables including local OCI-formatted catalogs (prefix oci://) in the list of operator catalogs defined in ImageSetConfig, so that these local catalogs are mirrored from the disk directly")
 	fs.StringVar(&o.OCIRegistriesConfig, "oci-registries-config", o.OCIRegistriesConfig, "Registries config file location (used only with --use-oci-feature flag)")
 	fs.BoolVar(&o.OCIInsecureSignaturePolicy, "oci-insecure-signature-policy", o.OCIInsecureSignaturePolicy, "If set, OCI catalog push will not try to push signatures")
 	fs.BoolVar(&o.SkipPruning, "skip-pruning", o.SkipPruning, "If set, will disable pruning globally")
 	fs.IntVar(&o.MaxNestedPaths, "max-nested-paths", 2, "Number of nested paths, for destination registries that limit nested paths")
-
+	fs.MarkDeprecated("use-oci-feature", "Use --include-local-oci-catalogs instead")
 }
 
 func (o *MirrorOptions) init() {

--- a/test/e2e/testcases.sh
+++ b/test/e2e/testcases.sh
@@ -244,7 +244,7 @@ function no_updates_exist {
 
 # Test OCI local catalog
 function oci_catalog {
-    workflow_oci_mirror imageset-config-oci-mirror.yaml "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}/test" -c="--use-oci-feature --dest-skip-tls --oci-insecure-signature-policy"
+    workflow_oci_mirror imageset-config-oci-mirror.yaml "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}/test" -c="--include-local-oci-catalogs --dest-skip-tls --oci-insecure-signature-policy"
     # podman pull docker://localhost.localdomain:5001/test/redhatgov/oc-mirror-dev:test-catalog-latest --tls-verify=false
     # baz.v1.0.0 
     crane digest --insecure localhost.localdomain:${REGISTRY_DISCONN_PORT}/test/${CATALOGNAMESPACE}@sha256:f5bf1128937e7486764341e7bfdce15150f70d0e48c57de1386602c7b25ad7b4
@@ -268,7 +268,7 @@ function oci_local_all {
     test/e2e/graph/main & PID_GO=$! 
     echo -e "go cincinnatti web service PID: ${PID_GO}"
     # copy relevant files and start the mirror process
-    workflow_oci_mirror_all imageset-config-oci-mirror-all.yaml "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}/test-catalog-latest" -c="--dest-skip-tls --oci-insecure-signature-policy --use-oci-feature"
+    workflow_oci_mirror_all imageset-config-oci-mirror-all.yaml "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}/test-catalog-latest" -c="--dest-skip-tls --oci-insecure-signature-policy --include-local-oci-catalogs"
 
     # use crane digest to verify
     crane digest --insecure localhost.localdomain:${REGISTRY_DISCONN_PORT}/test-catalog-latest/redhatgov/oc-mirror-dev:bar-v0.1.0


### PR DESCRIPTION
# Description

Based on the decision with the PM on April 24, `--use-oci-feature` flag is replaced by `--include-local-oci-catalogs` 
The previous flag is marked deprecated in 4.13, and is to be removed completely in the 4.14 version.

Fixes # OCPBUGS-12458

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

* Unit tests pass
* E2E tests pass
* manual tests with both flags give expected results.
* 
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules