### PR TITLE
CFE-899,CFE-958: feat: removes the registry dns

### DIFF
--- a/v2/pkg/operator/local_stored_collector.go
+++ b/v2/pkg/operator/local_stored_collector.go
@@ -182,36 +182,28 @@ func (o *LocalStorageCollector) prepareD2MCopyBatch(log clog.PluggableLoggerInte
 	var result []v1alpha3.CopyImageSchema
 	for _, relatedImgs := range images {
 		for _, img := range relatedImgs {
-			// TODO Make this more complete
-			// This logic will be useful for operators and releases
-			// strip the domain name from the img.Name
 			var src string
 			var dest string
 
-			domainAndPathComps := img.Image
-			// pathComponents := img.Name
-			// temporarily strip out the transport
-			transportAndRef := strings.Split(domainAndPathComps, "://")
+			imgRef := img.Image
+			transportAndRef := strings.Split(imgRef, "://")
 			if len(transportAndRef) > 1 {
-				domainAndPathComps = transportAndRef[1]
+				imgRef = transportAndRef[1]
 			}
-			src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, img.Image}, "/")
 
-			if isImageByDigest(img.Image) {
-				dest = strings.Join([]string{o.Opts.Destination, imageName(img.Image) + ":" + imageHash(img.Image)[:hashTruncLen]}, "/")
+			pathWithoutDNS, err := pathWithoutDNS(imgRef)
+			if err != nil {
+				o.Log.Error("%s", err.Error())
+				return nil, err
+			}
+
+			if isImageByDigest(imgRef) {
+				src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, pathWithoutDNS + ":" + imageHash(imgRef)[:hashTruncLen]}, "/")
+				dest = strings.Join([]string{o.Opts.Destination, pathWithoutDNS + ":" + imageHash(imgRef)[:hashTruncLen]}, "/")
 			} else {
-				dest = strings.Join([]string{o.Opts.Destination, img.Image}, "/")
+				src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, pathWithoutDNS}, "/")
+				dest = strings.Join([]string{o.Opts.Destination, pathWithoutDNS}, "/")
 			}
-
-			// the following is for having the destination without the initial domain name => later
-			// domainAndPathCompsArray := strings.Split(domainAndPathComps, "/")
-			// if len(domainAndPathCompsArray) > 2 {
-			// 	pathComponents = strings.Join(domainAndPathCompsArray[1:], "/")
-			// } else {
-			// 	return allImages, fmt.Errorf("unable to parse image %s correctly", img.Name)
-			// }
-			// src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, pathComponents}, "/")
-			// dst = strings.Join([]string{o.Opts.Destination, pathComponents}, "/") // already has a transport protocol
 
 			if src == "" || dest == "" {
 				return result, fmt.Errorf("unable to determine src %s or dst %s for %s", src, dest, img.Name)
@@ -232,19 +224,24 @@ func (o *LocalStorageCollector) prepareM2DCopyBatch(log clog.PluggableLoggerInte
 			imgRef := img.Image
 			var src string
 			var dest string
-			// no transport was provided, assume docker://
-			if !strings.Contains(src, "://") {
+			if !strings.Contains(imgRef, "://") {
 				src = dockerProtocol + imgRef
 			} else {
+				src = imgRef
 				transportAndRef := strings.Split(imgRef, "://")
-				// because we are reusing this to construct dest
 				imgRef = transportAndRef[1]
 			}
 
+			pathWithoutDNS, err := pathWithoutDNS(imgRef)
+			if err != nil {
+				o.Log.Error("%s", err.Error())
+				return nil, err
+			}
+
 			if isImageByDigest(imgRef) {
-				dest = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imageName(imgRef) + ":" + imageHash(imgRef)[:hashTruncLen]}, "/")
+				dest = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, pathWithoutDNS + ":" + imageHash(imgRef)[:hashTruncLen]}, "/")
 			} else {
-				dest = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgRef}, "/")
+				dest = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, pathWithoutDNS}, "/")
 			}
 
 			o.Log.Debug("source %s", src)
@@ -260,14 +257,23 @@ func isImageByDigest(imgRef string) bool {
 	return strings.Contains(imgRef, "@")
 }
 
-func imageName(imgRef string) string {
-	var imageName string
-	imgSplit := strings.Split(imgRef, "@")
-	if len(imgSplit) > 1 {
-		imageName = imgSplit[0]
+func pathWithoutDNS(imgRef string) (string, error) {
+
+	var imageName []string
+	if isImageByDigest(imgRef) {
+		imageNameSplit := strings.Split(imgRef, "@")
+		imageName = strings.Split(imageNameSplit[0], "/")
+	} else {
+		imageName = strings.Split(imgRef, "/")
 	}
 
-	return imageName
+	if len(imageName) > 2 {
+		return strings.Join(imageName[1:], "/"), nil
+	} else if len(imageName) == 1 {
+		return imageName[0], nil
+	} else {
+		return "", fmt.Errorf("unable to parse image %s correctly", imgRef)
+	}
 }
 
 func imageHash(imgRef string) string {

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/operator/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/operator/local_stored_collector.go
@@ -182,36 +182,28 @@ func (o *LocalStorageCollector) prepareD2MCopyBatch(log clog.PluggableLoggerInte
 	var result []v1alpha3.CopyImageSchema
 	for _, relatedImgs := range images {
 		for _, img := range relatedImgs {
-			// TODO Make this more complete
-			// This logic will be useful for operators and releases
-			// strip the domain name from the img.Name
 			var src string
 			var dest string
 
-			domainAndPathComps := img.Image
-			// pathComponents := img.Name
-			// temporarily strip out the transport
-			transportAndRef := strings.Split(domainAndPathComps, "://")
+			imgRef := img.Image
+			transportAndRef := strings.Split(imgRef, "://")
 			if len(transportAndRef) > 1 {
-				domainAndPathComps = transportAndRef[1]
+				imgRef = transportAndRef[1]
 			}
-			src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, img.Image}, "/")
 
-			if isImageByDigest(img.Image) {
-				dest = strings.Join([]string{o.Opts.Destination, imageName(img.Image) + ":" + imageHash(img.Image)[:hashTruncLen]}, "/")
+			pathWithoutDNS, err := pathWithoutDNS(imgRef)
+			if err != nil {
+				o.Log.Error("%s", err.Error())
+				return nil, err
+			}
+
+			if isImageByDigest(imgRef) {
+				src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, pathWithoutDNS + ":" + imageHash(imgRef)[:hashTruncLen]}, "/")
+				dest = strings.Join([]string{o.Opts.Destination, pathWithoutDNS + ":" + imageHash(imgRef)[:hashTruncLen]}, "/")
 			} else {
-				dest = strings.Join([]string{o.Opts.Destination, img.Image}, "/")
+				src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, pathWithoutDNS}, "/")
+				dest = strings.Join([]string{o.Opts.Destination, pathWithoutDNS}, "/")
 			}
-
-			// the following is for having the destination without the initial domain name => later
-			// domainAndPathCompsArray := strings.Split(domainAndPathComps, "/")
-			// if len(domainAndPathCompsArray) > 2 {
-			// 	pathComponents = strings.Join(domainAndPathCompsArray[1:], "/")
-			// } else {
-			// 	return allImages, fmt.Errorf("unable to parse image %s correctly", img.Name)
-			// }
-			// src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, pathComponents}, "/")
-			// dst = strings.Join([]string{o.Opts.Destination, pathComponents}, "/") // already has a transport protocol
 
 			if src == "" || dest == "" {
 				return result, fmt.Errorf("unable to determine src %s or dst %s for %s", src, dest, img.Name)
@@ -232,19 +224,24 @@ func (o *LocalStorageCollector) prepareM2DCopyBatch(log clog.PluggableLoggerInte
 			imgRef := img.Image
 			var src string
 			var dest string
-			// no transport was provided, assume docker://
-			if !strings.Contains(src, "://") {
+			if !strings.Contains(imgRef, "://") {
 				src = dockerProtocol + imgRef
 			} else {
+				src = imgRef
 				transportAndRef := strings.Split(imgRef, "://")
-				// because we are reusing this to construct dest
 				imgRef = transportAndRef[1]
 			}
 
+			pathWithoutDNS, err := pathWithoutDNS(imgRef)
+			if err != nil {
+				o.Log.Error("%s", err.Error())
+				return nil, err
+			}
+
 			if isImageByDigest(imgRef) {
-				dest = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imageName(imgRef) + ":" + imageHash(imgRef)[:hashTruncLen]}, "/")
+				dest = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, pathWithoutDNS + ":" + imageHash(imgRef)[:hashTruncLen]}, "/")
 			} else {
-				dest = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgRef}, "/")
+				dest = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, pathWithoutDNS}, "/")
 			}
 
 			o.Log.Debug("source %s", src)
@@ -260,14 +257,23 @@ func isImageByDigest(imgRef string) bool {
 	return strings.Contains(imgRef, "@")
 }
 
-func imageName(imgRef string) string {
-	var imageName string
-	imgSplit := strings.Split(imgRef, "@")
-	if len(imgSplit) > 1 {
-		imageName = imgSplit[0]
+func pathWithoutDNS(imgRef string) (string, error) {
+
+	var imageName []string
+	if isImageByDigest(imgRef) {
+		imageNameSplit := strings.Split(imgRef, "@")
+		imageName = strings.Split(imageNameSplit[0], "/")
+	} else {
+		imageName = strings.Split(imgRef, "/")
 	}
 
-	return imageName
+	if len(imageName) > 2 {
+		return strings.Join(imageName[1:], "/"), nil
+	} else if len(imageName) == 1 {
+		return imageName[0], nil
+	} else {
+		return "", fmt.Errorf("unable to parse image %s correctly", imgRef)
+	}
 }
 
 func imageHash(imgRef string) string {


### PR DESCRIPTION
# Description

It removes the registry DNS when storing the image on disk or mirroring to the destination.

[CFE-958](https://issues.redhat.com/browse/CFE-958)
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

ImageSetConfig:

```
apiVersion: mirror.openshift.io/v1alpha2
kind: ImageSetConfiguration
mirror:
  platform:
    channels:
      - name: stable-4.13
        minVersion: 4.13.14
        maxVersion: 4.13.14
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.13
      packages:
        - name: aws-load-balancer-operator
  additionalImages: 
   - name: registry.redhat.io/ubi8/ubi:latest
   - name: registry.redhat.io/ubi9/ubi@sha256:20f695d2a91352d4eaa25107535126727b5945bff38ed36a3e59590f495046f0

```

mirrorToDisk command:

```
oc-mirror -c /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-isc/isc.yaml file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/CFE-899-v2 --v2
```

diskToMirror command:

```
oc-mirror -c /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-isc/isc.yaml --from file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/CFE-899-v2 docker://localhost:6000 --v2
```

**Expected outcome:**
In the target registry the image repos should not contain the registry domain name as the example below:

```
{
  "repositories": [
    "albo/aws-load-balancer-controller-rhel8",
    "albo/aws-load-balancer-operator-bundle",
    "albo/aws-load-balancer-rhel8-operator",
    "openshift-release-dev/ocp-release",
    "openshift-release-dev/ocp-v4.0-art-dev",
    "openshift4/ose-kube-rbac-proxy",
    "redhat/redhat-operator-index",
    "ubi8/ubi",
    "ubi9/ubi"
  ]
}
```


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules