### PR TITLE
CLID-47,CLID-46: Use of TargetCatalog and TargetTag on all catalogs

### DIFF
--- a/v2/pkg/additional/local_stored_collector.go
+++ b/v2/pkg/additional/local_stored_collector.go
@@ -54,7 +54,7 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 			var dest string
 			src = imgSpec.ReferenceWithTransport
 
-			if imgSpec.IsImageByDigest() {
+			if imgSpec.IsImageByDigestOnly() {
 				dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
 			} else {
 				dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), imgSpec.PathComponent}, "/") + ":" + imgSpec.Tag
@@ -79,7 +79,7 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 					return nil, err
 				}
 
-				if imgSpec.IsImageByDigest() {
+				if imgSpec.IsImageByDigestOnly() {
 					src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
 					dest = strings.Join([]string{o.Opts.Destination, imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
 				} else {

--- a/v2/pkg/api/v1alpha2/types_config.go
+++ b/v2/pkg/api/v1alpha2/types_config.go
@@ -1,6 +1,8 @@
 package v1alpha2
 
 import (
+	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/openshift/oc-mirror/v2/pkg/image"
@@ -129,7 +131,6 @@ type Operator struct {
 	//     path-component = alpha-numeric [separator alpha-numeric]*
 	//     alpha-numeric  = /[a-z0-9]+/
 	//     separator      = /[_.]|__|[-]*/
-	// TargetCatalog will be preferred over TargetName if both are specified in te ImageSetConfig.
 	TargetCatalog string `json:"targetCatalog,omitempty"`
 	// TargetTag is the tag the catalog image will be built with. If unset,
 	// the catalog will be publish with the provided tag in the Catalog
@@ -159,17 +160,25 @@ func (o Operator) GetUniqueName() (string, error) {
 	}
 
 	if o.TargetTag != "" {
-		ctlgSpec.Digest = ""
 		ctlgSpec.Reference = strings.Replace(ctlgSpec.Reference, ctlgSpec.Tag, o.TargetTag, 1)
 		ctlgSpec.ReferenceWithTransport = strings.Replace(ctlgSpec.ReferenceWithTransport, ctlgSpec.Tag, o.TargetTag, 1)
 		ctlgSpec.Tag = o.TargetTag
 	}
 	if o.TargetCatalog != "" {
-		ctlgSpec.Reference = strings.Replace(ctlgSpec.Reference, ctlgSpec.PathComponent, o.TargetCatalog, 1)
-		ctlgSpec.ReferenceWithTransport = strings.Replace(ctlgSpec.ReferenceWithTransport, ctlgSpec.PathComponent, o.TargetCatalog, 1)
-		ctlgSpec.PathComponent = o.TargetCatalog
+		if IsValidPathComponent(o.TargetCatalog) {
+			ctlgSpec.Reference = strings.Replace(ctlgSpec.Reference, ctlgSpec.PathComponent, o.TargetCatalog, 1)
+			ctlgSpec.ReferenceWithTransport = strings.Replace(ctlgSpec.ReferenceWithTransport, ctlgSpec.PathComponent, o.TargetCatalog, 1)
+			ctlgSpec.PathComponent = o.TargetCatalog
+		} else {
+			return "", fmt.Errorf("targetCatalog: %s - value is not valid. It should not contain a tag or a digest. It is expected to be composed of 1 or more path components separated by /, where each path component is a set of alpha-numeric and  regexp (?:[._]|__|[-]*). For more, see https://github.com/containers/image/blob/main/docker/reference/regexp.go", o.TargetCatalog)
+		}
 	}
 	return ctlgSpec.Reference, nil
+}
+
+func IsValidPathComponent(targetCatalog string) bool {
+	pathComponentPattern := regexp.MustCompile(`^([a-z0-9]+((?:[._]|__|[-]*)[a-z0-9]+)*)(/([a-z0-9]+((?:[._]|__|[-]*)[a-z0-9]+)*))*$`)
+	return pathComponentPattern.MatchString(targetCatalog)
 }
 
 // IsHeadsOnly determine if the mode set mirrors only channel heads of all packages in the catalog.

--- a/v2/pkg/api/v1alpha2/types_config_test.go
+++ b/v2/pkg/api/v1alpha2/types_config_test.go
@@ -1,0 +1,41 @@
+package v1alpha2
+
+import "testing"
+
+func TestIsValidPathComponent(t *testing.T) {
+	tests := []struct {
+		name           string
+		targetCatalog  string
+		expectedResult bool
+	}{
+		{
+			name:           "Valid path component",
+			targetCatalog:  "my-namespace/my-target-name",
+			expectedResult: true,
+		},
+		{
+			name:           "Invalid path component - has tag",
+			targetCatalog:  "my-namespace/my-target-name:v4.10",
+			expectedResult: false,
+		},
+		{
+			name:           "Invalid path component - has digest",
+			targetCatalog:  "my-namespace/my-target-name@sha256:v4.10",
+			expectedResult: false,
+		},
+		{
+			name:           "Invalid path component with special characters",
+			targetCatalog:  "my$namespace/my-target-name",
+			expectedResult: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := IsValidPathComponent(test.targetCatalog)
+			if result != test.expectedResult {
+				t.Errorf("Expected %v, but got %v", test.expectedResult, result)
+			}
+		})
+	}
+}

--- a/v2/pkg/api/v1alpha3/types.go
+++ b/v2/pkg/api/v1alpha3/types.go
@@ -192,7 +192,7 @@ type RelatedImage struct {
 	TargetTag string `json:"targetTag"`
 	// Used to keep specific naming info for the related image
 	// if set should be used when mirroring
-	TargetName string `json:"tagetName"`
+	TargetCatalog string `json:"targetCatalog"`
 }
 
 // CopyImageSchema

--- a/v2/pkg/clusterresources/clusterresources.go
+++ b/v2/pkg/clusterresources/clusterresources.go
@@ -187,7 +187,7 @@ func (o *ClusterResourcesGenerator) generateCatalogSource(catalogRef string, cat
 	}
 
 	var csSuffix string
-	if catalogSpec.IsImageByDigest() {
+	if catalogSpec.IsImageByDigestOnly() {
 		if len(catalogSpec.Digest) >= hashTruncLen {
 			csSuffix = catalogSpec.Digest[:hashTruncLen]
 		} else {
@@ -362,11 +362,11 @@ func (o *ClusterResourcesGenerator) generateImageMirrors(allRelatedImages []v1al
 		toBeAdded := true
 		switch mode {
 		case TagsOnlyMode:
-			if srcImgSpec.IsImageByDigest() {
+			if srcImgSpec.IsImageByDigestOnly() {
 				toBeAdded = false
 			}
 		case DigestsOnlyMode:
-			if !srcImgSpec.IsImageByDigest() {
+			if !srcImgSpec.IsImageByDigestOnly() {
 				toBeAdded = false
 			}
 		}

--- a/v2/pkg/config/validate_test.go
+++ b/v2/pkg/config/validate_test.go
@@ -54,6 +54,27 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
+			name: "Valid/UniqueCatalogsWithTargetCatalogAndTargetTag",
+			config: &v1alpha2.ImageSetConfiguration{
+				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+					Mirror: v1alpha2.Mirror{
+						Operators: []v1alpha2.Operator{
+							{
+								Catalog:       "test-catalog:latest",
+								TargetCatalog: "test1",
+								TargetTag:     "v1.3",
+							},
+							{
+								Catalog:       "test-catalog:latest",
+								TargetCatalog: "test2",
+								TargetTag:     "latest",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "Valid/UniqueReleaseChannels",
 			config: &v1alpha2.ImageSetConfiguration{
 				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
@@ -110,6 +131,38 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			expError: "invalid configuration: catalog \"test:latest\": duplicate found in configuration",
+		},
+		{
+			name: "Invalid/CatalogWithTargetCatalogContainsTag",
+			config: &v1alpha2.ImageSetConfiguration{
+				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+					Mirror: v1alpha2.Mirror{
+						Operators: []v1alpha2.Operator{
+							{
+								Catalog:       "test-catalog1:latest",
+								TargetCatalog: "test:v1.3",
+							},
+						},
+					},
+				},
+			},
+			expError: "invalid configuration: targetCatalog: test:v1.3 - value is not valid. It should not contain a tag or a digest. It is expected to be composed of 1 or more path components separated by /, where each path component is a set of alpha-numeric and  regexp (?:[._]|__|[-]*). For more, see https://github.com/containers/image/blob/main/docker/reference/regexp.go",
+		},
+		{
+			name: "Invalid/CatalogWithTargetCatalogContainsDigest",
+			config: &v1alpha2.ImageSetConfiguration{
+				ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+					Mirror: v1alpha2.Mirror{
+						Operators: []v1alpha2.Operator{
+							{
+								Catalog:       "test-catalog1:latest",
+								TargetCatalog: "a/b/test@sha256:45df874",
+							},
+						},
+					},
+				},
+			},
+			expError: "invalid configuration: targetCatalog: a/b/test@sha256:45df874 - value is not valid. It should not contain a tag or a digest. It is expected to be composed of 1 or more path components separated by /, where each path component is a set of alpha-numeric and  regexp (?:[._]|__|[-]*). For more, see https://github.com/containers/image/blob/main/docker/reference/regexp.go",
 		},
 		{
 			name: "Invalid/DuplicateChannels",

--- a/v2/pkg/image/image.go
+++ b/v2/pkg/image/image.go
@@ -109,6 +109,10 @@ func (i ImageSpec) IsImageByDigest() bool {
 	return i.Digest != ""
 }
 
+func (i ImageSpec) IsImageByDigestOnly() bool {
+	return i.Tag == "" && i.Digest != ""
+}
+
 func WithMaxNestedPaths(imageRef string, maxNestedPaths int) (string, error) {
 	if maxNestedPaths == 0 {
 		return imageRef, nil

--- a/v2/pkg/operator/local_stored_collector.go
+++ b/v2/pkg/operator/local_stored_collector.go
@@ -61,6 +61,10 @@ func (o *LocalStorageCollector) OperatorImageCollector(ctx context.Context) ([]v
 		// download the operator index image
 		o.Log.Info("copying operator image %v", op.Catalog)
 
+		// CLID-47 double check that targetCatalog is valid
+		if op.TargetCatalog != "" && !v1alpha2.IsValidPathComponent(op.TargetCatalog) {
+			return []v1alpha3.CopyImageSchema{}, fmt.Errorf("invalid targetCatalog %s", op.TargetCatalog)
+		}
 		// CLID-27 ensure we pick up oci:// (on disk) catalogs
 		imgSpec, err := image.ParseRef(op.Catalog)
 		if err != nil {
@@ -214,20 +218,17 @@ func (o *LocalStorageCollector) OperatorImageCollector(ctx context.Context) ([]v
 			relatedImages[k] = v
 		}
 
-		// this ensures we either enforce using targetTag or targetCatalog
-		// but not both
 		var targetTag string
 		var targetCatalog string
 		if len(op.TargetTag) > 0 {
 			targetTag = op.TargetTag
-			targetCatalog = ""
 		} else {
-			if len(op.TargetCatalog) > 0 {
-				targetTag = ""
-				targetCatalog = op.TargetCatalog
-			} else {
-				targetTag = validDigest.Encoded()
-			}
+			targetTag = validDigest.Encoded()
+		}
+
+		if len(op.TargetCatalog) > 0 {
+			targetCatalog = op.TargetCatalog
+
 		}
 
 		componentName := imgSpec.ComponentName() + "." + catalogDigest
@@ -284,31 +285,33 @@ func (o LocalStorageCollector) prepareD2MCopyBatch(log clog.PluggableLoggerInter
 				return nil, err
 			}
 
-			if imgSpec.Transport != ociProtocol {
-				if imgSpec.IsImageByDigest() {
-					src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
-					dest = strings.Join([]string{o.Opts.Destination, imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
-				} else {
-					src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent}, "/") + ":" + imgSpec.Tag
-					dest = strings.Join([]string{o.Opts.Destination, imgSpec.PathComponent}, "/") + ":" + imgSpec.Tag
-				}
+			if img.Type == v1alpha2.TypeOperatorCatalog && len(img.TargetName) > 0 {
+				src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, img.TargetName}, "/")
+				dest = strings.Join([]string{o.Opts.Destination, img.TargetName}, "/")
+			} else if imgSpec.Transport == ociProtocol {
+				src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, img.Name}, "/")
+				dest = strings.Join([]string{o.Opts.Destination, img.Name}, "/")
 			} else {
-				if len(img.TargetName) > 0 {
-					src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, img.TargetName}, "/")
-					dest = strings.Join([]string{o.Opts.Destination, img.TargetName}, "/")
-				} else {
-					src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, img.Name + ":" + img.TargetTag}, "/")
-					dest = strings.Join([]string{o.Opts.Destination, img.Name + ":" + img.TargetTag}, "/")
-				}
+				src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent}, "/")
+				dest = strings.Join([]string{o.Opts.Destination, imgSpec.PathComponent}, "/")
 			}
-
+			if img.Type == v1alpha2.TypeOperatorCatalog && len(img.TargetTag) > 0 {
+				src = src + ":" + img.TargetTag
+				dest = dest + ":" + img.TargetTag
+			} else if imgSpec.Tag == "" {
+				src = src + ":" + imgSpec.Digest
+				dest = dest + ":" + imgSpec.Digest
+			} else {
+				src = src + ":" + imgSpec.Tag
+				dest = dest + ":" + imgSpec.Tag
+			}
 			if src == "" || dest == "" {
 				return result, fmt.Errorf("unable to determine src %s or dst %s for %s", src, dest, img.Image)
 			}
 
 			o.Log.Debug("source %s", src)
 			o.Log.Debug("destination %s", dest)
-			result = append(result, v1alpha3.CopyImageSchema{Origin: img.Image, Source: src, Destination: dest, Type: img.Type})
+			result = append(result, v1alpha3.CopyImageSchema{Origin: imgSpec.ReferenceWithTransport, Source: src, Destination: dest, Type: img.Type})
 		}
 	}
 	return result, nil
@@ -324,20 +327,21 @@ func (o LocalStorageCollector) prepareM2DCopyBatch(log clog.PluggableLoggerInter
 			if err != nil {
 				return nil, err
 			}
-			if imgSpec.Transport == ociProtocol {
-				src = ociProtocolTrimmed + imgSpec.Reference
-				if len(img.TargetName) > 0 {
-					dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), img.TargetName}, "/")
-				} else {
-					dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), img.Name + ":" + img.TargetTag}, "/")
-				}
+
+			src = imgSpec.ReferenceWithTransport
+			if img.Type == v1alpha2.TypeOperatorCatalog && len(img.TargetName) > 0 {
+				dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), img.TargetName}, "/")
+			} else if imgSpec.Transport == ociProtocol {
+				dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), img.Name}, "/")
 			} else {
-				src = imgSpec.ReferenceWithTransport
-				if imgSpec.IsImageByDigest() {
-					dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
-				} else {
-					dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), imgSpec.PathComponent}, "/") + ":" + imgSpec.Tag
-				}
+				dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), imgSpec.PathComponent}, "/")
+			}
+			if img.Type == v1alpha2.TypeOperatorCatalog && len(img.TargetTag) > 0 {
+				dest = dest + ":" + img.TargetTag
+			} else if imgSpec.Tag == "" {
+				dest = dest + ":" + imgSpec.Digest
+			} else {
+				dest = dest + ":" + imgSpec.Tag
 			}
 
 			o.Log.Debug("source %s", src)

--- a/v2/pkg/operator/local_stored_collector_test.go
+++ b/v2/pkg/operator/local_stored_collector_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/containers/image/v5/types"
@@ -32,183 +31,8 @@ type MockManifest struct {
 	FailExtract       bool
 }
 
-func TestOperatorLocalStoredCollector(t *testing.T) {
-	log := clog.New("trace")
-
-	tempDir := t.TempDir()
-	defer os.RemoveAll(tempDir)
-
-	// this test should cover over 80% M2D
-	t.Run("Testing OperatorImageCollector - Mirror to disk: should pass", func(t *testing.T) {
-		ctx := context.Background()
-		manifest := &MockManifest{Log: log}
-
-		ex := setupCollector_MirrorToDisk(tempDir, log, manifest)
-
-		// ensure coverage in new.go
-		_ = New(log, "working-dir", ex.Config, ex.Opts, ex.Mirror, manifest, "localhost:9999")
-
-		res, err := ex.OperatorImageCollector(ctx)
-		if err != nil {
-			t.Fatalf("should not fail")
-		}
-		log.Debug("completed test related images %v ", res)
-
-		// test with TargetTag
-		ex.Config.Mirror.Operators[3].TargetTag = "v4.14"
-		res, err = ex.OperatorImageCollector(ctx)
-		if err != nil {
-			t.Fatalf("should not fail")
-		}
-		log.Debug("completed test (with TargetTag set) related images %v ", res)
-
-		// test with TargetCatalog
-		ex.Config.Mirror.Operators[3].TargetTag = ""
-		ex.Config.Mirror.Operators[3].TargetCatalog = "test-catalog:v4.14"
-		res, err = ex.OperatorImageCollector(ctx)
-		if err == nil {
-			t.Fatalf("should fail")
-		}
-		log.Debug("completed test (with invalid TargetCatalog set) related images %v ", res)
-
-		// test with TargetCatalog for OCI catalog
-		ex.Config.Mirror.Operators[3].TargetTag = "v4.14"
-		ex.Config.Mirror.Operators[3].TargetCatalog = "test-catalog"
-		res, err = ex.OperatorImageCollector(ctx)
-		if err != nil {
-			t.Fatalf("should not fail")
-		}
-		log.Debug("completed test (with TargetCatalog and TargetTag set) related images %v ", res)
-
-		// test with TargetCatalog for registry catalog
-		ex.Config.Mirror.Operators[1].TargetTag = "v2.0"
-		ex.Config.Mirror.Operators[1].TargetCatalog = "test-namespace/test-catalog"
-		res, err = ex.OperatorImageCollector(ctx)
-		if err != nil {
-			t.Fatalf("should not fail")
-		}
-		ociScenarioCovered := false
-		registryScenarioCovered := false
-		for _, item := range res {
-			assert.Contains(t, item.Destination, ex.LocalStorageFQDN)
-			if item.Origin == "docker://certified-operators:v4.7" {
-				registryScenarioCovered = true
-				assert.Equal(t, dockerProtocol+ex.LocalStorageFQDN+"/test-namespace/test-catalog:v2.0", item.Destination)
-			}
-			if item.Origin == "oci://../../tests/simple-test-bundle" {
-				ociScenarioCovered = true
-				assert.Equal(t, dockerProtocol+ex.LocalStorageFQDN+"/test-catalog:v4.14", item.Destination)
-			}
-		}
-		if !ociScenarioCovered {
-			t.Fatalf("targetCatalog / targetTag should be covered for oci catalog but was not")
-		}
-		if !registryScenarioCovered {
-			t.Fatalf("targetCatalog / targetTag should be covered for registry catalog but was not")
-
-		}
-		log.Debug("completed test (with TargetCatalog and TargetTag set) related images %v ", res)
-	})
-
-	t.Run("Testing OperatorImageCollector - Disk to mirror : should pass", func(t *testing.T) {
-
-		os.RemoveAll("../../tests/hold-operator/")
-		os.RemoveAll("../../tests/operator-images")
-		os.RemoveAll("../../tests/tmp/")
-		ex := setupCollector_DiskToMirror(tempDir, log)
-
-		//copy tests/hold-test-fake to working-dir
-		err := copy.Copy("../../tests/working-dir-fake/hold-operator/redhat-operator-index/v4.14", filepath.Join(ex.Opts.Global.WorkingDir, operatorImageExtractDir, "ocp-release/4.13.9-x86_64"))
-		if err != nil {
-			t.Fatalf("should not fail")
-		}
-
-		res, err := ex.OperatorImageCollector(context.Background())
-		if err != nil {
-			t.Fatalf("should not fail: %v", err)
-		}
-		if len(res) == 0 {
-			t.Fatalf("should contain at least 1 image")
-		}
-		if !strings.Contains(res[0].Source, ex.LocalStorageFQDN) {
-			t.Fatalf("source images should be from local storage")
-		}
-		log.Debug("completed test related images %v ", res)
-
-		// test with invalid TargetCatalog
-		ex.Config.Mirror.Operators[1].TargetTag = ""
-		ex.Config.Mirror.Operators[1].TargetCatalog = "test-catalog:v4.14"
-		res, err = ex.OperatorImageCollector(context.Background())
-		if err == nil {
-			t.Fatalf("should fail")
-		}
-		log.Debug("completed test (with invalid TargetCatalog set) related images %v ", res)
-
-		// test with TargetCatalog on oci catalog
-		ex.Config.Mirror.Operators[1].TargetTag = "v4.14"
-		ex.Config.Mirror.Operators[1].TargetCatalog = "test-catalog"
-
-		// test with TargetCatalog on registry catalog
-		ex.Config.Mirror.Operators[0].TargetTag = "v2.0"
-		ex.Config.Mirror.Operators[0].TargetCatalog = "test-namespace/test-catalog"
-		res, err = ex.OperatorImageCollector(context.Background())
-		if err != nil {
-			t.Fatalf("should not fail")
-		}
-		ociScenarioCovered := false
-		registryScenarioCovered := false
-		for _, item := range res {
-			assert.Contains(t, item.Source, ex.LocalStorageFQDN)
-			assert.Contains(t, item.Destination, ex.Opts.Destination)
-			if item.Origin == "docker://redhat-operator-index:v4.14" {
-				registryScenarioCovered = true
-				assert.Equal(t, ex.Opts.Destination+"/test-namespace/test-catalog:v2.0", item.Destination)
-			}
-			if item.Origin == "oci://../../tests/simple-test-bundle" {
-				ociScenarioCovered = true
-				assert.Equal(t, ex.Opts.Destination+"/test-catalog:v4.14", item.Destination)
-			}
-		}
-		if !ociScenarioCovered {
-			t.Fatalf("targetCatalog / targetTag should be covered for oci catalog but was not")
-		}
-		if !registryScenarioCovered {
-			t.Fatalf("targetCatalog / targetTag should be covered for registry catalog but was not")
-
-		}
-		log.Debug("completed test (with TargetCatalog set) related images %v ", res)
-
-	})
-}
-
-func setupCollector_DiskToMirror(tempDir string, log clog.PluggableLoggerInterface) *LocalStorageCollector {
-	manifest := &MockManifest{Log: log}
-
-	globalD2M := &mirror.GlobalOptions{
-		TlsVerify:    false,
-		SecurePolicy: false,
-		WorkingDir:   tempDir + "/working-dir",
-		From:         tempDir,
-	}
-
-	_, sharedOpts := mirror.SharedImageFlags()
-	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
-	_, srcOptsD2M := mirror.ImageSrcFlags(globalD2M, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
-	_, destOptsD2M := mirror.ImageDestFlags(globalD2M, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
-	_, retryOpts := mirror.RetryFlags()
-
-	d2mOpts := mirror.CopyOptions{
-		Global:              globalD2M,
-		DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
-		SrcImage:            srcOptsD2M,
-		DestImage:           destOptsD2M,
-		RetryOpts:           retryOpts,
-		Destination:         "docker://localhost:5000/test",
-		Dev:                 false,
-		Mode:                mirror.DiskToMirror,
-	}
-
-	cfgd2m := v1alpha2.ImageSetConfiguration{
+var (
+	nominalConfigD2M = v1alpha2.ImageSetConfiguration{
 		ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
 			Mirror: v1alpha2.Mirror{
 				Operators: []v1alpha2.Operator{
@@ -222,45 +46,46 @@ func setupCollector_DiskToMirror(tempDir string, log clog.PluggableLoggerInterfa
 			},
 		},
 	}
-
-	ex := &LocalStorageCollector{
-		Log:              log,
-		Mirror:           &MockMirror{Fail: false},
-		Config:           cfgd2m,
-		Manifest:         manifest,
-		Opts:             d2mOpts,
-		LocalStorageFQDN: "localhost:9999",
+	failingConfigD2MWithTargetCatalog4OCI = v1alpha2.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+			Mirror: v1alpha2.Mirror{
+				Operators: []v1alpha2.Operator{
+					{
+						Catalog:       "oci://../../tests/simple-test-bundle",
+						TargetCatalog: "test-catalog:v4.14",
+					},
+				},
+			},
+		},
 	}
+	nominalConfigD2MWithTargetCatalogTag4OCI = v1alpha2.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+			Mirror: v1alpha2.Mirror{
+				Operators: []v1alpha2.Operator{
 
-	return ex
-}
-
-func setupCollector_MirrorToDisk(tempDir string, log clog.PluggableLoggerInterface, manifest *MockManifest) *LocalStorageCollector {
-
-	globalM2D := &mirror.GlobalOptions{
-		TlsVerify:    false,
-		SecurePolicy: false,
-		WorkingDir:   tempDir + "/working-dir",
+					{
+						Catalog:       "oci://../../tests/simple-test-bundle",
+						TargetTag:     "v4.14",
+						TargetCatalog: "test-catalog",
+					},
+				},
+			},
+		},
 	}
-
-	_, sharedOpts := mirror.SharedImageFlags()
-	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
-	_, retryOpts := mirror.RetryFlags()
-	_, srcOptsM2D := mirror.ImageSrcFlags(globalM2D, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
-	_, destOptsM2D := mirror.ImageDestFlags(globalM2D, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
-
-	m2dOpts := mirror.CopyOptions{
-		Global:              globalM2D,
-		DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
-		SrcImage:            srcOptsM2D,
-		DestImage:           destOptsM2D,
-		RetryOpts:           retryOpts,
-		Destination:         "file://test",
-		Dev:                 false,
-		Mode:                mirror.MirrorToDisk,
+	nominalConfigD2MWithTargetCatalogTag = v1alpha2.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+			Mirror: v1alpha2.Mirror{
+				Operators: []v1alpha2.Operator{
+					{
+						Catalog:       "redhat-operator-index:v4.14",
+						TargetCatalog: "test-namespace/test-catalog",
+						TargetTag:     "v2.0",
+					},
+				},
+			},
+		},
 	}
-
-	cfgm2d := v1alpha2.ImageSetConfiguration{
+	nominalConfigM2D = v1alpha2.ImageSetConfiguration{
 		ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
 			Mirror: v1alpha2.Mirror{
 				Platform: v1alpha2.Platform{
@@ -342,11 +167,412 @@ func setupCollector_MirrorToDisk(tempDir string, log clog.PluggableLoggerInterfa
 			},
 		},
 	}
+	nominalConfigM2DWithTargetTag4Oci = v1alpha2.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+			Mirror: v1alpha2.Mirror{
+				Operators: []v1alpha2.Operator{
+					{
+						Catalog:   "oci://../../tests/simple-test-bundle",
+						TargetTag: "v4.14",
+					},
+				},
+			},
+		},
+	}
+
+	failingConfigM2DWithTargetCatalog4Oci = v1alpha2.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+			Mirror: v1alpha2.Mirror{
+				Operators: []v1alpha2.Operator{
+					{
+						Catalog:       "oci://../../tests/simple-test-bundle",
+						TargetCatalog: "test-catalog:v4.14",
+					},
+				},
+			},
+		},
+	}
+	nominalConfigM2DWithTargetCatalogTag4Oci = v1alpha2.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+			Mirror: v1alpha2.Mirror{
+				Operators: []v1alpha2.Operator{
+					{
+						Catalog:       "oci://../../tests/simple-test-bundle",
+						TargetCatalog: "test-catalog",
+						TargetTag:     "v4.14",
+					},
+				},
+			},
+		},
+	}
+	nominalConfigM2DWithTargetCatalogTag = v1alpha2.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v1alpha2.ImageSetConfigurationSpec{
+			Mirror: v1alpha2.Mirror{
+				Operators: []v1alpha2.Operator{
+
+					{
+						TargetCatalog: "test-namespace/test-catalog",
+						TargetTag:     "v2.0",
+						Catalog:       "certified-operators:v4.7",
+						Full:          true,
+						IncludeConfig: v1alpha2.IncludeConfig{
+							Packages: []v1alpha2.IncludePackage{
+								{Name: "couchbase-operator"},
+								{
+									Name: "mongodb-operator",
+									IncludeBundle: v1alpha2.IncludeBundle{
+										MinVersion: "1.4.0",
+									},
+								},
+								{
+									Name: "crunchy-postgresql-operator",
+									Channels: []v1alpha2.IncludeChannel{
+										{Name: "stable"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
+func TestOperatorLocalStoredCollectorM2D(t *testing.T) {
+	log := clog.New("trace")
+
+	tempDir := t.TempDir()
+	defer os.RemoveAll(tempDir)
+	type testCase struct {
+		caseName       string
+		config         v1alpha2.ImageSetConfiguration
+		expectedResult []v1alpha3.CopyImageSchema
+		expectedError  bool
+	}
+
+	ctx := context.Background()
+	manifest := &MockManifest{Log: log}
+
+	testCases := []testCase{
+		{
+			caseName:      "OperatorImageCollector - Mirror to disk: should pass",
+			config:        nominalConfigM2D,
+			expectedError: false,
+			expectedResult: []v1alpha3.CopyImageSchema{
+				{
+					Source:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Type:        v1alpha2.TypeInvalid,
+				},
+				{
+					Source:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Type:        v1alpha2.TypeInvalid,
+				},
+				{
+					Source:      "docker://redhat-operators:v4.7",
+					Destination: "docker://localhost:9999/redhat-operators:v4.7",
+					Origin:      "docker://redhat-operators:v4.7",
+					Type:        v1alpha2.TypeOperatorCatalog,
+				},
+				{
+					Source:      "docker://certified-operators:v4.7",
+					Destination: "docker://localhost:9999/certified-operators:v4.7",
+					Origin:      "docker://certified-operators:v4.7",
+					Type:        v1alpha2.TypeOperatorCatalog,
+				},
+				{
+					Source:      "docker://community-operators:v4.7",
+					Destination: "docker://localhost:9999/community-operators:v4.7",
+					Origin:      "docker://community-operators:v4.7",
+					Type:        v1alpha2.TypeOperatorCatalog,
+				},
+				{
+					Source:      "oci://../../tests/simple-test-bundle",
+					Destination: "docker://localhost:9999/simple-test-bundle:3ef0b0141abd1548f60c4f3b23ecfc415142b0e842215f38e98610a3b2e52419",
+					Origin:      "oci://../../tests/simple-test-bundle",
+					Type:        v1alpha2.TypeOperatorCatalog,
+				},
+			},
+		},
+		{
+			caseName:      "OperatorImageCollector - Mirror to disk - OCI Catalog with TargetTag: should pass",
+			config:        nominalConfigM2DWithTargetTag4Oci,
+			expectedError: false,
+			expectedResult: []v1alpha3.CopyImageSchema{
+				{
+					Source:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Type:        v1alpha2.TypeInvalid,
+				},
+				{
+					Source:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Type:        v1alpha2.TypeInvalid,
+				},
+				{
+					Source:      "oci://../../tests/simple-test-bundle",
+					Destination: "docker://localhost:9999/simple-test-bundle:v4.14",
+					Origin:      "oci://../../tests/simple-test-bundle",
+					Type:        v1alpha2.TypeOperatorCatalog,
+				},
+			},
+		},
+		{
+			caseName:       "OperatorImageCollector - Mirror to disk - OCI Catalog with invalid TargetCatalog: should fail",
+			config:         failingConfigM2DWithTargetCatalog4Oci,
+			expectedError:  true,
+			expectedResult: []v1alpha3.CopyImageSchema{},
+		},
+		{
+			caseName:      "OperatorImageCollector - Mirror to disk - OCI Catalog with TargetTag + TargetCatalog: should pass",
+			config:        nominalConfigM2DWithTargetCatalogTag4Oci,
+			expectedError: false,
+			expectedResult: []v1alpha3.CopyImageSchema{
+				{
+					Source:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Type:        v1alpha2.TypeInvalid,
+				},
+				{
+					Source:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Type:        v1alpha2.TypeInvalid,
+				},
+				{
+					Source:      "oci://../../tests/simple-test-bundle",
+					Destination: "docker://localhost:9999/test-catalog:v4.14",
+					Origin:      "oci://../../tests/simple-test-bundle",
+					Type:        v1alpha2.TypeOperatorCatalog,
+				},
+			},
+		},
+		{
+			caseName:      "OperatorImageCollector - Mirror to disk - Catalog with TargetTag + TargetCatalog: should pass",
+			config:        nominalConfigM2DWithTargetCatalogTag,
+			expectedError: false,
+			expectedResult: []v1alpha3.CopyImageSchema{
+				{
+					Source:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Type:        v1alpha2.TypeInvalid,
+				},
+				{
+					Source:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Type:        v1alpha2.TypeInvalid,
+				},
+				{
+					Source:      "docker://certified-operators:v4.7",
+					Destination: "docker://localhost:9999/test-namespace/test-catalog:v2.0",
+					Origin:      "docker://certified-operators:v4.7",
+					Type:        v1alpha2.TypeOperatorCatalog,
+				},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.caseName, func(t *testing.T) {
+			ex := setupCollector_MirrorToDisk(tempDir, log, manifest)
+			ex = ex.withConfig(testCase.config)
+			res, err := ex.OperatorImageCollector(ctx)
+			if testCase.expectedError && err == nil {
+				t.Fatalf("should fail")
+			}
+			if !testCase.expectedError && err != nil {
+				t.Fatal("should not fail")
+			}
+			assert.ElementsMatch(t, testCase.expectedResult, res)
+		})
+	}
+
+	// this test should cover over 80% M2D
+	t.Run("Testing OperatorImageCollector - Mirror to disk: should pass", func(t *testing.T) {
+		ex := setupCollector_MirrorToDisk(tempDir, log, manifest)
+		// ensure coverage in new.go
+		_ = New(log, "working-dir", ex.Config, ex.Opts, ex.Mirror, manifest, "localhost:9999")
+	})
+}
+func TestOperatorLocalStoredCollectorD2M(t *testing.T) {
+	log := clog.New("trace")
+
+	tempDir := t.TempDir()
+	defer os.RemoveAll(tempDir)
+	type testCase struct {
+		caseName       string
+		config         v1alpha2.ImageSetConfiguration
+		expectedResult []v1alpha3.CopyImageSchema
+		expectedError  bool
+	}
+
+	ctx := context.Background()
+	os.RemoveAll("../../tests/hold-operator/")
+	os.RemoveAll("../../tests/operator-images")
+	os.RemoveAll("../../tests/tmp/")
+
+	//copy tests/hold-test-fake to working-dir
+	err := copy.Copy("../../tests/working-dir-fake/hold-operator/redhat-operator-index/v4.14", filepath.Join(tempDir, "working-dir", operatorImageExtractDir, "ocp-release/4.13.9-x86_64"))
+	if err != nil {
+		t.Fatalf("should not fail")
+	}
+
+	testCases := []testCase{
+		{
+			caseName:      "OperatorImageCollector - Disk to mirror : should pass",
+			config:        nominalConfigD2M,
+			expectedError: false,
+			expectedResult: []v1alpha3.CopyImageSchema{
+				{
+					Source:      "docker://localhost:9999/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Type:        v1alpha2.TypeInvalid,
+				},
+				{
+					Source:      "docker://localhost:9999/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Type:        v1alpha2.TypeInvalid,
+				},
+				{
+					Source:      "docker://localhost:9999/simple-test-bundle:3ef0b0141abd1548f60c4f3b23ecfc415142b0e842215f38e98610a3b2e52419",
+					Destination: "docker://localhost:5000/test/simple-test-bundle:3ef0b0141abd1548f60c4f3b23ecfc415142b0e842215f38e98610a3b2e52419",
+					Origin:      "oci://../../tests/simple-test-bundle",
+					Type:        v1alpha2.TypeOperatorCatalog,
+				},
+				{
+					Source:      "docker://localhost:9999/redhat-operator-index:v4.14",
+					Destination: "docker://localhost:5000/test/redhat-operator-index:v4.14",
+					Origin:      "docker://redhat-operator-index:v4.14",
+					Type:        v1alpha2.TypeOperatorCatalog,
+				},
+			},
+		},
+		{
+			caseName:      "OperatorImageCollector - Disk to mirror - OCI Catalog with invalid TargetCatalog: should fail",
+			config:        failingConfigD2MWithTargetCatalog4OCI,
+			expectedError: true,
+		},
+		{
+			caseName:      "OperatorImageCollector - Disk to mirror - OCI Catalog with TargetTag + TargetCatalog: should pass",
+			config:        nominalConfigD2MWithTargetCatalogTag4OCI,
+			expectedError: false,
+			expectedResult: []v1alpha3.CopyImageSchema{
+				{
+					Source:      "docker://localhost:9999/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Type:        v1alpha2.TypeInvalid,
+				},
+				{
+					Source:      "docker://localhost:9999/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Type:        v1alpha2.TypeInvalid,
+				},
+				{
+					Source:      "docker://localhost:9999/test-catalog:v4.14",
+					Destination: "docker://localhost:5000/test/test-catalog:v4.14",
+					Origin:      "oci://../../tests/simple-test-bundle",
+					Type:        v1alpha2.TypeOperatorCatalog,
+				},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.caseName, func(t *testing.T) {
+			ex := setupCollector_DiskToMirror(tempDir, log)
+			ex = ex.withConfig(testCase.config)
+			res, err := ex.OperatorImageCollector(ctx)
+			if testCase.expectedError && err == nil {
+				t.Fatalf("should fail")
+			}
+			if !testCase.expectedError && err != nil {
+				t.Fatal("should not fail")
+			}
+			assert.ElementsMatch(t, testCase.expectedResult, res)
+		})
+	}
+
+}
+
+func setupCollector_DiskToMirror(tempDir string, log clog.PluggableLoggerInterface) *LocalStorageCollector {
+	manifest := &MockManifest{Log: log}
+
+	globalD2M := &mirror.GlobalOptions{
+		TlsVerify:    false,
+		SecurePolicy: false,
+		WorkingDir:   tempDir + "/working-dir",
+		From:         tempDir,
+	}
+
+	_, sharedOpts := mirror.SharedImageFlags()
+	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
+	_, srcOptsD2M := mirror.ImageSrcFlags(globalD2M, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
+	_, destOptsD2M := mirror.ImageDestFlags(globalD2M, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
+	_, retryOpts := mirror.RetryFlags()
+
+	d2mOpts := mirror.CopyOptions{
+		Global:              globalD2M,
+		DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
+		SrcImage:            srcOptsD2M,
+		DestImage:           destOptsD2M,
+		RetryOpts:           retryOpts,
+		Destination:         "docker://localhost:5000/test",
+		Dev:                 false,
+		Mode:                mirror.DiskToMirror,
+	}
 
 	ex := &LocalStorageCollector{
 		Log:              log,
 		Mirror:           &MockMirror{Fail: false},
-		Config:           cfgm2d,
+		Config:           nominalConfigD2M,
+		Manifest:         manifest,
+		Opts:             d2mOpts,
+		LocalStorageFQDN: "localhost:9999",
+	}
+
+	return ex
+}
+
+func setupCollector_MirrorToDisk(tempDir string, log clog.PluggableLoggerInterface, manifest *MockManifest) *LocalStorageCollector {
+
+	globalM2D := &mirror.GlobalOptions{
+		TlsVerify:    false,
+		SecurePolicy: false,
+		WorkingDir:   tempDir + "/working-dir",
+	}
+
+	_, sharedOpts := mirror.SharedImageFlags()
+	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
+	_, retryOpts := mirror.RetryFlags()
+	_, srcOptsM2D := mirror.ImageSrcFlags(globalM2D, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
+	_, destOptsM2D := mirror.ImageDestFlags(globalM2D, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
+
+	m2dOpts := mirror.CopyOptions{
+		Global:              globalM2D,
+		DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
+		SrcImage:            srcOptsM2D,
+		DestImage:           destOptsM2D,
+		RetryOpts:           retryOpts,
+		Destination:         "file://test",
+		Dev:                 false,
+		Mode:                mirror.MirrorToDisk,
+	}
+
+	ex := &LocalStorageCollector{
+		Log:              log,
+		Mirror:           &MockMirror{Fail: false},
+		Config:           nominalConfigM2D,
 		Manifest:         manifest,
 		Opts:             m2dOpts,
 		LocalStorageFQDN: "localhost:9999",
@@ -453,4 +679,9 @@ func (o MockManifest) ConvertIndexToSingleManifest(dir string, oci *v1alpha3.OCI
 
 func (o MockManifest) GetDigest(ctx context.Context, sourceCtx *types.SystemContext, imgRef string) (string, error) {
 	return "", nil
+}
+
+func (ex *LocalStorageCollector) withConfig(cfg v1alpha2.ImageSetConfiguration) *LocalStorageCollector {
+	ex.Config = cfg
+	return ex
 }

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/additional/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/additional/local_stored_collector.go
@@ -54,7 +54,7 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 			var dest string
 			src = imgSpec.ReferenceWithTransport
 
-			if imgSpec.IsImageByDigest() {
+			if imgSpec.IsImageByDigestOnly() {
 				dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
 			} else {
 				dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), imgSpec.PathComponent}, "/") + ":" + imgSpec.Tag
@@ -79,7 +79,7 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 					return nil, err
 				}
 
-				if imgSpec.IsImageByDigest() {
+				if imgSpec.IsImageByDigestOnly() {
 					src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
 					dest = strings.Join([]string{o.Opts.Destination, imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
 				} else {

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/api/v1alpha2/types_config.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/api/v1alpha2/types_config.go
@@ -1,6 +1,8 @@
 package v1alpha2
 
 import (
+	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/openshift/oc-mirror/v2/pkg/image"
@@ -129,7 +131,6 @@ type Operator struct {
 	//     path-component = alpha-numeric [separator alpha-numeric]*
 	//     alpha-numeric  = /[a-z0-9]+/
 	//     separator      = /[_.]|__|[-]*/
-	// TargetCatalog will be preferred over TargetName if both are specified in te ImageSetConfig.
 	TargetCatalog string `json:"targetCatalog,omitempty"`
 	// TargetTag is the tag the catalog image will be built with. If unset,
 	// the catalog will be publish with the provided tag in the Catalog
@@ -159,17 +160,25 @@ func (o Operator) GetUniqueName() (string, error) {
 	}
 
 	if o.TargetTag != "" {
-		ctlgSpec.Digest = ""
 		ctlgSpec.Reference = strings.Replace(ctlgSpec.Reference, ctlgSpec.Tag, o.TargetTag, 1)
 		ctlgSpec.ReferenceWithTransport = strings.Replace(ctlgSpec.ReferenceWithTransport, ctlgSpec.Tag, o.TargetTag, 1)
 		ctlgSpec.Tag = o.TargetTag
 	}
 	if o.TargetCatalog != "" {
-		ctlgSpec.Reference = strings.Replace(ctlgSpec.Reference, ctlgSpec.PathComponent, o.TargetCatalog, 1)
-		ctlgSpec.ReferenceWithTransport = strings.Replace(ctlgSpec.ReferenceWithTransport, ctlgSpec.PathComponent, o.TargetCatalog, 1)
-		ctlgSpec.PathComponent = o.TargetCatalog
+		if IsValidPathComponent(o.TargetCatalog) {
+			ctlgSpec.Reference = strings.Replace(ctlgSpec.Reference, ctlgSpec.PathComponent, o.TargetCatalog, 1)
+			ctlgSpec.ReferenceWithTransport = strings.Replace(ctlgSpec.ReferenceWithTransport, ctlgSpec.PathComponent, o.TargetCatalog, 1)
+			ctlgSpec.PathComponent = o.TargetCatalog
+		} else {
+			return "", fmt.Errorf("targetCatalog: %s - value is not valid. It should not contain a tag or a digest. It is expected to be composed of 1 or more path components separated by /, where each path component is a set of alpha-numeric and  regexp (?:[._]|__|[-]*). For more, see https://github.com/containers/image/blob/main/docker/reference/regexp.go", o.TargetCatalog)
+		}
 	}
 	return ctlgSpec.Reference, nil
+}
+
+func IsValidPathComponent(targetCatalog string) bool {
+	pathComponentPattern := regexp.MustCompile(`^([a-z0-9]+((?:[._]|__|[-]*)[a-z0-9]+)*)(/([a-z0-9]+((?:[._]|__|[-]*)[a-z0-9]+)*))*$`)
+	return pathComponentPattern.MatchString(targetCatalog)
 }
 
 // IsHeadsOnly determine if the mode set mirrors only channel heads of all packages in the catalog.

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/api/v1alpha3/types.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/api/v1alpha3/types.go
@@ -192,7 +192,7 @@ type RelatedImage struct {
 	TargetTag string `json:"targetTag"`
 	// Used to keep specific naming info for the related image
 	// if set should be used when mirroring
-	TargetName string `json:"tagetName"`
+	TargetCatalog string `json:"targetCatalog"`
 }
 
 // CopyImageSchema

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/clusterresources/clusterresources.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/clusterresources/clusterresources.go
@@ -187,7 +187,7 @@ func (o *ClusterResourcesGenerator) generateCatalogSource(catalogRef string, cat
 	}
 
 	var csSuffix string
-	if catalogSpec.IsImageByDigest() {
+	if catalogSpec.IsImageByDigestOnly() {
 		if len(catalogSpec.Digest) >= hashTruncLen {
 			csSuffix = catalogSpec.Digest[:hashTruncLen]
 		} else {
@@ -362,11 +362,11 @@ func (o *ClusterResourcesGenerator) generateImageMirrors(allRelatedImages []v1al
 		toBeAdded := true
 		switch mode {
 		case TagsOnlyMode:
-			if srcImgSpec.IsImageByDigest() {
+			if srcImgSpec.IsImageByDigestOnly() {
 				toBeAdded = false
 			}
 		case DigestsOnlyMode:
-			if !srcImgSpec.IsImageByDigest() {
+			if !srcImgSpec.IsImageByDigestOnly() {
 				toBeAdded = false
 			}
 		}

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/image/image.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/image/image.go
@@ -109,6 +109,10 @@ func (i ImageSpec) IsImageByDigest() bool {
 	return i.Digest != ""
 }
 
+func (i ImageSpec) IsImageByDigestOnly() bool {
+	return i.Tag == "" && i.Digest != ""
+}
+
 func WithMaxNestedPaths(imageRef string, maxNestedPaths int) (string, error) {
 	if maxNestedPaths == 0 {
 		return imageRef, nil

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/operator/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/operator/local_stored_collector.go
@@ -61,6 +61,10 @@ func (o *LocalStorageCollector) OperatorImageCollector(ctx context.Context) ([]v
 		// download the operator index image
 		o.Log.Info("copying operator image %v", op.Catalog)
 
+		// CLID-47 double check that targetCatalog is valid
+		if op.TargetCatalog != "" && !v1alpha2.IsValidPathComponent(op.TargetCatalog) {
+			return []v1alpha3.CopyImageSchema{}, fmt.Errorf("invalid targetCatalog %s", op.TargetCatalog)
+		}
 		// CLID-27 ensure we pick up oci:// (on disk) catalogs
 		imgSpec, err := image.ParseRef(op.Catalog)
 		if err != nil {
@@ -214,20 +218,17 @@ func (o *LocalStorageCollector) OperatorImageCollector(ctx context.Context) ([]v
 			relatedImages[k] = v
 		}
 
-		// this ensures we either enforce using targetTag or targetCatalog
-		// but not both
 		var targetTag string
 		var targetCatalog string
 		if len(op.TargetTag) > 0 {
 			targetTag = op.TargetTag
-			targetCatalog = ""
 		} else {
-			if len(op.TargetCatalog) > 0 {
-				targetTag = ""
-				targetCatalog = op.TargetCatalog
-			} else {
-				targetTag = validDigest.Encoded()
-			}
+			targetTag = validDigest.Encoded()
+		}
+
+		if len(op.TargetCatalog) > 0 {
+			targetCatalog = op.TargetCatalog
+
 		}
 
 		componentName := imgSpec.ComponentName() + "." + catalogDigest
@@ -284,31 +285,33 @@ func (o LocalStorageCollector) prepareD2MCopyBatch(log clog.PluggableLoggerInter
 				return nil, err
 			}
 
-			if imgSpec.Transport != ociProtocol {
-				if imgSpec.IsImageByDigest() {
-					src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
-					dest = strings.Join([]string{o.Opts.Destination, imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
-				} else {
-					src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent}, "/") + ":" + imgSpec.Tag
-					dest = strings.Join([]string{o.Opts.Destination, imgSpec.PathComponent}, "/") + ":" + imgSpec.Tag
-				}
+			if img.Type == v1alpha2.TypeOperatorCatalog && len(img.TargetName) > 0 {
+				src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, img.TargetName}, "/")
+				dest = strings.Join([]string{o.Opts.Destination, img.TargetName}, "/")
+			} else if imgSpec.Transport == ociProtocol {
+				src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, img.Name}, "/")
+				dest = strings.Join([]string{o.Opts.Destination, img.Name}, "/")
 			} else {
-				if len(img.TargetName) > 0 {
-					src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, img.TargetName}, "/")
-					dest = strings.Join([]string{o.Opts.Destination, img.TargetName}, "/")
-				} else {
-					src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, img.Name + ":" + img.TargetTag}, "/")
-					dest = strings.Join([]string{o.Opts.Destination, img.Name + ":" + img.TargetTag}, "/")
-				}
+				src = dockerProtocol + strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent}, "/")
+				dest = strings.Join([]string{o.Opts.Destination, imgSpec.PathComponent}, "/")
 			}
-
+			if img.Type == v1alpha2.TypeOperatorCatalog && len(img.TargetTag) > 0 {
+				src = src + ":" + img.TargetTag
+				dest = dest + ":" + img.TargetTag
+			} else if imgSpec.Tag == "" {
+				src = src + ":" + imgSpec.Digest
+				dest = dest + ":" + imgSpec.Digest
+			} else {
+				src = src + ":" + imgSpec.Tag
+				dest = dest + ":" + imgSpec.Tag
+			}
 			if src == "" || dest == "" {
 				return result, fmt.Errorf("unable to determine src %s or dst %s for %s", src, dest, img.Image)
 			}
 
 			o.Log.Debug("source %s", src)
 			o.Log.Debug("destination %s", dest)
-			result = append(result, v1alpha3.CopyImageSchema{Origin: img.Image, Source: src, Destination: dest, Type: img.Type})
+			result = append(result, v1alpha3.CopyImageSchema{Origin: imgSpec.ReferenceWithTransport, Source: src, Destination: dest, Type: img.Type})
 		}
 	}
 	return result, nil
@@ -324,20 +327,21 @@ func (o LocalStorageCollector) prepareM2DCopyBatch(log clog.PluggableLoggerInter
 			if err != nil {
 				return nil, err
 			}
-			if imgSpec.Transport == ociProtocol {
-				src = ociProtocolTrimmed + imgSpec.Reference
-				if len(img.TargetName) > 0 {
-					dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), img.TargetName}, "/")
-				} else {
-					dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), img.Name + ":" + img.TargetTag}, "/")
-				}
+
+			src = imgSpec.ReferenceWithTransport
+			if img.Type == v1alpha2.TypeOperatorCatalog && len(img.TargetName) > 0 {
+				dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), img.TargetName}, "/")
+			} else if imgSpec.Transport == ociProtocol {
+				dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), img.Name}, "/")
 			} else {
-				src = imgSpec.ReferenceWithTransport
-				if imgSpec.IsImageByDigest() {
-					dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
-				} else {
-					dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), imgSpec.PathComponent}, "/") + ":" + imgSpec.Tag
-				}
+				dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), imgSpec.PathComponent}, "/")
+			}
+			if img.Type == v1alpha2.TypeOperatorCatalog && len(img.TargetTag) > 0 {
+				dest = dest + ":" + img.TargetTag
+			} else if imgSpec.Tag == "" {
+				dest = dest + ":" + imgSpec.Digest
+			} else {
+				dest = dest + ":" + imgSpec.Tag
 			}
 
 			o.Log.Debug("source %s", src)


### PR DESCRIPTION
# Description
Ensure that the current v2 respects the v1 TargetCatalog and TargetTag fields (if set) for oci catalog and registry catalogs.

Also TargetCatalog and TargetTag should not be mutually exclusive.

Invalid example:

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.14
    targetCatalog: abc/def:v5.5
    packages:
    - name: aws-load-balancer-operator
```

Valid example:

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.14
    targetCatalog: abc/def
    targetTag: v4.4
    packages:
    - name: aws-load-balancer-operator
```

Fixes # [CLID-47](https://issues.redhat.com//browse/CLID-47) [CLID-46](https://issues.redhat.com//browse/CLID-46)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using the following imagesetconfig, perform a mirror2Disk followed by a disk2Mirror:
```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.14
    targetCatalog: skhoury/redhat-operator-index
    targetTag: v4.14
    packages:
    - name: aws-load-balancer-operator
```
```
$ ./bin/oc-mirror --v2 -c clid-35.yaml file:///home/skhoury/clid35/
$ ./bin/oc-mirror --v2 -c clid-35.yaml --from file:///home/skhoury/clid35/ docker://localhost:5000/clid47
```
Next, perform a mirror 2 mirror, the expected outcome should be ok as well.
```
$ ./bin/oc-mirror --v2 -c clid-35.yaml --workspace file:///home/skhoury/clid35/ docker://localhost:5000/clid47b
$ curl http://localhost:5000/v2/clid47b/skhoury/redhat-operator-index/tags/list 
{"name":"clid47b/skhoury/redhat-operator-index","tags":["v4.14"]}
```
## Expected Outcome
```
$ curl http://localhost:5000/v2/clid47/skhoury/redhat-operator-index/tags/list 
{"name":"clid47/skhoury/redhat-operator-index","tags":["v4.14"]}
```