### PR TITLE
OCPBUGS-17545: Improve extracting opm binary from catalogs

### DIFF
--- a/pkg/cli/mirror/util.go
+++ b/pkg/cli/mirror/util.go
@@ -10,11 +10,13 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"k8s.io/klog/v2"
 )
@@ -30,10 +32,15 @@ func getRemoteOpts(ctx context.Context, insecure bool) []remote.Option {
 }
 
 func getCraneOpts(ctx context.Context, insecure bool) []crane.Option {
+	currentPlatform := v1.Platform{
+		Architecture: runtime.GOARCH,
+		OS:           runtime.GOOS,
+	}
 	opts := []crane.Option{
 		crane.WithAuthFromKeychain(authn.DefaultKeychain),
 		crane.WithTransport(createRT(insecure)),
 		crane.WithContext(ctx),
+		crane.WithPlatform(&currentPlatform),
 	}
 	if insecure {
 		opts = append(opts, crane.Insecure)

--- a/pkg/config/metadata.go
+++ b/pkg/config/metadata.go
@@ -101,6 +101,9 @@ const (
 	// OpmBinDir is the location of the
 	// catalog opm binary
 	OpmBinDir = "bin"
+	// OpmBinDir is the location to which catalog
+	// contents are extracted to get the opm binary
+	CtlgExtractionDir = "extracted"
 	// IncludeConfigFile is the file where
 	// catalog include config data for incorporation
 	// into the metadata is located.


### PR DESCRIPTION
# Description

This PR improves the way the opm binary is extracted from catalogs by leveraging the ENTRYPOINT from the container image config.
It also forces pulling the container image that matches the runtime architecture and OS.

Fixes # OCPBUGS-17545

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This was tested both on amd64 and arm64 OSs with:
```bash
 ./bin/oc-mirror -c iscv2.yaml docker://localhost:5000/aws --dest-use-http --dest-skip-tls
```
and the following config:
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  # additionalImages: 
  #   - name: registry.redhat.io/ubi8/ubi:latest  
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.13
      packages:
      - name: node-observability-operator
      # - name: aws-load-balancer-operator  
      # - name: 3scale-operator
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules