### PR TITLE
OCPBUGS-16801: fix: fixes the bug on catalog when using field archiveSize: 1

### DIFF
--- a/pkg/cli/mirror/publish.go
+++ b/pkg/cli/mirror/publish.go
@@ -1,6 +1,7 @@
 package mirror
 
 import (
+	"archive/tar"
 	"context"
 	"errors"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/opencontainers/go-digest"
 	"github.com/openshift/library-go/pkg/image/reference"
@@ -15,6 +17,7 @@ import (
 	"github.com/openshift/oc/pkg/cli/image/imagesource"
 	imagemanifest "github.com/openshift/oc/pkg/cli/image/manifest"
 	imgmirror "github.com/openshift/oc/pkg/cli/image/mirror"
+	"golang.org/x/exp/slices"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 
@@ -452,16 +455,95 @@ func (o *MirrorOptions) fetchBlob(ctx context.Context, regctx *registryclient.Co
 }
 
 func unpack(archiveFilePath, dest string, filesInArchive map[string]string) error {
-	archivePath, found := filesInArchive[archiveFilePath]
-	if !found {
+	archivePaths := getArchivePathsFromMap(filesInArchive, archiveFilePath)
+
+	if len(archivePaths) == 0 {
 		return &ErrArchiveFileNotFound{archiveFilePath}
 	}
-	if err := archive.NewArchiver().Extract(archivePath, archiveFilePath, dest); err != nil {
-		return err
+
+	for _, archivePath := range archivePaths {
+		if archiveFilePath == config.CatalogsDir {
+			err := unarchive(archivePath, dest)
+			if err != nil {
+				klog.V(2).Info("unarchive failed with the error: %s", err.Error())
+				return err
+			}
+		} else {
+			if err := archive.NewArchiver().Extract(archivePath, archiveFilePath, dest); err != nil {
+				return err
+			}
+			if _, err := os.Stat(filepath.Join(dest, archiveFilePath)); err != nil {
+				return err
+			}
+		}
 	}
-	if _, err := os.Stat(filepath.Join(dest, archiveFilePath)); err != nil {
-		return err
+
+	return nil
+}
+
+func getArchivePathsFromMap(m map[string]string, key string) []string {
+	var archivePaths []string
+	for k, v := range m {
+		if strings.Contains(k, key) {
+			if slices.Contains(archivePaths, v) {
+				continue
+			}
+			archivePaths = append(archivePaths, v)
+		}
 	}
+	return archivePaths
+}
+
+func unarchive(archivePath, dest string) error {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return fmt.Errorf("error opening tar %s: %v", archivePath, err)
+	}
+	reader := tar.NewReader(file)
+	for {
+		header, err := reader.Next()
+
+		// break the infinite loop when EOF
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			return fmt.Errorf("error reading archive %s: %v", archivePath, err)
+		}
+
+		if header == nil {
+			continue
+		}
+		if header.Typeflag == tar.TypeReg {
+			if strings.HasPrefix(header.Name, config.CatalogsDir) {
+				fmt.Println(header.Name)
+				fpath := filepath.Join(dest, header.Name)
+
+				err := os.MkdirAll(filepath.Dir(fpath), 0755)
+				if err != nil {
+					return fmt.Errorf("%s: making directory for file: %v", fpath, err)
+				}
+
+				out, err := os.Create(fpath)
+				if err != nil {
+					return fmt.Errorf("%s: creating new file: %v", fpath, err)
+				}
+				defer out.Close()
+
+				err = out.Chmod(os.FileMode(header.Mode))
+				if err != nil {
+					return fmt.Errorf("%s: changing file mode: %v", fpath, err)
+				}
+
+				_, err = io.Copy(out, reader)
+				if err != nil {
+					return fmt.Errorf("%s: writing file: %v", fpath, err)
+				}
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
# Description

Currently when the field archiveSize on imageSetConfig is set to 1 the mirroring fails for catalogs. 

It was happening because the code was not looping in all archives generated to extract all the catalog content. Also, the folder structure was being kept only in the first archive generated.

The fix is to loop in all archives and also to get all files related with the catalogs/ folder, even if the archive does not have the catalog folder structure inside.



Fixes # (OCPBUGS-16801)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
apiVersion: mirror.openshift.io/v1alpha2
kind: ImageSetConfiguration
archiveSize: 1
storageConfig:
  local:
    path: metadata
mirror:
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.11
    packages:
    - name: netobserv-operator
      channels:
      - name: stable
```

```
./bin/oc-mirror -c ./ocpbugs/ocpbugs-16801.yaml file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/ocpbugs-16801
```

```
./bin/oc-mirror --from /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/ocpbugs-16801 docker://localhost:7000 --dest-skip-tls --dest-use-http
```

## Expected Outcome
```
curl http://localhost:7000/v2/_catalog | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   418  100   418    0     0   137k      0 --:--:-- --:--:-- --:--:--  204k
{
  "repositories": [
    "network-observability/network-observability-console-plugin-rhel9",
    "network-observability/network-observability-ebpf-agent-rhel9",
    "network-observability/network-observability-flowlogs-pipeline-rhel9",
    "network-observability/network-observability-operator-bundle",
    "network-observability/network-observability-rhel9-operator",
    "oc-mirror",
    "openshift4/ose-kube-rbac-proxy",
    "redhat/redhat-operator-index"
  ]
}
```