### PR TITLE
OCPBUGS-31466: Fix for oc-mirror new defaultChannel override

### DIFF
--- a/pkg/operator/diff/internal/diff.go
+++ b/pkg/operator/diff/internal/diff.go
@@ -207,6 +207,14 @@ func (g *DiffGenerator) Run(oldModel, newModel model.Model) (model.Model, error)
 						// no use continuing
 						break
 					}
+				} else {
+					// necessary as this happens in the second pass
+					// check to see if we have a default channel in previous run
+					if len(pkg.Channels) == 1 && pkg.Name == newPkg.Name {
+						outputModel[idx].DefaultChannel = newPkg.Channels[pkg.Channels[0].Name]
+						overrideSet = true
+						break
+					}
 				}
 			}
 			if !overrideSet {


### PR DESCRIPTION
# Description

This fixes the problem on the new "defaultChannel" field. The problem arises when re-executing oc-mirror with packages that have this field set

Fixes # OCPBUGS-31466

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with this imagesetconfig.yaml

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
storageConfig:
  local:
    path: ./operator-images
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.14
      packages:
        - name: aws-load-balancer-operator
          defaultChannel: stable-v0.2
          channels:
            - name: stable-v0.2
              minVersion: 0.2.0
              maxVersion: 0.2.0
        - name: cluster-kube-descheduler-operator
          defaultChannel: "4.13"
          channels:
            - name: "4.13"
```

First pass works perfectly, second pass failed with error about invalid package and default channel


## Expected Outcome

Re-execute oc-mirror with the exact same imagesetconfig

It should report "No new images detected, process stopping" rather than an error