### PR TITLE
OCPBUGS-24371,OCPBUGS-24372: Fix default port for V2 'prepare' subcommand

### DIFF
--- a/v2/pkg/cli/executor.go
+++ b/v2/pkg/cli/executor.go
@@ -686,7 +686,7 @@ func NewPrepareCommand(log clog.PluggableLoggerInterface) *cobra.Command {
 	cmd.Flags().StringVar(&opts.Global.LogLevel, "loglevel", "info", "Log level one of (info, debug, trace, error)")
 	cmd.Flags().StringVar(&opts.Global.WorkingDir, "dir", "working-dir", "Assets directory")
 	cmd.Flags().StringVar(&opts.Global.From, "from", "", "local storage directory for disk to mirror workflow")
-	cmd.Flags().Uint16VarP(&opts.Global.Port, "port", "p", 5000, "HTTP port used by oc-mirror's local storage instance")
+	cmd.Flags().Uint16VarP(&opts.Global.Port, "port", "p", 55000, "HTTP port used by oc-mirror's local storage instance")
 	cmd.Flags().BoolVar(&opts.Global.V2, "v2", opts.Global.V2, "Redirect the flow to oc-mirror v2 - PLEASE DO NOT USE that. V2 is still under development and it is not ready to be used.")
 	// nolint: errcheck
 	cmd.Flags().MarkHidden("v2")
@@ -744,7 +744,10 @@ func (o *ExecutorSchema) CompletePrepare(args []string) error {
 	if err != nil {
 		return err
 	}
-
+	err = o.setupLocalStorageDir()
+	if err != nil {
+		return err
+	}
 	client, _ := release.NewOCPClient(uuid.New())
 
 	signature := release.NewSignatureClient(o.Log, o.Config, o.Opts)

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/cli/executor.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/cli/executor.go
@@ -686,7 +686,7 @@ func NewPrepareCommand(log clog.PluggableLoggerInterface) *cobra.Command {
 	cmd.Flags().StringVar(&opts.Global.LogLevel, "loglevel", "info", "Log level one of (info, debug, trace, error)")
 	cmd.Flags().StringVar(&opts.Global.WorkingDir, "dir", "working-dir", "Assets directory")
 	cmd.Flags().StringVar(&opts.Global.From, "from", "", "local storage directory for disk to mirror workflow")
-	cmd.Flags().Uint16VarP(&opts.Global.Port, "port", "p", 5000, "HTTP port used by oc-mirror's local storage instance")
+	cmd.Flags().Uint16VarP(&opts.Global.Port, "port", "p", 55000, "HTTP port used by oc-mirror's local storage instance")
 	cmd.Flags().BoolVar(&opts.Global.V2, "v2", opts.Global.V2, "Redirect the flow to oc-mirror v2 - PLEASE DO NOT USE that. V2 is still under development and it is not ready to be used.")
 	// nolint: errcheck
 	cmd.Flags().MarkHidden("v2")
@@ -744,7 +744,10 @@ func (o *ExecutorSchema) CompletePrepare(args []string) error {
 	if err != nil {
 		return err
 	}
-
+	err = o.setupLocalStorageDir()
+	if err != nil {
+		return err
+	}
 	client, _ := release.NewOCPClient(uuid.New())
 
 	signature := release.NewSignatureClient(o.Log, o.Config, o.Opts)


### PR DESCRIPTION
# Description

Fixes issues found by @zhouying7780

> 1. when I use prepare , the command still use 5000 as default port , not like the help info use 55000
> 2. when I specify port for prepare , I hit error :
```
oc-mirror  --v2 prepare --from [file://out](file:///) --config config-filter.yaml [file://out](file:///)  -p 5005
--v2 flag identified, flow redirected to the oc-mirror v2 version. PLEASE DO NOT USE that. V2 is still under development and it is not ready to be used. 
2023/12/04 05:39:17  [INFO]   : mode prepare 
2023/12/04 05:39:17  [ERROR]  :  error using the local storage folder for caching
```
Fixes 

- [OCPBUGS-24371](https://issues.redhat.com/browse/OCPBUGS-24371)
- [OCPBUGS-24372](https://issues.redhat.com/browse/OCPBUGS-24372)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Verified by running the commands as specified by QE and making sure no errors are found in the outcome

## Expected Outcome
No errors while running commands as specified by QE