### PR TITLE
OCPBUGS-13871: fix: changes on help info content

### DIFF
--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -70,7 +70,7 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&o.MaxPerRegistry, "max-per-registry", 6, "Number of concurrent requests allowed per registry")
 	fs.BoolVar(&o.IncludeLocalOCICatalogs, "use-oci-feature", o.IncludeLocalOCICatalogs, "Deprecated, use --include-local-oci-catalog instead")
 	fs.BoolVar(&o.IncludeLocalOCICatalogs, "include-local-oci-catalogs", o.IncludeLocalOCICatalogs, "If set, enables including local OCI-formatted catalogs (prefix oci://) in the list of operator catalogs defined in ImageSetConfig, so that these local catalogs are mirrored from the disk directly")
-	fs.StringVar(&o.OCIRegistriesConfig, "oci-registries-config", o.OCIRegistriesConfig, "Registries config file location (used only with --use-oci-feature flag)")
+	fs.StringVar(&o.OCIRegistriesConfig, "oci-registries-config", o.OCIRegistriesConfig, "Registries config file location (used only with --include-local-oci-catalog flag)")
 	fs.BoolVar(&o.OCIInsecureSignaturePolicy, "oci-insecure-signature-policy", o.OCIInsecureSignaturePolicy, "If set, OCI catalog push will not try to push signatures")
 	fs.BoolVar(&o.SkipPruning, "skip-pruning", o.SkipPruning, "If set, will disable pruning globally")
 	fs.MarkDeprecated("use-oci-feature", "Use --include-local-oci-catalogs instead")


### PR DESCRIPTION
# Description

--help info was saying to use --oci-registries-config flag only with --use-oci-feature flag. As --use-oci-feature is deprecated this help info was wrong and it was changed with a correct message.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```oc-mirror --help```

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules