### PR TITLE
OCPBUGS-19429: Fix cross EUS channel upgrade path calculation

### DIFF
--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -26,7 +26,8 @@ const (
 	// UpdateURL is the Cincinnati endpoint for the OpenShift platform.
 	UpdateURL = "https://api.openshift.com/api/upgrades_info/v1/graph"
 	// OkdUpdateURL is the Cincinnati endpoint for the OKD platform.
-	OkdUpdateURL = "https://origin-release.ci.openshift.org/graph"
+	OkdUpdateURL                = "https://origin-release.ci.openshift.org/graph"
+	extendedUpdateSupportPrefix = "eus-"
 )
 
 // Error is returned when are unable to get updates.
@@ -233,7 +234,11 @@ func calculate(ctx context.Context, c Client, arch, sourceChannel, targetChannel
 	}
 	// We immediately bump the source channel since current source channel upgrades have
 	// already been calculated
-	source.Minor++
+	if strings.HasPrefix(sourceChannel, extendedUpdateSupportPrefix) {
+		source.Minor += 2
+	} else {
+		source.Minor++
+	}
 	currChannel := fmt.Sprintf("%s-%v.%v", prefix, source.Major, source.Minor)
 
 	var targetVer semver.Version


### PR DESCRIPTION
# Description

This is still a work in progress.
Although the error message doesn't appear anymore, the console output shows the following message, when imagesetconfig uses eus-4.12+eus-4.14 : 
`No upgrade path for 4.12.44 in target channel eus-4.14`

According to #forum-ocp-updates, and [docs](https://docs.openshift.com/container-platform/4.14/updating/understanding_updates/understanding-update-channels-release.html#fast-stable-channel-strategies_understanding-update-channels-releases) :

> The promotion delay before promoting a release to the stable channel represents the only difference between the two channels. Updates to the latest z-streams are generally promoted to the stable channel within a week or two, however the delay when initially rolling out updates to the latest minor is much longer, generally 45-90 days.
This explains why eus-4.14 hasn't picked up 4.13 and 4.12 releases yet.

Fixes # [OCPBUGS-19429](https://issues.redhat.com/browse/OCPBUGS-19429)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  platform:
    channels:
    - name: eus-4.10
    - name: eus-4.12
    # - name: stable-4.12
    # - name: stable-4.13
    graph: true
```
## Expected Outcome
The mirroring MirrorToMirror succeeds.