### PR TITLE
OCPBUGS-13332: Create rfc 1035 compliant catalog source name

### DIFF
--- a/pkg/cli/mirror/manifests.go
+++ b/pkg/cli/mirror/manifests.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	cincinnativ1 "github.com/openshift/cincinnati-operator/api/v1"
@@ -17,6 +19,7 @@ import (
 	"github.com/openshift/oc-mirror/pkg/image"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
@@ -303,15 +306,11 @@ func WriteCatalogSource(mapping image.TypedImageMapping, dir string) error {
 	names := make(map[string]int, len(mapping))
 	for source, dest := range mapping {
 		name := source.Ref.Name
-
-		// In case the source ref has multiple path components (organization, namespace + subnamespace):
-		// Ex: foo.com/cp/test/common-services@sha256:ef64abd2c4c9acdc433ed4454b008d90891fe18fe33d3a53e7d6104a4a8bf5c5
-		// In this case, the `source.Ref.Name`` will contain some path-components, in addition to the image name, separated by `/`
-		// For the above example: name = `test/common-services`
-		// Since name is used to generate the file name, `os.WriteFile` will fail in this case, as subdir test
-		// doesn't exist. Therefore we replace `/` with `-`
-		name = strings.ReplaceAll(name, "/", "-")
-
+		name, err := createRFC1035NameForCatalogSource(name)
+		// in theory this should never error
+		if err != nil {
+			return err
+		}
 		value, found := names[name]
 		if found {
 			value++
@@ -330,6 +329,89 @@ func WriteCatalogSource(mapping image.TypedImageMapping, dir string) error {
 		}
 	}
 	return nil
+}
+
+/*
+CreateRFC1035Name converts the provided name to an RFC 1035 compliant name suitable
+for use in a catalog source. Unacceptable characters are converted to a dash.
+Duplicate consecutive dashes are converted to a single dash.
+
+RFC 1035 compliant strings:
+
+- must consist of lower case alphanumeric characters or '-'
+
+- must start with an alphabetic character
+
+- must end with an alphanumeric character
+
+# Arguments
+
+• nameIn: the string to use as a basis for conversion. It is assumed that this is the
+name portion of a DockerImageReference
+
+# Returns
+
+• string: a string compliant with RFC 1035 or empty string if error occurs
+
+• error: non nil if error occurs, nil otherwise
+*/
+func createRFC1035NameForCatalogSource(nameIn string) (string, error) {
+	// In case the nameIn argument has multiple path components (organization, namespace + subnamespace):
+	// Ex: foo.com/cp/test/common-services@sha256:ef64abd2c4c9acdc433ed4454b008d90891fe18fe33d3a53e7d6104a4a8bf5c5
+	// In this case, the `source.Ref.Name` will contain some path-components, in addition to the image name, separated by `/`
+	// For the above example: name = `test/common-services`
+	// Since name is used to generate the file name, `os.WriteFile` will fail in this case, as sub directory test
+	// doesn't exist. Therefore we replace all `/` with `-`. This also goes for any other "unacceptable" character
+	// that is not compliant with RFC 1035.
+
+	// start by making sure name starts with lower case alpha character, so prefix with `cs-`
+	name := strings.Join([]string{"cs", nameIn}, "-")
+	// modify name to be RFC 1035 compliant
+	name = strings.Map(toRFC1035, name)
+
+	// paranoid check to make sure the last character is alpha numeric
+	lastChar, _ := utf8.DecodeLastRuneInString(name)
+	if !(unicode.IsNumber(lastChar) || unicode.IsLetter(lastChar)) {
+		// convert name to have `-0` suffix
+		name = strings.Join([]string{name, "0"}, "-")
+	}
+
+	// remove duplicate dashes
+	stringBuilder := strings.Builder{}
+	var lastEncounteredRune rune
+	for position, currentRune := range name {
+		if currentRune != lastEncounteredRune || position == 0 || currentRune != '-' {
+			stringBuilder.WriteRune(currentRune)
+			lastEncounteredRune = currentRune
+		}
+	}
+	name = stringBuilder.String()
+
+	// double check that the final name conforms to RFC 1035 (this should never fail)
+	errs := validation.IsDNS1035Label(name)
+	if len(errs) != 0 {
+		return "", fmt.Errorf("error creating catalog source name: %s", strings.Join(errs, ", "))
+	}
+	return name, nil
+}
+
+/*
+toRFC1035 converts the supplied rune to a dash if its not
+a through z, 0 through 9 or a dash
+*/
+func toRFC1035(r rune) rune {
+	r = unicode.ToLower(r)
+	switch {
+	case r >= 'a' && r <= 'z':
+		return r
+	case r >= '0' && r <= '9':
+		return r
+	case r == '-':
+		return r
+	default:
+		// convert unacceptable character
+		return '-'
+	}
 }
 
 // WriteUpdateService will generate an UpdateService object and write it to disk

--- a/pkg/cli/mirror/manifests_test.go
+++ b/pkg/cli/mirror/manifests_test.go
@@ -524,8 +524,8 @@ func TestWriteCatalogSource(t *testing.T) {
 					Category: v1alpha2.TypeOperatorCatalog},
 			},
 			expectedFiles: []string{
-				"catalogSource-dev.yaml",
-				"catalogSource-staging.yaml",
+				"catalogSource-cs-dev.yaml",
+				"catalogSource-cs-staging.yaml",
 			},
 		},
 		{
@@ -587,9 +587,9 @@ func TestWriteCatalogSource(t *testing.T) {
 					Category: v1alpha2.TypeOperatorCatalog},
 			},
 			expectedFiles: []string{
-				"catalogSource-dev.yaml",
-				"catalogSource-dev-1.yaml",
-				"catalogSource-dev-2.yaml",
+				"catalogSource-cs-dev.yaml",
+				"catalogSource-cs-dev-1.yaml",
+				"catalogSource-cs-dev-2.yaml",
 			},
 		},
 		{
@@ -623,7 +623,7 @@ func TestWriteCatalogSource(t *testing.T) {
 					Category: v1alpha2.TypeOperatorCatalog},
 			},
 			expectedFiles: []string{
-				"catalogSource-test-common-services.yaml",
+				"catalogSource-cs-test-common-services.yaml",
 			},
 		},
 	}
@@ -771,6 +771,30 @@ func TestCreateRFC1035NameForCatalogSource(t *testing.T) {
 			testName:  "bunch of dashes",
 			input:     "/////",
 			expected:  "cs-0", // ends in -0 suffix because string would end with dash, and this is not allowed
+			assertion: assert.NoError,
+		},
+		{
+			testName:  "very long path - exactly 62 characters with cs- prefix",
+			input:     "abcd/efgh/ijkl/mnop/qrst/uvwx/yzab/cdef/ghij/klmn/opqr/stuv",
+			expected:  "cs-abcd-efgh-ijkl-mnop-qrst-uvwx-yzab-cdef-ghij-klmn-opqr-stuv",
+			assertion: assert.NoError,
+		},
+		{
+			testName:  "very long path - exactly 63 characters with cs- prefix",
+			input:     "abcd/efgh/ijkl/mnop/qrst/uvwx/yzab/cdef/ghij/klmn/opqr/stuvw",
+			expected:  "cs-abcd-efgh-ijkl-mnop-qrst-uvwx-yzab-cdef-ghij-klmn-opqr-stuvw",
+			assertion: assert.NoError,
+		},
+		{
+			testName:  "very long path - longer than allowed 63 characters with cs- prefix results in no suffix",
+			input:     "abcd/efgh/ijkl/mnop/qrst/uvwx/yzab/cdef/ghij/klmn/opqr/stuvwx",
+			expected:  "cs-abcd-efgh-ijkl-mnop-qrst-uvwx-yzab-cdef-ghij-klmn-opqr-stuvw",
+			assertion: assert.NoError,
+		},
+		{
+			testName:  "very long path - longer than allowed 63 characters with cs- prefix results with suffix",
+			input:     "abcd/efgh/ijkl/mnop/qrst/uvwx/yzab/cdef/ghij/klmn/opqr/stuv/wxyz/abcd",
+			expected:  "cs-abcd-efgh-ijkl-mnop-qrst-uvwx-yzab-cdef-ghij-klmn-opqr-stu-0",
 			assertion: assert.NoError,
 		},
 	}


### PR DESCRIPTION
# Description

Create catalog source metadata.name values that are compliant with RFC 1035. The generated name is also suitable for naming the catalog source file as well.

Fixes # OCPBUGS-13332

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] run oc mirror

1. Copy single architecture catalog in OCI format
    ```
    skopeo --override-os linux copy --format v2s2 docker://icr.io/cpopen/ibm-zcon-zosconnect-catalog@sha256:6f02ecef46020bcd21bdd24a01f435023d5fc3943972ef0d9769d5276e178e76 oci:///tmp/611/oci-index
    ```
1. Create ISC in /tmp/611/oci-index/isc.yaml
    ```yaml
    kind: ImageSetConfiguration
    apiVersion: mirror.openshift.io/v1alpha2
    storageConfig:
      local:
        path: /tmp/localstorage
    mirror:
      operators:
      - catalog: oci:///tmp/611/oci-index
    ```
1. change current working directory to  "/tmp/611"
1. run oc mirror with destination as a local registry
    ```
    oc mirror --config /tmp/611/oci-index/isc.yaml docker://localhost:5000/single-oci --dest-skip-tls --dest-use-http --include-local-oci-catalogs
    ```
1. RESULT:
    - note that resulting name complies with RFC 1035 and is of the form `cs-<generated name>[-0]` where the generated name varies depending on the input provided in the ISC. The name starts with `cs-` to ensure that the name starts with a alpha character, and an optional suffix of `-0` is used only if the last character of the generated name ends with a non alphanumeric character. This `-0` suffix should rarely be necessary, but is provided in order to be compliant with RFC 1035. Note that the name is used in the catalog source metadata.name and as part of the file name.
        - Example file name 
          `/tmp/611/oc-mirror-workspace/results-1684276766/catalogSource-cs-611-oci-index.yaml`
        - Example catalog source:
          ```apiVersion: operators.coreos.com/v1alpha1
          kind: CatalogSource
          metadata:
            name: cs-611-oci-index
            namespace: openshift-marketplace
          spec:
            image: localhost:5000/multi-oci/tmp/611/oci-index:b2dd61
            sourceType: grpc
          ```

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules