### PR TITLE
OCPBUGS-23003: Fix to ensure operator not found error exits with correct status

### DIFF
--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -445,8 +445,15 @@ func (o *OperatorOptions) verifyDC(dic diff.DiffIncludeConfig, dc *declcfg.Decla
 		klog.V(2).Infof("Checking for package: %s", pkg)
 
 		if !dcMap[pkg.Name] {
-			// The operator package wasn't found. Log the error and continue on.
-			o.Logger.Errorf("Operator %s was not found, please check name, minVersion, maxVersion, and channels in the config file.", pkg.Name)
+			// The operator package wasn't found.
+			// OCPBUGS-25003 - request is to exit immediately
+			// Log the error and continue if --continue-on-error flag is set
+			msg := fmt.Sprintf("Operator %s was not found, please check name, minVersion, maxVersion, and channels in the config file.", pkg.Name)
+			if !o.MirrorOptions.ContinueOnError {
+				return fmt.Errorf(msg)
+			} else {
+				o.Logger.Errorf(msg)
+			}
 		}
 	}
 

--- a/pkg/cli/mirror/operator_test.go
+++ b/pkg/cli/mirror/operator_test.go
@@ -164,7 +164,8 @@ func TestPinImages(t *testing.T) {
 func TestVerifyDC(t *testing.T) {
 
 	mo := &MirrorOptions{
-		RootOptions: &cli.RootOptions{},
+		RootOptions:     &cli.RootOptions{},
+		ContinueOnError: true,
 	}
 	o := NewOperatorOptions(mo)
 	o.complete()


### PR DESCRIPTION
# Description

This fix ensures that the operator not found error exits with the correct error code and does not continue processing.


Fixes # OCPBUGS-23003

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Verify as described in the JIRA Issue

Used this ImageSetConfig

```
apiVersion: mirror.openshift.io/v1alpha2
kind: ImageSetConfiguration
mirror:
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.14
    targetName: redhat-operator-index
    targetTag: v4.14-n2-tst1
    packages:
    - name: cincinnati-operator
      channels: 
      - name: 'v1'
        minVersion: '5.0.2'
        maxVersion: '5.0.2'
    - name: cluster-logging
      channels: 
      - name: 'stable'
        minVersion: '5.7.7'
        maxVersion: '5.7.7'
```

With command line

```
oc-mirror --config ocpbugs-23003.yaml file://ocpbugs-23003
```

## Expected Outcome
The process should not continue, it should end with this message

_error: Operator cluster-logging was not found, please check name, minVersion, maxVersion, and channels in the config file._

Verify output code

```
echo $?
1
```

Use the cli with the flag --continue-on-error to ignore this error

```
oc-mirror --config ocpbugs-23003.yaml file://ocpbugs-23003 --continue-on-error
```