### PR TITLE
CLID-17: feat: docker v2s2 manifest list / oci image index implementation

### DIFF
--- a/v2/pkg/additional/const.go
+++ b/v2/pkg/additional/const.go
@@ -3,5 +3,4 @@ package additional
 const (
 	dockerProtocol string = "docker://"
 	ociProtocol    string = "oci://"
-	hashTruncLen   int    = 12
 )

--- a/v2/pkg/additional/local_stored_collector.go
+++ b/v2/pkg/additional/local_stored_collector.go
@@ -41,7 +41,7 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 			src = imgSpec.ReferenceWithTransport
 
 			if imgSpec.IsImageByDigest() {
-				dest = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent + ":" + imgSpec.Digest[:hashTruncLen]}, "/")
+				dest = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
 			} else {
 				dest = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent}, "/") + ":" + imgSpec.Tag
 			}
@@ -66,8 +66,8 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 				}
 
 				if imgSpec.IsImageByDigest() {
-					src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent + ":" + imgSpec.Digest[:hashTruncLen]}, "/")
-					dest = strings.Join([]string{o.Opts.Destination, imgSpec.PathComponent + ":" + imgSpec.Digest[:hashTruncLen]}, "/")
+					src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
+					dest = strings.Join([]string{o.Opts.Destination, imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
 				} else {
 					src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent}, "/") + ":" + imgSpec.Tag
 					dest = strings.Join([]string{o.Opts.Destination, imgSpec.PathComponent}, "/") + ":" + imgSpec.Tag

--- a/v2/pkg/additional/local_stored_collector_test.go
+++ b/v2/pkg/additional/local_stored_collector_test.go
@@ -186,3 +186,7 @@ func (o MockManifest) ExtractLayersOCI(filePath, toPath, label string, oci *v1al
 func (o MockManifest) ExtractLayers(filePath, name, label string) error {
 	return nil
 }
+
+func (o MockManifest) ConvertIndexToSingleManifest(dir string, oci *v1alpha3.OCISchema) error {
+	return nil
+}

--- a/v2/pkg/api/v1alpha3/types.go
+++ b/v2/pkg/api/v1alpha3/types.go
@@ -82,16 +82,16 @@ type Status struct {
 // OCISchema
 type OCISchema struct {
 	SchemaVersion int           `json:"schemaVersion"`
-	MediaType     string        `json:"mediaType"`
+	MediaType     string        `json:"mediaType,omitempty"`
 	Manifests     []OCIManifest `json:"manifests"`
-	Config        OCIManifest   `json:"config"`
-	Layers        []OCIManifest `json:"layers"`
+	Config        OCIManifest   `json:"config,omitempty"`
+	Layers        []OCIManifest `json:"layers,omitempty"`
 }
 
 type OCIManifest struct {
-	MediaType string `json:"mediaType"`
-	Digest    string `json:"digest"`
-	Size      int    `json:"size"`
+	MediaType string `json:"mediaType,omitempty"`
+	Digest    string `json:"digest,omitempty"`
+	Size      int    `json:"size,omitempty"`
 }
 
 // OperatorConfigSchema

--- a/v2/pkg/batch/worker.go
+++ b/v2/pkg/batch/worker.go
@@ -90,7 +90,6 @@ func (o *Batch) Worker(ctx context.Context, images []v1alpha3.CopyImageSchema, o
 			index := (i * b.BatchSize) + x
 			o.Log.Debug("source %s ", images[index].Source)
 			o.Log.Debug("destination %s ", images[index].Destination)
-			opts.MultiArch = "all"
 			go func(ctx context.Context, src, dest string, opts *mirror.CopyOptions, writer bufio.Writer) {
 				defer wg.Done()
 				err := o.Mirror.Run(ctx, src, dest, "copy", opts, writer)

--- a/v2/pkg/batch/worker_test.go
+++ b/v2/pkg/batch/worker_test.go
@@ -65,22 +65,22 @@ func TestWorker(t *testing.T) {
 type Mirror struct{}
 type Manifest struct{}
 
-func (o *Mirror) Run(ctx context.Context, src, dest string, mode mirror.Mode, opts *mirror.CopyOptions, stdout bufio.Writer) error {
+func (o Mirror) Run(ctx context.Context, src, dest string, mode mirror.Mode, opts *mirror.CopyOptions, stdout bufio.Writer) error {
 	return nil
 }
 
-func (o *Mirror) Check(ctx context.Context, image string, opts *mirror.CopyOptions) (bool, error) {
+func (o Mirror) Check(ctx context.Context, image string, opts *mirror.CopyOptions) (bool, error) {
 	return true, nil
 }
 
-func (o *Manifest) GetOperatorConfig(file string) (*v1alpha3.OperatorConfigSchema, error) {
+func (o Manifest) GetOperatorConfig(file string) (*v1alpha3.OperatorConfigSchema, error) {
 	opcl := v1alpha3.OperatorLabels{OperatorsOperatorframeworkIoIndexConfigsV1: "/configs"}
 	opc := v1alpha3.OperatorConfig{Labels: opcl}
 	ocs := &v1alpha3.OperatorConfigSchema{Config: opc}
 	return ocs, nil
 }
 
-func (o *Manifest) GetReleaseSchema(filePath string) ([]v1alpha3.RelatedImage, error) {
+func (o Manifest) GetReleaseSchema(filePath string) ([]v1alpha3.RelatedImage, error) {
 	relatedImages := []v1alpha3.RelatedImage{
 		{Name: "testA", Image: "registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"},
 		{Name: "testB", Image: "registry/name/namespace/sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"},
@@ -90,7 +90,7 @@ func (o *Manifest) GetReleaseSchema(filePath string) ([]v1alpha3.RelatedImage, e
 	return relatedImages, nil
 }
 
-func (o *Manifest) GetImageIndex(name string) (*v1alpha3.OCISchema, error) {
+func (o Manifest) GetImageIndex(name string) (*v1alpha3.OCISchema, error) {
 	return &v1alpha3.OCISchema{
 		SchemaVersion: 2,
 		Manifests: []v1alpha3.OCIManifest{
@@ -103,7 +103,7 @@ func (o *Manifest) GetImageIndex(name string) (*v1alpha3.OCISchema, error) {
 	}, nil
 }
 
-func (o *Manifest) GetImageManifest(name string) (*v1alpha3.OCISchema, error) {
+func (o Manifest) GetImageManifest(name string) (*v1alpha3.OCISchema, error) {
 	return &v1alpha3.OCISchema{
 		SchemaVersion: 2,
 		Manifests: []v1alpha3.OCIManifest{
@@ -125,7 +125,7 @@ func (o Manifest) GetCatalog(filePath string) (manifest.OperatorCatalog, error) 
 	return manifest.OperatorCatalog{}, nil
 }
 
-func (o *Manifest) GetRelatedImagesFromCatalog(operatorCatalog manifest.OperatorCatalog, ctlgInIsc v1alpha2.Operator) (map[string][]v1alpha3.RelatedImage, error) {
+func (o Manifest) GetRelatedImagesFromCatalog(operatorCatalog manifest.OperatorCatalog, ctlgInIsc v1alpha2.Operator) (map[string][]v1alpha3.RelatedImage, error) {
 	relatedImages := make(map[string][]v1alpha3.RelatedImage)
 	relatedImages["abc"] = []v1alpha3.RelatedImage{
 		{Name: "testA", Image: "sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"},
@@ -134,10 +134,14 @@ func (o *Manifest) GetRelatedImagesFromCatalog(operatorCatalog manifest.Operator
 	return relatedImages, nil
 }
 
-func (o *Manifest) ExtractLayersOCI(filePath, toPath, label string, oci *v1alpha3.OCISchema) error {
+func (o Manifest) ExtractLayersOCI(filePath, toPath, label string, oci *v1alpha3.OCISchema) error {
 	return nil
 }
 
-func (o *Manifest) ExtractLayers(filePath, name, label string) error {
+func (o Manifest) ExtractLayers(filePath, name, label string) error {
+	return nil
+}
+
+func (o Manifest) ConvertIndexToSingleManifest(dir string, oci *v1alpha3.OCISchema) error {
 	return nil
 }

--- a/v2/pkg/cli/executor_test.go
+++ b/v2/pkg/cli/executor_test.go
@@ -51,7 +51,7 @@ func TestExecutorMirroring(t *testing.T) {
 	_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 	_, retryOpts := mirror.RetryFlags()
 
-	opts := mirror.CopyOptions{
+	opts := &mirror.CopyOptions{
 		Global:              global,
 		DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
 		SrcImage:            srcOpts,
@@ -85,8 +85,8 @@ func TestExecutorMirroring(t *testing.T) {
 	nie.Is(fmt.Errorf("interrupt error"))
 
 	t.Run("Testing Executor : mirrorToDisk should pass", func(t *testing.T) {
-		collector := &Collector{Log: log, Config: cfg, Opts: opts, Fail: false}
-		batch := &Batch{Log: log, Config: cfg, Opts: opts}
+		collector := &Collector{Log: log, Config: cfg, Opts: *opts, Fail: false}
+		batch := &Batch{Log: log, Config: cfg, Opts: *opts}
 		archiver := MockArchiver{opts.Destination}
 
 		ex := &ExecutorSchema{
@@ -116,8 +116,8 @@ func TestExecutorMirroring(t *testing.T) {
 	})
 
 	t.Run("Testing Executor : diskToMirror should pass", func(t *testing.T) {
-		collector := &Collector{Log: log, Config: cfg, Opts: opts, Fail: false}
-		batch := &Batch{Log: log, Config: cfg, Opts: opts}
+		collector := &Collector{Log: log, Config: cfg, Opts: *opts, Fail: false}
+		batch := &Batch{Log: log, Config: cfg, Opts: *opts}
 		archiver := MockMirrorUnArchiver{}
 		cr := MockClusterResources{}
 		cfg.Mirror.Platform.Graph = true
@@ -150,8 +150,8 @@ func TestExecutorMirroring(t *testing.T) {
 	})
 
 	t.Run("Testing Executor : diskToMirror should fail", func(t *testing.T) {
-		collector := &Collector{Log: log, Config: cfg, Opts: opts, Fail: false}
-		batch := &Batch{Log: log, Config: cfg, Opts: opts}
+		collector := &Collector{Log: log, Config: cfg, Opts: *opts, Fail: false}
+		batch := &Batch{Log: log, Config: cfg, Opts: *opts}
 		archiver := MockMirrorUnArchiver{Fail: true}
 		cr := MockClusterResources{}
 		cfg.Mirror.Platform.Graph = true
@@ -209,7 +209,7 @@ func TestExecutorValidate(t *testing.T) {
 		_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 		_, retryOpts := mirror.RetryFlags()
 
-		opts := mirror.CopyOptions{
+		opts := &mirror.CopyOptions{
 			Global:              global,
 			DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
 			SrcImage:            srcOpts,
@@ -288,7 +288,7 @@ func TestExecutorComplete(t *testing.T) {
 		_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 		_, retryOpts := mirror.RetryFlags()
 
-		opts := mirror.CopyOptions{
+		opts := &mirror.CopyOptions{
 			Global:              global,
 			DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
 			SrcImage:            srcOpts,
@@ -359,7 +359,7 @@ func TestExecutorValidatePrepare(t *testing.T) {
 		_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 		_, retryOpts := mirror.RetryFlags()
 
-		opts := mirror.CopyOptions{
+		opts := &mirror.CopyOptions{
 			Global:              global,
 			DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
 			SrcImage:            srcOpts,
@@ -420,7 +420,7 @@ func TestExecutorCompletePrepare(t *testing.T) {
 		_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 		_, retryOpts := mirror.RetryFlags()
 
-		opts := mirror.CopyOptions{
+		opts := &mirror.CopyOptions{
 			Global:              global,
 			DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
 			SrcImage:            srcOpts,
@@ -468,7 +468,7 @@ func TestExecutorRunPrepare(t *testing.T) {
 		_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 		_, retryOpts := mirror.RetryFlags()
 
-		opts := mirror.CopyOptions{
+		opts := &mirror.CopyOptions{
 			Global:              global,
 			DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
 			SrcImage:            srcOpts,
@@ -500,7 +500,7 @@ func TestExecutorRunPrepare(t *testing.T) {
 			log.Error("imagesetconfig %v ", err)
 		}
 
-		collector := &Collector{Log: log, Config: cfg, Opts: opts, Fail: false}
+		collector := &Collector{Log: log, Config: cfg, Opts: *opts, Fail: false}
 		mockMirror := Mirror{}
 
 		ex := &ExecutorSchema{
@@ -543,7 +543,7 @@ func TestExecutorSetupLocalStorage(t *testing.T) {
 		_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 		_, retryOpts := mirror.RetryFlags()
 
-		opts := mirror.CopyOptions{
+		opts := &mirror.CopyOptions{
 			Global:              global,
 			DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
 			SrcImage:            srcOpts,
@@ -577,7 +577,7 @@ func TestExecutorSetupWorkingDir(t *testing.T) {
 			WorkingDir:   "/root",
 		}
 
-		opts := mirror.CopyOptions{
+		opts := &mirror.CopyOptions{
 			Global: global,
 		}
 
@@ -627,7 +627,7 @@ func TestExecutorSetupLogsLevelAndDir(t *testing.T) {
 			SecurePolicy: false,
 		}
 
-		opts := mirror.CopyOptions{
+		opts := &mirror.CopyOptions{
 			Global: global,
 		}
 
@@ -668,7 +668,7 @@ func TestExecutorCollectAll(t *testing.T) {
 		_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 		_, retryOpts := mirror.RetryFlags()
 
-		opts := mirror.CopyOptions{
+		opts := &mirror.CopyOptions{
 			Global:              global,
 			DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
 			SrcImage:            srcOpts,
@@ -680,8 +680,8 @@ func TestExecutorCollectAll(t *testing.T) {
 
 		// read the ImageSetConfiguration
 		cfg, _ := config.ReadConfig("../../tests/isc.yaml")
-		failCollector := &Collector{Log: log, Config: cfg, Opts: opts, Fail: true}
-		collector := &Collector{Log: log, Config: cfg, Opts: opts, Fail: false}
+		failCollector := &Collector{Log: log, Config: cfg, Opts: *opts, Fail: true}
+		collector := &Collector{Log: log, Config: cfg, Opts: *opts, Fail: false}
 
 		mkdir := MockMakeDir{}
 

--- a/v2/pkg/manifest/interface.go
+++ b/v2/pkg/manifest/interface.go
@@ -13,4 +13,5 @@ type ManifestInterface interface {
 	GetRelatedImagesFromCatalog(operatorCatalog OperatorCatalog, ctlgInIsc v1alpha2.Operator) (map[string][]v1alpha3.RelatedImage, error)
 	ExtractLayersOCI(filePath, toPath, label string, oci *v1alpha3.OCISchema) error
 	GetReleaseSchema(filePath string) ([]v1alpha3.RelatedImage, error)
+	ConvertIndexToSingleManifest(dir string, oci *v1alpha3.OCISchema) error
 }

--- a/v2/pkg/operator/local_stored_collector_test.go
+++ b/v2/pkg/operator/local_stored_collector_test.go
@@ -374,3 +374,7 @@ func (o MockManifest) ExtractLayersOCI(filePath, toPath, label string, oci *v1al
 	}
 	return nil
 }
+
+func (o MockManifest) ConvertIndexToSingleManifest(dir string, oci *v1alpha3.OCISchema) error {
+	return nil
+}

--- a/v2/pkg/release/local_stored_collector_test.go
+++ b/v2/pkg/release/local_stored_collector_test.go
@@ -431,6 +431,10 @@ func (o MockManifest) ExtractLayersOCI(filePath, toPath, label string, oci *v1al
 	return nil
 }
 
+func (o MockManifest) ConvertIndexToSingleManifest(dir string, oci *v1alpha3.OCISchema) error {
+	return nil
+}
+
 func (o MockCincinnati) GetReleaseReferenceImages(ctx context.Context) []v1alpha3.CopyImageSchema {
 	var res []v1alpha3.CopyImageSchema
 	res = append(res, v1alpha3.CopyImageSchema{Source: "quay.io/openshift-release-dev/ocp-release:4.13.10-x86_64", Destination: "localhost:9999/ocp-release:4.13.10-x86_64"})

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/additional/const.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/additional/const.go
@@ -3,5 +3,4 @@ package additional
 const (
 	dockerProtocol string = "docker://"
 	ociProtocol    string = "oci://"
-	hashTruncLen   int    = 12
 )

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/additional/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/additional/local_stored_collector.go
@@ -41,7 +41,7 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 			src = imgSpec.ReferenceWithTransport
 
 			if imgSpec.IsImageByDigest() {
-				dest = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent + ":" + imgSpec.Digest[:hashTruncLen]}, "/")
+				dest = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
 			} else {
 				dest = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent}, "/") + ":" + imgSpec.Tag
 			}
@@ -66,8 +66,8 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 				}
 
 				if imgSpec.IsImageByDigest() {
-					src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent + ":" + imgSpec.Digest[:hashTruncLen]}, "/")
-					dest = strings.Join([]string{o.Opts.Destination, imgSpec.PathComponent + ":" + imgSpec.Digest[:hashTruncLen]}, "/")
+					src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
+					dest = strings.Join([]string{o.Opts.Destination, imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
 				} else {
 					src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent}, "/") + ":" + imgSpec.Tag
 					dest = strings.Join([]string{o.Opts.Destination, imgSpec.PathComponent}, "/") + ":" + imgSpec.Tag

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/api/v1alpha3/types.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/api/v1alpha3/types.go
@@ -82,16 +82,16 @@ type Status struct {
 // OCISchema
 type OCISchema struct {
 	SchemaVersion int           `json:"schemaVersion"`
-	MediaType     string        `json:"mediaType"`
+	MediaType     string        `json:"mediaType,omitempty"`
 	Manifests     []OCIManifest `json:"manifests"`
-	Config        OCIManifest   `json:"config"`
-	Layers        []OCIManifest `json:"layers"`
+	Config        OCIManifest   `json:"config,omitempty"`
+	Layers        []OCIManifest `json:"layers,omitempty"`
 }
 
 type OCIManifest struct {
-	MediaType string `json:"mediaType"`
-	Digest    string `json:"digest"`
-	Size      int    `json:"size"`
+	MediaType string `json:"mediaType,omitempty"`
+	Digest    string `json:"digest,omitempty"`
+	Size      int    `json:"size,omitempty"`
 }
 
 // OperatorConfigSchema

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/batch/worker.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/batch/worker.go
@@ -90,7 +90,6 @@ func (o *Batch) Worker(ctx context.Context, images []v1alpha3.CopyImageSchema, o
 			index := (i * b.BatchSize) + x
 			o.Log.Debug("source %s ", images[index].Source)
 			o.Log.Debug("destination %s ", images[index].Destination)
-			opts.MultiArch = "all"
 			go func(ctx context.Context, src, dest string, opts *mirror.CopyOptions, writer bufio.Writer) {
 				defer wg.Done()
 				err := o.Mirror.Run(ctx, src, dest, "copy", opts, writer)

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/manifest/interface.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/manifest/interface.go
@@ -13,4 +13,5 @@ type ManifestInterface interface {
 	GetRelatedImagesFromCatalog(operatorCatalog OperatorCatalog, ctlgInIsc v1alpha2.Operator) (map[string][]v1alpha3.RelatedImage, error)
 	ExtractLayersOCI(filePath, toPath, label string, oci *v1alpha3.OCISchema) error
 	GetReleaseSchema(filePath string) ([]v1alpha3.RelatedImage, error)
+	ConvertIndexToSingleManifest(dir string, oci *v1alpha3.OCISchema) error
 }


### PR DESCRIPTION
# Description

This PR contains changes required to allow the mirroring of multi-arch operator catalogs (manifest list / OCI image index).

The changes presented here take into account the case where the index.json contains a reference to a manifest list inside of blobs/sha256 folder and also when the index.json contains the platform information directly. 

[CLID-17](https://issues.redhat.com/browse/CLID-17)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Mirroring multi-arch catalog (manifest list) scenario

## Step 0 - Get the oci redhat-operator-index multi-arch with skopeo

```
skopeo copy --all docker://registry.redhat.io/redhat/redhat-operator-index:v4.15 oci:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/redhat-operator-index --remove-signatures
```

Use this ImageSetConfiguration

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
    - catalog: oci:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/redhat-operator-index
      packages:
        - name: aws-load-balancer-operator
```

## Step 1 - mirror to disk

```
./bin/oc-mirror -c /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-isc/clid-17.yaml file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-17-multi-arch --v2
```

## Step 2 - disk to mirror
```
./bin/oc-mirror -c /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-isc/clid-17.yaml --from file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-17-multi-arch docker://localhost:7000 --v2
```

## Step 3 - skopeo copy from your local registry to check the binaries

```
skopeo copy --all docker://localhost:7000/redhat-operator-index:ec835f0c9883554442c3306aebf5555766426b9cb7379388c16c4c457cfd89f8 oci:///ho
me/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-clid-17-tests/redhat-operator-index-multi-arch-from-local --remove-signatures --src-tls-verify=false
```

Check the index.json which must be a reference to a manifest list inside of blobs/sha256 folder with for archs (amd64, arm, ppc, s390x)

## Step 4 - create folder to store the binaries by arch
```
mkdir /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-clid-17-tests/redhat-operator-index-multi-arch-from-local/amd64
```
```
mkdir /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-clid-17-tests/redhat-operator-index-multi-arch-from-local/arm
```
```
mkdir /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-clid-17-tests/redhat-operator-index-multi-arch-from-local/ppc
```
```
mkdir /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-clid-17-tests/redhat-operator-index-multi-arch-from-local/s390x
```

## Step 5 - untar all the blobs which contains the opm binary
### untar opm for amd64
```
tar xvf ./alex-tests/alex-clid-17-tests/redhat-operator-index-multi-arch-from-local/blobs/sha256/5a8a8d52ea677380025ae27b2d008f26430c7fa621da8c47f1d832d86127659e -C ./alex-tests/alex-clid-17-tests/redhat-operator-index-multi-arch-from-local/amd64
```

### untar opm for arm
```
tar xvf ./alex-tests/alex-clid-17-tests/redhat-operator-index-multi-arch-from-local/blobs/sha256/3be23da3d332a73a6a8dacbfa1c363929853c9b5d5af9355fb17a0b0c28c6092 -C ./alex-tests/alex-clid-17-tests/redhat-operator-index-multi-arch-from-local/arm
```

### untar opm for ppc 
```
tar xvf ./alex-tests/alex-clid-17-tests/redhat-operator-index-multi-arch-from-local/blobs/sha256/62fb9b72c0134d464b47647f22fa8fcc34f1ee52de26ee03de5e3c2c79d5913a -C ./alex-tests/alex-clid-17-tests/redhat-operator-index-multi-arch-from-local/ppc
```

### untar opm for s390x
```
tar xvf ./alex-tests/alex-clid-17-tests/redhat-operator-index-multi-arch-from-local/blobs/sha256/64a1efcdc4920cf6438b7997158ccb0c9dadf344716ab411889ff0075175b9f5 -C ./alex-tests/alex-clid-17-tests/redhat-operator-index-multi-arch-from-local/s390x
```


## Step 6 (last one) - Check if the binaries extracted are the expected by arch

### amd64 opm binary
```
file ./alex-tests/alex-clid-17-tests/redhat-operator-index-multi-arch-from-local/amd64/usr/bin/registry/opm
```
### Expected output:

```
ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, Go BuildID=kxOdAx20T5HcBUtdduyV/qAdo3HcfDXtaTjJhIhdn/8X4-hXPbmZ15EYWN6uDL/sZLLN5NuWzI9mGQSIaJq, BuildID[sha1]=6ee12eb52e48f11a806309de28e81eb8c1cfc168, with debug_info, not stripped, too many notes (256)
```

### arm opm binary
```
file ./alex-tests/alex-clid-17-tests/redhat-operator-index-multi-arch-from-local/arm/usr/bin/registry/opm
```

### Expected output:
```
ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, Go BuildID=41zgkAQisAWE-avGa4oI/bUDMtu54rwT8gd32xlH4/OOcdM00qAjtN-NULw0br/VbQTAImPFdnlFza7ZVmI, BuildID[sha1]=b27120537963df82a3c34d289b579efa361be994, with debug_info, not stripped, too many notes (256)
```

### ppc opm binary
```
file ./alex-tests/alex-clid-17-tests/redhat-operator-index-multi-arch-from-local/ppc/usr/bin/registry/opm
```

### Expected output: 
```
ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500, OpenPOWER ELF V2 ABI, version 1 (SYSV), dynamically linked, interpreter /lib64/ld64.so.2, for GNU/Linux 3.10.0, Go BuildID=2-O24C6A1C1eRiu83jAS/SD6m9kqwrBj2rSXAK15y/V6izCl7y6kSnTJJuYXRa/wf94iW0ZT8xoxnrCPrt2, BuildID[sha1]=dcced02867e41751cdb70dbae059d601d5363bef, with debug_info, not stripped, too many notes (256)
```

### s390x opm binary
```
file ./alex-tests/alex-clid-17-tests/redhat-operator-index-multi-arch-from-local/s390x/usr/bin/registry/opm
```

### Expected output:
```
ELF 64-bit MSB executable, IBM S/390, version 1 (SYSV), dynamically linked, interpreter /lib/ld64.so.1, for GNU/Linux 3.2.0, Go BuildID=tb3T1QXe9AJEuGbNKr76/ciod0YfjbaEW-YAa4_Ih/xCRX1qiRjqmPxscU2Waq/q4fP-mVTNdOHIV1CVaBp, BuildID[sha1]=aa4221ea49c3af50ceec1f9ba594ec4fc01ba751, with debug_info, not stripped, too many notes (256)
```