### PR TITLE
OCPBUGS-17714: Ensure errors are nil before closing registry to avoid…

### DIFF
--- a/pkg/cli/mirror/fbc_operators.go
+++ b/pkg/cli/mirror/fbc_operators.go
@@ -445,7 +445,7 @@ func findFirstAvailableMirror(ctx context.Context, mirrors []sysregistriesv2.End
 		}
 		imgsrc, err := regFuncs.newImageSource(ctx, nil, imgRef)
 		defer func() {
-			if imgsrc != nil && err == nil && finalError == nil {
+			if imgsrc != nil && err == nil {
 				err = imgsrc.Close()
 				if err != nil {
 					klog.V(3).Infof("%s is not closed", imgsrc)

--- a/pkg/cli/mirror/fbc_operators.go
+++ b/pkg/cli/mirror/fbc_operators.go
@@ -445,7 +445,7 @@ func findFirstAvailableMirror(ctx context.Context, mirrors []sysregistriesv2.End
 		}
 		imgsrc, err := regFuncs.newImageSource(ctx, nil, imgRef)
 		defer func() {
-			if imgsrc != nil {
+			if imgsrc != nil && err == nil && finalError == nil {
 				err = imgsrc.Close()
 				if err != nil {
 					klog.V(3).Infof("%s is not closed", imgsrc)


### PR DESCRIPTION
… panic

This fix ensures errors are nil before trying to close the registry, this will avoid a panic

Fixes # OCPBUGS-17714

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Verified locally with the following registries.config and Image Set Config

```[[registry]]
  location = "registry.redhat.io"
  insecure = false
  blocked = false
  mirror-by-digest-only = false
  prefix = ""
  [[registry.mirror]]
    location = "localhost:5000"
    insecure = true

```

Image Set Config

```apiVersion: mirror.openshift.io/v1alpha2
kind: ImageSetConfiguration
mirror:
  operators:
    - catalog: oci://ocpbugs-17714
      packages:
      - name: aws-load-balancer-operator

```


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules