### PR TITLE
CLID-9,CLID-23: feat: hide unnecessary flags

### DIFF
--- a/v2/pkg/cli/executor.go
+++ b/v2/pkg/cli/executor.go
@@ -190,13 +190,45 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.Global.StrictArchiving, "strict-archive", false, "// If set, generates archives that are strictly less than `archiveSize`, failing for files that exceed that limit.")
 	cmd.Flags().StringVar(&opts.Global.SinceString, "since", "", "Include all new content since specified date (format yyyy-MM-dd). When not provided, new content since previous mirroring is mirrored")
 	// nolint: errcheck
-	cmd.Flags().MarkHidden("v2")
 	cmd.Flags().AddFlagSet(&flagSharedOpts)
 	cmd.Flags().AddFlagSet(&flagRetryOpts)
 	cmd.Flags().AddFlagSet(&flagDepTLS)
 	cmd.Flags().AddFlagSet(&flagSrcOpts)
 	cmd.Flags().AddFlagSet(&flagDestOpts)
+	HideFlags(cmd)
 	return cmd
+}
+
+func HideFlags(cmd *cobra.Command) {
+	cmd.Flags().MarkHidden("v2")
+	cmd.Flags().MarkHidden("dest-authfile")
+	cmd.Flags().MarkHidden("dest-cert-dir")
+	cmd.Flags().MarkHidden("dest-compress")
+	cmd.Flags().MarkHidden("dest-compress-format")
+	cmd.Flags().MarkHidden("dest-compress-level")
+	cmd.Flags().MarkHidden("dest-creds")
+	cmd.Flags().MarkHidden("dest-daemon-host")
+	cmd.Flags().MarkHidden("dest-decompress")
+	cmd.Flags().MarkHidden("dest-no-creds")
+	cmd.Flags().MarkHidden("dest-oci-accept-uncompressed-layers")
+	cmd.Flags().MarkHidden("dest-password")
+	cmd.Flags().MarkHidden("dest-precompute-digests")
+	cmd.Flags().MarkHidden("dest-registry-token")
+	cmd.Flags().MarkHidden("dest-shared-blob-dir")
+	cmd.Flags().MarkHidden("dest-username")
+	cmd.Flags().MarkHidden("dir")
+	cmd.Flags().MarkHidden("force")
+	cmd.Flags().MarkHidden("quiet")
+	cmd.Flags().MarkHidden("retry-times")
+	cmd.Flags().MarkHidden("src-authfile")
+	cmd.Flags().MarkHidden("src-cert-dir")
+	cmd.Flags().MarkHidden("src-creds")
+	cmd.Flags().MarkHidden("src-daemon-host")
+	cmd.Flags().MarkHidden("src-no-creds")
+	cmd.Flags().MarkHidden("src-password")
+	cmd.Flags().MarkHidden("src-registry-token")
+	cmd.Flags().MarkHidden("src-shared-blob-dir")
+	cmd.Flags().MarkHidden("src-username")
 }
 
 // Validate - cobra validation

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/cli/executor.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/cli/executor.go
@@ -190,13 +190,45 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.Global.StrictArchiving, "strict-archive", false, "// If set, generates archives that are strictly less than `archiveSize`, failing for files that exceed that limit.")
 	cmd.Flags().StringVar(&opts.Global.SinceString, "since", "", "Include all new content since specified date (format yyyy-MM-dd). When not provided, new content since previous mirroring is mirrored")
 	// nolint: errcheck
-	cmd.Flags().MarkHidden("v2")
 	cmd.Flags().AddFlagSet(&flagSharedOpts)
 	cmd.Flags().AddFlagSet(&flagRetryOpts)
 	cmd.Flags().AddFlagSet(&flagDepTLS)
 	cmd.Flags().AddFlagSet(&flagSrcOpts)
 	cmd.Flags().AddFlagSet(&flagDestOpts)
+	HideFlags(cmd)
 	return cmd
+}
+
+func HideFlags(cmd *cobra.Command) {
+	cmd.Flags().MarkHidden("v2")
+	cmd.Flags().MarkHidden("dest-authfile")
+	cmd.Flags().MarkHidden("dest-cert-dir")
+	cmd.Flags().MarkHidden("dest-compress")
+	cmd.Flags().MarkHidden("dest-compress-format")
+	cmd.Flags().MarkHidden("dest-compress-level")
+	cmd.Flags().MarkHidden("dest-creds")
+	cmd.Flags().MarkHidden("dest-daemon-host")
+	cmd.Flags().MarkHidden("dest-decompress")
+	cmd.Flags().MarkHidden("dest-no-creds")
+	cmd.Flags().MarkHidden("dest-oci-accept-uncompressed-layers")
+	cmd.Flags().MarkHidden("dest-password")
+	cmd.Flags().MarkHidden("dest-precompute-digests")
+	cmd.Flags().MarkHidden("dest-registry-token")
+	cmd.Flags().MarkHidden("dest-shared-blob-dir")
+	cmd.Flags().MarkHidden("dest-username")
+	cmd.Flags().MarkHidden("dir")
+	cmd.Flags().MarkHidden("force")
+	cmd.Flags().MarkHidden("quiet")
+	cmd.Flags().MarkHidden("retry-times")
+	cmd.Flags().MarkHidden("src-authfile")
+	cmd.Flags().MarkHidden("src-cert-dir")
+	cmd.Flags().MarkHidden("src-creds")
+	cmd.Flags().MarkHidden("src-daemon-host")
+	cmd.Flags().MarkHidden("src-no-creds")
+	cmd.Flags().MarkHidden("src-password")
+	cmd.Flags().MarkHidden("src-registry-token")
+	cmd.Flags().MarkHidden("src-shared-blob-dir")
+	cmd.Flags().MarkHidden("src-username")
 }
 
 // Validate - cobra validation


### PR DESCRIPTION
# Description

Since v2 is using containers/image as the underlying go mod to mirror images, some of the flags were inherited because of this dependency but they are not necessary needed to be exposed to customers.

This PR hides all the unnecessary flags that are being used currently only internally.

Fixes # [CLID-9](https://issues.redhat.com/browse/CLID-9) and [CLID-23](https://issues.redhat.com/browse/CLID-23)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`./bin/oc-mirror --v2 --help`

## Expected Outcome
```
Flags:
  -c, --config string                Path to imageset configuration file
      --dest-tls-verify              require HTTPS and verify certificates when talking to the container registry or daemon
      --from string                  local storage directory for disk to mirror workflow
  -h, --help                         help for oc-mirror
      --loglevel string              Log level one of (info, debug, trace, error) (default "info")
      --max-nested-paths int         Number of nested paths, for destination registries that limit nested paths
  -p, --port uint16                  HTTP port used by oc-mirror's local storage instance (default 55000)
      --secure-policy                If set (default is false), will enable signature verification (secure policy for signature verification).
      --since string                 Include all new content since specified date (format yyyy-MM-dd). When not provided, new content since previous mirroring is mirrored
      --src-tls-verify               require HTTPS and verify certificates when talking to the container registry or daemon
      --strict-archive archiveSize   // If set, generates archives that are strictly less than archiveSize, failing for files that exceed that limit.
  -v, --version                      version for oc-mirror

```