### PR TITLE
CFE-905: Make local storage port configurable via command line

### DIFF
--- a/v2/pkg/mirror/options.go
+++ b/v2/pkg/mirror/options.go
@@ -463,6 +463,7 @@ type GlobalOptions struct {
 	TmpDir             string        // Path to use for big temporary files
 	Dir                string        // working directory
 	From               string        // local storage for diskToMirror workflow
+	Port               uint16        // HTTP port used by oc-mirror's local storage instance
 	ConfigPath         string        // Path to use for imagesetconfig
 	ReleaseFrom        string        // Used for release mirroring (diskToMirror)
 	OperatorsFrom      string        // Used for operators mirroring (diskToMirror)


### PR DESCRIPTION
# Description

Introducing the `-p` flag for the v2 mirroring command. 
`-p` or `--port` enables a user to specify the port that could be used by v2/oc-mirror for the local storage registry instance. 

Fixes # [CFE-905](https://issues.redhat.com/browse/CFE-905)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Nominal case
```bash
build/mirror --config isc.yaml file:///tmp/storage
```
- [x] Net bind error case (port is not allowed to be used)
```bash
build/mirror --config isc.yaml -p 22 file:///tmp/storage
```

**Test Configuration**:
* ImageSetConfig
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  additionalImages: 
    - name: registry.redhat.io/ubi8/ubi:latest  
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules