### PR TITLE
WIP: Unlock MirrorToDisk workflow for local oci catalogs

### DIFF
--- a/pkg/cli/mirror/fbc_operators.go
+++ b/pkg/cli/mirror/fbc_operators.go
@@ -175,7 +175,7 @@ func (o *MirrorOptions) addRelatedImageToMapping(ctx context.Context, mapping *s
 	}
 
 	// TODO : why file:// ? can we be more smart about setting the transport protocol
-	srcTIR, err := image.ParseReference(filePrefix + strings.ToLower(from))
+	srcTIR, err := image.ParseReference(strings.ToLower(from))
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -257,15 +257,15 @@ func (o *MirrorOptions) Validate() error {
 	mirrorToMirror := len(o.ToMirror) > 0 && len(o.ConfigPath) > 0
 
 	// mirrorToDisk workflow is not supported with the oci feature
-	if o.IncludeLocalOCICatalogs && mirrorToDisk {
-		return fmt.Errorf("oci feature cannot be used when mirroring to local archive")
-	}
+	// if o.IncludeLocalOCICatalogs && mirrorToDisk {
+	// 	return fmt.Errorf("oci feature cannot be used when mirroring to local archive")
+	// }
 	// diskToMirror workflow is not supported with the oci feature
 	if o.IncludeLocalOCICatalogs && diskToMirror {
 		return fmt.Errorf("oci feature cannot be used when publishing from a local archive to a registry")
 	}
 	// mirrorToMirror workflow using the oci feature must have at least on operator set with oci:// prefix
-	if mirrorToMirror {
+	if mirrorToMirror || mirrorToDisk {
 		bIsFBOCI := false
 		cfg, err := config.ReadConfig(o.ConfigPath)
 		if err != nil {
@@ -274,6 +274,7 @@ func (o *MirrorOptions) Validate() error {
 		for _, op := range cfg.Mirror.Operators {
 			if op.IsFBCOCI() {
 				bIsFBOCI = true
+				break
 			}
 		}
 		if o.IncludeLocalOCICatalogs && !bIsFBOCI {

--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -528,13 +528,20 @@ func (o *OperatorOptions) plan(ctx context.Context, dc *declcfg.DeclarativeConfi
 		var syncMapResult sync.Map
 		start := time.Now()
 		g, ctx := errgroup.WithContext(ctx)
+		destReg := o.ToMirror
+		mirrorToDisk := len(o.OutputDir) > 0 && o.From == ""
+		mirrorToMirror := len(o.ToMirror) > 0 && len(o.ConfigPath) > 0
+		if mirrorToDisk && !mirrorToMirror {
+			destReg = "file://redhat/redhat-operator-index"
+		}
+
 		// create mappings for the related images that will moved from the workspace to the final destination
 		for _, i := range relatedImages {
 			// avoid closure problems by making a copy of i
 			copyofI := i
 			g.Go(func() error {
 				// intentionally removed the usernamespace from the call, because mirror.go is going to add it back!!
-				err := o.addRelatedImageToMapping(ctx, &syncMapResult, copyofI, o.ToMirror, "")
+				err := o.addRelatedImageToMapping(ctx, &syncMapResult, copyofI, destReg, "")
 				if err != nil {
 					return err
 				}

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -37,6 +37,9 @@ func (t TypedImageReference) String() string {
 	case DestinationOCI:
 		return fmt.Sprintf("oci://%s", t.Ref.Exact())
 	default:
+		if len(t.Ref.Namespace) == 0 && libgoref.IsRegistryDockerHub(t.Ref.Registry) {
+			t.Ref.Namespace = "library"
+		}
 		return t.Ref.Exact()
 	}
 }

--- a/pkg/image/mapping.go
+++ b/pkg/image/mapping.go
@@ -163,20 +163,17 @@ func ReadImageMapping(mappingsPath, separator string, typ v1alpha2.ImageType) (T
 // WriteImageMapping writes key map k/v to an io.Writer.
 func WriteImageMapping(nestedPaths int, m TypedImageMapping, output io.Writer) error {
 	var strFrom, strTo string
-	for fromStr, toStr := range m {
+	for fromImage, toImage := range m {
 		// Prefer tag over id for mapping file for
 		// compatability with `oc image mirror`.
-		if toStr.Ref.Tag != "" {
-			toStr.Ref.ID = ""
+		if toImage.Ref.Tag != "" {
+			toImage.Ref.ID = ""
 		}
 		// OCPBUGS-11922
-		if nestedPaths > 0 {
-			strFrom = fromStr.Ref.String()
-			strTo = toStr.Ref.String()
-		} else {
-			strFrom = fromStr.Ref.Exact()
-			strTo = toStr.Ref.Exact()
-		}
+
+		strFrom = fromImage.String()
+		strTo = toImage.String()
+
 		_, err := output.Write([]byte(fmt.Sprintf("%s=%s\n", strFrom, strTo)))
 		if err != nil {
 			return err


### PR DESCRIPTION
modified:   pkg/cli/mirror/fbc_operators.go
            Removes the use of `file://` for source references of related images
modified:   pkg/cli/mirror/mirror.go

modified:   pkg/cli/mirror/operator.go
            Set the destinationRef to file:// (static for now) when calling addRelatedImageToMapping for MirrorToDisk use case
modified:   pkg/image/image.go
            Add logic from DockerImageReference.String (adding `library` as namespace when registry is docker default) to TypedImageReference.String()
modified:   pkg/image/mapping.go
            WriteImageMapping modified in order to use TypedImage.String instead of TypedImage.Ref.String so that the DestinationType while rendering the string

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules