### PR TITLE
OCPBUGS-22947: Should not generate graph with prepare subcommand

### DIFF
--- a/v2/pkg/cli/executor.go
+++ b/v2/pkg/cli/executor.go
@@ -177,7 +177,9 @@ func (o *ExecutorSchema) Validate(dest []string) error {
 	}
 	if strings.Contains(dest[0], dockerProtocol) && o.Opts.Global.From == "" {
 		return fmt.Errorf("when destination is file://, diskToMirror workflow is assumed, and the --from argument become mandatory")
-
+	}
+	if len(o.Opts.Global.From) > 0 && !strings.Contains(o.Opts.Global.From, fileProtocol) {
+		return fmt.Errorf("when --from is used, it must have file:// prefix")
 	}
 	if strings.Contains(dest[0], fileProtocol) || strings.Contains(dest[0], dockerProtocol) {
 		return nil
@@ -552,6 +554,9 @@ func (o *ExecutorSchema) ValidatePrepare(dest []string) error {
 	}
 	if o.Opts.Global.From == "" {
 		return fmt.Errorf("with prepare command, the --from argument become mandatory(prefix : file://)")
+	}
+	if !strings.Contains(o.Opts.Global.From, fileProtocol) {
+		return fmt.Errorf("when --from is used, it must have file:// prefix")
 	}
 	return nil
 }

--- a/v2/pkg/release/local_stored_collector.go
+++ b/v2/pkg/release/local_stored_collector.go
@@ -146,15 +146,6 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v1
 				return []v1alpha3.CopyImageSchema{}, err
 			}
 			allImages = append(allImages, tmpAllImages...)
-
-		}
-		if o.Config.Mirror.Platform.Graph {
-			o.Log.Info("creating graph data image")
-			err := o.CreateGraphImage(ctx)
-			if err != nil {
-				return []v1alpha3.CopyImageSchema{}, err
-			}
-			o.Log.Info("graph image created and pushed to cache.")
 		}
 		// save the releasesForFilter to json cache,
 		// so that it can be used during diskToMirror flow
@@ -162,6 +153,14 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v1
 		if err != nil {
 			return []v1alpha3.CopyImageSchema{}, fmt.Errorf("[ReleaseImageCollector] unable to save cincinnati response: %v", err)
 		}
+	} else if o.Opts.Mode == mirrorToDisk && o.Config.Mirror.Platform.Graph {
+		o.Log.Info("creating graph data image")
+		err := o.CreateGraphImage(ctx)
+		if err != nil {
+			return []v1alpha3.CopyImageSchema{}, err
+		}
+		o.Log.Info("graph image created and pushed to cache.")
+
 	} else if o.Opts.Mode == diskToMirror {
 
 		releaseImages, releaseFolders, err := o.identifyReleases()

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/cli/executor.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/cli/executor.go
@@ -177,7 +177,9 @@ func (o *ExecutorSchema) Validate(dest []string) error {
 	}
 	if strings.Contains(dest[0], dockerProtocol) && o.Opts.Global.From == "" {
 		return fmt.Errorf("when destination is file://, diskToMirror workflow is assumed, and the --from argument become mandatory")
-
+	}
+	if len(o.Opts.Global.From) > 0 && !strings.Contains(o.Opts.Global.From, fileProtocol) {
+		return fmt.Errorf("when --from is used, it must have file:// prefix")
 	}
 	if strings.Contains(dest[0], fileProtocol) || strings.Contains(dest[0], dockerProtocol) {
 		return nil
@@ -552,6 +554,9 @@ func (o *ExecutorSchema) ValidatePrepare(dest []string) error {
 	}
 	if o.Opts.Global.From == "" {
 		return fmt.Errorf("with prepare command, the --from argument become mandatory(prefix : file://)")
+	}
+	if !strings.Contains(o.Opts.Global.From, fileProtocol) {
+		return fmt.Errorf("when --from is used, it must have file:// prefix")
 	}
 	return nil
 }

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/release/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/release/local_stored_collector.go
@@ -146,15 +146,6 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v1
 				return []v1alpha3.CopyImageSchema{}, err
 			}
 			allImages = append(allImages, tmpAllImages...)
-
-		}
-		if o.Config.Mirror.Platform.Graph {
-			o.Log.Info("creating graph data image")
-			err := o.CreateGraphImage(ctx)
-			if err != nil {
-				return []v1alpha3.CopyImageSchema{}, err
-			}
-			o.Log.Info("graph image created and pushed to cache.")
 		}
 		// save the releasesForFilter to json cache,
 		// so that it can be used during diskToMirror flow
@@ -162,6 +153,14 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v1
 		if err != nil {
 			return []v1alpha3.CopyImageSchema{}, fmt.Errorf("[ReleaseImageCollector] unable to save cincinnati response: %v", err)
 		}
+	} else if o.Opts.Mode == mirrorToDisk && o.Config.Mirror.Platform.Graph {
+		o.Log.Info("creating graph data image")
+		err := o.CreateGraphImage(ctx)
+		if err != nil {
+			return []v1alpha3.CopyImageSchema{}, err
+		}
+		o.Log.Info("graph image created and pushed to cache.")
+
 	} else if o.Opts.Mode == diskToMirror {
 
 		releaseImages, releaseFolders, err := o.identifyReleases()


### PR DESCRIPTION
# Description
This issue fixes the panic that was happening during the use of prepare subcommand, because the graph image was getting generated, at a time where the subcommand does not create an `ImageBuilder` for the `CreateGraphImage` to use.

Fixes # OCPBUGS-22947

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

* Prepare subcommand
```
./bin/oc-mirror --v2 prepare -c cfe-969.yml --from file:///home/skhoury/release 
```
* Disk to mirror workflow
```
./bin/oc-mirror --v2 -c cfe-969.yml --from file:///home/skhoury/release docker://localhost:5000/cfe969
```

## Expected Outcome
Both commands should succeed and not panic