### PR TITLE
OCPBUGS-31084: feat: retro-compatible version cmd with v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	targets/openshift/images.mk \
 	targets/openshift/deps-gomod.mk \
 )
+
+GO_LD_EXTRAFLAGS=$(call version-ldflags,github.com/openshift/oc-mirror/v2/pkg/version)
+
 #v2 workspace required change
 #GO_MOD_FLAGS = -mod=readonly
 GO_BUILD_PACKAGES := ./cmd/...

--- a/v2/pkg/cli/executor.go
+++ b/v2/pkg/cli/executor.go
@@ -37,6 +37,7 @@ import (
 	"github.com/openshift/oc-mirror/v2/pkg/mirror"
 	"github.com/openshift/oc-mirror/v2/pkg/operator"
 	"github.com/openshift/oc-mirror/v2/pkg/release"
+	"github.com/openshift/oc-mirror/v2/pkg/version"
 	"github.com/spf13/cobra"
 )
 
@@ -178,6 +179,7 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(NewPrepareCommand(log))
+	cmd.AddCommand(version.NewVersionCommand(log))
 	cmd.PersistentFlags().StringVarP(&opts.Global.ConfigPath, "config", "c", "", "Path to imageset configuration file")
 	cmd.Flags().StringVar(&opts.Global.LogLevel, "loglevel", "info", "Log level one of (info, debug, trace, error)")
 	cmd.Flags().StringVar(&opts.Global.WorkingDir, "dir", workingDir, "Assets directory")

--- a/v2/pkg/version/version.go
+++ b/v2/pkg/version/version.go
@@ -1,0 +1,143 @@
+package version
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+
+	clog "github.com/openshift/oc-mirror/v2/pkg/log"
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/util/templates"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	// commitFromGit is a constant representing the source version that
+	// generated this build. It should be set during build via -ldflags.
+	commitFromGit string
+	// versionFromGit is a constant representing the version tag that
+	// generated this build. It should be set during build via -ldflags.
+	versionFromGit = "v0.0.0-unknown"
+	// major version
+	majorFromGit string
+	// minor version
+	minorFromGit string
+	// build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	buildDate string
+	// state of git tree, either "clean" or "dirty"
+	gitTreeState string
+)
+
+type Info struct {
+	Major        string `json:"major"`
+	Minor        string `json:"minor"`
+	GitVersion   string `json:"gitVersion"`
+	GitCommit    string `json:"gitCommit"`
+	GitTreeState string `json:"gitTreeState"`
+	BuildDate    string `json:"buildDate"`
+	GoVersion    string `json:"goVersion"`
+	Compiler     string `json:"compiler"`
+	Platform     string `json:"platform"`
+}
+
+type VersionOptions struct {
+	Output string
+	Short  bool
+	V2     bool
+}
+
+// Version is a struct for version information
+type Version struct {
+	ClientVersion *Info `json:"clientVersion,omitempty" yaml:"clientVersion,omitempty"`
+}
+
+func NewVersionCommand(log clog.PluggableLoggerInterface) *cobra.Command {
+	o := VersionOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Output version",
+		Example: templates.Examples(`
+			# Get oc-mirror version
+			oc-mirror version
+		`),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := o.Validate(); err != nil {
+				log.Error(" %v ", err)
+				os.Exit(1)
+			}
+
+			if err := o.Run(); err != nil {
+				log.Error(" %v ", err)
+				os.Exit(1)
+			}
+		},
+	}
+
+	fs := cmd.Flags()
+	fs.BoolVar(&o.Short, "short", o.Short, "Print just the version number")
+	fs.MarkDeprecated("short", "and will be removed in a future release. Use oc-mirror version instead.")
+	fs.StringVar(&o.Output, "output", o.Output, "One of 'yaml' or 'json'.")
+	fs.BoolVar(&o.V2, "v2", o.V2, "Redirect the flow to oc-mirror v2 - V2 is still under development and it is not production ready.")
+	fs.MarkHidden("v2")
+	cmd.PersistentFlags()
+
+	return cmd
+}
+
+func (o *VersionOptions) Validate() error {
+	if o.Output != "" && o.Output != "yaml" && o.Output != "json" {
+		return errors.New(`--output must be 'yaml' or 'json'`)
+	}
+
+	return nil
+}
+
+func (o *VersionOptions) Run() error {
+	var versionInfo Version
+
+	clientVersion := Get()
+	versionInfo.ClientVersion = &clientVersion
+
+	switch o.Output {
+	case "":
+		if o.Short {
+			fmt.Fprintf(os.Stdout, "Client Version: %s\n", clientVersion.GitVersion)
+		} else {
+			fmt.Fprintf(os.Stderr, "WARNING: This version information is deprecated and will be replaced with the output from --short. Use --output=yaml|json to get the full version.\n")
+			fmt.Fprintf(os.Stdout, "Client Version: %#v\n", clientVersion)
+		}
+	case "yaml":
+		marshalled, err := yaml.Marshal(&versionInfo)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(os.Stdout, string(marshalled))
+	case "json":
+		marshalled, err := json.MarshalIndent(&versionInfo, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(os.Stdout, string(marshalled))
+	default:
+		return fmt.Errorf("VersionOptions were not validated: --output=%q should have been rejected", o.Output)
+	}
+
+	return nil
+}
+
+func Get() Info {
+	return Info{
+		Major:        majorFromGit,
+		Minor:        minorFromGit,
+		GitCommit:    commitFromGit,
+		GitVersion:   versionFromGit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}

--- a/v2/pkg/version/version_test.go
+++ b/v2/pkg/version/version_test.go
@@ -1,0 +1,102 @@
+package version
+
+import (
+	"testing"
+
+	clog "github.com/openshift/oc-mirror/v2/pkg/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewVersionCommand(t *testing.T) {
+	log := clog.New("info")
+	cmd := NewVersionCommand(log)
+	require.NotNil(t, cmd)
+}
+
+func TestVersionValidate(t *testing.T) {
+
+	type spec struct {
+		name     string
+		opts     *VersionOptions
+		expError string
+	}
+
+	cases := []spec{
+		{
+			name: "Invalid/InvalidOutput",
+			opts: &VersionOptions{
+				Output: "invalid",
+			},
+			expError: "--output must be 'yaml' or 'json'",
+		},
+		{
+			name: "Valid/YAMLOutput",
+			opts: &VersionOptions{
+				Output: "yaml",
+			},
+			expError: "",
+		},
+		{
+			name: "Valid/JSONOutput",
+			opts: &VersionOptions{
+				Output: "json",
+			},
+			expError: "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.opts.Validate()
+			if c.expError != "" {
+				require.EqualError(t, err, c.expError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestVersionRun(t *testing.T) {
+
+	type spec struct {
+		name     string
+		opts     *VersionOptions
+		expError string
+	}
+
+	cases := []spec{
+		{
+			name: "Invalid/InvalidOutput",
+			opts: &VersionOptions{
+				Output: "invalid",
+			},
+			expError: "VersionOptions were not validated: --output=\"invalid\" should have been rejected",
+		},
+		{
+			name: "Valid/YAMLOutput",
+			opts: &VersionOptions{
+				Output: "yaml",
+			},
+			expError: "",
+		},
+		{
+			name: "Valid/JSONOutput",
+			opts: &VersionOptions{
+				Output: "json",
+			},
+			expError: "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.opts.Run()
+			if c.expError != "" {
+				require.EqualError(t, err, c.expError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/cli/executor.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/cli/executor.go
@@ -37,6 +37,7 @@ import (
 	"github.com/openshift/oc-mirror/v2/pkg/mirror"
 	"github.com/openshift/oc-mirror/v2/pkg/operator"
 	"github.com/openshift/oc-mirror/v2/pkg/release"
+	"github.com/openshift/oc-mirror/v2/pkg/version"
 	"github.com/spf13/cobra"
 )
 
@@ -178,6 +179,7 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(NewPrepareCommand(log))
+	cmd.AddCommand(version.NewVersionCommand(log))
 	cmd.PersistentFlags().StringVarP(&opts.Global.ConfigPath, "config", "c", "", "Path to imageset configuration file")
 	cmd.Flags().StringVar(&opts.Global.LogLevel, "loglevel", "info", "Log level one of (info, debug, trace, error)")
 	cmd.Flags().StringVar(&opts.Global.WorkingDir, "dir", workingDir, "Assets directory")

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/version/version.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/version/version.go
@@ -1,0 +1,143 @@
+package version
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+
+	clog "github.com/openshift/oc-mirror/v2/pkg/log"
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/util/templates"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	// commitFromGit is a constant representing the source version that
+	// generated this build. It should be set during build via -ldflags.
+	commitFromGit string
+	// versionFromGit is a constant representing the version tag that
+	// generated this build. It should be set during build via -ldflags.
+	versionFromGit = "v0.0.0-unknown"
+	// major version
+	majorFromGit string
+	// minor version
+	minorFromGit string
+	// build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	buildDate string
+	// state of git tree, either "clean" or "dirty"
+	gitTreeState string
+)
+
+type Info struct {
+	Major        string `json:"major"`
+	Minor        string `json:"minor"`
+	GitVersion   string `json:"gitVersion"`
+	GitCommit    string `json:"gitCommit"`
+	GitTreeState string `json:"gitTreeState"`
+	BuildDate    string `json:"buildDate"`
+	GoVersion    string `json:"goVersion"`
+	Compiler     string `json:"compiler"`
+	Platform     string `json:"platform"`
+}
+
+type VersionOptions struct {
+	Output string
+	Short  bool
+	V2     bool
+}
+
+// Version is a struct for version information
+type Version struct {
+	ClientVersion *Info `json:"clientVersion,omitempty" yaml:"clientVersion,omitempty"`
+}
+
+func NewVersionCommand(log clog.PluggableLoggerInterface) *cobra.Command {
+	o := VersionOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Output version",
+		Example: templates.Examples(`
+			# Get oc-mirror version
+			oc-mirror version
+		`),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := o.Validate(); err != nil {
+				log.Error(" %v ", err)
+				os.Exit(1)
+			}
+
+			if err := o.Run(); err != nil {
+				log.Error(" %v ", err)
+				os.Exit(1)
+			}
+		},
+	}
+
+	fs := cmd.Flags()
+	fs.BoolVar(&o.Short, "short", o.Short, "Print just the version number")
+	fs.MarkDeprecated("short", "and will be removed in a future release. Use oc-mirror version instead.")
+	fs.StringVar(&o.Output, "output", o.Output, "One of 'yaml' or 'json'.")
+	fs.BoolVar(&o.V2, "v2", o.V2, "Redirect the flow to oc-mirror v2 - V2 is still under development and it is not production ready.")
+	fs.MarkHidden("v2")
+	cmd.PersistentFlags()
+
+	return cmd
+}
+
+func (o *VersionOptions) Validate() error {
+	if o.Output != "" && o.Output != "yaml" && o.Output != "json" {
+		return errors.New(`--output must be 'yaml' or 'json'`)
+	}
+
+	return nil
+}
+
+func (o *VersionOptions) Run() error {
+	var versionInfo Version
+
+	clientVersion := Get()
+	versionInfo.ClientVersion = &clientVersion
+
+	switch o.Output {
+	case "":
+		if o.Short {
+			fmt.Fprintf(os.Stdout, "Client Version: %s\n", clientVersion.GitVersion)
+		} else {
+			fmt.Fprintf(os.Stderr, "WARNING: This version information is deprecated and will be replaced with the output from --short. Use --output=yaml|json to get the full version.\n")
+			fmt.Fprintf(os.Stdout, "Client Version: %#v\n", clientVersion)
+		}
+	case "yaml":
+		marshalled, err := yaml.Marshal(&versionInfo)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(os.Stdout, string(marshalled))
+	case "json":
+		marshalled, err := json.MarshalIndent(&versionInfo, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(os.Stdout, string(marshalled))
+	default:
+		return fmt.Errorf("VersionOptions were not validated: --output=%q should have been rejected", o.Output)
+	}
+
+	return nil
+}
+
+func Get() Info {
+	return Info{
+		Major:        majorFromGit,
+		Minor:        minorFromGit,
+		GitCommit:    commitFromGit,
+		GitVersion:   versionFromGit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -984,6 +984,7 @@ github.com/openshift/oc-mirror/v2/pkg/manifest
 github.com/openshift/oc-mirror/v2/pkg/mirror
 github.com/openshift/oc-mirror/v2/pkg/operator
 github.com/openshift/oc-mirror/v2/pkg/release
+github.com/openshift/oc-mirror/v2/pkg/version
 # github.com/operator-framework/api v0.17.7
 ## explicit; go 1.19
 github.com/operator-framework/api/pkg/constraints


### PR DESCRIPTION
# Description

These are the required changes to have the version command retro compatible with v1

Fixes [OCPBUGS-31084](https://issues.redhat.com/browse/OCPBUGS-31084)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
./bin/oc-mirror version 
```

```
./bin/oc-mirror version --v2
```

## Expected Outcome
Both commands above should return the same output