### PR TITLE
OCPBUGS-14194: fix oc-mirror should check metadata sequence when --include-local-oci-catalogs is used

### DIFF
--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -646,12 +646,11 @@ func (o *MirrorOptions) mirrorToMirrorWrapper(ctx context.Context, cfg v1alpha2.
 	if err != nil {
 		return err
 	}
-	if !o.IncludeLocalOCICatalogs {
-		var curr v1alpha2.Metadata
-		berr := targetBackend.ReadMetadata(ctx, &curr, config.MetadataBasePath)
-		if err := o.checkSequence(meta, curr, berr); err != nil {
-			return err
-		}
+
+	var curr v1alpha2.Metadata
+	berr := targetBackend.ReadMetadata(ctx, &curr, config.MetadataBasePath)
+	if err := o.checkSequence(meta, curr, berr); err != nil {
+		return err
 	}
 
 	// Change the destination to registry


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules