### PR TITLE
CFE-977,CFE-992: Integrate all the building blocks together - Disk to Mirror

### DIFF
--- a/v2/pkg/additional/local_stored_collector.go
+++ b/v2/pkg/additional/local_stored_collector.go
@@ -29,7 +29,7 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 
 	var allImages []v1alpha3.CopyImageSchema
 
-	if o.Opts.IsMirrorToDisk() {
+	if o.Opts.IsMirrorToDisk() || o.Opts.IsPrepare() {
 		for _, img := range o.Config.ImageSetConfigurationSpec.Mirror.AdditionalImages {
 			imgSpec, err := image.ParseRef(img.Name)
 			if err != nil {

--- a/v2/pkg/archive/archive_test.go
+++ b/v2/pkg/archive/archive_test.go
@@ -18,23 +18,15 @@ import (
 type mockBlobGatherer struct{}
 type mockHistory struct{}
 
-// type MockFileCreator struct {
-// 	Buffer *bytes.Buffer
-// }
-
-// type nopCloser struct {
-// 	io.Writer
-// }
-
 var expectedTarContents = []string{
-	// "docker/registry/v2/blobs/sha256/2e/2e39d55595ea56337b5b788e96e6afdec3db09d2759d903cbe120468187c4644/data",
-	// "docker/registry/v2/blobs/sha256/4c/4c0f6aace7053de3b9c1476b33c9a763e45a099c8c7ae9117773c9a8e5b8506b/data",
-	// "docker/registry/v2/blobs/sha256/53/53c56977ccd20c0d87df0ad52036c55b27201e1a63874c2644383d0c532f5aee/data",
+	// is in history // "docker/registry/v2/blobs/sha256/2e/2e39d55595ea56337b5b788e96e6afdec3db09d2759d903cbe120468187c4644/data",
+	// is in history // "docker/registry/v2/blobs/sha256/4c/4c0f6aace7053de3b9c1476b33c9a763e45a099c8c7ae9117773c9a8e5b8506b/data",
+	// is in history // "docker/registry/v2/blobs/sha256/53/53c56977ccd20c0d87df0ad52036c55b27201e1a63874c2644383d0c532f5aee/data",
 	"docker/registry/v2/blobs/sha256/63/6376a0276facf61d87fdf7c6f21d761ee25ba8ceba934d64752d43e84fe0cb98/data",
 	"docker/registry/v2/blobs/sha256/6e/6e1ac33d11e06db5e850fec4a1ec07f6c2ab15f130c2fdf0f9d0d0a5c83651e7/data",
-	// "docker/registry/v2/blobs/sha256/94/94343313ec1512ab02267e4bc3ce09eecb01fda5bf26c56e2f028ecc72e80b18/data",
+	// is in history // "docker/registry/v2/blobs/sha256/94/94343313ec1512ab02267e4bc3ce09eecb01fda5bf26c56e2f028ecc72e80b18/data",
 	"docker/registry/v2/blobs/sha256/9b/9b6fa335dba394d437930ad79e308e01da4f624328e49d00c0ff44775d2e4769/data",
-	// "docker/registry/v2/blobs/sha256/cf/cfaa7496ab546c36ab14859f93fbd2d8a3588b344b18d5fbe74dd834e4a6f7eb/data",
+	// is in history // "docker/registry/v2/blobs/sha256/cf/cfaa7496ab546c36ab14859f93fbd2d8a3588b344b18d5fbe74dd834e4a6f7eb/data",
 	"docker/registry/v2/blobs/sha256/db/db870970ba330193164dacc88657df261d75bce1552ea474dbc7cf08b2fae2ed/data",
 	"docker/registry/v2/blobs/sha256/e1/e1bb0572465a9e03d7af5024abb36d7227b5bf133c448b54656d908982127874/data",
 	"docker/registry/v2/blobs/sha256/e6/e6c589cf5f402a60a83a01653304d7a8dcdd47b93a395a797b5622a18904bd66/data",
@@ -222,13 +214,6 @@ func (mbg mockBlobGatherer) GatherBlobs(ctx context.Context, imgRef string) (map
 	}
 	return blobs, nil
 }
-
-// func (m MockFileCreator) Create(name string) (io.WriteCloser, error) {
-// 	m.Buffer = new(bytes.Buffer)
-// 	return nopCloser{m.Buffer}, nil
-// }
-
-// func (nopCloser) Close() error { return nil }
 
 func (m mockHistory) Read() (map[string]string, error) {
 	historyMap := map[string]string{

--- a/v2/pkg/operator/local_stored_collector.go
+++ b/v2/pkg/operator/local_stored_collector.go
@@ -169,7 +169,7 @@ func (o *LocalStorageCollector) OperatorImageCollector(ctx context.Context) ([]v
 	}
 	o.Log.Info("images to copy (before duplicates) %d ", count)
 	// check the mode
-	if o.Opts.IsMirrorToDisk() {
+	if o.Opts.IsMirrorToDisk() || o.Opts.IsPrepare() {
 
 		allImages, err = o.prepareM2DCopyBatch(o.Log, dir, relatedImages)
 		if err != nil {

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/additional/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/additional/local_stored_collector.go
@@ -29,7 +29,7 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 
 	var allImages []v1alpha3.CopyImageSchema
 
-	if o.Opts.IsMirrorToDisk() {
+	if o.Opts.IsMirrorToDisk() || o.Opts.IsPrepare() {
 		for _, img := range o.Config.ImageSetConfigurationSpec.Mirror.AdditionalImages {
 			imgSpec, err := image.ParseRef(img.Name)
 			if err != nil {

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/operator/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/operator/local_stored_collector.go
@@ -169,7 +169,7 @@ func (o *LocalStorageCollector) OperatorImageCollector(ctx context.Context) ([]v
 	}
 	o.Log.Info("images to copy (before duplicates) %d ", count)
 	// check the mode
-	if o.Opts.IsMirrorToDisk() {
+	if o.Opts.IsMirrorToDisk() || o.Opts.IsPrepare() {
 
 		allImages, err = o.prepareM2DCopyBatch(o.Log, dir, relatedImages)
 		if err != nil {


### PR DESCRIPTION
# Description

Integrates previous PRs #738  into the DiskToMirror workflow by

* calling unarchiver to extract the archive
* starting up the local storage based on the extracted content

Fixes # [CFE-992](https://issues.redhat.com/browse/CFE-992)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

With the 3 imageSetConfigs below, several tests were done:

|Test #| Command   | Expected outcome | Pass/Fail |
|--------| -------- | ----------- |----------- |
| 1| `./bin/oc-mirror --v2 --config isc1.yml file:///home/skhoury/cfe992main` | `/home/skhoury/cfe992main/mirror_000001.tar` is created | :white_check_mark:Pass |
| 2|`mkdir ~/cfe922enc`<br>`mv ~/cfe992main/mirror_000001.tar ~/cfe922enc/`<br>`./bin/oc-mirror --v2 --config isc1.yml --from file:///home/skhoury/cfe992enc -p 6000 docker://localhost:5000` |`curl -v http://localhost:5000/v2/ubi8/ubi/manifests/latest` gives HTTP200|:white_check_mark:Pass |
| 3| `./bin/oc-mirror prepare --v2 --config isc1.yml --from file:///home/skhoury/cfe992main -p 6000` | command completes successfully - no images reported missing | :white_check_mark:Pass |
| 4| `./bin/oc-mirror prepare --v2 --config isc2.yml --from file:///home/skhoury/cfe992main -p 6000` | command completes with error - ubi9 reported missing | :white_check_mark:Pass |
| 5| `./bin/oc-mirror --v2 --config isc2.yml file:///home/skhoury/cfe992main` | `/home/skhoury/cfe992main/mirror_000001.tar` is created | :white_check_mark:Pass |
| 6| `./bin/oc-mirror prepare --v2 --config isc2.yml --from file:///home/skhoury/cfe992main -p 6000` | command completes successfully - no images reported missing | :white_check_mark:Pass |
| 7|`mv ~/cfe992main/mirror_000001.tar ~/cfe922enc/`<br>`./bin/oc-mirror  --v2 --config isc2.yml --from file:///home/skhoury/cfe992enc -p 6000 docker://localhost:5000` |`curl -v http://localhost:5000/v2/ubi9/ubi/manifests/latest` gives HTTP200|:white_check_mark:Pass |
| 8|`./bin/oc-mirror --v2 --config isc3.yml file:///home/skhoury/cfe992main` | `/home/skhoury/cfe992main/mirror_000001.tar` is created | :white_check_mark:Pass |
| 9|`mv ~/cfe992main/mirror_000001.tar ~/cfe922enc/`<br>`./bin/oc-mirror  --v2 --config isc3.yml --from file:///home/skhoury/cfe992main -p 6000 docker://localhost:5000` |`curl -v http://localhost:5000/v2/openshift/graph-image/manifests/latest` gives HTTP200|:white_check_mark:Pass |
| 10|`./bin/oc-mirror  --v2 --config isc3.yml --from file:///home/skhoury/cfe992enc -p 6000 docker://localhost:5000` |command finishes successfully|:white_check_mark:Pass |
**isc1.yaml**
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  additionalImages:
  - name: registry.redhat.io/ubi8/ubi:latest
```

**isc2.yaml**
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  additionalImages:
  - name: registry.redhat.io/ubi8/ubi:latest
  - name: registry.redhat.io/ubi9/ubi:latest
```

**isc3.yaml**
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  platform:
    channels:
    - name: stable-4.14
    graph: true
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.14
    packages:
    - name: aws-load-balancer-operator
  additionalImages:
  - name: registry.redhat.io/ubi8/ubi:latest
```

## Expected Outcome
See above