### PR TITLE
OCPBUGS-11840: ParseImageReference supports cases where both tag …

### DIFF
--- a/pkg/api/v1alpha2/types_config_test.go
+++ b/pkg/api/v1alpha2/types_config_test.go
@@ -6,6 +6,58 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestParseImageReference(t *testing.T) {
+	type spec struct {
+		desc          string
+		input         string
+		expRegistry   string
+		expNamespace  string
+		expRepository string
+		expDigest     string
+		expTag        string
+	}
+
+	specs := []spec{
+		{
+			desc:          "remote image with both tag and digest",
+			input:         "cp.icr.io/cp/cpd/postgresql:13.7@sha256:e05434bfdb4b306fbc2e697112e1343907e368eb5f348c1779562d31b9f32ac5",
+			expRegistry:   "cp.icr.io",
+			expNamespace:  "cp/cpd",
+			expRepository: "postgresql",
+			expDigest:     "e05434bfdb4b306fbc2e697112e1343907e368eb5f348c1779562d31b9f32ac5",
+			expTag:        "13.7",
+		},
+		{
+			desc:          "remote image with tag",
+			input:         "quay.io/redhatgov/oc-mirror-dev:foo-bundle-v0.3.1",
+			expRegistry:   "quay.io",
+			expNamespace:  "redhatgov",
+			expRepository: "oc-mirror-dev",
+			expDigest:     "",
+			expTag:        "foo-bundle-v0.3.1",
+		},
+		{
+			desc:          "remote image with digest",
+			input:         "quay.io/redhatgov/oc-mirror-dev@sha256:7e1e74b87a503e95db5203334917856f61aece90a72e8d53a9fd903344eb78a5",
+			expRegistry:   "quay.io",
+			expNamespace:  "redhatgov",
+			expRepository: "oc-mirror-dev",
+			expDigest:     "7e1e74b87a503e95db5203334917856f61aece90a72e8d53a9fd903344eb78a5",
+			expTag:        "",
+		},
+	}
+
+	for _, s := range specs {
+		t.Run(s.desc, func(t *testing.T) {
+			reg, ns, repo, tag, id := ParseImageReference(s.input)
+			require.Equal(t, s.expRegistry, reg)
+			require.Equal(t, s.expNamespace, ns)
+			require.Equal(t, s.expRepository, repo)
+			require.Equal(t, s.expTag, tag)
+			require.Equal(t, s.expDigest, id)
+		})
+	}
+}
 func TestGetUniqueName(t *testing.T) {
 	type spec struct {
 		desc     string


### PR DESCRIPTION
…and digest are present in a ref

# Description

This PR provides support for parsing container image references that have both tag and digest provided.
When such references (ex: cp.icr.io/cp/cpd/postgresql:13.7@sha256:e05434bfdb4b306fbc2e697112e1343907e368eb5f348c1779562d31b9f32ac5) exist in an operator package's relatedImages, this causes oc-mirror to fail mirroring

Fixes # OCPBUGS-11840

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Additional unit test added. 
We couldn't use the reference provided in the jira issue to test: unauthorized to access registry
We couldn't reproduce the issue by using the following: This mirrors correctly and doesnt need a fix
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  platform: {}
  operators: []
  additionalImages: 
  # - name: cp.icr.io/cp/cpd/postgresql:13.7@sha256:e05434bfdb4b306fbc2e697112e1343907e368eb5f348c1779562d31b9f32ac5
  - name: quay.io/okd/scos-release:4.13.0-0.okd-scos-2023-05-04-192252@sha256:b3cbd04e527992111b3a736b8d6f59c8406d0ae59cda1bfdfb542519a4c1610c
  helm: {}
```
We tried recreating a catalog with a related image containing both tag and digest using 
```bash
cd test/operator/
 export REGISTRY=localhost:5000
export CATALOG_NAMESPACE=in-11840
make publish
```
But this fails because podman doesn't support using tag and digest at the same time. Error:
```bash
2023-05-15 11:17:09,654 publish_images [  ERROR  ]: Command errored: podman build . --format=docker -t quay.io/okd/scos-release:4.13.0-0.okd-scos-2023-05-04-192252@sha256:b3cbd04e527992111b3a736b8d6f59c8406d0ae59cda1bfdfb542519a4c1610c --build-arg RELATED_IMAGE=quay.io/okd/scos-release:4.13.0-0.okd-scos-2023-05-04-192252@sha256:b3cbd04e527992111b3a736b8d6f59c8406d0ae59cda1bfdfb542519a4c1610c
ShellRuntimeException: (125, 'Error: tag quay.io/okd/scos-release:4.13.0-0.okd-scos-2023-05-04-192252@sha256:b3cbd04e527992111b3a736b8d6f59c8406d0ae59cda1bfdfb542519a4c1610c: Docker references with both a tag and digest are currently not supported')
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules