### PR TITLE
OCPBUGS-13762: make addRelatedImageToMapping multithreaded

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require golang.org/x/sys v0.4.0 // indirect
 require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/otiai10/copy v1.2.0
+	golang.org/x/sync v0.1.0
 )
 
 require (
@@ -206,7 +207,6 @@ require (
 	golang.org/x/exp v0.0.0-20221002003631-540bb7301a08 // indirect
 	golang.org/x/net v0.5.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2 // indirect
-	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/term v0.4.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect

--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/containerd/containerd/errdefs"
@@ -27,6 +28,7 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/image/containerdregistry"
 	"github.com/otiai10/copy"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/klog/v2"
@@ -431,16 +433,38 @@ func (o *OperatorOptions) plan(ctx context.Context, dc *declcfg.DeclarativeConfi
 
 		// place related images into the workspace - aka mirrorToDisk
 		// TODO this should probably be done only if artifacts have not been copied
-		result := image.TypedImageMapping{}
+		var syncMapResult sync.Map
+		start := time.Now()
+		g, ctx := errgroup.WithContext(ctx)
 		// create mappings for the related images that will moved from the workspace to the final destination
 		for _, i := range relatedImages {
-			// intentionally removed the usernamespace from the call, because mirror.go is going to add it back!!
-			err := o.addRelatedImageToMapping(ctx, result, i, o.ToMirror, "")
-			if err != nil {
-				return nil, err
-			}
-
+			// avoid closure problems by making a copy of i
+			copyofI := i
+			g.Go(func() error {
+				// intentionally removed the usernamespace from the call, because mirror.go is going to add it back!!
+				err := o.addRelatedImageToMapping(ctx, &syncMapResult, copyofI, o.ToMirror, "")
+				if err != nil {
+					return err
+				}
+				return nil
+			})
 		}
+		// if error occurs in one of the go routines, get the first error and bail out
+		if err := g.Wait(); err != nil {
+			return nil, err
+		}
+		duration := time.Since(start)
+		klog.Infof("%d related images processed in %s", len(relatedImages), duration)
+
+		result := image.TypedImageMapping{}
+		syncMapResult.Range(func(key, value any) bool {
+			source := key.(image.TypedImage)
+			destination := value.(image.TypedImage)
+			result[source] = destination
+			// always continue iteration
+			return true
+		})
+
 		if err := o.writeMappingFile(mappingFile, result); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# Description

Currently execution of addRelatedImageToMapping when using `--oci-registries-config` flag explicitly or getting registries.conf from the environment is terribly slow and gets worse as the number of related images expands. This change makes this code multi threaded to improve performance. In my testing approximately 470 images took approximately 13 minutes. After the change it takes approximately 14 seconds.

- make execution of addRelatedImageToMapping multi threaded
- make addRelatedImageToMapping take a sync.Map to support concurrency
- convert sync.Map back to image.TypedImageMapping after processing
- fix bug so that we actually use the mirror value if we found one

Fixes # OCPBUGS-13762

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

1. Copy catalog image to disk in OCI layout
    ```
    mkdir -p /tmp/oci/registriesconf/performance
    skopeo --override-os linux copy docker://quay.io/jhunkins/ocp13762:v1 oci:///tmp/oci/registriesconf/performance --format v2s2
    ```
1. Create a ~/.config/containers/registries.conf file with this content:
    <details>
      <summary>Click me</summary>

    ```
    $ cat ~/.config/containers/registries.conf
    [[registry]]
    location = "icr.io/cpopen"
    insecure = false
    blocked = false
    mirror-by-digest-only = true
    prefix = ""
    [[registry.mirror]]
      location = "quay.io/jhunkins"
      insecure = false
    ```
    </details>
1. Create a ISC `[path to isc]/isc-registriesconf-performance.yaml`
    <details>
      <summary>Click me</summary>
  

    ```yaml
    kind: ImageSetConfiguration
    apiVersion: mirror.openshift.io/v1alpha2
    mirror:
      operators:
      - catalog: oci:///tmp/oci/registriesconf/performance
        full: true
        targetTag: latest
        targetCatalog: ibm-catalog
    storageConfig:
      local:
        path: /tmp/oc-mirror-temp

    ```
    <details>
1. run oc mirror with OCI flags (running with dry run is sufficient to replicate this issue)
    ```
    oc mirror --config [path to isc]/isc-registriesconf-performance.yaml --include-local-oci-catalogs --oci-insecure-signature-policy --dest-use-http docker://localhost:5000/oci --skip-cleanup --dry-run
    ```

Results:

output in log now says:

```
402 related images processed in 10.269692843s
```

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules