### PR TITLE
[release-4.12] OCPBUGS-29232: Capability to override default channel

### DIFF
--- a/pkg/api/v1alpha2/types_include_config.go
+++ b/pkg/api/v1alpha2/types_include_config.go
@@ -27,6 +27,13 @@ type IncludePackage struct {
 
 	// All channels containing these bundles are parsed for an upgrade graph.
 	IncludeBundle `json:",inline"`
+
+	// New field added due to the following filed cases for oc-mirror
+	// - CASE03657982
+	// - CASE03655018
+	// - CASE03676821
+	// Ability to override default channel.
+	DefaultChannel string `json:"defaultChannel,omitempty"`
 }
 
 // IncludeChannel contains a name (required) and versions (optional)
@@ -66,7 +73,7 @@ func (ic *IncludeConfig) ConvertToDiffIncludeConfig() (dic diff.DiffIncludeConfi
 			return dic, fmt.Errorf("package %s: %v", pkg.Name, err)
 		}
 
-		dpkg := diff.DiffIncludePackage{Name: pkg.Name}
+		dpkg := diff.DiffIncludePackage{Name: pkg.Name, DefaultChannel: pkg.DefaultChannel}
 		switch {
 		case pkg.MinVersion != "" && pkg.MaxVersion != "":
 			dpkg.Range = fmt.Sprintf(">=%s <=%s", pkg.MinVersion, pkg.MaxVersion)

--- a/pkg/cli/mirror/mirror_test.go
+++ b/pkg/cli/mirror/mirror_test.go
@@ -299,15 +299,15 @@ func TestMirrorValidate(t *testing.T) {
 			expError: "",
 		},
 		{
-			name: "Valid/MirrortoDisk",
+			name: "Valid/MirrorToDisk",
 			opts: &MirrorOptions{
-				ConfigPath: "foo",
+				ConfigPath: "testdata/configs/iscfg.yaml",
 				ToMirror:   u.Host,
 			},
 			expError: "",
 		},
 		{
-			name: "Valid/DisktoMirror",
+			name: "Valid/DiskToMirror",
 			opts: &MirrorOptions{
 				From:     t.TempDir(),
 				ToMirror: u.Host,
@@ -317,7 +317,7 @@ func TestMirrorValidate(t *testing.T) {
 		{
 			name: "Valid/MirrorToMirror",
 			opts: &MirrorOptions{
-				ConfigPath: "foo",
+				ConfigPath: "testdata/configs/iscfg.yaml",
 				ToMirror:   u.Host,
 			},
 			expError: "",

--- a/pkg/operator/diff/diff.go
+++ b/pkg/operator/diff/diff.go
@@ -128,6 +128,13 @@ type DiffIncludePackage struct {
 	// and cannot combined with `Range` in `DiffIncludeChannel`.
 	// Range setting is mutually exclusive with channel versions/bundles/range settings.
 	Range string `json:"range,omitempty" yaml:"range,omitempty"`
+	// New field added due to the following filed cases for oc-mirror
+	// - CASE03657982
+	// - CASE03655018
+	// - CASE03676821
+	// - OCPBUGS-385
+	// Ability to override default channel.
+	DefaultChannel string `json:"defaultChannel,omitempty" yaml:"defaultChannel,omitempty"`
 }
 
 // DiffIncludeChannel contains a name (required) and versions (optional)
@@ -201,6 +208,7 @@ func convertIncludeConfigToIncluder(c DiffIncludeConfig) (includer diffInternal.
 	for pkgI, cpkg := range c.Packages {
 		pkg := &includer.Packages[pkgI]
 		pkg.Name = cpkg.Name
+		pkg.DefaultChannel = cpkg.DefaultChannel
 		pkg.AllChannels.Versions = cpkg.Versions
 		pkg.AllChannels.Bundles = cpkg.Bundles
 		if cpkg.Range != "" {

--- a/pkg/operator/diff/internal/diff.go
+++ b/pkg/operator/diff/internal/diff.go
@@ -174,7 +174,6 @@ func (g *DiffGenerator) Run(oldModel, newModel model.Model) (model.Model, error)
 			}
 
 		}
-
 	}
 
 	if !g.SkipDependencies {
@@ -185,22 +184,40 @@ func (g *DiffGenerator) Run(oldModel, newModel model.Model) (model.Model, error)
 	}
 
 	// Default channel may not have been copied, so set it to the new default channel here.
-	for _, outputPkg := range outputModel {
+	for idx, outputPkg := range outputModel {
+		overrideSet := false
 		newPkg, found := newModel[outputPkg.Name]
 		if !found {
 			return nil, fmt.Errorf("package %s not present in the diff new model", outputPkg.Name)
 		}
 		var outputHasDefault bool
 		outputPkg.DefaultChannel, outputHasDefault = outputPkg.Channels[newPkg.DefaultChannel.Name]
-		if !outputHasDefault {
-			// Set the defaultChannel using the priority of a channel when the default got filtered out
-			// If no channels with the Priority property, raise an error
-			if err := setDefaultChannel(outputPkg, newPkg.DefaultChannel.Name); err != nil {
-				return nil, err
+		if !outputHasDefault && !overrideSet {
+			// OCPBUGS-385
+			// check if selectedDefaultChannel is the same as the channel being looked at
+			// if yes the then set it, this ensures we select the correct override for the selected
+			// package
+			for _, pkg := range g.Includer.Packages {
+				// check if the selectedDefaultChannel is valid
+				if len(pkg.DefaultChannel) > 0 {
+					overrideDefaultChannel, isValid := newPkg.Channels[pkg.DefaultChannel]
+					if pkg.Name == newPkg.Name && isValid {
+						outputModel[idx].DefaultChannel = overrideDefaultChannel
+						overrideSet = true
+						// no use continuing
+						break
+					}
+				}
+			}
+			if !overrideSet {
+				// Set the defaultChannel using the priority of a channel when the default got filtered out
+				// If no channels with the Priority property, raise an error
+				if err := setDefaultChannel(outputPkg, newPkg.DefaultChannel.Name); err != nil {
+					return nil, err
+				}
 			}
 		}
 	}
-
 	return outputModel, nil
 }
 
@@ -262,7 +279,7 @@ This can be resolved by one of the following changes:
 3) by changing the ImageSetConfiguration to filter channels or packages in such as way that it will include a package version that exists in the current default channel`)
 
 	// include a short message that does not mention any of the above to keep things simple
-	return fmt.Errorf("the current default channel %q for package %q could not be determined... ensure that your ImageSetConfiguration filtering criteria results in a package version that exists in the current default channel", newPackageDefaultChannelName, outputPkg.Name)
+	return fmt.Errorf("the current default channel %q for package %q could not be determined... ensure that your ImageSetConfiguration filtering criteria results in a package version that exists in the current default channel or use the 'defaultChannel' field ", newPackageDefaultChannelName, outputPkg.Name)
 }
 
 // pruneOldFromNewPackage prune any bundles and channels from newPkg that

--- a/pkg/operator/diff/internal/diff_include.go
+++ b/pkg/operator/diff/internal/diff_include.go
@@ -51,6 +51,12 @@ type DiffIncludePackage struct {
 	// HeadsOnly is the mode that selects the head of the channels only.
 	// This setting will be overridden by any versions or bundles in the channels.
 	HeadsOnly bool
+	// New field added due to the following filed cases for oc-mirror
+	// - CASE03657982
+	// - CASE03655018
+	// - CASE03676821
+	// ability to override default channel
+	DefaultChannel string `json:"defaultChannel,omitempty"`
 }
 
 // DiffIncludeChannel specifies a channel, and optionally bundles and bundle versions

--- a/pkg/operator/diff/internal/diff_test.go
+++ b/pkg/operator/diff/internal/diff_test.go
@@ -3804,7 +3804,108 @@ func TestSetDefaultChannelRange(t *testing.T) {
 							property.MustBuildPackage("ibm-mq", "1.7.0"),
 						},
 					},
+				},
+			},
+		},
+
+		{
+			name:   "ibm-mq-test/Valid/OverrideDefaultChannel",
+			oldCfg: declcfg.DeclarativeConfig{},
+			newCfg: declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{Schema: declcfg.SchemaPackage, Name: "ibm-mq", DefaultChannel: "v1.8"},
+				},
+				Channels: []declcfg.Channel{
+					{Schema: declcfg.SchemaChannel, Name: "v1.8", Package: "ibm-mq", Entries: []declcfg.ChannelEntry{
+						{Name: "ibm-mq.v1.8.1"}},
+						Properties: []property.Property{
+							property.MustBuildChannelPriority("v1.8", 3),
+						},
+					},
+					{Schema: declcfg.SchemaChannel, Name: "v1.7", Package: "ibm-mq", Entries: []declcfg.ChannelEntry{
+						{Name: "ibm-mq.v1.7.0"}},
+						Properties: []property.Property{
+							property.MustBuildChannelPriority("v1.7", 1),
+						},
+					},
+					{Schema: declcfg.SchemaChannel, Name: "v1.6", Package: "ibm-mq", Entries: []declcfg.ChannelEntry{
+						{Name: "ibm-mq.v1.6.0"}},
+						Properties: []property.Property{
+							property.MustBuildChannelPriority("v1.6", 2),
+						},
+					},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  declcfg.SchemaBundle,
+						Name:    "ibm-mq.v1.6.0",
+						Package: "ibm-mq",
+						Image:   "reg/ibm-mq:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("ibm-mq", "1.6.0"),
+						},
+					},
+					{
+						Schema:  declcfg.SchemaBundle,
+						Name:    "ibm-mq.v1.7.0",
+						Package: "ibm-mq",
+						Image:   "reg/ibm-mq:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("ibm-mq", "1.7.0"),
+						},
+					},
+					{
+						Schema:  declcfg.SchemaBundle,
+						Name:    "ibm-mq.v1.8.1",
+						Package: "ibm-mq",
+						Image:   "reg/ibm-mq:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("ibm-mq", "1.8.1"),
+						},
+					},
 				}},
+			g: &DiffGenerator{
+				IncludeAdditively: false,
+				HeadsOnly:         false,
+				SkipDependencies:  true,
+				Includer: DiffIncluder{
+					Packages: []DiffIncludePackage{
+						{
+							Name: "ibm-mq",
+							Channels: []DiffIncludeChannel{
+								{
+									Name: "v1.7",
+								},
+							},
+							DefaultChannel: "v1.7",
+						},
+					},
+				},
+			},
+			expCfg: declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{Schema: declcfg.SchemaPackage, Name: "ibm-mq", DefaultChannel: "v1.7"},
+				},
+				Channels: []declcfg.Channel{
+					{Schema: declcfg.SchemaChannel, Name: "v1.7", Package: "ibm-mq", Entries: []declcfg.ChannelEntry{
+						{Name: "ibm-mq.v1.7.0"}},
+						Properties: []property.Property{
+							property.MustBuildChannelPriority("v1.7", 1),
+						},
+					},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  declcfg.SchemaBundle,
+						Name:    "ibm-mq.v1.7.0",
+						Package: "ibm-mq",
+						Image:   "reg/ibm-mq:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("ibm-mq", "1.7.0"),
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -3814,9 +3915,6 @@ func TestSetDefaultChannelRange(t *testing.T) {
 				s.assertion = require.NoError
 			}
 
-			//oldModel, err := declcfg.ConvertToModel(s.oldCfg)
-			//require.NoError(t, err)
-
 			newModel, err := declcfg.ConvertToModel(s.newCfg)
 			require.NoError(t, err)
 
@@ -3825,7 +3923,6 @@ func TestSetDefaultChannelRange(t *testing.T) {
 
 			if err := outputModel.Validate(); err != nil {
 				fmt.Println(err)
-				//return nil, err
 			}
 
 			outputCfg := declcfg.ConvertFromModel(outputModel)


### PR DESCRIPTION
This fix address the issues found [here](https://issues.redhat.com/browse/OCPBUGS-385) .

The TL;DR is that dev teams can change the default channel from one release to the next, this causes customers who have set CICD pipelines to have to change their ImageSetConfig each time a version changes.
This fix allow the use of a field in the ImageSetConfig to override the default channel and specify any channel and use the HEAD (latest version of that channel).

It means that the customer needs to be aware of the caveats not using the default channel when mirroring. This will mean we need to update our documents accordingly. We will work with the docs team as to find the appropriate wording and track (link) the docs issue to this.

Fixes # [OCPBUGS-385](https://issues.redhat.com/browse/OCPBUGS-385)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been tested locally and seems to working as expected.
We will need thorough testing from QE to ensure this fix works.

##  Expected Outcome
The ImageSetConfig used is as follows

apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.12
    packages:
    - name: elasticsearch-operator
      overrideDefaultChannel: true
      channels:
      - name: stable

NB the overrideDefaultChannel flag is at the package level , also there can only be one channel specified.

Use the following cli to execute

bin/oc-mirror --config test-isc.yml file://<some-path>
The head of the current channel "stable" is version "elasticsearch-operator.v5.8.0"

To verify this

execute the command as shown above
update the ImageSetConfig to use the defaultChannel (HEAD is the same elasticsearch-operator.v5.8.0)
execute the oc command but ensure the contents are save in a different folder
compare folders
The elasticsearch-operator was the operator of interest in the listed JIRA, I also tested using the cluster-logging operator and also got the expected results (also expecting v5.8.0 version).

Maybe QE could look at a random set of operators to verify this on

