### PR TITLE
OCPBUGS-21854: cincinnati-graph-data.tar.gz is created only for succe…

### DIFF
--- a/pkg/cli/mirror/cincinnati_graph_image.go
+++ b/pkg/cli/mirror/cincinnati_graph_image.go
@@ -151,16 +151,6 @@ func (o *MirrorOptions) buildGraphImage(ctx context.Context, srcSignatureDir str
 
 // downloadsGraphData will download the current Cincinnati graph data
 func downloadGraphData(ctx context.Context, dir string) error {
-	// TODO(jpower432): It would be helpful to validate
-	// the source of this downloaded file before processing
-	// it further
-	graphArchive := filepath.Join(dir, outputFile)
-	out, err := os.Create(filepath.Clean(graphArchive))
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
 	req, err := http.NewRequest("GET", graphURL, nil)
 	if err != nil {
 		return err
@@ -189,6 +179,15 @@ func downloadGraphData(ctx context.Context, dir string) error {
 		return fmt.Errorf("unexpected HTTP status: %s", resp.Status)
 	}
 
+	// TODO(jpower432): It would be helpful to validate
+	// the source of this downloaded file before processing
+	// it further
+	graphArchive := filepath.Join(dir, outputFile)
+	out, err := os.Create(filepath.Clean(graphArchive))
+	if err != nil {
+		return err
+	}
+	defer out.Close()
 	_, err = io.Copy(out, resp.Body)
 	return err
 }

--- a/pkg/cli/mirror/cincinnati_graph_image.go
+++ b/pkg/cli/mirror/cincinnati_graph_image.go
@@ -176,6 +176,7 @@ func downloadGraphData(ctx context.Context, dir string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		klog.Errorf("call to Cincinatti API returned with status HTTP %s", resp.Status)
 		return fmt.Errorf("unexpected HTTP status: %s", resp.Status)
 	}
 
@@ -188,7 +189,8 @@ func downloadGraphData(ctx context.Context, dir string) error {
 		return err
 	}
 	defer out.Close()
-	_, err = io.Copy(out, resp.Body)
+	bytesWritten, err := io.Copy(out, resp.Body)
+	klog.V(5).Infof("HTTP body for request to Cincinnati API is %d bytes, and was written to %s", bytesWritten, graphArchive)
 	return err
 }
 

--- a/pkg/cli/mirror/create.go
+++ b/pkg/cli/mirror/create.go
@@ -143,6 +143,7 @@ func (o *MirrorOptions) run(
 			if err := downloadGraphData(ctx, releaseDir); err != nil {
 				return mmappings, err
 			}
+			klog.V(5).Infof("graph data download complete. Downloaded to %s", releaseDir)
 		}
 	}
 


### PR DESCRIPTION
…ssful API call

# Description

PARTIAL FIX - DONT MERGE
Fixes [OCPBUGS-21854](https://issues.redhat.com/browse/OCPBUGS-21854)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The cincinnati-graph-data.tar.gz gets created [here](https://github.com/openshift/oc-mirror/blob/90202e830bf7a243eb473506b79c1f067805af35/pkg/cli/mirror/create.go#L143-L145).
Using a debugger, I shut down the internet connection before the HTTP request is issued, and can see that the file cincinnati-graph-data.tar.gz is not created anymore under `cmd/oc-mirror/oc-mirror-workspace/src/cincinnati`

## Expected Outcome
Please describe the outcome expected from the tests