### PR TITLE
OCPBUGS-22947 - Follow up: remove default value for --from

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -3,7 +3,6 @@ module github.com/openshift/oc-mirror/v2
 go 1.19
 
 require (
-	github.com/BurntSushi/toml v1.3.2
 	github.com/blang/semver/v4 v4.0.0
 	github.com/containers/common v0.51.0
 	github.com/containers/image/v5 v5.26.0
@@ -34,6 +33,7 @@ require (
 require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/BurntSushi/toml v1.3.2 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Microsoft/hcsshim v0.9.9 // indirect

--- a/v2/pkg/cli/executor.go
+++ b/v2/pkg/cli/executor.go
@@ -153,7 +153,7 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&opts.Global.ConfigPath, "config", "c", "", "Path to imageset configuration file")
 	cmd.Flags().StringVar(&opts.Global.LogLevel, "loglevel", "info", "Log level one of (info, debug, trace, error)")
 	cmd.Flags().StringVar(&opts.Global.Dir, "dir", "working-dir", "Assets directory")
-	cmd.Flags().StringVar(&opts.Global.From, "from", "working-dir", "local storage directory for disk to mirror workflow")
+	cmd.Flags().StringVar(&opts.Global.From, "from", "", "local storage directory for disk to mirror workflow")
 	cmd.Flags().Uint16VarP(&opts.Global.Port, "port", "p", 5000, "HTTP port used by oc-mirror's local storage instance")
 	cmd.Flags().BoolVarP(&opts.Global.Quiet, "quiet", "q", false, "enable detailed logging when copying images")
 	cmd.Flags().BoolVarP(&opts.Global.Force, "force", "f", false, "force the copy and mirror functionality")
@@ -175,7 +175,7 @@ func (o *ExecutorSchema) Validate(dest []string) error {
 		return fmt.Errorf("use the --config flag it is mandatory")
 	}
 	if strings.Contains(dest[0], dockerProtocol) && o.Opts.Global.From == "" {
-		return fmt.Errorf("when destination is file://, diskToMirror workflow is assumed, and the --from argument become mandatory")
+		return fmt.Errorf("when destination is docker://, diskToMirror workflow is assumed, and the --from argument become mandatory")
 	}
 	if len(o.Opts.Global.From) > 0 && !strings.Contains(o.Opts.Global.From, fileProtocol) {
 		return fmt.Errorf("when --from is used, it must have file:// prefix")

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/cli/executor.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/cli/executor.go
@@ -153,7 +153,7 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&opts.Global.ConfigPath, "config", "c", "", "Path to imageset configuration file")
 	cmd.Flags().StringVar(&opts.Global.LogLevel, "loglevel", "info", "Log level one of (info, debug, trace, error)")
 	cmd.Flags().StringVar(&opts.Global.Dir, "dir", "working-dir", "Assets directory")
-	cmd.Flags().StringVar(&opts.Global.From, "from", "working-dir", "local storage directory for disk to mirror workflow")
+	cmd.Flags().StringVar(&opts.Global.From, "from", "", "local storage directory for disk to mirror workflow")
 	cmd.Flags().Uint16VarP(&opts.Global.Port, "port", "p", 5000, "HTTP port used by oc-mirror's local storage instance")
 	cmd.Flags().BoolVarP(&opts.Global.Quiet, "quiet", "q", false, "enable detailed logging when copying images")
 	cmd.Flags().BoolVarP(&opts.Global.Force, "force", "f", false, "force the copy and mirror functionality")
@@ -175,7 +175,7 @@ func (o *ExecutorSchema) Validate(dest []string) error {
 		return fmt.Errorf("use the --config flag it is mandatory")
 	}
 	if strings.Contains(dest[0], dockerProtocol) && o.Opts.Global.From == "" {
-		return fmt.Errorf("when destination is file://, diskToMirror workflow is assumed, and the --from argument become mandatory")
+		return fmt.Errorf("when destination is docker://, diskToMirror workflow is assumed, and the --from argument become mandatory")
 	}
 	if len(o.Opts.Global.From) > 0 && !strings.Contains(o.Opts.Global.From, fileProtocol) {
 		return fmt.Errorf("when --from is used, it must have file:// prefix")


### PR DESCRIPTION
# Description

This PR removes the default value (`working-dir`) that was assigned by default to the `--from` command argument. 
With this change the From option will never be initialized for the mirrorToDisk workflow, where the --from is not used. 
Furthermore, we can ensure that --from really becomes mandatory for the diskToMirror workflow, and the user cannot forget to add it in the input arguments.

Fixes # OCPBUGS-22947

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

* ./bin/oc-mirror --config cfg.yml file:///home/skhoury/release/   --v2
*  ./bin/oc-mirror --config cfg.yml  --from file:///home/skhoury/release/ docker://localhost:5000/22947  --v2
* ./bin/oc-mirror prepare --config cfg.yml  --from file:///home/skhoury/release/ docker://localhost:5000/22947  --v2

Following is cfg.yaml
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
 platform:
   channels:
   - name: stable-4.13
     minVersion: 4.13.10
     maxVersion: 4.13.10
   graph: true
```
## Expected Outcome
No Errors