### PR TITLE
OCPBUGS-13871 docs: changes the help message for oci-registries-config flag

### DIFF
--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -34,7 +34,7 @@ type MirrorOptions struct {
 	ContinueOnError            bool   // If an error occurs, keep going and attempt to complete operations if possible
 	IgnoreHistory              bool   // Ignore past mirrors when downloading images and packing layers
 	MaxPerRegistry             int    // Number of concurrent requests allowed per registry
-	OCIRegistriesConfig        string // Registries config file location (used only with --use-oci-feature flag)
+	OCIRegistriesConfig        string // Registries config file location (it works only with local oci catalogs)
 	OCIInsecureSignaturePolicy bool   // If set, OCI catalog push will not try to push signatures
 	MaxNestedPaths             int
 	// cancelCh is a channel listening for command cancellations
@@ -68,7 +68,7 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 		"404/NotFound errors encountered while pulling images explicitly specified in the config "+
 		"will not be skipped")
 	fs.IntVar(&o.MaxPerRegistry, "max-per-registry", 6, "Number of concurrent requests allowed per registry")
-	fs.StringVar(&o.OCIRegistriesConfig, "oci-registries-config", o.OCIRegistriesConfig, "Registries config file location (used only with --include-local-oci-catalog flag)")
+	fs.StringVar(&o.OCIRegistriesConfig, "oci-registries-config", o.OCIRegistriesConfig, "Registries config file location (it works only with local oci catalogs)")
 	fs.BoolVar(&o.OCIInsecureSignaturePolicy, "oci-insecure-signature-policy", o.OCIInsecureSignaturePolicy, "If set, OCI catalog push will not try to push signatures")
 	fs.BoolVar(&o.SkipPruning, "skip-pruning", o.SkipPruning, "If set, will disable pruning globally")
 	fs.IntVar(&o.MaxNestedPaths, "max-nested-paths", 0, "Number of nested paths, for destination registries that limit nested paths")


### PR DESCRIPTION
# Description

It changes the help message since --include-local-oci-catalog is being removed on 4.14

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

```oc-mirror --help```

```--oci-registries-config string    Registries config file location (it works only with local oci catalogs)```