### PR TITLE
OCPBUGS-31024: Ommit icon from catalogSource if empty

### DIFF
--- a/v2/pkg/api/operator-framework/v1alpha1/catalogsource_types.go
+++ b/v2/pkg/api/operator-framework/v1alpha1/catalogsource_types.go
@@ -86,7 +86,7 @@ type CatalogSourceSpec struct {
 	DisplayName string `json:"displayName,omitempty"`
 	Description string `json:"description,omitempty"`
 	Publisher   string `json:"publisher,omitempty"`
-	Icon        Icon   `json:"icon,omitempty"`
+	Icon        *Icon  `json:"icon,omitempty"`
 }
 
 type Icon struct{}

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/api/operator-framework/v1alpha1/catalogsource_types.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/api/operator-framework/v1alpha1/catalogsource_types.go
@@ -86,7 +86,7 @@ type CatalogSourceSpec struct {
 	DisplayName string `json:"displayName,omitempty"`
 	Description string `json:"description,omitempty"`
 	Publisher   string `json:"publisher,omitempty"`
-	Icon        Icon   `json:"icon,omitempty"`
+	Icon        *Icon  `json:"icon,omitempty"`
 }
 
 type Icon struct{}


### PR DESCRIPTION
# Description



Fixes # OCPBUGS-31024

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests pass. 

## Expected Outcome
CatalogSource file generated doesn't contain `icon: {}`