### PR TITLE
OCPBUGS-14402: fix

### DIFF
--- a/pkg/cli/mirror/fbc_operators.go
+++ b/pkg/cli/mirror/fbc_operators.go
@@ -86,7 +86,7 @@ func (o *MirrorOptions) generateSrcToFileMapping(ctx context.Context, relatedIma
 		}
 		reg, err := sysregistriesv2.FindRegistry(newSystemContext(o.SourceSkipTLS, o.OCIRegistriesConfig), i.Image)
 		if err != nil {
-			klog.Warningf("Cannot find registry for %s", i.Image)
+			klog.Warningf("Cannot find registry for %s: %v", i.Image, err)
 		}
 		if reg != nil && len(reg.Mirrors) > 0 {
 			// i.Image is coming from a declarativeConfig (ClusterServiceVersion) it's therefore always a docker ref

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -624,6 +624,7 @@ func (o *MirrorOptions) writeMappingFile(mappingPath string, mapping image.Typed
 
 func (o *MirrorOptions) mirrorToMirrorWrapper(ctx context.Context, cfg v1alpha2.ImageSetConfiguration, cleanup cleanupFunc) error {
 	destInsecure := o.DestPlainHTTP || o.DestSkipTLS
+	srcInsecure := o.SourcePlainHTTP || o.SourceSkipTLS
 
 	mappingPath := filepath.Join(o.Dir, mappingFile)
 
@@ -670,7 +671,7 @@ func (o *MirrorOptions) mirrorToMirrorWrapper(ctx context.Context, cfg v1alpha2.
 
 	// QUESTION(jpower432): Can you specify different TLS configuration for source
 	// and destination with `oc image mirror`?
-	if err := o.mirrorMappings(cfg, mapping, destInsecure); err != nil {
+	if err := o.mirrorMappings(cfg, mapping, destInsecure || srcInsecure); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
# Description

When calling oc to mirror the contents of mappings.txt, ImageMirrorOptions is constructed: SecurityOptions rely now both on --source-skip-tls || --source-use-http || --dest-skip-tls || --dest-use-http



Fixes # OCPBUGS-14402

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

E2E tests and unit tests pass

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules