### PR TITLE
CLID-9,CLID-24: Support incremental mirroring using archives by date

### DIFF
--- a/v2/pkg/archive/archive.go
+++ b/v2/pkg/archive/archive.go
@@ -36,7 +36,7 @@ func NewMirrorArchive(opts *mirror.CopyOptions, destination, iscPath, workingDir
 		logg.Warn("unable to delete past archives from %s: %v", destination, err)
 	}
 	// create the history interface
-	history, err := history.NewHistory(workingDir, time.Time{}, logg, history.OSFileCreator{})
+	history, err := history.NewHistory(workingDir, opts.Global.Since, logg, history.OSFileCreator{})
 	if err != nil {
 		return &MirrorArchive{}, err
 	}

--- a/v2/pkg/archive/archive.go
+++ b/v2/pkg/archive/archive.go
@@ -70,7 +70,7 @@ func NewMirrorArchive(opts *mirror.CopyOptions, destination, iscPath, workingDir
 func NewPermissiveMirrorArchive(opts *mirror.CopyOptions, destination, iscPath, workingDir, cacheDir string, maxSize int64, logg clog.PluggableLoggerInterface) (*MirrorArchive, error) {
 
 	// create the history interface
-	history, err := history.NewHistory(workingDir, time.Time{}, logg, history.OSFileCreator{})
+	history, err := history.NewHistory(workingDir, opts.Global.Since, logg, history.OSFileCreator{})
 	if err != nil {
 		return &MirrorArchive{}, err
 	}

--- a/v2/pkg/archive/permissive_adder.go
+++ b/v2/pkg/archive/permissive_adder.go
@@ -254,7 +254,3 @@ func (o *permissiveAdder) exceptionChunk(oversizedFileInfo fs.FileInfo, oversize
 
 	return nil
 }
-
-func (o *permissiveAdder) getOversizedFiles() map[string]int64 {
-	return o.oversizedFiles
-}

--- a/v2/pkg/clusterresources/clusterresources.go
+++ b/v2/pkg/clusterresources/clusterresources.go
@@ -186,7 +186,7 @@ func (o *ClusterResourcesGenerator) generateCatalogSource(catalogRef string, cat
 		return err
 	}
 
-	csSuffix := "0" // default value
+	var csSuffix string
 	if catalogSpec.IsImageByDigest() {
 		if len(catalogSpec.Digest) >= hashTruncLen {
 			csSuffix = catalogSpec.Digest[:hashTruncLen]
@@ -196,6 +196,10 @@ func (o *ClusterResourcesGenerator) generateCatalogSource(catalogRef string, cat
 	} else {
 		tag := catalogSpec.Tag
 		csSuffix = strings.Map(toRFC1035, tag)
+	}
+
+	if csSuffix == "" {
+		csSuffix = "0" // default value
 	}
 
 	pathComponents := strings.Split(catalogSpec.PathComponent, "/")

--- a/v2/pkg/mirror/options.go
+++ b/v2/pkg/mirror/options.go
@@ -52,7 +52,8 @@ type GlobalOptions struct {
 	V2                 bool          // Redirect the flow to oc-mirror v2 - PLEASE DO NOT USE that. V2 is still under development and it is not ready to be used.
 	MaxNestedPaths     int           // Sets the maximum allowed path-components on the destination registry
 	StrictArchiving    bool          // If set, generates archives that are strictly less than `archiveSize`, failing for files that exceed that limit.
-
+	SinceString        string        // Sets the date since which all content mirrored after is included in the archive
+	Since              time.Time     // Sets the date since which all content mirrored after is included in the archive
 }
 
 type CopyOptions struct {

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/archive/archive.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/archive/archive.go
@@ -36,7 +36,7 @@ func NewMirrorArchive(opts *mirror.CopyOptions, destination, iscPath, workingDir
 		logg.Warn("unable to delete past archives from %s: %v", destination, err)
 	}
 	// create the history interface
-	history, err := history.NewHistory(workingDir, time.Time{}, logg, history.OSFileCreator{})
+	history, err := history.NewHistory(workingDir, opts.Global.Since, logg, history.OSFileCreator{})
 	if err != nil {
 		return &MirrorArchive{}, err
 	}

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/archive/archive.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/archive/archive.go
@@ -70,7 +70,7 @@ func NewMirrorArchive(opts *mirror.CopyOptions, destination, iscPath, workingDir
 func NewPermissiveMirrorArchive(opts *mirror.CopyOptions, destination, iscPath, workingDir, cacheDir string, maxSize int64, logg clog.PluggableLoggerInterface) (*MirrorArchive, error) {
 
 	// create the history interface
-	history, err := history.NewHistory(workingDir, time.Time{}, logg, history.OSFileCreator{})
+	history, err := history.NewHistory(workingDir, opts.Global.Since, logg, history.OSFileCreator{})
 	if err != nil {
 		return &MirrorArchive{}, err
 	}

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/archive/permissive_adder.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/archive/permissive_adder.go
@@ -254,7 +254,3 @@ func (o *permissiveAdder) exceptionChunk(oversizedFileInfo fs.FileInfo, oversize
 
 	return nil
 }
-
-func (o *permissiveAdder) getOversizedFiles() map[string]int64 {
-	return o.oversizedFiles
-}

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/clusterresources/clusterresources.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/clusterresources/clusterresources.go
@@ -186,7 +186,7 @@ func (o *ClusterResourcesGenerator) generateCatalogSource(catalogRef string, cat
 		return err
 	}
 
-	csSuffix := "0" // default value
+	var csSuffix string
 	if catalogSpec.IsImageByDigest() {
 		if len(catalogSpec.Digest) >= hashTruncLen {
 			csSuffix = catalogSpec.Digest[:hashTruncLen]
@@ -196,6 +196,10 @@ func (o *ClusterResourcesGenerator) generateCatalogSource(catalogRef string, cat
 	} else {
 		tag := catalogSpec.Tag
 		csSuffix = strings.Map(toRFC1035, tag)
+	}
+
+	if csSuffix == "" {
+		csSuffix = "0" // default value
 	}
 
 	pathComponents := strings.Split(catalogSpec.PathComponent, "/")

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/mirror/options.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/mirror/options.go
@@ -52,7 +52,8 @@ type GlobalOptions struct {
 	V2                 bool          // Redirect the flow to oc-mirror v2 - PLEASE DO NOT USE that. V2 is still under development and it is not ready to be used.
 	MaxNestedPaths     int           // Sets the maximum allowed path-components on the destination registry
 	StrictArchiving    bool          // If set, generates archives that are strictly less than `archiveSize`, failing for files that exceed that limit.
-
+	SinceString        string        // Sets the date since which all content mirrored after is included in the archive
+	Since              time.Time     // Sets the date since which all content mirrored after is included in the archive
 }
 
 type CopyOptions struct {


### PR DESCRIPTION
# Description

This PR adds the --since flag for oc-mirror v2. 
```bash
./bin/oc-mirror --v2 --help
--v2 flag identified, flow redirected to the oc-mirror v2 version. PLEASE DO NOT USE that. V2 is still under development and it is not ready to be used. 
Create and publish user-configured mirrors with a declarative configuration input. used for authenticating to the registries.
### truncated ###
      --since string                          Include all new content since specified date (format yyyy-MM-dd). When not provided, new content since previous mirroring is mirrored
### truncated ####
```

Fixes # [CLID-9](https://issues.redhat.com//browse/CLID-9) and [CLID-24](https://issues.redhat.com//browse/CLID-24)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

With the following ImageSetConfig:
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.14
    packages:
      - name: aws-load-balancer-operator
  additionalImages:
  - name: "gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0"
  - name: "quay.io/cockroachdb/cockroach-helm-operator:6.0.0"
  - name: "quay.io/helmoperators/cockroachdb:v5.0.3"
  - name: "quay.io/helmoperators/cockroachdb:v5.0.4"
  - name: "quay.io/openshift-community-operators/cockroachdb@sha256:a5d4f4467250074216eb1ba1c36e06a3ab797d81c431427fc2aca97ecaf4e9d8"
  - name: "quay.io/openshift-community-operators/cockroachdb@sha256:d3016b1507515fc7712f9c47fd9082baf9ccb070aaab58ed0ef6e5abdedde8ba"
  - name: "quay.io/openshift-community-operators/cockroachdb@sha256:f42337e7b85a46d83c94694638e2312e10ca16a03542399a65ba783c94a32b63"
```

Here' s the test process I followed:
```bash
$  ./bin/oc-mirror --v2 -c clid-9.yaml file:///home/skhoury/clid-9/
$  rm /home/skhoury/clid-9/mirror_000001.tar # we're not interested in this archive contents.
 $ mv ~/clid-9/working-dir/.history/.history-2024-02-07T09:55:57Z ~/clid-9/working-dir/.history/.history-2024-01-07T09:55:57Z # simulate that the former mirror was done a month ago
$  ./bin/oc-mirror --v2 -c clid-9.yaml file:///home/skhoury/clid-9/ # this mirroring should not generate an archive with any blobs
$  tar tvf /home/skhoury/clid-9/mirror_000001.tar | grep docker/registry/v2/blobs | wc -l
0
$ rm /home/skhoury/clid-9/mirror_000001.tar # getting ready to perform another test
$ ./bin/oc-mirror --v2 -c clid-9.yaml file:///home/skhoury/clid-9/ --since 2024-01-01
$ tar tvf /home/skhoury/clid-9/mirror_000001.tar | grep docker/registry/v2/blobs | wc -l # this shows that blobs were added
112
```