### PR TITLE
CLID-67: feat: adds --v1 flag to redirect to legacy code

### DIFF
--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -25,6 +25,7 @@ type MirrorOptions struct {
 	SourceSkipTLS              bool   // Disable TLS validation for source registry
 	DestSkipTLS                bool   // Disable TLS validation for destination registry
 	V2                         bool   // Redirect the flow to oc-mirror v2 - PLEASE DO NOT USE that. V2 is still under development and it is not ready to be used.
+	V1                         bool   // Redirect the flow to oc-mirror v1 - This flag is going to redirect the flow to v1 (legacy code) when v2 becomes the default (still under development).
 	SourcePlainHTTP            bool   // Use plain HTTP for source registry
 	DestPlainHTTP              bool   // Use plain HTTP for destination registry
 	SkipVerification           bool   // Skip verifying the integrity of the retrieved content.
@@ -55,6 +56,7 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.SourceSkipTLS, "source-skip-tls", o.SourceSkipTLS, "Disable TLS validation for source registry")
 	fs.BoolVar(&o.DestSkipTLS, "dest-skip-tls", o.DestSkipTLS, "Disable TLS validation for destination registry")
 	fs.BoolVar(&o.V2, "v2", o.V2, "Redirect the flow to oc-mirror v2 - PLEASE DO NOT USE that. V2 is still under development and it is not ready to be used.")
+	fs.BoolVar(&o.V1, "v1", o.V1, "Redirect the flow to oc-mirror v1 - This flag is going to redirect the flow to v1 (legacy code) when v2 becomes the default (still under development).")
 	fs.BoolVar(&o.SourcePlainHTTP, "source-use-http", o.SourcePlainHTTP, "Use plain HTTP for source registry")
 	fs.BoolVar(&o.DestPlainHTTP, "dest-use-http", o.DestPlainHTTP, "Use plain HTTP for destination registry")
 	fs.BoolVar(&o.SkipVerification, "skip-verification", o.SkipVerification, "Skip verifying the integrity of the retrieved content."+

--- a/v2/pkg/operator/const.go
+++ b/v2/pkg/operator/const.go
@@ -1,7 +1,6 @@
 package operator
 
 const (
-	indexJson               string = "index.json"
 	operatorImageExtractDir string = "hold-operator"
 	dockerProtocol          string = "docker://"
 	ociProtocol             string = "oci://"
@@ -10,6 +9,4 @@ const (
 	blobsDir                string = "blobs/sha256"
 	errMsg                  string = "[OperatorImageCollector] %v "
 	logsFile                string = "operator.log"
-	sha256                  string = "sha256:"
-	annotation              string = "-annotation-"
 )

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/operator/const.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/operator/const.go
@@ -1,7 +1,6 @@
 package operator
 
 const (
-	indexJson               string = "index.json"
 	operatorImageExtractDir string = "hold-operator"
 	dockerProtocol          string = "docker://"
 	ociProtocol             string = "oci://"
@@ -10,6 +9,4 @@ const (
 	blobsDir                string = "blobs/sha256"
 	errMsg                  string = "[OperatorImageCollector] %v "
 	logsFile                string = "operator.log"
-	sha256                  string = "sha256:"
-	annotation              string = "-annotation-"
 )


### PR DESCRIPTION
# Description

As part of the v2 migration, it is necessary to guarantee that v1 (legacy code) is available until the deprecate period finishes. It was added a --v1 flag to redirect the flow to v1.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
./bin/oc-mirror --help
```

## Expected Outcome
--v1 flag should show in the --help 