### PR TITLE
MULTIARCH-3440: refine multiarch support for test-unit and test-e2e using dockerfile and add ppc64le build to Makefile

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,7 @@ builds:
     goarch:
       - amd64
       - ppc64le
+      - s390x
     env:
       - CGO_ENABLED=1
     flags:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - ppc64le
     env:
       - CGO_ENABLED=1
     flags:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,7 @@ builds:
       - amd64
       - ppc64le
       - s390x
+      - arm64
     env:
       - CGO_ENABLED=1
     flags:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,18 @@ ARG DNF_LIST="\
   git \
   gpgme-devel \
   libassuan-devel \
+  wget \
+  pigz \
 "
 
 #################################################################################
-# Build UBI8 Builder
+# Build UBI8 Builder with multi-arch support
 RUN set -ex \
+     && ARCH=$(arch | sed 's|x86_64|amd64|g')                                   \
      && dnf install -y --nodocs --setopt=install_weak_deps=false ${DNF_LIST}    \
      && dnf clean all -y                                                        \
-     && GO_VERSION=go1.19.5                                       \
-     && curl -sL https://golang.org/dl/${GO_VERSION}.linux-amd64.tar.gz         \
+     && GO_VERSION=go1.19.5                                                     \
+     && curl -sL https://golang.org/dl/${GO_VERSION}.linux-${ARCH}.tar.gz       \
         | tar xzvf - --directory /usr/local/                                    \
      && /usr/local/go/bin/go version                                            \
      && ln -f /usr/local/go/bin/go /usr/bin/go

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,22 +20,19 @@ ARG DNF_LIST="\
 
 #################################################################################
 # Build UBI8 Builder with multi-arch support
-# Link gcc to /usr/bin/s390x-linux-gnu-gcc as go requires it on s390x
 RUN set -ex \
-     && ARCH=$(arch | sed 's|x86_64|amd64|g')                                   \
+     && ARCH=$(arch | sed 's|x86_64|amd64|g' | sed 's|aarch64|arm64|g')         \
      && dnf install -y --nodocs --setopt=install_weak_deps=false ${DNF_LIST}    \
      && dnf clean all -y                                                        \
      && GO_VERSION=go1.19.5                                                     \
      && curl -sL https://golang.org/dl/${GO_VERSION}.linux-${ARCH}.tar.gz       \
         | tar xzvf - --directory /usr/local/                                    \
      && /usr/local/go/bin/go version                                            \
-     && ln -f /usr/local/go/bin/go /usr/bin/go                                  \
-     && ln /usr/bin/gcc /usr/bin/s390x-linux-gnu-gcc
+     && ln -f /usr/local/go/bin/go /usr/bin/go
 
 #################################################################################
 # Link gcc to /usr/bin/s390x-linux-gnu-gcc as go requires it on s390x
-RUN ARCH=$(arch | sed 's|x86_64|amd64|g')                                       \
-     && [ "${ARCH}" == "s390x" ]                                                \
+RUN [ "$(arch)" == "s390x" ]                                                    \
      && ln /usr/bin/gcc /usr/bin/s390x-linux-gnu-gcc                            \
      || echo "Not running on s390x, skip linking gcc binary"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ARG DNF_LIST="\
 
 #################################################################################
 # Build UBI8 Builder with multi-arch support
+# Link gcc to /usr/bin/s390x-linux-gnu-gcc as go requires it on s390x
 RUN set -ex \
      && ARCH=$(arch | sed 's|x86_64|amd64|g')                                   \
      && dnf install -y --nodocs --setopt=install_weak_deps=false ${DNF_LIST}    \
@@ -28,7 +29,8 @@ RUN set -ex \
      && curl -sL https://golang.org/dl/${GO_VERSION}.linux-${ARCH}.tar.gz       \
         | tar xzvf - --directory /usr/local/                                    \
      && /usr/local/go/bin/go version                                            \
-     && ln -f /usr/local/go/bin/go /usr/bin/go
+     && ln -f /usr/local/go/bin/go /usr/bin/go                                  \
+     && ln /usr/bin/gcc /usr/bin/s390x-linux-gnu-gcc
 
 WORKDIR /build
 ENTRYPOINT ["make"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,13 @@ RUN set -ex \
      && ln -f /usr/local/go/bin/go /usr/bin/go                                  \
      && ln /usr/bin/gcc /usr/bin/s390x-linux-gnu-gcc
 
+#################################################################################
+# Link gcc to /usr/bin/s390x-linux-gnu-gcc as go requires it on s390x
+RUN ARCH=$(arch | sed 's|x86_64|amd64|g')                                       \
+     && [ "${ARCH}" == "s390x" ]                                                \
+     && ln /usr/bin/gcc /usr/bin/s390x-linux-gnu-gcc                            \
+     || echo "Not running on s390x, skip linking gcc binary"
+
 WORKDIR /build
 ENTRYPOINT ["make"]
 CMD []

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,11 @@ cross-build-linux-amd64:
 	+@GOOS=linux GOARCH=amd64 $(MAKE) "$(GO_BUILD_FLAGS)" --no-print-directory build GO_BUILD_BINDIR=$(GO_BUILD_BINDIR)/linux-amd64
 .PHONY: cross-build-linux-amd64
 
-cross-build: cross-build-linux-amd64
+cross-build-linux-ppc64le:
+	+@GOOS=linux GOARCH=ppc64le $(MAKE) "$(GO_BUILD_FLAGS)" --no-print-directory build GO_BUILD_BINDIR=$(GO_BUILD_BINDIR)/linux-amd64
+.PHONY: cross-build-linux-ppc64le
+
+cross-build: cross-build-linux-amd64 cross-build-linux-ppc64le
 .PHONY: cross-build
 
 hack-build: clean

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,11 @@ cross-build-linux-s390x:
 	+@GOOS=linux GOARCH=s390x $(MAKE) "$(GO_BUILD_FLAGS)" --no-print-directory build GO_BUILD_BINDIR=$(GO_BUILD_BINDIR)/linux-s390x
 .PHONY: cross-build-linux-s390x
 
-cross-build: cross-build-linux-amd64 cross-build-linux-ppc64le cross-build-linux-s390x
+cross-build-linux-arm64:
+	+@GOOS=linux GOARCH=arm64 $(MAKE) "$(GO_BUILD_FLAGS)" --no-print-directory build GO_BUILD_BINDIR=$(GO_BUILD_BINDIR)/linux-arm64
+.PHONY: cross-build-linux-arm64
+
+cross-build: cross-build-linux-amd64 cross-build-linux-ppc64le cross-build-linux-s390x cross-build-linux-arm64
 .PHONY: cross-build
 
 hack-build: clean

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,11 @@ cross-build-linux-ppc64le:
 	+@GOOS=linux GOARCH=ppc64le $(MAKE) "$(GO_BUILD_FLAGS)" --no-print-directory build GO_BUILD_BINDIR=$(GO_BUILD_BINDIR)/linux-ppc64le
 .PHONY: cross-build-linux-ppc64le
 
-cross-build: cross-build-linux-amd64 cross-build-linux-ppc64le
+cross-build-linux-s390x:
+	+@GOOS=linux GOARCH=s390x $(MAKE) "$(GO_BUILD_FLAGS)" --no-print-directory build GO_BUILD_BINDIR=$(GO_BUILD_BINDIR)/linux-s390x
+.PHONY: cross-build-linux-s390x
+
+cross-build: cross-build-linux-amd64 cross-build-linux-ppc64le cross-build-linux-s390x
 .PHONY: cross-build
 
 hack-build: clean
@@ -75,12 +79,12 @@ publish-catalog:
 	@cd test/operator && make
 .PHONY: publish-catalog
 
-format: 
+format:
 	$(GO) fmt ./pkg/...
 	$(GO) fmt ./cmd/...
 .PHONY: format
 
-vet: 
-	$(GO) vet $(GO_BUILD_FLAGS) ./pkg/... 
-	$(GO) vet $(GO_BUILD_FLAGS) ./cmd/...  
+vet:
+	$(GO) vet $(GO_BUILD_FLAGS) ./pkg/...
+	$(GO) vet $(GO_BUILD_FLAGS) ./cmd/...
 .PHONY: vet

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ cross-build-linux-amd64:
 .PHONY: cross-build-linux-amd64
 
 cross-build-linux-ppc64le:
-	+@GOOS=linux GOARCH=ppc64le $(MAKE) "$(GO_BUILD_FLAGS)" --no-print-directory build GO_BUILD_BINDIR=$(GO_BUILD_BINDIR)/linux-amd64
+	+@GOOS=linux GOARCH=ppc64le $(MAKE) "$(GO_BUILD_FLAGS)" --no-print-directory build GO_BUILD_BINDIR=$(GO_BUILD_BINDIR)/linux-ppc64le
 .PHONY: cross-build-linux-ppc64le
 
 cross-build: cross-build-linux-amd64 cross-build-linux-ppc64le

--- a/test/e2e/e2e-simple.sh
+++ b/test/e2e/e2e-simple.sh
@@ -32,8 +32,12 @@ METADATA_OCI_CATALOG="oci://${DIR}/artifacts/rhop-ctlg-oci"
 TARGET_CATALOG_NAME="target-name"
 TARGET_CATALOG_TAG="target-tag"
 
-
 GOBIN=$HOME/go/bin
+# Check if this is running with a different location
+if [ ! -d $GOBIN ]
+then 
+    GOBIN=/usr/local/go/bin/
+fi
 PATH=$PATH:$GOBIN
 
 mkdir -p $DATA_TMP


### PR DESCRIPTION
# Description

This PR enables multiarch support in the build and tests in this case ppc64le.

- Update the .goreleaser.yaml to include ppc64le
- Update the Dockerfile to include wget and pigz dependency
- Update the Dockerfile to consider arch it's built on
- Update the util.sh to be arch agnostic
- Update the cross build for ppc64le

Note, the [PR #1680](https://github.com/google/go-containerregistry/pull/1680#event-9120119057) builds go-containerregistry for ppc64le.  When a new release is cut for the go-containerregistry, this build will not be necessary.

opm requires a Power9 machine to run.

Fixes # [MULTIARCH-3440](https://issues.redhat.com//browse/MULTIARCH-3440)

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- test-unit is run successfully 

```
# podman run --rm -v .:/build:z local/go-toolset test-unit
Makefile:53: warning: overriding recipe for target 'test-unit'
vendor/github.com/openshift/build-machinery-go/make/targets/golang/test-unit.mk:7: warning: ignoring old recipe for target 'test-unit'
go test -tags "json1 btrfs_noversion exclude_graphdriver_btrfs libdm_no_deferred_remove exclude_graphdriver_devicemapper " -coverprofile=coverage.out -race -count=1 ./pkg/...
ok      github.com/openshift/oc-mirror/pkg/api/v1alpha1 0.012s
ok      github.com/openshift/oc-mirror/pkg/api/v1alpha2 0.012s
ok      github.com/openshift/oc-mirror/pkg/archive      0.025s
ok      github.com/openshift/oc-mirror/pkg/bundle       0.011s
ok      github.com/openshift/oc-mirror/pkg/cincinnati   0.011s
?       github.com/openshift/oc-mirror/pkg/cli  [no test files]
ok      github.com/openshift/oc-mirror/pkg/cli/mirror   0.028s
ok      github.com/openshift/oc-mirror/pkg/cli/mirror/describe  0.041s
ok      github.com/openshift/oc-mirror/pkg/cli/mirror/initcmd   0.011s
ok      github.com/openshift/oc-mirror/pkg/cli/mirror/list      0.015s
ok      github.com/openshift/oc-mirror/pkg/cli/mirror/version   0.011s
ok      github.com/openshift/oc-mirror/pkg/config       0.014s
ok      github.com/openshift/oc-mirror/pkg/image        0.023s
ok      github.com/openshift/oc-mirror/pkg/image/builder        0.011s
ok      github.com/openshift/oc-mirror/pkg/metadata     0.012s
ok      github.com/openshift/oc-mirror/pkg/metadata/storage     0.011s
ok      github.com/openshift/oc-mirror/pkg/operator     0.012s
ok      github.com/openshift/oc-mirror/pkg/operator/diff        0.011s
ok      github.com/openshift/oc-mirror/pkg/operator/diff/internal       0.011s
?       github.com/openshift/oc-mirror/pkg/version      [no test files]

# echo $?
0
```

- test-e2e runs on ppc64le successfully.

**Test Configuration**:
* Firmware version: Power9 
* Hardware: PowerVS Centos8 machine
* Toolchain: Makefile, Podman
* SDK: n/a

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules