### PR TITLE
OCPBUGS-17546: pod catalogsource generated by oc-mirror will crashloopBackOff randomly

### DIFF
--- a/pkg/image/builder/image_builder.go
+++ b/pkg/image/builder/image_builder.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -361,7 +362,7 @@ func LayerFromPathWithUidGid(targetPath, path string, uid int, gid int) (v1.Laye
 		if !info.IsDir() {
 			hdr.Size = info.Size()
 		}
-
+		hdr.ChangeTime = time.Now()
 		if info.Mode().IsDir() {
 			hdr.Typeflag = tar.TypeDir
 		} else if info.Mode().IsRegular() {

--- a/test/e2e/lib/check.sh
+++ b/test/e2e/lib/check.sh
@@ -26,9 +26,9 @@ function check_bundles() {
   mv index.json $index_dir
 
   # extract the cache from the tar file
-  local cache_dir="${extraction_dir}/tmp/cache"
-  tar xvf $extraction_dir/temp.tar /tmp
-  mv tmp "${extraction_dir}"
+  local cache_dir="${extraction_dir}/cache"
+  tar xvf $extraction_dir/temp.tar /cache
+  mv cache "${extraction_dir}"
 
   # extract the opm binary from the tar file
   local opm_path="${extraction_dir}/opm"


### PR DESCRIPTION
# Description

This PR fixes [OCPBUGS-17546](https://issues.redhat.com/browse/OCPBUGS-17546) by:
* Avoiding the whiteout of /tmp
   * Replacing it by .wh.tmp/cache still failed on the cluster
* Creating a new layer with /cache folder, containing the cache
* Building layer for /configs based on the folder containing the fbc json instead of the fbc json file only

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

* E2E tests pass
* Run oc-mirror with the following command
```
$ ./bin/oc-mirror -c ~/oc-mirror-tests11/isc.yaml docker://localhost:5000/tests13 --dest-skip-tls --dest-use-http
```
  * where isc.yaml is:
```
apiVersion: mirror.openshift.io/v1alpha2
kind: ImageSetConfiguration
storageConfig:
  local:
    path: /home/skhoury/oc-mirror-tests13/oc-mirror-metadata
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.13
      packages:
        - name: advanced-cluster-management
        - name: ptp-operator
        - name: redhat-oadp-operator
```
* Copy this image to quay.io
```
skopeo copy docker://localhost:5000/tests13/redhat/redhat-operator-index:v4.13 docker://quay.io/skhoury/redhat-operator-index:v4.1313 --src-tls-verify=false
```
* Modify the catalogsource to point to the public (quay.io) image
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: cs-redhat-operator-index13
  namespace: openshift-marketplace
spec:
  image: quay.io/skhoury/redhat-operator-index:v4.1313
  sourceType: grpc
```
* On a cluster, deploy the catalogsource
```
$ oc create -f catalogsource.yaml
```
* The pod should run
```
$ oc get pods -n openshift-marketplace
NAME                                   READY   STATUS             RESTARTS       AGE
cs-redhat-operator-index13-m5mnz       1/1     Running            0              59m

```
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules