### PR TITLE
OCPBUGS-17998: fix: ICSP with incorrect mirror path

### DIFF
--- a/pkg/cli/mirror/manifests.go
+++ b/pkg/cli/mirror/manifests.go
@@ -15,7 +15,6 @@ import (
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	cincinnativ1 "github.com/openshift/cincinnati-operator/api/v1"
 	"github.com/openshift/library-go/pkg/image/reference"
-	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
 	"github.com/openshift/oc-mirror/pkg/image"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -184,8 +183,7 @@ func getRegistryMapping(icspScope string, mapping image.TypedImageMapping) (map[
 			registryMapping[k.Ref.AsRepository().String()] = v.Ref.AsRepository().String()
 		case icspScope == namespaceICSPScope:
 			source := path.Join(imgRegistry, imgNamespace)
-			reg, org, _, _, _ := v1alpha2.ParseImageReference(v.Ref.AsRepository().Exact())
-			dest := path.Join(reg, org)
+			dest := path.Join(v.Ref.Registry, v.Ref.Namespace)
 			registryMapping[source] = dest
 		default:
 			return registryMapping, fmt.Errorf("invalid ICSP scope %s", icspScope)


### PR DESCRIPTION
# Description

The generated ICSP was 

Fixes OCPBUGS-17998

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


Test 1

Commands used:

//mirrorToDisk workflow
```
./bin/oc-mirror -c ./ocpbugs/ocpbugs-17998.yaml file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/nvidia
```

//diskToMirror workflow
```
./bin/oc-mirror --from ./nvidia docker://localhost:6000 --dest-skip-tls --dest-use-http
```

ISC used:
```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
archiveSize: 4
storageConfig:
  local:
    path: /home/aguidi/go/src/github.com/aguidirh/oc-mirror/nvidiastorage
mirror:
  operators:
  - catalog: registry.redhat.io/redhat/certified-operator-index:v4.11
    packages:
    - name: nvidia-network-operator
```
ICSP generated:
```
apiVersion: operator.openshift.io/v1alpha1
kind: ImageContentSourcePolicy
metadata:
  labels:
    operators.openshift.org/catalog: "true"
  name: operator-0
spec:
  repositoryDigestMirrors:
  - mirrors:
    - localhost:6000/nvidia-network-operator
    source: registry.connect.redhat.com/nvidia-network-operator
  - mirrors:
    - localhost:6000/nvidia
    source: nvcr.io/nvidia
  - mirrors:
    - localhost:6000/k8snetworkplumbingwg
    source: ghcr.io/k8snetworkplumbingwg
  - mirrors:
    - localhost:6000/kubebuilder
    source: gcr.io/kubebuilder
```
Local registry after mirroring:
```
{
  "repositories": [
    "k8snetworkplumbingwg/sriov-network-device-plugin",
    "kubebuilder/kube-rbac-proxy",
    "nvidia/cloud-native/k8s-rdma-shared-dev-plugin",
    "nvidia/cloud-native/network-operator",
    "nvidia/mellanox/mofed",
    "nvidia-network-operator/nvidia-network-operator",
    "oc-mirror",
    "redhat/certified-operator-index"
  ]
}
```


=========================================================

Test 2

Commands used:

//mirrorToDisk workflow
```
./bin/oc-mirror -c ./ocpbugs/ocpbugs-17998.yaml file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/nvidia 
```
//diskToMirror workflow
```
./bin/oc-mirror --from ./nvidia docker://localhost:6000 --dest-skip-tls --dest-use-http
```

ISC used:
```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
archiveSize: 4
storageConfig:
  local:
    path: /home/aguidi/go/src/github.com/aguidirh/oc-mirror/nvidiastorage
mirror:
  operators:
  - catalog: registry.redhat.io/redhat/certified-operator-index:v4.11
    targetCatalog: my-nvidia-namespace/nvidia
    packages:
    - name: nvidia-network-operator
```
ISCP generated:
```
apiVersion: operator.openshift.io/v1alpha1
kind: ImageContentSourcePolicy
metadata:
  labels:
    operators.openshift.org/catalog: "true"
  name: operator-0
spec:
  repositoryDigestMirrors:
  - mirrors:
    - localhost:6000/nvidia
    source: nvcr.io/nvidia
  - mirrors:
    - localhost:6000/kubebuilder
    source: gcr.io/kubebuilder
  - mirrors:
    - localhost:6000/nvidia-network-operator
    source: registry.connect.redhat.com/nvidia-network-operator
  - mirrors:
    - localhost:6000/k8snetworkplumbingwg
    source: ghcr.io/k8snetworkplumbingwg
```
Local registry after mirroring:
```
{
  "repositories": [
    "k8snetworkplumbingwg/sriov-network-device-plugin",
    "kubebuilder/kube-rbac-proxy",
    "my-nvidia-namespace/nvidia",
    "nvidia/cloud-native/k8s-rdma-shared-dev-plugin",
    "nvidia/cloud-native/network-operator",
    "nvidia/mellanox/mofed",
    "nvidia-network-operator/nvidia-network-operator",
    "oc-mirror"
  ]
}
```
=========================================================

Test 3

Command used:
```
./bin/oc-mirror --config isx_nvidia.yaml docker://localhost:5000/a --dest-skip-tls --dest-use-http
```
ISC used:
```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2

mirror:
  operators:
  #- catalog: registry.redhat.io/redhat/certified-operator-index:v4.11
  - catalog: oci:///home/skhoury/coi411
    packages:
    - name: nvidia-network-operator
```
ICSP generated:
```
apiVersion: operator.openshift.io/v1alpha1
kind: ImageContentSourcePolicy
metadata:
  labels:
    operators.openshift.org/catalog: "true"
  name: operator-0
spec:
  repositoryDigestMirrors:
  - mirrors:
    - localhost:5000/a/nvidia
    source: nvcr.io/nvidia
  - mirrors:
    - localhost:5000/a/nvidia-network-operator
    source: registry.connect.redhat.com/nvidia-network-operator
  - mirrors:
    - localhost:5000/a/k8snetworkplumbingwg
    source: ghcr.io/k8snetworkplumbingwg
  - mirrors:
    - localhost:5000/a/kubebuilder
    source: gcr.io/kubebuilder
```
=========================================================

Test 4

Command used:
```
./bin/oc-mirror --config isx_nvidia.yaml docker://localhost:5000/b --dest-skip-tls --dest-use-http
```
ISC used:
```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2

mirror:
  operators:
  #- catalog: registry.redhat.io/redhat/certified-operator-index:v4.11
  - catalog: oci:///home/skhoury/coi411
    targetCatalog: b/rh/certified-operator-index:v4.11
    packages:
    - name: nvidia-network-operator
```
ISCP generated:
```
apiVersion: operator.openshift.io/v1alpha1
kind: ImageContentSourcePolicy
metadata:
  labels:
    operators.openshift.org/catalog: "true"
  name: operator-0
spec:
  repositoryDigestMirrors:
  - mirrors:
    - localhost:5000/b/nvidia
    source: nvcr.io/nvidia
  - mirrors:
    - localhost:5000/b/nvidia-network-operator
    source: registry.connect.redhat.com/nvidia-network-operator
  - mirrors:
    - localhost:5000/b/kubebuilder
    source: gcr.io/kubebuilder
  - mirrors:
    - localhost:5000/b/k8snetworkplumbingwg
    source: ghcr.io/k8snetworkplumbingwg
```
**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules