### PR TITLE
OCPBUGS-15329: Fix " OCI index found, but accept header does not suppo…"

### DIFF
--- a/pkg/image/association_builder.go
+++ b/pkg/image/association_builder.go
@@ -343,4 +343,5 @@ var preferManifestList = distribution.WithManifestMediaTypes([]string{
 	manifestlist.MediaTypeManifestList,
 	schema2.MediaTypeManifest,
 	imgspecv1.MediaTypeImageManifest,
+	imgspecv1.MediaTypeImageIndex,
 })


### PR DESCRIPTION
…rt OCI indexes

# Description

Mirroring using the following imageSetConfig results in an error:

```bash
oc-mirror --config certified-operator-index-imageset-conf-v4.12.yaml file://tmp/operator/
```
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
storageConfig:
  local:
    path: /tmp/mirror
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/certified-operator-index:v4.12
      targetName: certified-operator-index-06-20-2023-00-00-00
      packages:
        - name: kubeturbo-certified
          channels:
            - name: 'stable'
              maxVersion: '8.9.2'
              minVersion: '8.9.2'
```
Error message:
```
error: unable to retrieve source image icr.io/cpopen/kubeturbo-operator manifest sha256:cc6499b8c5c7a3dfd829d75d7bc73fca6c467bfb5e3235e62018e7ef18220a21: unknown: OCI index found, but accept header does not support OCI indexes
error: an error occurred during planning
```
Fixes OCPBUGS-15329


## Type of change

The fix consists of accepting OCI indexes  while building mirroring metadata and creating layer associations....



- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

End to End manual test using the imageSetConfig provided above.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules