### PR TITLE
OCPBUGS-26513: Add Type for CopyImageSchema; Skip graph for IDMS; Fix UpdateService

### DIFF
--- a/v2/pkg/api/v1alpha3/types.go
+++ b/v2/pkg/api/v1alpha3/types.go
@@ -3,6 +3,7 @@ package v1alpha3
 import (
 	"time"
 
+	"github.com/openshift/oc-mirror/v2/pkg/api/v1alpha2"
 	"github.com/operator-framework/operator-registry/alpha/property"
 )
 
@@ -233,6 +234,9 @@ type Bundle struct {
 type RelatedImage struct {
 	Name  string `json:"name"`
 	Image string `json:"image"`
+	// Type: metadata to explain why this image is being copied
+	// it doesn't need to be persisted to JSON
+	Type v1alpha2.ImageType `json:"-"`
 }
 
 // DeclarativeConfig this updates the existing dclrcfg
@@ -271,6 +275,9 @@ type CopyImageSchema struct {
 	Destination string
 	// Origin: Original reference to the image
 	Origin string
+	// Type: metadata to explain why this image is being copied
+	// it doesn´t need to be persisted to json
+	Type v1alpha2.ImageType `json:"-"`
 }
 
 // SignatureContentSchema

--- a/v2/pkg/clusterresources/clusterresources.go
+++ b/v2/pkg/clusterresources/clusterresources.go
@@ -149,7 +149,7 @@ func generateImageMirrors(allRelatedImages []v1alpha3.CopyImageSchema) (map[stri
 	return mirrors, nil
 }
 
-func (o *ClusterResourcesGenerator) UpdateServiceGenerator(graphImage, releaseImageRef string) error {
+func (o *ClusterResourcesGenerator) UpdateServiceGenerator(graphImageRef, releaseImageRef string) error {
 	// truncate tag or digest from release image
 	// according to https://docs.openshift.com/container-platform/4.14/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.html#update-service-create-service-cli_updating-restricted-network-cluster-osus
 	releaseImage, err := image.ParseRef(releaseImageRef)
@@ -157,6 +157,12 @@ func (o *ClusterResourcesGenerator) UpdateServiceGenerator(graphImage, releaseIm
 		return err
 	}
 	releaseImageName := releaseImage.Name
+
+	graphImage, err := image.ParseRef(graphImageRef)
+	if err != nil {
+		return err
+	}
+
 	osus := updateservicev1.UpdateService{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: updateservicev1.GroupVersion.String(),
@@ -168,7 +174,7 @@ func (o *ClusterResourcesGenerator) UpdateServiceGenerator(graphImage, releaseIm
 		Spec: updateservicev1.UpdateServiceSpec{
 			Replicas:       2,
 			Releases:       releaseImageName,
-			GraphDataImage: graphImage,
+			GraphDataImage: graphImage.Reference,
 		},
 	}
 

--- a/v2/pkg/clusterresources/clusterresources.go
+++ b/v2/pkg/clusterresources/clusterresources.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	confv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/oc-mirror/v2/pkg/api/v1alpha2"
 	"github.com/openshift/oc-mirror/v2/pkg/api/v1alpha3"
 	updateservicev1 "github.com/openshift/oc-mirror/v2/pkg/clusterresources/updateservice/v1"
 	"github.com/openshift/oc-mirror/v2/pkg/image"
@@ -102,6 +103,12 @@ func generateImageMirrors(allRelatedImages []v1alpha3.CopyImageSchema) (map[stri
 	for _, relatedImage := range allRelatedImages {
 		if relatedImage.Origin == "" {
 			return nil, fmt.Errorf("unable to generate IDMS/ITMS: original reference for (%s,%s) undetermined", relatedImage.Source, relatedImage.Destination)
+		}
+		if relatedImage.Type == v1alpha2.TypeCincinnatiGraph {
+			// cincinnati graph image doesn't need to be in the IDMS file.
+			// it has been generated from scratch by oc-mirror and will be copied to the destination registry.
+			// The updateservice.yaml file will instruct the cluster to use it.
+			continue
 		}
 		// locate source namespace
 		// strip away protocol

--- a/v2/pkg/clusterresources/const.go
+++ b/v2/pkg/clusterresources/const.go
@@ -2,7 +2,7 @@ package clusterresources
 
 const (
 	clusterResourcesDir       string = "cluster-resources"
-	updateServiceFilename     string = "updateService"
+	updateServiceFilename     string = "updateService.yaml"
 	updateServiceResourceName string = "update-service-oc-mirror"
 	updateServiceResourceKind string = "UpdateService"
 )

--- a/v2/pkg/manifest/oci-manifest.go
+++ b/v2/pkg/manifest/oci-manifest.go
@@ -177,7 +177,7 @@ func (o *Manifest) GetReleaseSchema(filePath string) ([]v1alpha3.RelatedImage, e
 
 	var allImages []v1alpha3.RelatedImage
 	for _, item := range release.Spec.Tags {
-		allImages = append(allImages, v1alpha3.RelatedImage{Image: item.From.Name, Name: item.Name})
+		allImages = append(allImages, v1alpha3.RelatedImage{Image: item.From.Name, Name: item.Name, Type: v1alpha2.TypeOCPReleaseContent})
 	}
 	return allImages, nil
 }

--- a/v2/pkg/operator/const.go
+++ b/v2/pkg/operator/const.go
@@ -9,5 +9,5 @@ const (
 	operatorImageDir        string = "operator-images"
 	blobsDir                string = "blobs/sha256" // TODO blobsDir should not make assumptions about algorithm
 	errMsg                  string = "[OperatorImageCollector] %v "
-	logsFile                string = "logs/operator.log"
+	logsFile                string = "operator.log"
 )

--- a/v2/pkg/release/local_stored_collector.go
+++ b/v2/pkg/release/local_stored_collector.go
@@ -140,7 +140,7 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v1
 				return []v1alpha3.CopyImageSchema{}, fmt.Errorf(errMsg, err)
 			}
 			//add the release image itself
-			allRelatedImages = append(allRelatedImages, v1alpha3.RelatedImage{Image: value.Source, Name: value.Source})
+			allRelatedImages = append(allRelatedImages, v1alpha3.RelatedImage{Image: value.Source, Name: value.Source, Type: v1alpha2.TypeOCPRelease})
 			tmpAllImages, err := o.prepareM2DCopyBatch(o.Log, allRelatedImages)
 			if err != nil {
 				return []v1alpha3.CopyImageSchema{}, err
@@ -166,6 +166,7 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v1
 				Source:      graphImgRef,
 				Destination: graphImgRef,
 				Origin:      graphImgRef,
+				Type:        v1alpha2.TypeCincinnatiGraph,
 			}
 			allImages = append(allImages, graphCopy)
 		}
@@ -204,6 +205,7 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v1
 				// If this supposition is false, then we need to implement a mechanism to save
 				// the digest of the graph image and use it here
 				Image: filepath.Join(o.LocalStorageFQDN, graphImageName) + ":latest",
+				Type:  v1alpha2.TypeCincinnatiGraph,
 			}
 			o.GraphDataImage = graphRelatedImage.Image
 			allRelatedImages = append(allRelatedImages, graphRelatedImage)
@@ -242,7 +244,7 @@ func (o LocalStorageCollector) prepareD2MCopyBatch(log clog.PluggableLoggerInter
 
 		o.Log.Debug("source %s", src)
 		o.Log.Debug("destination %s", dest)
-		result = append(result, v1alpha3.CopyImageSchema{Origin: img.Image, Source: src, Destination: dest})
+		result = append(result, v1alpha3.CopyImageSchema{Origin: img.Image, Source: src, Destination: dest, Type: img.Type})
 
 	}
 	return result, nil
@@ -268,7 +270,7 @@ func (o LocalStorageCollector) prepareM2DCopyBatch(log clog.PluggableLoggerInter
 		}
 		o.Log.Debug("source %s", src)
 		o.Log.Debug("destination %s", dest)
-		result = append(result, v1alpha3.CopyImageSchema{Source: src, Destination: dest})
+		result = append(result, v1alpha3.CopyImageSchema{Source: src, Destination: dest, Type: img.Type})
 	}
 	return result, nil
 }
@@ -299,7 +301,7 @@ func (o LocalStorageCollector) identifyReleases() ([]v1alpha3.RelatedImage, []st
 		releasePath = strings.TrimPrefix(releasePath, ociProtocolTrimmed)
 		releaseHoldPath := strings.Replace(releasePath, releaseImageDir, releaseImageExtractDir, 1)
 		releaseFolders = append(releaseFolders, releaseHoldPath)
-		releaseImages = append(releaseImages, v1alpha3.RelatedImage{Name: copy.Source, Image: copy.Source})
+		releaseImages = append(releaseImages, v1alpha3.RelatedImage{Name: copy.Source, Image: copy.Source, Type: v1alpha2.TypeOCPRelease})
 	}
 	return releaseImages, releaseFolders, nil
 }

--- a/v2/pkg/release/local_stored_collector.go
+++ b/v2/pkg/release/local_stored_collector.go
@@ -207,14 +207,28 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v1
 				Image: filepath.Join(o.LocalStorageFQDN, graphImageName) + ":latest",
 				Type:  v1alpha2.TypeCincinnatiGraph,
 			}
-			o.GraphDataImage = graphRelatedImage.Image
-			allRelatedImages = append(allRelatedImages, graphRelatedImage)
+			// OCPBUGS-26513: In order to get the destination for the graphDataImage
+			// into `o.GraphDataImage`, we call `prepareD2MCopyBatch` on an array
+			// containing only the graph image. This way we can easily identify the destination
+			// of the graph image.
+			graphImageSlice := []v1alpha3.RelatedImage{graphRelatedImage}
+			graphCopySlice, err := o.prepareD2MCopyBatch(o.Log, graphImageSlice)
+			if err != nil {
+				return []v1alpha3.CopyImageSchema{}, err
+			}
+			// if there is no error, we are certain that the slice only contains 1 element
+			// but double checking...
+			if len(graphCopySlice) != 1 {
+				return []v1alpha3.CopyImageSchema{}, fmt.Errorf("error while calculating the destination reference for the graph image")
+			}
+			o.GraphDataImage = graphCopySlice[0].Destination
+			allImages = append(allImages, graphCopySlice...)
 		}
-		allImages, err = o.prepareD2MCopyBatch(o.Log, allRelatedImages)
+		releaseCopyImages, err := o.prepareD2MCopyBatch(o.Log, allRelatedImages)
 		if err != nil {
 			return []v1alpha3.CopyImageSchema{}, err
 		}
-
+		allImages = append(allImages, releaseCopyImages...)
 	}
 
 	return allImages, nil
@@ -340,7 +354,19 @@ func (o LocalStorageCollector) saveReleasesForFilter(r releasesForFilter, to str
 // by the collector.
 func (o *LocalStorageCollector) GraphImage() (string, error) {
 	if o.GraphDataImage == "" {
-		o.GraphDataImage = filepath.Join(o.LocalStorageFQDN, graphImageName) + ":latest"
+		sourceGraphDataImage := filepath.Join(o.LocalStorageFQDN, graphImageName) + ":latest"
+		graphRelatedImage := []v1alpha3.RelatedImage{
+			{
+				Name:  "release",
+				Image: sourceGraphDataImage,
+				Type:  v1alpha2.TypeCincinnatiGraph,
+			},
+		}
+		graphCopyImage, err := o.prepareD2MCopyBatch(nil, graphRelatedImage)
+		if err != nil {
+			return "", fmt.Errorf("collector could not establish the destination for the graph image: %v", err)
+		}
+		o.GraphDataImage = graphCopyImage[0].Destination
 	}
 	return o.GraphDataImage, nil
 }
@@ -353,7 +379,7 @@ func (o *LocalStorageCollector) ReleaseImage() (string, error) {
 	if len(o.Releases) == 0 {
 		releaseImages, _, err := o.identifyReleases()
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("collector could not establish the destination for the release image: %v", err)
 		}
 		o.Releases = []string{}
 		for _, img := range releaseImages {
@@ -361,8 +387,20 @@ func (o *LocalStorageCollector) ReleaseImage() (string, error) {
 		}
 	}
 	if len(o.Releases) > 0 {
-		return o.Releases[0], nil
+		releaseRelatedImage := []v1alpha3.RelatedImage{
+			{
+				Name:  "release",
+				Image: o.Releases[0],
+				Type:  v1alpha2.TypeOCPRelease,
+			},
+		}
+		releaseCopyImage, err := o.prepareD2MCopyBatch(nil, releaseRelatedImage)
+		if err != nil {
+			return "", fmt.Errorf("collector could not establish the destination for the release image: %v", err)
+		}
+		return releaseCopyImage[0].Destination, nil
+
 	} else {
-		return "", fmt.Errorf("collector could not established the list of releases to mirror")
+		return "", fmt.Errorf("collector could not establish the destination for the release image")
 	}
 }

--- a/v2/pkg/release/local_stored_collector_test.go
+++ b/v2/pkg/release/local_stored_collector_test.go
@@ -105,15 +105,16 @@ func TestGraphImage(t *testing.T) {
 
 	tempDir := t.TempDir()
 	defer os.RemoveAll(tempDir)
-	t.Run("Testing GraphImage : should pass", func(t *testing.T) {
+	t.Run("Testing GraphImage : should fail", func(t *testing.T) {
 		ex := setupCollector_DiskToMirror(tempDir, log)
 
 		res, err := ex.GraphImage()
 		if err != nil {
 			t.Fatalf("should pass")
 		}
-		assert.Equal(t, "localhost:9999/openshift/graph-image:latest", res)
+		assert.Equal(t, ex.Opts.Destination+"/"+graphImageName+":latest", res)
 	})
+
 }
 
 func TestReleaseImage(t *testing.T) {
@@ -140,7 +141,7 @@ func TestReleaseImage(t *testing.T) {
 		if err != nil {
 			t.Fatalf("should pass: %v", err)
 		}
-		assert.Contains(t, res, "quay.io/openshift-release-dev/ocp-release")
+		assert.Contains(t, res, "localhost:5000/test/openshift-release-dev/ocp-release")
 	})
 }
 

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/api/v1alpha3/types.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/api/v1alpha3/types.go
@@ -3,6 +3,7 @@ package v1alpha3
 import (
 	"time"
 
+	"github.com/openshift/oc-mirror/v2/pkg/api/v1alpha2"
 	"github.com/operator-framework/operator-registry/alpha/property"
 )
 
@@ -233,6 +234,9 @@ type Bundle struct {
 type RelatedImage struct {
 	Name  string `json:"name"`
 	Image string `json:"image"`
+	// Type: metadata to explain why this image is being copied
+	// it doesn't need to be persisted to JSON
+	Type v1alpha2.ImageType `json:"-"`
 }
 
 // DeclarativeConfig this updates the existing dclrcfg
@@ -271,6 +275,9 @@ type CopyImageSchema struct {
 	Destination string
 	// Origin: Original reference to the image
 	Origin string
+	// Type: metadata to explain why this image is being copied
+	// it doesn´t need to be persisted to json
+	Type v1alpha2.ImageType `json:"-"`
 }
 
 // SignatureContentSchema

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/clusterresources/clusterresources.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/clusterresources/clusterresources.go
@@ -149,7 +149,7 @@ func generateImageMirrors(allRelatedImages []v1alpha3.CopyImageSchema) (map[stri
 	return mirrors, nil
 }
 
-func (o *ClusterResourcesGenerator) UpdateServiceGenerator(graphImage, releaseImageRef string) error {
+func (o *ClusterResourcesGenerator) UpdateServiceGenerator(graphImageRef, releaseImageRef string) error {
 	// truncate tag or digest from release image
 	// according to https://docs.openshift.com/container-platform/4.14/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.html#update-service-create-service-cli_updating-restricted-network-cluster-osus
 	releaseImage, err := image.ParseRef(releaseImageRef)
@@ -157,6 +157,12 @@ func (o *ClusterResourcesGenerator) UpdateServiceGenerator(graphImage, releaseIm
 		return err
 	}
 	releaseImageName := releaseImage.Name
+
+	graphImage, err := image.ParseRef(graphImageRef)
+	if err != nil {
+		return err
+	}
+
 	osus := updateservicev1.UpdateService{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: updateservicev1.GroupVersion.String(),
@@ -168,7 +174,7 @@ func (o *ClusterResourcesGenerator) UpdateServiceGenerator(graphImage, releaseIm
 		Spec: updateservicev1.UpdateServiceSpec{
 			Replicas:       2,
 			Releases:       releaseImageName,
-			GraphDataImage: graphImage,
+			GraphDataImage: graphImage.Reference,
 		},
 	}
 

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/clusterresources/clusterresources.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/clusterresources/clusterresources.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	confv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/oc-mirror/v2/pkg/api/v1alpha2"
 	"github.com/openshift/oc-mirror/v2/pkg/api/v1alpha3"
 	updateservicev1 "github.com/openshift/oc-mirror/v2/pkg/clusterresources/updateservice/v1"
 	"github.com/openshift/oc-mirror/v2/pkg/image"
@@ -102,6 +103,12 @@ func generateImageMirrors(allRelatedImages []v1alpha3.CopyImageSchema) (map[stri
 	for _, relatedImage := range allRelatedImages {
 		if relatedImage.Origin == "" {
 			return nil, fmt.Errorf("unable to generate IDMS/ITMS: original reference for (%s,%s) undetermined", relatedImage.Source, relatedImage.Destination)
+		}
+		if relatedImage.Type == v1alpha2.TypeCincinnatiGraph {
+			// cincinnati graph image doesn't need to be in the IDMS file.
+			// it has been generated from scratch by oc-mirror and will be copied to the destination registry.
+			// The updateservice.yaml file will instruct the cluster to use it.
+			continue
 		}
 		// locate source namespace
 		// strip away protocol

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/clusterresources/const.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/clusterresources/const.go
@@ -2,7 +2,7 @@ package clusterresources
 
 const (
 	clusterResourcesDir       string = "cluster-resources"
-	updateServiceFilename     string = "updateService"
+	updateServiceFilename     string = "updateService.yaml"
 	updateServiceResourceName string = "update-service-oc-mirror"
 	updateServiceResourceKind string = "UpdateService"
 )

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/manifest/oci-manifest.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/manifest/oci-manifest.go
@@ -177,7 +177,7 @@ func (o *Manifest) GetReleaseSchema(filePath string) ([]v1alpha3.RelatedImage, e
 
 	var allImages []v1alpha3.RelatedImage
 	for _, item := range release.Spec.Tags {
-		allImages = append(allImages, v1alpha3.RelatedImage{Image: item.From.Name, Name: item.Name})
+		allImages = append(allImages, v1alpha3.RelatedImage{Image: item.From.Name, Name: item.Name, Type: v1alpha2.TypeOCPReleaseContent})
 	}
 	return allImages, nil
 }

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/operator/const.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/operator/const.go
@@ -9,5 +9,5 @@ const (
 	operatorImageDir        string = "operator-images"
 	blobsDir                string = "blobs/sha256" // TODO blobsDir should not make assumptions about algorithm
 	errMsg                  string = "[OperatorImageCollector] %v "
-	logsFile                string = "logs/operator.log"
+	logsFile                string = "operator.log"
 )

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/release/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/release/local_stored_collector.go
@@ -140,7 +140,7 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v1
 				return []v1alpha3.CopyImageSchema{}, fmt.Errorf(errMsg, err)
 			}
 			//add the release image itself
-			allRelatedImages = append(allRelatedImages, v1alpha3.RelatedImage{Image: value.Source, Name: value.Source})
+			allRelatedImages = append(allRelatedImages, v1alpha3.RelatedImage{Image: value.Source, Name: value.Source, Type: v1alpha2.TypeOCPRelease})
 			tmpAllImages, err := o.prepareM2DCopyBatch(o.Log, allRelatedImages)
 			if err != nil {
 				return []v1alpha3.CopyImageSchema{}, err
@@ -166,6 +166,7 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v1
 				Source:      graphImgRef,
 				Destination: graphImgRef,
 				Origin:      graphImgRef,
+				Type:        v1alpha2.TypeCincinnatiGraph,
 			}
 			allImages = append(allImages, graphCopy)
 		}
@@ -204,6 +205,7 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v1
 				// If this supposition is false, then we need to implement a mechanism to save
 				// the digest of the graph image and use it here
 				Image: filepath.Join(o.LocalStorageFQDN, graphImageName) + ":latest",
+				Type:  v1alpha2.TypeCincinnatiGraph,
 			}
 			o.GraphDataImage = graphRelatedImage.Image
 			allRelatedImages = append(allRelatedImages, graphRelatedImage)
@@ -242,7 +244,7 @@ func (o LocalStorageCollector) prepareD2MCopyBatch(log clog.PluggableLoggerInter
 
 		o.Log.Debug("source %s", src)
 		o.Log.Debug("destination %s", dest)
-		result = append(result, v1alpha3.CopyImageSchema{Origin: img.Image, Source: src, Destination: dest})
+		result = append(result, v1alpha3.CopyImageSchema{Origin: img.Image, Source: src, Destination: dest, Type: img.Type})
 
 	}
 	return result, nil
@@ -268,7 +270,7 @@ func (o LocalStorageCollector) prepareM2DCopyBatch(log clog.PluggableLoggerInter
 		}
 		o.Log.Debug("source %s", src)
 		o.Log.Debug("destination %s", dest)
-		result = append(result, v1alpha3.CopyImageSchema{Source: src, Destination: dest})
+		result = append(result, v1alpha3.CopyImageSchema{Source: src, Destination: dest, Type: img.Type})
 	}
 	return result, nil
 }
@@ -299,7 +301,7 @@ func (o LocalStorageCollector) identifyReleases() ([]v1alpha3.RelatedImage, []st
 		releasePath = strings.TrimPrefix(releasePath, ociProtocolTrimmed)
 		releaseHoldPath := strings.Replace(releasePath, releaseImageDir, releaseImageExtractDir, 1)
 		releaseFolders = append(releaseFolders, releaseHoldPath)
-		releaseImages = append(releaseImages, v1alpha3.RelatedImage{Name: copy.Source, Image: copy.Source})
+		releaseImages = append(releaseImages, v1alpha3.RelatedImage{Name: copy.Source, Image: copy.Source, Type: v1alpha2.TypeOCPRelease})
 	}
 	return releaseImages, releaseFolders, nil
 }

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/release/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/release/local_stored_collector.go
@@ -207,14 +207,28 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v1
 				Image: filepath.Join(o.LocalStorageFQDN, graphImageName) + ":latest",
 				Type:  v1alpha2.TypeCincinnatiGraph,
 			}
-			o.GraphDataImage = graphRelatedImage.Image
-			allRelatedImages = append(allRelatedImages, graphRelatedImage)
+			// OCPBUGS-26513: In order to get the destination for the graphDataImage
+			// into `o.GraphDataImage`, we call `prepareD2MCopyBatch` on an array
+			// containing only the graph image. This way we can easily identify the destination
+			// of the graph image.
+			graphImageSlice := []v1alpha3.RelatedImage{graphRelatedImage}
+			graphCopySlice, err := o.prepareD2MCopyBatch(o.Log, graphImageSlice)
+			if err != nil {
+				return []v1alpha3.CopyImageSchema{}, err
+			}
+			// if there is no error, we are certain that the slice only contains 1 element
+			// but double checking...
+			if len(graphCopySlice) != 1 {
+				return []v1alpha3.CopyImageSchema{}, fmt.Errorf("error while calculating the destination reference for the graph image")
+			}
+			o.GraphDataImage = graphCopySlice[0].Destination
+			allImages = append(allImages, graphCopySlice...)
 		}
-		allImages, err = o.prepareD2MCopyBatch(o.Log, allRelatedImages)
+		releaseCopyImages, err := o.prepareD2MCopyBatch(o.Log, allRelatedImages)
 		if err != nil {
 			return []v1alpha3.CopyImageSchema{}, err
 		}
-
+		allImages = append(allImages, releaseCopyImages...)
 	}
 
 	return allImages, nil
@@ -340,7 +354,19 @@ func (o LocalStorageCollector) saveReleasesForFilter(r releasesForFilter, to str
 // by the collector.
 func (o *LocalStorageCollector) GraphImage() (string, error) {
 	if o.GraphDataImage == "" {
-		o.GraphDataImage = filepath.Join(o.LocalStorageFQDN, graphImageName) + ":latest"
+		sourceGraphDataImage := filepath.Join(o.LocalStorageFQDN, graphImageName) + ":latest"
+		graphRelatedImage := []v1alpha3.RelatedImage{
+			{
+				Name:  "release",
+				Image: sourceGraphDataImage,
+				Type:  v1alpha2.TypeCincinnatiGraph,
+			},
+		}
+		graphCopyImage, err := o.prepareD2MCopyBatch(nil, graphRelatedImage)
+		if err != nil {
+			return "", fmt.Errorf("collector could not establish the destination for the graph image: %v", err)
+		}
+		o.GraphDataImage = graphCopyImage[0].Destination
 	}
 	return o.GraphDataImage, nil
 }
@@ -353,7 +379,7 @@ func (o *LocalStorageCollector) ReleaseImage() (string, error) {
 	if len(o.Releases) == 0 {
 		releaseImages, _, err := o.identifyReleases()
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("collector could not establish the destination for the release image: %v", err)
 		}
 		o.Releases = []string{}
 		for _, img := range releaseImages {
@@ -361,8 +387,20 @@ func (o *LocalStorageCollector) ReleaseImage() (string, error) {
 		}
 	}
 	if len(o.Releases) > 0 {
-		return o.Releases[0], nil
+		releaseRelatedImage := []v1alpha3.RelatedImage{
+			{
+				Name:  "release",
+				Image: o.Releases[0],
+				Type:  v1alpha2.TypeOCPRelease,
+			},
+		}
+		releaseCopyImage, err := o.prepareD2MCopyBatch(nil, releaseRelatedImage)
+		if err != nil {
+			return "", fmt.Errorf("collector could not establish the destination for the release image: %v", err)
+		}
+		return releaseCopyImage[0].Destination, nil
+
 	} else {
-		return "", fmt.Errorf("collector could not established the list of releases to mirror")
+		return "", fmt.Errorf("collector could not establish the destination for the release image")
 	}
 }


### PR DESCRIPTION
# Description
This PR introduces a `Type` for `CopyImageSchema`.
`Type` is following `v1alpha2.ImageType`, with possible values:
* `TypeOCPRelease`
* `TypeOCPReleaseContent`
* `TypeCincinnatiGraph`
* `TypeOperatorCatalog`
* `TypeOperatorBundle`
* `TypeOperatorRelatedImage`
* `TypeGeneric`

This enables us to later distinguish and exclude the graph image from the list of images passed to clusterresource Generator interface (responsible for IDMS/ITMS/UpdateService generation) when generating IDMS.

In this PR, we also switch to using the destination reference of the graph image in the `updateService.yaml` custom resource instead of the source reference (in oc-mirror cache).

Fixes # [OCPBUGS-26513](https://issues.redhat.com/browse/OCPBUGS-26513)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
With the following imagesetconfig, perform MirrorToDisk, followed by DiskToMirror, and control the IDMS file generated.
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  platform:
    channels:
    - name: stable-4.14
      minVersion: 4.14.2
      maxVersion: 4.14.2
    graph: true
```
## Expected Outcome
IDMS file generated doesn't contain an entry for `source: localhost:55000/openshift`:
```yaml
apiVersion: config.openshift.io/v1
kind: ImageDigestMirrorSet
metadata:
  creationTimestamp: null
  name: idms-2024-01-09t14-10-17z
spec:
  imageDigestMirrors:
  - mirrors:
    - localhost:5000/openshift-release-dev
    source: quay.io/openshift-release-dev
status: {}
```