### PR TITLE
MIXEDARCH-265: Enable mirroring of the multi release image

### DIFF
--- a/docs/design/imageset-configuration.md
+++ b/docs/design/imageset-configuration.md
@@ -4,6 +4,7 @@ Design: oc-mirror Imageset Configuration
 - [Design: oc-mirror Imageset Configuration](#design-oc-mirror-imageset-configuration)
 - [Content Types](#content-types)
   - [Platforms](#platforms)
+    - [Architectures](#architectures)
   - [Operators](#operators)
   - [Additional Images](#additional-images)
   - [Helm Chart](#helm-chart)
@@ -19,6 +20,10 @@ Design: oc-mirror Imageset Configuration
 Release channels for container management platforms can be specified for mirroring. 
 Currently, OpenShift Container Platform is supported by all `oc-mirror` commands.
 OKD is a supported type in the imageset configuration, but not by the `oc-mirror` list commands.
+
+### Architectures
+
+This is the list of release payload architectures that will be mirrored. An empty value will default to `amd64`. Additional supported values are: `arm64`, `ppc64le`, `s390x`, and `multi`. Note, `multi` is a [schema2](https://github.com/opencontainers/image-spec/blob/main/image-index.md#example-image-index) (aka "fat" manifest) list of all 4 architectures. Therefore it will use ~4x more registry space than a single architecure release.
 
 ## Operators
 

--- a/docs/examples/imageset-config-release-alt-arch.yaml
+++ b/docs/examples/imageset-config-release-alt-arch.yaml
@@ -6,7 +6,7 @@ kind: ImageSetConfiguration
 mirror:
   platform:
     architectures:
-      - "s390x"
+      - "s390x" # Valid values are: amd64(default), arm64, ppc64le, s390x and multi.
     channels:
       - name: stable-4.9
         minVersion: 4.9.13

--- a/docs/imageset-config-ref.yaml
+++ b/docs/imageset-config-ref.yaml
@@ -7,7 +7,7 @@ storageConfig:
 mirror:
   platform:
     architectures:
-      - "s390x" # Architectures to mirror for the collection of release versions (defaults to amd64)
+      - "s390x" # Architectures to mirror for the collection of release versions. Valid values are: amd64(default), arm64, ppc64le, s390x and multi.
     channels:
       - name: stable-4.9 # References the latest stable release
       - name: stable-4.7 # Annotation references min and max version. 

--- a/pkg/cli/mirror/list/releases.go
+++ b/pkg/cli/mirror/list/releases.go
@@ -55,6 +55,9 @@ func NewReleasesCommand(f kcmdutil.Factory, ro *cli.RootOptions) *cobra.Command 
 
 			# List all OpenShift channels for a specific version
 			oc-mirror list releases --channels --version=4.8
+
+			# List OpenShift channels for a specific version and one or more release architecture. Valid architectures: amd64 (default), arm64, ppc64le, s390x, multi.
+			oc-mirror list releases --channels --version=4.13 --filter-by-archs amd64,arm64,ppc64le,s390x,multi
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete())

--- a/pkg/cli/mirror/release.go
+++ b/pkg/cli/mirror/release.go
@@ -365,6 +365,7 @@ func (o *ReleaseOptions) getMapping(opts *release.MirrorOptions) (image.TypedIma
 
 	opts.IOStreams.Out = file
 	opts.ToMirror = true
+	opts.KeepManifestList = true
 	if err := opts.Validate(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

Enable mirroring the 'multi' release payload.


## Type of change


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Passed Local tests

- [x]  make test-unit
- [x]  make test-e2e

Verified that I could mirror multi and single arch payloads to quay.io:

`./bin/oc-mirror --config mirror.yaml docker://quay.io/jeffdyoung`

mirror.yaml:
```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
storageConfig: 
 registry:
   imageURL: quay.io/jeffdyoung/oc-mirror
mirror:
  platform:
    architectures:
      - "multi"
      - "arm64"
      - "amd64"
    channels:
    - name: stable-4.13
      type: ocp
    - name: fast-4.13
      type: ocp
```
