### PR TITLE
OCPBUGS-24243: remove unnecessary print statement from pkg/cli/options.go

### DIFF
--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -44,7 +44,6 @@ func (o *RootOptions) LogfilePreRun(cmd *cobra.Command, _ []string) {
 
 	logFile, err := os.OpenFile(".oc-mirror.log", os.O_CREATE|os.O_APPEND|os.O_RDWR, 0600)
 	if err == nil {
-		fmt.Println("Logging to .oc-mirror.log")
 		klog.SetOutput(io.MultiWriter(o.IOStreams.Out, logFile))
 	} else {
 		fmt.Printf("Failed to open .oc-mirror.log for writing. Err: %s. Running without logging.\n",


### PR DESCRIPTION
# Description

Hi all! [As part of a fix for running `oc-mirror` on a RO filesystem](https://github.com/openshift/oc-mirror/commit/97db160a1ac084c03c8266649c9e2fe140b631b8), a print statement was added to the codebase that runs on every invocation of `oc-mirror` as noted in https://github.com/openshift/oc-mirror/issues/710 

Looking throughout the rest of the codebase, I don't see any other `fmt.Println` statements, so I'm thinking this could be a development debugging line that inadvertently got left in.

### What

This PR removes the "Logging to .oc-mirror" log line, but leaves the failure print statement, as that is probably a good one to have. I'm happy to update this PR to remove that print statement as well if desired.

### Why

This print statement interferes with some automation tasks, such as the (Open Shift disconnected installation docs)[https://docs.openshift.com/container-platform/4.12/installing/disconnected_install/installing-mirroring-disconnected.html] example for creating an `imageset.yaml`

Fixes [# (710)](https://github.com/openshift/oc-mirror/issues/710)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I don't currently have an environment where I can build & test this, however as it is a single line change, I believe it will be fine.