### PR TITLE
CLID-70: fix: issue when mirroring multiple catalogs

### DIFF
--- a/v2/pkg/image/image.go
+++ b/v2/pkg/image/image.go
@@ -130,3 +130,12 @@ func WithMaxNestedPaths(imageRef string, maxNestedPaths int) (string, error) {
 	}
 	return strings.Replace(imageRef, spec.PathComponent, pathWithMaxNexted, 1), nil
 }
+
+func (i ImageSpec) ComponentName() string {
+	if strings.Contains(i.PathComponent, "/") {
+		pathComponents := strings.Split(i.PathComponent, "/")
+		return pathComponents[len(pathComponents)-1]
+	} else {
+		return i.PathComponent
+	}
+}

--- a/v2/pkg/operator/local_stored_collector.go
+++ b/v2/pkg/operator/local_stored_collector.go
@@ -177,9 +177,12 @@ func (o *LocalStorageCollector) OperatorImageCollector(ctx context.Context) ([]v
 			return []v1alpha3.CopyImageSchema{}, err
 		}
 
-		relatedImages, err = o.Manifest.GetRelatedImagesFromCatalog(operatorCatalog, op)
+		ri, err := o.Manifest.GetRelatedImagesFromCatalog(operatorCatalog, op)
 		if err != nil {
 			return []v1alpha3.CopyImageSchema{}, err
+		}
+		for k, v := range ri {
+			relatedImages[k] = v
 		}
 
 		// this ensures we either enforce using targetTag or targetCatalog
@@ -197,7 +200,7 @@ func (o *LocalStorageCollector) OperatorImageCollector(ctx context.Context) ([]v
 				targetTag = validDigest.Encoded()[:hashTruncLen]
 			}
 		}
-		relatedImages["index"] = []v1alpha3.RelatedImage{
+		relatedImages[imgSpec.ComponentName()+"."+imgSpec.Tag] = []v1alpha3.RelatedImage{
 			{
 				Name:       catalogName,
 				Image:      op.Catalog,

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/image/image.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/image/image.go
@@ -130,3 +130,12 @@ func WithMaxNestedPaths(imageRef string, maxNestedPaths int) (string, error) {
 	}
 	return strings.Replace(imageRef, spec.PathComponent, pathWithMaxNexted, 1), nil
 }
+
+func (i ImageSpec) ComponentName() string {
+	if strings.Contains(i.PathComponent, "/") {
+		pathComponents := strings.Split(i.PathComponent, "/")
+		return pathComponents[len(pathComponents)-1]
+	} else {
+		return i.PathComponent
+	}
+}

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/operator/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/operator/local_stored_collector.go
@@ -177,9 +177,12 @@ func (o *LocalStorageCollector) OperatorImageCollector(ctx context.Context) ([]v
 			return []v1alpha3.CopyImageSchema{}, err
 		}
 
-		relatedImages, err = o.Manifest.GetRelatedImagesFromCatalog(operatorCatalog, op)
+		ri, err := o.Manifest.GetRelatedImagesFromCatalog(operatorCatalog, op)
 		if err != nil {
 			return []v1alpha3.CopyImageSchema{}, err
+		}
+		for k, v := range ri {
+			relatedImages[k] = v
 		}
 
 		// this ensures we either enforce using targetTag or targetCatalog
@@ -197,7 +200,7 @@ func (o *LocalStorageCollector) OperatorImageCollector(ctx context.Context) ([]v
 				targetTag = validDigest.Encoded()[:hashTruncLen]
 			}
 		}
-		relatedImages["index"] = []v1alpha3.RelatedImage{
+		relatedImages[imgSpec.ComponentName()+"."+imgSpec.Tag] = []v1alpha3.RelatedImage{
 			{
 				Name:       catalogName,
 				Image:      op.Catalog,


### PR DESCRIPTION
# Description

There was an issue on v2 when trying to mirroring multiple catalogs in the same mirroring flow (2 catalogs in the ImageSetConfiguration)

Fixes # [CLID-70](https://issues.redhat.com//browse/CLID-70)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

mirrorToDisk and diskToMirror using the following ImageSetConfiguration:

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/community-operator-index:v4.11
      packages:
        - name: 3scale-community-operator
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.14
      packages:
        - name: aws-load-balancer-operator
```

## Expected Outcome
Target registry:

```
{
  "repositories": [
    "3scale/3scale-operator",
    "albo/aws-load-balancer-controller-rhel8",
    "albo/aws-load-balancer-operator-bundle",
    "albo/aws-load-balancer-rhel8-operator",
    "openshift-community-operators/3scale-community-operator",
    "openshift4/ose-kube-rbac-proxy",
    "redhat/community-operator-index",
    "redhat/redhat-operator-index"
  ]
}
```