### PR TITLE
OCPBUGS-23339: fix IDMS custom resource name

### DIFF
--- a/v2/pkg/clusterresources/clusterresources.go
+++ b/v2/pkg/clusterresources/clusterresources.go
@@ -39,7 +39,11 @@ func (c *ClusterResourcesGenerator) IDMSGenerator(ctx context.Context, allRelate
 
 	// determine the name of the IDMS resource
 	// TODO determine name (based on date?)
-	name := "idms_" + time.Now().Format(time.RFC3339)
+	dateTime := time.Now().UTC().Format(time.RFC3339)
+	// replace all : by -
+	dateTime = strings.ReplaceAll(dateTime, ":", "-")
+	dateTime = strings.ToLower(dateTime)
+	name := "idms-" + dateTime
 
 	// locate the output directory
 	idmsFileName := filepath.Join(opts.Global.WorkingDir, clusterResourcesDir, name+".yaml")

--- a/v2/pkg/clusterresources/clusterresources_test.go
+++ b/v2/pkg/clusterresources/clusterresources_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/openshift/oc-mirror/v2/pkg/api/v1alpha2"
@@ -116,7 +118,22 @@ func TestIDMSGenerator(t *testing.T) {
 		if len(idmsFiles) != 1 {
 			t.Fatalf("output folder should contain 1 idms yaml file")
 		}
+		// check idmsFile has a name that is
+		//compliant with Kubernetes requested
+		// RFC-1035 + RFC1123
+		// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+		customResourceName := strings.TrimSuffix(idmsFiles[0].Name(), ".yaml")
+		if !isValidRFC1123(customResourceName) {
+			t.Fatalf("IDMS custom resource name %s doesn't  respect RFC1123", idmsFiles[0].Name())
+		}
 	})
+}
+
+func isValidRFC1123(name string) bool {
+	// Regular expression to match RFC1123 compliant names
+	rfc1123Regex := "^[a-zA-Z0-9][-a-zA-Z0-9]*[a-zA-Z0-9]$"
+	match, _ := regexp.MatchString(rfc1123Regex, name)
+	return match && len(name) <= 63
 }
 
 func TestGenerateImageMirrors(t *testing.T) {

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/clusterresources/clusterresources.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/clusterresources/clusterresources.go
@@ -39,7 +39,11 @@ func (c *ClusterResourcesGenerator) IDMSGenerator(ctx context.Context, allRelate
 
 	// determine the name of the IDMS resource
 	// TODO determine name (based on date?)
-	name := "idms_" + time.Now().Format(time.RFC3339)
+	dateTime := time.Now().UTC().Format(time.RFC3339)
+	// replace all : by -
+	dateTime = strings.ReplaceAll(dateTime, ":", "-")
+	dateTime = strings.ToLower(dateTime)
+	name := "idms-" + dateTime
 
 	// locate the output directory
 	idmsFileName := filepath.Join(opts.Global.WorkingDir, clusterResourcesDir, name+".yaml")


### PR DESCRIPTION
# Description
This fixes the issue encountered when deploying the IDMS resource generated by oc-mirror v2 to a cluster by:
* replacing `:` and `_` in the name by `-`

Fixes # [OCPBUGS-23339](https://issues.redhat.com/browse/OCPBUGS-23339)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
* Added a unit test to check for compliance with RFC1123
* Deployed the  IDMS generated from the below imagesetconfig (after mirrorToDisk + diskToMirror) to a 4.14.3 ROSA cluster successfully.
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  additionalImages:
  - name: registry.redhat.io/ubi8/ubi:latest
```
  

## Expected Outcome
The IDMS generated from the command above deploys correctly on a cluster
```yaml
apiVersion: config.openshift.io/v1
kind: ImageDigestMirrorSet
metadata:
  creationTimestamp: null
  name: idms-2023-11-29t16-15-14z
spec:
  imageDigestMirrors:
  - mirrors:
    - localhost:5000/ubi8
    source: registry.redhat.io/ubi8
status: {}
```