### PR TITLE
OCPBUGS-25346: Generate both oc-mirror binaries for rhel9 and rhel8

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.20-openshift-4.15
+  tag: rhel-9-release-golang-1.20-openshift-4.15

--- a/images/cli/Dockerfile.ci
+++ b/images/cli/Dockerfile.ci
@@ -1,11 +1,18 @@
 # This Dockerfile is used by CI to publish the oc-mirror image.
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder_rhel8
 WORKDIR /go/src/github.com/openshift/oc-mirror
 COPY . .
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/4.15:base
-COPY --from=builder /go/src/github.com/openshift/oc-mirror/bin/oc-mirror /usr/bin/
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.15 AS builder_rhel9
+WORKDIR /go/src/github.com/openshift/oc-mirror
+COPY . .
+RUN make build
+
+FROM registry.ci.openshift.org/ocp/4.15:base-rhel9
+COPY --from=builder_rhel8 /go/src/github.com/openshift/oc-mirror/bin/oc-mirror /usr/bin/oc-mirror.rhel8
+COPY --from=builder_rhel9 /go/src/github.com/openshift/oc-mirror/bin/oc-mirror /usr/bin/oc-mirror
+COPY --from=builder_rhel9 /go/src/github.com/openshift/oc-mirror/bin/oc-mirror /usr/bin/oc-mirror.rhel9
 
 LABEL io.k8s.display-name="oc-mirror" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \


### PR DESCRIPTION
# Description

This PR cherry-picks the dockerfile changes in order to generate both rhel9 and rhel8 binaries, and adapts them to 4.15 context.

Fixes # OCPBUGS-25346

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Through prow build and automated tests.

## Expected Outcome
The docker image generated by the ci should contain 2 binaries: oc-mirror.rhel8 and oc-mirror.rhel9

From the logs of the ci job images, build02 cluster was used.
Login to that cluster ( see [instructions](https://docs.ci.openshift.org/docs/how-tos/use-registries-in-build-farm/)
then
```bash
oc registry login  
 skopeo copy docker://registry.build02.ci.openshift.org/ci-op-zcqrt91z/pipeline:oc-mirror oci:///home/skhoury/rel415_mirror
Getting image source signatures
Copying blob 397bffd2f247 done   | 
Copying blob ca1636478fe5 done   | 
Copying blob d1c21e1bfa89 done   | 
Copying blob 13c9a347b47c done   | 
Copying blob 8c9a579830bc done   | 
Copying config cb664ca284 done   | 
Writing manifest to image destination
╭─╼skhoury@fedora ~ 
╰─ -$ cd rel415_mirror/blobs/sha256/
╭─╼skhoury@fedora ~/.../blobs/sha256 
╰─ -$ for i in `ls `
> do 
> echo $i
> tar tvf $i | grep oc-mirror
> echo ----
> done
13c9a347b47c4b1b110976860d7000e2e90960634bea697084bb29eedfad9723
----
3112543dd7e4af7e3c14651164c3dc0d939ed1177bbfbb38f3e35bcdb649443c
tar: This does not look like a tar archive
tar: Skipping to next header
tar: Exiting with failure status due to previous errors
----
397bffd2f247532b177d8fc47d3c51573355d2b84e3f6c11ee1e21cbe3472553
-rwxr-xr-x 0/0       157317408 2024-02-29 16:33 usr/bin/oc-mirror
-rwxr-xr-x 0/0       157049624 2024-02-29 16:30 usr/bin/oc-mirror.rhel8
-rwxr-xr-x 0/0       157317408 2024-02-29 16:33 usr/bin/oc-mirror.rhel9
----
```
