### PR TITLE
OCPBUGS-24359: Fix including duplicate blobs in archive

### DIFF
--- a/v2/pkg/archive/archive_test.go
+++ b/v2/pkg/archive/archive_test.go
@@ -151,7 +151,7 @@ func TestArchive_AddBlobsDiff(t *testing.T) {
 		"sha256:9b6fa335dba394d437930ad79e308e01da4f624328e49d00c0ff44775d2e4769": "",
 		"sha256:e6c589cf5f402a60a83a01653304d7a8dcdd47b93a395a797b5622a18904bd66": "",
 	}
-	actualAddedBlobs, err := ma.addBlobsDiff(collectedBlobs, historyBlobs)
+	actualAddedBlobs, err := ma.addBlobsDiff(collectedBlobs, historyBlobs, map[string]string{})
 	assert.NoError(t, err, "call addBlobsDiff should not return an error")
 	assert.Equal(t, expectedAddedBlobs, actualAddedBlobs)
 


### PR DESCRIPTION
# Description

When constructing the archive at the end of the MirrorToDisk workflow, oc-mirror v2 was only checking if the blob was already included in previous archives by comparing its digest to the history map.
This is not sufficient, as the blob might already be included in the current tar, as several images may include the same blob.

This change compares the blob's digest to both the map of digests from history AND the map of digests included so far in archive, before taking the decision to include it in the archive.

Fixes # [OCPBUGS-24359](https://issues.redhat.com/browse/OCPBUGS-24359)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Perform a MirrorToDisk with `./bin/oc-mirror --v2 -c isc_23236.yaml file:///home/skhoury/23236` and this imageSetConfig:
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  platform:
    channels:
    - name: stable-4.14
      minVersion: 4.14.2
      maxVersion: 4.14.3
    graph: true
```

## Expected Outcome
1. The mirroring is a success.
2. The archive (mirror_000001.tar) size is 29G, compared to previously 93G. 29G is slightly more than v1-generated archive (mirror_seq1_000000.tar) with 28G.
```bash
╭─╼skhoury@fedora ~/23236 
╰─ -$ ls -lha
total 57G
drwxr-xr-x. 1 skhoury skhoury  210 Dec  6 18:08 .
drwx------. 1 skhoury skhoury 7.7K Dec  6 15:35 ..
-rw-r--r--. 1 skhoury skhoury  29G Dec  6 18:10 mirror_000001.tar
-rw-r--r--. 1 skhoury skhoury  28G Dec  6 16:11 mirror_seq1_000000.tar
drwxr-xr-x. 1 skhoury skhoury    6 Dec  6 15:41 oc-mirror-workspace
drwxr-xr-x. 1 skhoury skhoury  212 Dec  6 18:08 working-dir
```
3. Moving the tar to another file (simulates sneaker-net, or moving the disk physically to the enclave), and performing a DiskToMirror succeeds.


@zhouying7780, @lmzuccarelli , @aguidirh the size difference between the v1 archive and v2 archive is the extra metadata we have in working-dir. 
We can probably trim it down a knotch by excluding folder `working-dir/release-images` from the archive, which is the whole release image, with all its content. It gains ~1G. But I haven't implemented that yet. Please let me know.

