### PR TITLE
Update list updates CLI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ If a user does not desire content removal from a mirror registry, they can eithe
     ```
 - List updates since last run for releases and operators
   ```sh
-  ./bin/oc-mirror list updates --config imageset-config.yaml
+  ./bin/oc-mirror list updates imageset-config.yaml
   ```
 For configuration and options, see the [expanded overview](./docs/overview.md) and [usage](./docs/usage.md) docs.
 


### PR DESCRIPTION
# Description

As of now, the CLI command `list updates` doesn't take a `--config` argument, but rather use the mirror-config file as a positional argument.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] Documentation update :wink: 