### PR TITLE
install skopeo to download local-oci-catalogs

### DIFF
--- a/test/integration/scripts/ci-prereqs.sh
+++ b/test/integration/scripts/ci-prereqs.sh
@@ -22,6 +22,7 @@ dnf_provides=(
     [gcc]=/usr/bin/gcc
     [libffi-devel]=/usr/include/ffi.h
     [openssl-devel]=/usr/include/openssl/ssl.h
+    [skopeo]=/usr/bin/skopeo
 )
 
 # Map which packages need installed


### PR DESCRIPTION
# Description

To mirror internal operators and expand  images to disconnected cluster, we must download catalog image to local and then upload images using the mirror registry defined in oci-registries-config.

For example:
1) skopeo copy docker://${origin_index_image} "oci:///${work_dir}/oci-local-catalog" --remove-signatures
2)
```
    cat <<EOF |tee "registry.conf"
[[registry]]
 location = "registry.redhat.io"
 insecure = true
 blocked = false
 mirror-by-digest-only = false
 [[registry.mirror]]
    location = "internal.registry.redhat.io"
    insecure = true
EOF
```

3) oc-mirror --config imageset-config.yaml docker://${MIRROR_REGISTRY_HOST} --include-local-oci-catalogs --oci-registries-config=registry.conf --continue-on-error --skip-missing
Fixes # (issue)

# How Has This Been Tested?
No idea how to test in on PROW