### PR TITLE
PROJQUAY-6345: Skipping mirror failure if manifest not found during prune

### DIFF
--- a/pkg/cli/mirror/prune.go
+++ b/pkg/cli/mirror/prune.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -162,7 +163,9 @@ func (o *MirrorOptions) pruneImages(deleter imageprune.ManifestDeleter, manifest
 
 				for _, manifest := range manifests {
 					err := deleter.DeleteManifest(k, manifest)
-					if err != nil {
+					if structuredErr, ok := err.(*transport.Error); ok && structuredErr.StatusCode == http.StatusNotFound {
+						klog.Infof("Manifest %s not found in repo %s", manifest, k)
+					} else if err != nil {
 						err = fmt.Errorf("repo %q manifest %s: %w", k, manifest, err)
 						errorsCh <- err
 					}

--- a/pkg/cli/mirror/prune_test.go
+++ b/pkg/cli/mirror/prune_test.go
@@ -550,6 +550,20 @@ func TestPruneImages(t *testing.T) {
 				"repo1|digest5",
 			},
 		},
+		{
+			desc: "Success/MissingImages",
+			images: map[string][]string{
+				"repo1": {"digest1", "digest2", "digest3", "missing1", "missing2"},
+			},
+			expInvocation: 5,
+			exp: []string{
+				"repo1|digest1",
+				"repo1|digest2",
+				"repo1|digest3",
+				"repo1|missing1",
+				"repo1|missing2",
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -576,6 +590,9 @@ func (p *fakeManifestDeleter) DeleteManifest(repo, manifest string) error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 	p.invocations.Insert(fmt.Sprintf("%s|%s", repo, manifest))
+	if strings.HasPrefix(manifest, "missing") {
+		p.err = &transport.Error{StatusCode: 404}
+	}
 	return p.err
 }
 


### PR DESCRIPTION
# Description

The pruning image process during the mirror operation has the possibility of failing when using RedHat Quay. In Quay, when tags are deleted the manifests are automatically eligible for garbage collection. When pruning manifest lists `oc mirror` will attempt to delete the child manifests by digest as well as the parent manifest. Since the child manifests are automatically eligible for garbage collection, they return 404 when `oc mirror` attempts to delete them directly. Since the garbage collection process is already handled within Quay, this change prevents a failure if the manifest returns a 404 during the image prune.

Fixes # [(issue)](https://issues.redhat.com/browse/PROJQUAY-6345)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

Reproduced through steps provided in the mentioned issue.

## Expected Outcome
When `--skip-pruning-missing-manifests` is set to true the mirror will not fail if a 404 is returned when pruning manifests.