### PR TITLE
[release-4.12] OCPBUGS-14065: Fix destination image reference

### DIFF
--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -682,7 +682,7 @@ func (o *MirrorOptions) mirrorMappings(cfg v1alpha2.ImageSetConfiguration, image
 
 		mappings = append(mappings, mirror.Mapping{
 			Source:      srcRef.TypedImageReference,
-			Destination: dstRef.TypedImageReference,
+			Destination: dstTIR,
 			Name:        srcRef.Ref.Name,
 		})
 	}

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -73,8 +73,8 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.OCIFeatureAction, "oci-feature-action", o.OCIFeatureAction, "One of copy or mirror")
 	fs.StringVar(&o.OCIRegistriesConfig, "oci-registries-config", o.OCIRegistriesConfig, "Registries config file location (used only with --use-oci-feature flag)")
 	fs.BoolVar(&o.OCIInsecureSignaturePolicy, "oci-insecure-signature-policy", o.OCIInsecureSignaturePolicy, "If set, OCI catalog push will not try to push signatures")
-	fs.IntVar(&o.MaxNestedPaths, "max-nested-paths", 2, "Number of nested paths, for destination registries that limit nested paths")
 	fs.BoolVar(&o.SkipPruning, "skip-pruning", o.SkipPruning, "If set, will disable pruning globally")
+	fs.IntVar(&o.MaxNestedPaths, "max-nested-paths", 0, "Number of nested paths, for destination registries that limit nested paths")
 }
 
 func (o *MirrorOptions) init() {

--- a/pkg/image/mapping_test.go
+++ b/pkg/image/mapping_test.go
@@ -376,7 +376,7 @@ func TestWriteImageMapping(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			output := new(strings.Builder)
-			err := WriteImageMapping(test.mapping, output)
+			err := WriteImageMapping(0, test.mapping, output)
 			if test.err != "" {
 				require.EqualError(t, err, test.err)
 			} else {


### PR DESCRIPTION
# Description

This is a fix for the change to --max-nested-paths implementation. The image reference was incorrect. This addresses the fix.

Fixes # OCPBUGS-14065

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally

ImageSetConfig 

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
storageConfig:
  local:
    path: ./oc-mirror-metadata
mirror:
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.12
    packages:
    - name: local-storage-operator
      channels:
      - name: stable
 ```

Cli

```
oc-mirror --config isc-ocpbugs-14065.yaml docker://localhost:5000/lmz-test --max-nested-paths=2 --dest-use-http
```

Results 
- mapping.txt

```
registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:116dbeb371324607d361d4f1a9daeb5890e44d29b96c9800b2b1d93d21635dec=localhost:5000/lmz-test/openshift4-ose-kube-rbac-proxy:ec31b7f8
registry.redhat.io/openshift4/ose-local-storage-diskmaker@sha256:398414dc2abad094c2e97a57514d69d5c80790510e19af105692f2864cc9c566=localhost:5000/lmz-test/openshift4-ose-local-storage-diskmaker:df3814e9
registry.redhat.io/openshift4/ose-local-storage-operator@sha256:5f01648146118a5c156733f174addf7f64b794b1edda8e237fb42cb353222102=localhost:5000/lmz-test/openshift4-ose-local-storage-operator:d7f3b07
registry.redhat.io/openshift4/ose-local-storage-operator-bundle@sha256:56386aaf90d66683b384a49b052f8b2ed7f969ef47d83b7e76badf2ddf5339e1=localhost:5000/lmz-test/openshift4-ose-local-storage-operator-bundle:3dbae7c1
registry.redhat.io/redhat/redhat-operator-index:v4.12=localhost:5000/lmz-test/redhat/redhat-operator-index:v4.12
```

- imageContentSourcePolicy,yaml

```
---
apiVersion: operator.openshift.io/v1alpha1
kind: ImageContentSourcePolicy
metadata:
  labels:
    operators.openshift.org/catalog: "true"
  name: operator-0
spec:
  repositoryDigestMirrors:
  - mirrors:
    - localhost:5000/lmz-test/openshift4-ose-local-storage-operator
    source: registry.redhat.io/openshift4/ose-local-storage-operator
  - mirrors:
    - localhost:5000/lmz-test/openshift4-ose-local-storage-operator-bundle
    source: registry.redhat.io/openshift4/ose-local-storage-operator-bundle
  - mirrors:
    - localhost:5000/lmz-test/redhat/redhat-operator-index
    source: registry.redhat.io/redhat/redhat-operator-index
  - mirrors:
    - localhost:5000/lmz-test/openshift4-ose-kube-rbac-proxy
    source: registry.redhat.io/openshift4/ose-kube-rbac-proxy
  - mirrors:
    - localhost:5000/lmz-test/openshift4-ose-local-storage-diskmaker
    source: registry.redhat.io/openshift4/ose-local-storage-diskmaker
```

- registry list (local docker registry server)
```
{
  "repositories": [
    "lmz-test/openshift4-ose-kube-rbac-proxy",
    "lmz-test/openshift4-ose-local-storage-diskmaker",
    "lmz-test/openshift4-ose-local-storage-operator",
    "lmz-test/openshift4-ose-local-storage-operator-bundle",
    "lmz-test/redhat/redhat-operator-index"
  ]
}

```

As can be seen with max nested paths the change is:

lmz-test/openshift4/ose-local-storage... => lmz-test/openshift4-ose-local-storage...

(slash "/" gets converted to "-" after namespace "lmz-test")



# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules