### PR TITLE
OCPBUGS-31344: fix: issue when different versions of the same catalog

### DIFF
--- a/v2/pkg/additional/local_stored_collector_test.go
+++ b/v2/pkg/additional/local_stored_collector_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/containers/image/v5/types"
 	"github.com/openshift/oc-mirror/v2/pkg/api/v1alpha2"
 	"github.com/openshift/oc-mirror/v2/pkg/api/v1alpha3"
 	clog "github.com/openshift/oc-mirror/v2/pkg/log"
@@ -188,4 +189,8 @@ func (o MockManifest) ExtractLayers(filePath, name, label string) error {
 
 func (o MockManifest) ConvertIndexToSingleManifest(dir string, oci *v1alpha3.OCISchema) error {
 	return nil
+}
+
+func (o MockManifest) GetDigest(ctx context.Context, sourceCtx *types.SystemContext, imgRef string) (string, error) {
+	return "", nil
 }

--- a/v2/pkg/batch/worker_test.go
+++ b/v2/pkg/batch/worker_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/containers/image/v5/types"
 	"github.com/openshift/oc-mirror/v2/pkg/api/v1alpha2"
 	"github.com/openshift/oc-mirror/v2/pkg/api/v1alpha3"
 	clog "github.com/openshift/oc-mirror/v2/pkg/log"
@@ -143,4 +144,8 @@ func (o Manifest) ExtractLayers(filePath, name, label string) error {
 
 func (o Manifest) ConvertIndexToSingleManifest(dir string, oci *v1alpha3.OCISchema) error {
 	return nil
+}
+
+func (o Manifest) GetDigest(ctx context.Context, sourceCtx *types.SystemContext, imgRef string) (string, error) {
+	return "", nil
 }

--- a/v2/pkg/manifest/interface.go
+++ b/v2/pkg/manifest/interface.go
@@ -1,6 +1,9 @@
 package manifest
 
 import (
+	"context"
+
+	"github.com/containers/image/v5/types"
 	"github.com/openshift/oc-mirror/v2/pkg/api/v1alpha2"
 	"github.com/openshift/oc-mirror/v2/pkg/api/v1alpha3"
 )
@@ -14,4 +17,5 @@ type ManifestInterface interface {
 	ExtractLayersOCI(filePath, toPath, label string, oci *v1alpha3.OCISchema) error
 	GetReleaseSchema(filePath string) ([]v1alpha3.RelatedImage, error)
 	ConvertIndexToSingleManifest(dir string, oci *v1alpha3.OCISchema) error
+	GetDigest(ctx context.Context, sourceCtx *types.SystemContext, imgRef string) (string, error)
 }

--- a/v2/pkg/operator/local_stored_collector_test.go
+++ b/v2/pkg/operator/local_stored_collector_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/containers/image/v5/types"
 	"github.com/openshift/oc-mirror/v2/pkg/api/v1alpha2"
 	"github.com/openshift/oc-mirror/v2/pkg/api/v1alpha3"
 	clog "github.com/openshift/oc-mirror/v2/pkg/log"
@@ -376,4 +377,8 @@ func (o MockManifest) ExtractLayersOCI(filePath, toPath, label string, oci *v1al
 
 func (o MockManifest) ConvertIndexToSingleManifest(dir string, oci *v1alpha3.OCISchema) error {
 	return nil
+}
+
+func (o MockManifest) GetDigest(ctx context.Context, sourceCtx *types.SystemContext, imgRef string) (string, error) {
+	return "", nil
 }

--- a/v2/pkg/release/local_stored_collector_test.go
+++ b/v2/pkg/release/local_stored_collector_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/containers/image/v5/types"
 	"github.com/google/uuid"
 	"github.com/openshift/oc-mirror/v2/pkg/api/v1alpha2"
 	"github.com/openshift/oc-mirror/v2/pkg/api/v1alpha3"
@@ -432,6 +433,10 @@ func (o MockManifest) ExtractLayersOCI(filePath, toPath, label string, oci *v1al
 
 func (o MockManifest) ConvertIndexToSingleManifest(dir string, oci *v1alpha3.OCISchema) error {
 	return nil
+}
+
+func (o MockManifest) GetDigest(ctx context.Context, sourceCtx *types.SystemContext, imgRef string) (string, error) {
+	return "", nil
 }
 
 func (o MockCincinnati) GetReleaseReferenceImages(ctx context.Context) []v1alpha3.CopyImageSchema {

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/manifest/interface.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/manifest/interface.go
@@ -1,6 +1,9 @@
 package manifest
 
 import (
+	"context"
+
+	"github.com/containers/image/v5/types"
 	"github.com/openshift/oc-mirror/v2/pkg/api/v1alpha2"
 	"github.com/openshift/oc-mirror/v2/pkg/api/v1alpha3"
 )
@@ -14,4 +17,5 @@ type ManifestInterface interface {
 	ExtractLayersOCI(filePath, toPath, label string, oci *v1alpha3.OCISchema) error
 	GetReleaseSchema(filePath string) ([]v1alpha3.RelatedImage, error)
 	ConvertIndexToSingleManifest(dir string, oci *v1alpha3.OCISchema) error
+	GetDigest(ctx context.Context, sourceCtx *types.SystemContext, imgRef string) (string, error)
 }


### PR DESCRIPTION
# Description

There was an issue when there were different versions of the same catalog present in the ImageSetConfiguration. In order to guarantee that each catalog is unique (even if it is a patch version or oci on disk), folders based on the digest are going to be created.

Fixes [OCPBUGS-31344](https://issues.redhat.com/browse/OCPBUGS-31344) 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. First copy the oci operator index to disk:

```
skopeo copy docker://registry.redhat.io/redhat/redhat-operator-index:v4.12 oci:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/app1/noo/redhat-operator-index  --remove-signatures
```

2. Create the following ImageSetConfiguration:

```
apiVersion: mirror.openshift.io/v1alpha2
kind: ImageSetConfiguration
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.12
      packages:
       - name: elasticsearch-operator
    - catalog: oci:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/app1/noo/redhat-operator-index
      packages:
        - name: cluster-kube-descheduler-operator
        - name: odf-operator
    - catalog: registry.redhat.io/redhat/redhat-operator-index@sha256:3bc7277269d87362b08520386f9a3abf717e7f22b62114ddac0a43a88b420578
      packages:
       - name: aws-load-balancer-operator
```

3. mirrorToDisk
```
./bin/oc-mirror -c /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-isc/ocpbugs/ocpbugs-31344.yaml file://ocpbugs-31344 --v2
```

4. diskToMirror
```
./bin/oc-mirror -c /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-isc/ocpbugs/ocpbugs-31344.yaml --from file://ocpbugs-31344 docker://localhost:6000 --v2
```

## Expected Outcome
No errors and all the 3 tags should be present in the target registry, for the 3 different operator catalogs included in the ImageSetConfiguration:

by tag and digest:
```
curl http://localhost:6000/v2/redhat/redhat-operator-index/tags/list | jq
{
  "name": "redhat/redhat-operator-index",
  "tags": [
    "3bc7277269d87362b08520386f9a3abf717e7f22b62114ddac0a43a88b420578",
    "v4.12"
  ]
}
```

from oci on disk:
```
curl http://localhost:6000/v2/redhat-operator-index/tags/list | jq
{
  "name": "redhat-operator-index",
  "tags": [
    "df5c6a18da93660cd51309119961c498f98ecdecb7fdf91d87319d753fbbfaac"
  ]
}
```

