### PR TITLE
[release-4.12] OCPBUGS-14065: fix: Limit the nested repository path while mirroring the images

### DIFF
--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -73,8 +73,8 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.OCIFeatureAction, "oci-feature-action", o.OCIFeatureAction, "One of copy or mirror")
 	fs.StringVar(&o.OCIRegistriesConfig, "oci-registries-config", o.OCIRegistriesConfig, "Registries config file location (used only with --use-oci-feature flag)")
 	fs.BoolVar(&o.OCIInsecureSignaturePolicy, "oci-insecure-signature-policy", o.OCIInsecureSignaturePolicy, "If set, OCI catalog push will not try to push signatures")
-	fs.IntVar(&o.MaxNestedPaths, "max-nested-paths", 2, "Number of nested paths, for destination registries that limit nested paths")
 	fs.BoolVar(&o.SkipPruning, "skip-pruning", o.SkipPruning, "If set, will disable pruning globally")
+	fs.IntVar(&o.MaxNestedPaths, "max-nested-paths", 0, "Number of nested paths, for destination registries that limit nested paths")
 }
 
 func (o *MirrorOptions) init() {

--- a/pkg/image/mapping_test.go
+++ b/pkg/image/mapping_test.go
@@ -376,7 +376,7 @@ func TestWriteImageMapping(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			output := new(strings.Builder)
-			err := WriteImageMapping(test.mapping, output)
+			err := WriteImageMapping(0, test.mapping, output)
 			if test.err != "" {
 				require.EqualError(t, err, test.err)
 			} else {


### PR DESCRIPTION
# Description

This fix is based on the fix created for 4.13 but only with essentials changes needed for 4.12

Based on #623 and #634 

Fixes # ([OCPBUGS-14065](https://issues.redhat.com/browse/OCPBUGS-14065))

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update