### PR TITLE
NO-ISSUE: Make A.Guidi approver on oc-mirror

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,5 +6,6 @@ approvers:
   - lmzuccarelli
   - sherine-k
   - jerpeter1
+  - aguidirh
 component: oc
 subcomponent: oc-mirror


### PR DESCRIPTION
This PR simply instates Alex as approver of the repository
Kudos to @aguidirh ! :+1: 