### PR TITLE
CLID-54: Mirror to mirror workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,9 @@ test-e2e: build
 	mkdir -p v2/tests/results-integration
 	@cd v2 && $(GO) test $(GO_BUILD_FLAGS) -coverprofile=tests/results-integration/cover-additional.out -race -count=1 ./pkg/... -run TestIntegrationAdditional
 	@cd v2 && $(GO) test $(GO_BUILD_FLAGS) -coverprofile=tests/results-integration/cover-release.out -race -count=1 ./pkg/... -run TestIntegrationRelease
+	@cd v2 && $(GO) test $(GO_BUILD_FLAGS) -coverprofile=tests/results-integration/cover-additional.out -race -count=1 ./pkg/... -run TestIntegrationAdditionalM2M
+	@cd v2 && $(GO) test $(GO_BUILD_FLAGS) -coverprofile=tests/results-integration/cover-release.out -race -count=1 ./pkg/... -run TestIntegrationReleaseM2M
+
 .PHONY: test-e2e
 
 test-integration: hack-build

--- a/docs/enclave_support.md
+++ b/docs/enclave_support.md
@@ -15,7 +15,7 @@ In this context, enclave users are interested in:
 ## When can I use the feature?
 :warning: **The Enclave support feature is an MVP in Developer Preview and should not be used in production.**
 
-In the OpenShift 4.15 release, the enclave workflow is a Developer Preview MVP (Minimal Viable Product). It is intended to graduate it to Tech Preview in OpenShift 4.16. 
+In the OpenShift 4.16 release, the enclave workflow is in Tech Preview. 
 
 After GA, this new mirroring technique is intended to replace the existing oc-mirror. 
 
@@ -27,18 +27,7 @@ oc-mirror --v2 --help
 ```
 
 
-The Enclave Support feature (`--v2`) has the **following limitations**:
-* Mirroring **OCP releases only**. Operator catalogs, additional images and Helm charts are not yet supported.
-* Mirroring to **fully disconnected clusters only**. In other words, mirroring to a registry  directly (Mirror-to-mirror) is not yet available.
-  * Mirroring is only possible by: 
-    * Generating an archive for the mirroring content described in the image set config (Mirror-to-disk)
-      ```bash
-      oc-mirror --v2 -c imageset_config.yaml file:///home/user/mirror_content
-      ```
-    * Mirroring from the archive to the disconnected registry (disk-to-mirror)
-      ```bash
-      oc-mirror --v2 -c imageset_config.yaml --from file:///home/user/mirror_content docker://disconnected_registry.internal:5000/
-      ```
+The Enclave Support feature (`--v2`) mirrors OCP releases, Operator catalogs, additional images. **Helm charts** are not yet supported.
 
 
 ## Reference Architecture Diagram for Enclave Support
@@ -180,3 +169,16 @@ oc-mirror --v2 -c isc-enclave.yaml
 ```
 
 The administrators of the OCP cluster in Enclave1 are now ready to install/upgrade that cluster.
+
+## How to mirror to a partially disconnected cluster? (Mirror to mirror)
+
+This workflow can be used when the environment from which oc-mirror is executed has access to both:
+* the public internet, and specifically redhat registries where OCP releases and OCP operators are delivered
+* the destination registry,  the remote registry where images will be mirrored to.
+
+In order to use the Mirror to Mirror workflow, the user can execute:
+```bash=
+oc-mirror --v2 -c isc-m2m.yaml --workspace file:///home/user/enterprise-content docker://enterprise-registry.in/
+```
+
+The images are copied from the source registry directly to the destination registry, without intermediate copies on the local machine. Custom resource manifests such as IDMS, ITMS, CatalogSource, UpdateService will be generated in the workspace provided, under `/home/user/enterprise-content/working-dir/cluster-resources`

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -30,6 +30,8 @@ test-integration:
 	mkdir -p tests/results-integration
 	go test -coverprofile=tests/results-integration/cover-additional.out  -race -count=1 ./... -run TestIntegrationAdditional
 	go test -coverprofile=tests/results-integration/cover-release.out  -race -count=1 ./... -run TestIntegrationRelease
+	go test -coverprofile=tests/results-integration/cover-additional.out  -race -count=1 ./... -run TestIntegrationAdditionalM2M
+	go test -coverprofile=tests/results-integration/cover-release.out  -race -count=1 ./... -run TestIntegrationReleaseM2M
 
 
 cover:

--- a/v2/pkg/mirror/const.go
+++ b/v2/pkg/mirror/const.go
@@ -1,10 +1,11 @@
 package mirror
 
 const (
-	MirrorToDisk      = "mirrorToDisk"
-	DiskToMirror      = "diskToMirror"
-	Prepare           = "prepare"
-	CopyMode     Mode = "copy"
-	DeleteMode   Mode = "delete"
-	CheckMode    Mode = "check"
+	MirrorToDisk        = "mirrorToDisk"
+	DiskToMirror        = "diskToMirror"
+	MirrorToMirror      = "mirrorToMirror"
+	Prepare             = "prepare"
+	CopyMode       Mode = "copy"
+	DeleteMode     Mode = "delete"
+	CheckMode      Mode = "check"
 )

--- a/v2/pkg/mirror/options.go
+++ b/v2/pkg/mirror/options.go
@@ -76,7 +76,7 @@ type CopyOptions struct {
 	EncryptLayer             []int     // The list of layers to encrypt
 	EncryptionKeys           []string  // Keys needed to encrypt the image
 	DecryptionKeys           []string  // Keys needed to decrypt the image
-	Mode                     string    // 2 options disktoMirror or mirrorToDisk (for now)
+	Mode                     string    // possible values: mirrorToDisk, disktoMirror or mirrorToMirror
 	Dev                      bool      // developer mode - will be removed when completed
 	Destination              string    // what to target to
 	UUID                     uuid.UUID // set uuid
@@ -137,6 +137,10 @@ type imageDestOptions struct {
 
 func (cp CopyOptions) IsMirrorToDisk() bool {
 	return cp.Mode == MirrorToDisk
+}
+
+func (cp CopyOptions) IsMirrorToMirror() bool {
+	return cp.Mode == MirrorToMirror
 }
 
 func (cp CopyOptions) IsDiskToMirror() bool {

--- a/v2/pkg/release/graph.go
+++ b/v2/pkg/release/graph.go
@@ -51,7 +51,7 @@ func (o *LocalStorageCollector) CreateGraphImage(ctx context.Context, url string
 	cmd := []string{"/bin/bash", "-c", fmt.Sprintf("exec cp -rp %s/* %s", graphDataDir, graphDataMountPath)}
 
 	// update a ubi9 image with this new graphLayer and new cmd
-	graphImageRef := filepath.Join(o.LocalStorageFQDN, graphImageName) + ":latest"
+	graphImageRef := filepath.Join(o.destinationRegistry(), graphImageName) + ":latest"
 	err = o.ImageBuilder.BuildAndPush(ctx, graphImageRef, layoutPath, cmd, graphLayer)
 	if err != nil {
 		return "", err

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/mirror/const.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/mirror/const.go
@@ -1,10 +1,11 @@
 package mirror
 
 const (
-	MirrorToDisk      = "mirrorToDisk"
-	DiskToMirror      = "diskToMirror"
-	Prepare           = "prepare"
-	CopyMode     Mode = "copy"
-	DeleteMode   Mode = "delete"
-	CheckMode    Mode = "check"
+	MirrorToDisk        = "mirrorToDisk"
+	DiskToMirror        = "diskToMirror"
+	MirrorToMirror      = "mirrorToMirror"
+	Prepare             = "prepare"
+	CopyMode       Mode = "copy"
+	DeleteMode     Mode = "delete"
+	CheckMode      Mode = "check"
 )

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/mirror/options.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/mirror/options.go
@@ -76,7 +76,7 @@ type CopyOptions struct {
 	EncryptLayer             []int     // The list of layers to encrypt
 	EncryptionKeys           []string  // Keys needed to encrypt the image
 	DecryptionKeys           []string  // Keys needed to decrypt the image
-	Mode                     string    // 2 options disktoMirror or mirrorToDisk (for now)
+	Mode                     string    // possible values: mirrorToDisk, disktoMirror or mirrorToMirror
 	Dev                      bool      // developer mode - will be removed when completed
 	Destination              string    // what to target to
 	UUID                     uuid.UUID // set uuid
@@ -137,6 +137,10 @@ type imageDestOptions struct {
 
 func (cp CopyOptions) IsMirrorToDisk() bool {
 	return cp.Mode == MirrorToDisk
+}
+
+func (cp CopyOptions) IsMirrorToMirror() bool {
+	return cp.Mode == MirrorToMirror
 }
 
 func (cp CopyOptions) IsDiskToMirror() bool {

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/release/graph.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/release/graph.go
@@ -51,7 +51,7 @@ func (o *LocalStorageCollector) CreateGraphImage(ctx context.Context, url string
 	cmd := []string{"/bin/bash", "-c", fmt.Sprintf("exec cp -rp %s/* %s", graphDataDir, graphDataMountPath)}
 
 	// update a ubi9 image with this new graphLayer and new cmd
-	graphImageRef := filepath.Join(o.LocalStorageFQDN, graphImageName) + ":latest"
+	graphImageRef := filepath.Join(o.destinationRegistry(), graphImageName) + ":latest"
 	err = o.ImageBuilder.BuildAndPush(ctx, graphImageRef, layoutPath, cmd, graphLayer)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
# Description

This PR introduces support for MirrorToMirror workflow in the v2 of oc-mirror.

It also introduces the command argument `--workspace` that can be used with this workflow to point to the parent directory of the working-dir (if existing). 

Fixes # [CLID-54](https://issues.redhat.com//browse/CLID-54)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Perform a direct mirror to mirror workflow with:
```bash
cat isc.yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  platform:
    channels:
    - name: stable-4.13
    # graph: true
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.14
    packages:
    - name: aws-load-balancer-operator
    - name: external-dns-operator
  additionalImages:
  - name: registry.redhat.io/ubi8/ubi:latest
 ./bin/oc-mirror --v2 -c isc.yaml --workspace file:///home/skhoury/clid20/ docker://localhost:5000/m2m
```

## Expected Outcome

- 185 images mirrored
- IDMS and ITMS files generated and not empty
- catalogsource file generated

PS: not yet tested:
* graph image generation
* use of --max-nested-paths