### PR TITLE
CLID-58,CLID-95,CLID-60: improvements on log output

### DIFF
--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -145,9 +145,11 @@ func buildV1Cmd() *cobra.Command {
 }
 
 func buildV2Cmd() *cobra.Command {
-	fmt.Println("--v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.")
-
 	log := clog.New("info")
+
+	fmt.Println()
+	log.Info("⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.")
+
 	cmd := cliV2.NewMirrorCmd(log)
 	return cmd
 }

--- a/v2/pkg/additional/const.go
+++ b/v2/pkg/additional/const.go
@@ -1,6 +1,8 @@
 package additional
 
 const (
-	dockerProtocol string = "docker://"
-	ociProtocol    string = "oci://"
+	dockerProtocol  = "docker://"
+	ociProtocol     = "oci://"
+	collectorPrefix = "[AdditionalImagesCollector] "
+	errMsg          = collectorPrefix + "%s"
 )

--- a/v2/pkg/additional/local_stored_collector.go
+++ b/v2/pkg/additional/local_stored_collector.go
@@ -41,13 +41,13 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 
 	var allImages []v1alpha3.CopyImageSchema
 
-	o.Log.Debug("multiArch=%v for additional images collections", o.Opts.MultiArch)
+	o.Log.Debug(collectorPrefix+"setting copy option o.Opts.MultiArch=%s when collecting releases image", o.Opts.MultiArch)
 
 	if o.Opts.IsMirrorToDisk() || o.Opts.IsMirrorToMirror() || o.Opts.IsPrepare() {
 		for _, img := range o.Config.ImageSetConfigurationSpec.Mirror.AdditionalImages {
 			imgSpec, err := image.ParseRef(img.Name)
 			if err != nil {
-				o.Log.Error("%s", err.Error())
+				o.Log.Error(errMsg, err.Error())
 				return nil, err
 			}
 			var src string
@@ -60,8 +60,8 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 				dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), imgSpec.PathComponent}, "/") + ":" + imgSpec.Tag
 			}
 
-			o.Log.Debug("source %s", src)
-			o.Log.Debug("destination %s", dest)
+			o.Log.Debug(collectorPrefix+"source %s", src)
+			o.Log.Debug(collectorPrefix+"destination %s", dest)
 			allImages = append(allImages, v1alpha3.CopyImageSchema{Source: src, Destination: dest, Origin: src, Type: v1alpha2.TypeGeneric})
 
 		}
@@ -75,7 +75,7 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 			if !strings.HasPrefix(img.Name, ociProtocol) {
 				imgSpec, err := image.ParseRef(img.Name)
 				if err != nil {
-					o.Log.Error("%s", err.Error())
+					o.Log.Error(errMsg, err.Error())
 					return nil, err
 				}
 
@@ -94,11 +94,12 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 			}
 
 			if src == "" || dest == "" {
+				o.Log.Error(collectorPrefix+"unable to determine src %s or dst %s for %s", src, dest, img.Name)
 				return allImages, fmt.Errorf("unable to determine src %s or dst %s for %s", src, dest, img.Name)
 			}
 
-			o.Log.Debug("source %s", src)
-			o.Log.Debug("destination %s", dest)
+			o.Log.Debug(collectorPrefix+"source %s", src)
+			o.Log.Debug(collectorPrefix+"destination %s", dest)
 			allImages = append(allImages, v1alpha3.CopyImageSchema{Origin: img.Name, Source: src, Destination: dest, Type: v1alpha2.TypeGeneric})
 		}
 	}

--- a/v2/pkg/api/v1alpha3/types.go
+++ b/v2/pkg/api/v1alpha3/types.go
@@ -195,6 +195,13 @@ type RelatedImage struct {
 	TargetCatalog string `json:"targetCatalog"`
 }
 
+type CollectorSchema struct {
+	TotalReleaseImages    int
+	TotalOperatorImages   int
+	TotalAdditionalImages int
+	AllImages             []CopyImageSchema
+}
+
 // CopyImageSchema
 type CopyImageSchema struct {
 	// Source: from where to copy the image

--- a/v2/pkg/batch/const.go
+++ b/v2/pkg/batch/const.go
@@ -1,0 +1,7 @@
+package batch
+
+const (
+	BATCH_SIZE   int    = 8
+	logFile      string = "worker-{batch}.log"
+	workerPrefix string = "[Worker] "
+)

--- a/v2/pkg/batch/worker_test.go
+++ b/v2/pkg/batch/worker_test.go
@@ -53,7 +53,7 @@ func TestWorker(t *testing.T) {
 			{Source: "docker://registry/name/namespace/sometestimage-h@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:test"},
 			{Source: "docker://registry/name/namespace/sometestimage-i@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:test"},
 		}
-		err := w.Worker(context.Background(), relatedImages, opts)
+		err := w.Worker(context.Background(), v1alpha3.CollectorSchema{AllImages: relatedImages}, opts)
 		if err != nil {
 			t.Fatal("should pass")
 		}

--- a/v2/pkg/cli/const.go
+++ b/v2/pkg/cli/const.go
@@ -1,0 +1,5 @@
+package cli
+
+const (
+	collecAllPrefix = "[CollectAll] "
+)

--- a/v2/pkg/cli/executor_test.go
+++ b/v2/pkg/cli/executor_test.go
@@ -738,7 +738,7 @@ func (o *Diff) CheckDiff(prevCfg v1alpha2.ImageSetConfiguration) (bool, error) {
 	return false, nil
 }
 
-func (o *Batch) Worker(ctx context.Context, images []v1alpha3.CopyImageSchema, opts mirror.CopyOptions) error {
+func (o Batch) Worker(ctx context.Context, collectorSchema v1alpha3.CollectorSchema, opts mirror.CopyOptions) error {
 	if o.Fail {
 		return fmt.Errorf("forced error")
 	}

--- a/v2/pkg/cli/prepare.go
+++ b/v2/pkg/cli/prepare.go
@@ -171,7 +171,7 @@ func (o *ExecutorSchema) RunPrepare(cmd *cobra.Command, args []string) error {
 	o.Log.Info(startMessage, o.Opts.Global.Port)
 	go startLocalRegistry(&o.LocalStorageService, o.localStorageInterruptChannel)
 
-	allImages, err := o.CollectAll(cmd.Context())
+	collectorSchema, err := o.CollectAll(cmd.Context())
 	if err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func (o *ExecutorSchema) RunPrepare(cmd *cobra.Command, args []string) error {
 	imagesAvailable := map[string]bool{}
 	atLeastOneMissing := false
 	var buff bytes.Buffer
-	for _, img := range allImages {
+	for _, img := range collectorSchema.AllImages {
 		buff.WriteString(img.Destination + "\n")
 		exists, err := o.Mirror.Check(cmd.Context(), img.Destination, o.Opts)
 		if err != nil {

--- a/v2/pkg/clusterresources/clusterresources.go
+++ b/v2/pkg/clusterresources/clusterresources.go
@@ -62,6 +62,8 @@ const (
 )
 
 func (o *ClusterResourcesGenerator) IDMS_ITMSGenerator(allRelatedImages []v1alpha3.CopyImageSchema, forceRepositoryScope bool) error {
+	o.Log.Info("📄 Generating IDMS and ITMS files...")
+
 	// byDigestMirrors
 	byDigestMirrors, err := o.generateImageMirrors(allRelatedImages, DigestsOnlyMode, forceRepositoryScope)
 	if err != nil {
@@ -168,6 +170,7 @@ func writeMirrorSet[T confv1.ImageDigestMirrorSet | confv1.ImageTagMirrorSet](mi
 }
 
 func (o *ClusterResourcesGenerator) CatalogSourceGenerator(allRelatedImages []v1alpha3.CopyImageSchema) error {
+	o.Log.Info("📄 Generating CatalogSource file...")
 	for _, copyImage := range allRelatedImages {
 		if copyImage.Type == v1alpha2.TypeOperatorCatalog {
 			// check if ImageSetConfig contains a CatalogSourceTemplate for this catalog, and use it
@@ -446,6 +449,7 @@ func (o *ClusterResourcesGenerator) generateImageMirrors(allRelatedImages []v1al
 }
 
 func (o *ClusterResourcesGenerator) UpdateServiceGenerator(graphImageRef, releaseImageRef string) error {
+	o.Log.Info("📄 Generating UpdateService file...")
 	// truncate tag or digest from release image
 	// according to https://docs.openshift.com/container-platform/4.14/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.html#update-service-create-service-cli_updating-restricted-network-cluster-osus
 	releaseImage, err := image.ParseRef(releaseImageRef)
@@ -486,12 +490,12 @@ func (o *ClusterResourcesGenerator) UpdateServiceGenerator(graphImageRef, releas
 	osusPath := filepath.Join(o.WorkingDir, clusterResourcesDir, updateServiceFilename)
 
 	if _, err := os.Stat(osusPath); errors.Is(err, os.ErrNotExist) {
-		o.Log.Info("%s does not exist, creating it", osusPath)
+		o.Log.Debug("%s does not exist, creating it", osusPath)
 		err := os.MkdirAll(filepath.Dir(osusPath), 0755)
 		if err != nil {
 			return err
 		}
-		o.Log.Info("%s dir created", filepath.Dir(osusPath))
+		o.Log.Debug("%s dir created", filepath.Dir(osusPath))
 	}
 	osusFile, err := os.Create(osusPath)
 	if err != nil {

--- a/v2/pkg/delete/delete_images.go
+++ b/v2/pkg/delete/delete_images.go
@@ -34,7 +34,8 @@ type DeleteImages struct {
 
 // WriteDeleteMetaData
 func (o DeleteImages) WriteDeleteMetaData(images []v1alpha3.CopyImageSchema) error {
-	o.Log.Info("writing delete metadata images to %s ", o.Opts.Global.WorkingDir+deleteDir)
+	o.Log.Info("📄 Generating delete file...")
+	o.Log.Info("%s file created", o.Opts.Global.WorkingDir+deleteDir)
 
 	// we write the image and related blobs in yaml format to file for further processing
 	filename := filepath.Join(o.Opts.Global.WorkingDir, deleteImagesYaml)
@@ -132,7 +133,7 @@ func (o DeleteImages) WriteDeleteMetaData(images []v1alpha3.CopyImageSchema) err
 
 // DeleteRegistryImages - deletes both remote and local registries
 func (o DeleteImages) DeleteRegistryImages(images v1alpha3.DeleteImageList) error {
-	o.Log.Info("deleting images from remote registry")
+	o.Log.Debug("deleting images from remote registry")
 	var rrUpdatedImages []v1alpha3.CopyImageSchema
 	var lsUpdatedImages []v1alpha3.CopyImageSchema
 
@@ -154,13 +155,13 @@ func (o DeleteImages) DeleteRegistryImages(images v1alpha3.DeleteImageList) erro
 
 	}
 	if !o.Opts.Global.DeleteGenerate && len(o.Opts.Global.DeleteDestination) > 0 {
-		err := o.Batch.Worker(context.Background(), rrUpdatedImages, o.Opts)
+		err := o.Batch.Worker(context.Background(), v1alpha3.CollectorSchema{AllImages: rrUpdatedImages}, o.Opts)
 		if err != nil {
 			return err
 		}
 	}
 	if o.Opts.Global.ForceCacheDelete {
-		err := o.Batch.Worker(context.Background(), lsUpdatedImages, o.Opts)
+		err := o.Batch.Worker(context.Background(), v1alpha3.CollectorSchema{AllImages: lsUpdatedImages}, o.Opts)
 		if err != nil {
 			return err
 		}
@@ -172,6 +173,7 @@ func (o DeleteImages) DeleteRegistryImages(images v1alpha3.DeleteImageList) erro
 // used to verify the delete yaml is well formed as well as being
 // the base for both local cache delete and remote registry delete
 func (o DeleteImages) ReadDeleteMetaData() (v1alpha3.DeleteImageList, error) {
+	o.Log.Info("👀 Reading delete file...")
 	var list v1alpha3.DeleteImageList
 	var fileName string
 

--- a/v2/pkg/delete/delete_images_test.go
+++ b/v2/pkg/delete/delete_images_test.go
@@ -734,7 +734,7 @@ type mockBlobs struct {
 
 type mockManifest struct{}
 
-func (o *mockBatch) Worker(ctx context.Context, images []v1alpha3.CopyImageSchema, opts mirror.CopyOptions) error {
+func (o mockBatch) Worker(ctx context.Context, collectorSchema v1alpha3.CollectorSchema, opts mirror.CopyOptions) error {
 	if o.Fail {
 		return fmt.Errorf("forced error")
 	}

--- a/v2/pkg/manifest/oci-manifest.go
+++ b/v2/pkg/manifest/oci-manifest.go
@@ -118,7 +118,7 @@ func (o Manifest) ExtractLayersOCI(fromPath, toPath, label string, oci *v1alpha3
 			}
 		}
 	} else {
-		o.Log.Info("extract directory exists (nop)")
+		o.Log.Debug("extract directory exists (nop)")
 	}
 	return nil
 }

--- a/v2/pkg/mirror/mirror.go
+++ b/v2/pkg/mirror/mirror.go
@@ -176,6 +176,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 		ForceManifestMIMEType:            manifestType,
 		ImageListSelection:               imageListSelection,
 		PreserveDigests:                  opts.PreserveDigests,
+		MaxParallelDownloads:             opts.MaxParallelDownloads,
 	}
 
 	return retry.IfNecessary(ctx, func() error {

--- a/v2/pkg/mirror/options.go
+++ b/v2/pkg/mirror/options.go
@@ -87,6 +87,7 @@ type CopyOptions struct {
 	UUID                     uuid.UUID // set uuid
 	ImageType                string    // release, catalog-operator, additionalImage
 	Stdout                   io.Writer
+	MaxParallelDownloads     uint
 	Function                 string // copy or delete (default is copy)
 }
 

--- a/v2/pkg/operator/const.go
+++ b/v2/pkg/operator/const.go
@@ -1,12 +1,13 @@
 package operator
 
 const (
-	operatorImageExtractDir string = "hold-operator"
-	dockerProtocol          string = "docker://"
-	ociProtocol             string = "oci://"
-	ociProtocolTrimmed      string = "oci:"
-	operatorImageDir        string = "operator-images"
-	blobsDir                string = "blobs/sha256"
-	errMsg                  string = "[OperatorImageCollector] %v "
-	logsFile                string = "operator.log"
+	operatorImageExtractDir = "hold-operator"
+	dockerProtocol          = "docker://"
+	ociProtocol             = "oci://"
+	ociProtocolTrimmed      = "oci:"
+	operatorImageDir        = "operator-images"
+	blobsDir                = "blobs/sha256"
+	collectorPrefix         = "[OperatorImageCollector] "
+	errMsg                  = collectorPrefix + "%s"
+	logsFile                = "operator.log"
 )

--- a/v2/pkg/release/cincinnati.go
+++ b/v2/pkg/release/cincinnati.go
@@ -169,7 +169,7 @@ func (o *CincinnatiSchema) GetReleaseReferenceImages(ctx context.Context) []v1al
 			} else {
 				// Range is set. Ensure full is true so this
 				// is skipped when processing release metadata.
-				o.Log.Info("processing minimum version %s and maximum version %s\n", ch.MinVersion, ch.MaxVersion)
+				o.Log.Debug("processing minimum version %s and maximum version %s", ch.MinVersion, ch.MaxVersion)
 				ch.Full = true
 				versionsByChannel[ch.Name] = ch
 			}
@@ -300,7 +300,7 @@ func getCrossChannelDownloads(ctx context.Context, log clog.PluggableLoggerInter
 func gatherUpdates(log clog.PluggableLoggerInterface, current, newest Update, updates []Update) []v1alpha3.CopyImageSchema {
 	var allImages []v1alpha3.CopyImageSchema
 	for _, update := range updates {
-		log.Info("Found update %s\n", update.Version)
+		log.Debug("Found update %s", update.Version)
 		allImages = append(allImages, v1alpha3.CopyImageSchema{Source: update.Image, Destination: ""})
 	}
 

--- a/v2/pkg/release/const.go
+++ b/v2/pkg/release/const.go
@@ -25,6 +25,7 @@ const (
 	imageReferences             = "image-references"
 	releaseImageExtractFullPath = releaseManifests + "/" + imageReferences
 	blobsDir                    = "blobs/sha256"
-	errMsg                      = "[ReleaseImageCollector] %v "
+	collectorPrefix             = "[ReleaseImageCollector] "
+	errMsg                      = collectorPrefix + "%s"
 	logFile                     = "release.log"
 )

--- a/v2/pkg/release/signature.go
+++ b/v2/pkg/release/signature.go
@@ -51,13 +51,13 @@ func (o SignatureSchema) GenerateReleaseSignatures(ctx context.Context, images [
 		digest = imgSpec.Digest
 
 		if digest != "" {
-			o.Log.Info("signature %s", digest)
+			o.Log.Debug("signature %s", digest)
 			// check if the image is in the cache else
 			// do a lookup and download it to cache
 			data, err = os.ReadFile(o.Opts.Global.WorkingDir + SignatureDir + digest)
 			if err != nil {
 				if os.IsNotExist(err) {
-					o.Log.Warn("signature for %s not in cache", digest)
+					o.Log.Debug("signature for %s not in cache", digest)
 				}
 			}
 		} else {
@@ -140,7 +140,7 @@ func (o SignatureSchema) GenerateReleaseSignatures(ctx context.Context, images [
 				o.Log.Error("unexpected openpgp.MessageDetails: neither Signature nor SignatureV3 is set")
 			}
 
-			o.Log.Info("content %s", string(content))
+			o.Log.Debug("content %s", string(content))
 			// update the image with the actaul reference from the contents json
 			var signSchema *v1alpha3.SignatureContentSchema
 			err = json.Unmarshal(content, &signSchema)
@@ -149,7 +149,7 @@ func (o SignatureSchema) GenerateReleaseSignatures(ctx context.Context, images [
 				return []v1alpha3.CopyImageSchema{}, err
 			}
 			img.Source = signSchema.Critical.Identity.DockerReference
-			o.Log.Info("image found : %s", signSchema.Critical.Identity.DockerReference)
+			o.Log.Debug("image found : %s", signSchema.Critical.Identity.DockerReference)
 			// o.Log.Info("public Key : %s", strings.ToUpper(fmt.Sprintf("%x", md.SignedBy.PublicKey.Fingerprint)))
 
 			// write signature to cache

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/additional/const.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/additional/const.go
@@ -1,6 +1,8 @@
 package additional
 
 const (
-	dockerProtocol string = "docker://"
-	ociProtocol    string = "oci://"
+	dockerProtocol  = "docker://"
+	ociProtocol     = "oci://"
+	collectorPrefix = "[AdditionalImagesCollector] "
+	errMsg          = collectorPrefix + "%s"
 )

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/additional/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/additional/local_stored_collector.go
@@ -41,13 +41,13 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 
 	var allImages []v1alpha3.CopyImageSchema
 
-	o.Log.Debug("multiArch=%v for additional images collections", o.Opts.MultiArch)
+	o.Log.Debug(collectorPrefix+"setting copy option o.Opts.MultiArch=%s when collecting releases image", o.Opts.MultiArch)
 
 	if o.Opts.IsMirrorToDisk() || o.Opts.IsMirrorToMirror() || o.Opts.IsPrepare() {
 		for _, img := range o.Config.ImageSetConfigurationSpec.Mirror.AdditionalImages {
 			imgSpec, err := image.ParseRef(img.Name)
 			if err != nil {
-				o.Log.Error("%s", err.Error())
+				o.Log.Error(errMsg, err.Error())
 				return nil, err
 			}
 			var src string
@@ -60,8 +60,8 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 				dest = dockerProtocol + strings.Join([]string{o.destinationRegistry(), imgSpec.PathComponent}, "/") + ":" + imgSpec.Tag
 			}
 
-			o.Log.Debug("source %s", src)
-			o.Log.Debug("destination %s", dest)
+			o.Log.Debug(collectorPrefix+"source %s", src)
+			o.Log.Debug(collectorPrefix+"destination %s", dest)
 			allImages = append(allImages, v1alpha3.CopyImageSchema{Source: src, Destination: dest, Origin: src, Type: v1alpha2.TypeGeneric})
 
 		}
@@ -75,7 +75,7 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 			if !strings.HasPrefix(img.Name, ociProtocol) {
 				imgSpec, err := image.ParseRef(img.Name)
 				if err != nil {
-					o.Log.Error("%s", err.Error())
+					o.Log.Error(errMsg, err.Error())
 					return nil, err
 				}
 
@@ -94,11 +94,12 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 			}
 
 			if src == "" || dest == "" {
+				o.Log.Error(collectorPrefix+"unable to determine src %s or dst %s for %s", src, dest, img.Name)
 				return allImages, fmt.Errorf("unable to determine src %s or dst %s for %s", src, dest, img.Name)
 			}
 
-			o.Log.Debug("source %s", src)
-			o.Log.Debug("destination %s", dest)
+			o.Log.Debug(collectorPrefix+"source %s", src)
+			o.Log.Debug(collectorPrefix+"destination %s", dest)
 			allImages = append(allImages, v1alpha3.CopyImageSchema{Origin: img.Name, Source: src, Destination: dest, Type: v1alpha2.TypeGeneric})
 		}
 	}

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/api/v1alpha3/types.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/api/v1alpha3/types.go
@@ -195,6 +195,13 @@ type RelatedImage struct {
 	TargetCatalog string `json:"targetCatalog"`
 }
 
+type CollectorSchema struct {
+	TotalReleaseImages    int
+	TotalOperatorImages   int
+	TotalAdditionalImages int
+	AllImages             []CopyImageSchema
+}
+
 // CopyImageSchema
 type CopyImageSchema struct {
 	// Source: from where to copy the image

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/batch/const.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/batch/const.go
@@ -1,0 +1,7 @@
+package batch
+
+const (
+	BATCH_SIZE   int    = 8
+	logFile      string = "worker-{batch}.log"
+	workerPrefix string = "[Worker] "
+)

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/cli/const.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/cli/const.go
@@ -1,0 +1,5 @@
+package cli
+
+const (
+	collecAllPrefix = "[CollectAll] "
+)

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/cli/prepare.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/cli/prepare.go
@@ -171,7 +171,7 @@ func (o *ExecutorSchema) RunPrepare(cmd *cobra.Command, args []string) error {
 	o.Log.Info(startMessage, o.Opts.Global.Port)
 	go startLocalRegistry(&o.LocalStorageService, o.localStorageInterruptChannel)
 
-	allImages, err := o.CollectAll(cmd.Context())
+	collectorSchema, err := o.CollectAll(cmd.Context())
 	if err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func (o *ExecutorSchema) RunPrepare(cmd *cobra.Command, args []string) error {
 	imagesAvailable := map[string]bool{}
 	atLeastOneMissing := false
 	var buff bytes.Buffer
-	for _, img := range allImages {
+	for _, img := range collectorSchema.AllImages {
 		buff.WriteString(img.Destination + "\n")
 		exists, err := o.Mirror.Check(cmd.Context(), img.Destination, o.Opts)
 		if err != nil {

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/clusterresources/clusterresources.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/clusterresources/clusterresources.go
@@ -62,6 +62,8 @@ const (
 )
 
 func (o *ClusterResourcesGenerator) IDMS_ITMSGenerator(allRelatedImages []v1alpha3.CopyImageSchema, forceRepositoryScope bool) error {
+	o.Log.Info("📄 Generating IDMS and ITMS files...")
+
 	// byDigestMirrors
 	byDigestMirrors, err := o.generateImageMirrors(allRelatedImages, DigestsOnlyMode, forceRepositoryScope)
 	if err != nil {
@@ -168,6 +170,7 @@ func writeMirrorSet[T confv1.ImageDigestMirrorSet | confv1.ImageTagMirrorSet](mi
 }
 
 func (o *ClusterResourcesGenerator) CatalogSourceGenerator(allRelatedImages []v1alpha3.CopyImageSchema) error {
+	o.Log.Info("📄 Generating CatalogSource file...")
 	for _, copyImage := range allRelatedImages {
 		if copyImage.Type == v1alpha2.TypeOperatorCatalog {
 			// check if ImageSetConfig contains a CatalogSourceTemplate for this catalog, and use it
@@ -446,6 +449,7 @@ func (o *ClusterResourcesGenerator) generateImageMirrors(allRelatedImages []v1al
 }
 
 func (o *ClusterResourcesGenerator) UpdateServiceGenerator(graphImageRef, releaseImageRef string) error {
+	o.Log.Info("📄 Generating UpdateService file...")
 	// truncate tag or digest from release image
 	// according to https://docs.openshift.com/container-platform/4.14/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.html#update-service-create-service-cli_updating-restricted-network-cluster-osus
 	releaseImage, err := image.ParseRef(releaseImageRef)
@@ -486,12 +490,12 @@ func (o *ClusterResourcesGenerator) UpdateServiceGenerator(graphImageRef, releas
 	osusPath := filepath.Join(o.WorkingDir, clusterResourcesDir, updateServiceFilename)
 
 	if _, err := os.Stat(osusPath); errors.Is(err, os.ErrNotExist) {
-		o.Log.Info("%s does not exist, creating it", osusPath)
+		o.Log.Debug("%s does not exist, creating it", osusPath)
 		err := os.MkdirAll(filepath.Dir(osusPath), 0755)
 		if err != nil {
 			return err
 		}
-		o.Log.Info("%s dir created", filepath.Dir(osusPath))
+		o.Log.Debug("%s dir created", filepath.Dir(osusPath))
 	}
 	osusFile, err := os.Create(osusPath)
 	if err != nil {

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/delete/delete_images.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/delete/delete_images.go
@@ -34,7 +34,8 @@ type DeleteImages struct {
 
 // WriteDeleteMetaData
 func (o DeleteImages) WriteDeleteMetaData(images []v1alpha3.CopyImageSchema) error {
-	o.Log.Info("writing delete metadata images to %s ", o.Opts.Global.WorkingDir+deleteDir)
+	o.Log.Info("📄 Generating delete file...")
+	o.Log.Info("%s file created", o.Opts.Global.WorkingDir+deleteDir)
 
 	// we write the image and related blobs in yaml format to file for further processing
 	filename := filepath.Join(o.Opts.Global.WorkingDir, deleteImagesYaml)
@@ -132,7 +133,7 @@ func (o DeleteImages) WriteDeleteMetaData(images []v1alpha3.CopyImageSchema) err
 
 // DeleteRegistryImages - deletes both remote and local registries
 func (o DeleteImages) DeleteRegistryImages(images v1alpha3.DeleteImageList) error {
-	o.Log.Info("deleting images from remote registry")
+	o.Log.Debug("deleting images from remote registry")
 	var rrUpdatedImages []v1alpha3.CopyImageSchema
 	var lsUpdatedImages []v1alpha3.CopyImageSchema
 
@@ -154,13 +155,13 @@ func (o DeleteImages) DeleteRegistryImages(images v1alpha3.DeleteImageList) erro
 
 	}
 	if !o.Opts.Global.DeleteGenerate && len(o.Opts.Global.DeleteDestination) > 0 {
-		err := o.Batch.Worker(context.Background(), rrUpdatedImages, o.Opts)
+		err := o.Batch.Worker(context.Background(), v1alpha3.CollectorSchema{AllImages: rrUpdatedImages}, o.Opts)
 		if err != nil {
 			return err
 		}
 	}
 	if o.Opts.Global.ForceCacheDelete {
-		err := o.Batch.Worker(context.Background(), lsUpdatedImages, o.Opts)
+		err := o.Batch.Worker(context.Background(), v1alpha3.CollectorSchema{AllImages: lsUpdatedImages}, o.Opts)
 		if err != nil {
 			return err
 		}
@@ -172,6 +173,7 @@ func (o DeleteImages) DeleteRegistryImages(images v1alpha3.DeleteImageList) erro
 // used to verify the delete yaml is well formed as well as being
 // the base for both local cache delete and remote registry delete
 func (o DeleteImages) ReadDeleteMetaData() (v1alpha3.DeleteImageList, error) {
+	o.Log.Info("👀 Reading delete file...")
 	var list v1alpha3.DeleteImageList
 	var fileName string
 

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/manifest/oci-manifest.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/manifest/oci-manifest.go
@@ -118,7 +118,7 @@ func (o Manifest) ExtractLayersOCI(fromPath, toPath, label string, oci *v1alpha3
 			}
 		}
 	} else {
-		o.Log.Info("extract directory exists (nop)")
+		o.Log.Debug("extract directory exists (nop)")
 	}
 	return nil
 }

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/mirror/mirror.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/mirror/mirror.go
@@ -176,6 +176,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 		ForceManifestMIMEType:            manifestType,
 		ImageListSelection:               imageListSelection,
 		PreserveDigests:                  opts.PreserveDigests,
+		MaxParallelDownloads:             opts.MaxParallelDownloads,
 	}
 
 	return retry.IfNecessary(ctx, func() error {

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/mirror/options.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/mirror/options.go
@@ -87,6 +87,7 @@ type CopyOptions struct {
 	UUID                     uuid.UUID // set uuid
 	ImageType                string    // release, catalog-operator, additionalImage
 	Stdout                   io.Writer
+	MaxParallelDownloads     uint
 	Function                 string // copy or delete (default is copy)
 }
 

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/operator/const.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/operator/const.go
@@ -1,12 +1,13 @@
 package operator
 
 const (
-	operatorImageExtractDir string = "hold-operator"
-	dockerProtocol          string = "docker://"
-	ociProtocol             string = "oci://"
-	ociProtocolTrimmed      string = "oci:"
-	operatorImageDir        string = "operator-images"
-	blobsDir                string = "blobs/sha256"
-	errMsg                  string = "[OperatorImageCollector] %v "
-	logsFile                string = "operator.log"
+	operatorImageExtractDir = "hold-operator"
+	dockerProtocol          = "docker://"
+	ociProtocol             = "oci://"
+	ociProtocolTrimmed      = "oci:"
+	operatorImageDir        = "operator-images"
+	blobsDir                = "blobs/sha256"
+	collectorPrefix         = "[OperatorImageCollector] "
+	errMsg                  = collectorPrefix + "%s"
+	logsFile                = "operator.log"
 )

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/release/cincinnati.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/release/cincinnati.go
@@ -169,7 +169,7 @@ func (o *CincinnatiSchema) GetReleaseReferenceImages(ctx context.Context) []v1al
 			} else {
 				// Range is set. Ensure full is true so this
 				// is skipped when processing release metadata.
-				o.Log.Info("processing minimum version %s and maximum version %s\n", ch.MinVersion, ch.MaxVersion)
+				o.Log.Debug("processing minimum version %s and maximum version %s", ch.MinVersion, ch.MaxVersion)
 				ch.Full = true
 				versionsByChannel[ch.Name] = ch
 			}
@@ -300,7 +300,7 @@ func getCrossChannelDownloads(ctx context.Context, log clog.PluggableLoggerInter
 func gatherUpdates(log clog.PluggableLoggerInterface, current, newest Update, updates []Update) []v1alpha3.CopyImageSchema {
 	var allImages []v1alpha3.CopyImageSchema
 	for _, update := range updates {
-		log.Info("Found update %s\n", update.Version)
+		log.Debug("Found update %s", update.Version)
 		allImages = append(allImages, v1alpha3.CopyImageSchema{Source: update.Image, Destination: ""})
 	}
 

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/release/const.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/release/const.go
@@ -25,6 +25,7 @@ const (
 	imageReferences             = "image-references"
 	releaseImageExtractFullPath = releaseManifests + "/" + imageReferences
 	blobsDir                    = "blobs/sha256"
-	errMsg                      = "[ReleaseImageCollector] %v "
+	collectorPrefix             = "[ReleaseImageCollector] "
+	errMsg                      = collectorPrefix + "%s"
 	logFile                     = "release.log"
 )

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/release/signature.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/release/signature.go
@@ -51,13 +51,13 @@ func (o SignatureSchema) GenerateReleaseSignatures(ctx context.Context, images [
 		digest = imgSpec.Digest
 
 		if digest != "" {
-			o.Log.Info("signature %s", digest)
+			o.Log.Debug("signature %s", digest)
 			// check if the image is in the cache else
 			// do a lookup and download it to cache
 			data, err = os.ReadFile(o.Opts.Global.WorkingDir + SignatureDir + digest)
 			if err != nil {
 				if os.IsNotExist(err) {
-					o.Log.Warn("signature for %s not in cache", digest)
+					o.Log.Debug("signature for %s not in cache", digest)
 				}
 			}
 		} else {
@@ -140,7 +140,7 @@ func (o SignatureSchema) GenerateReleaseSignatures(ctx context.Context, images [
 				o.Log.Error("unexpected openpgp.MessageDetails: neither Signature nor SignatureV3 is set")
 			}
 
-			o.Log.Info("content %s", string(content))
+			o.Log.Debug("content %s", string(content))
 			// update the image with the actaul reference from the contents json
 			var signSchema *v1alpha3.SignatureContentSchema
 			err = json.Unmarshal(content, &signSchema)
@@ -149,7 +149,7 @@ func (o SignatureSchema) GenerateReleaseSignatures(ctx context.Context, images [
 				return []v1alpha3.CopyImageSchema{}, err
 			}
 			img.Source = signSchema.Critical.Identity.DockerReference
-			o.Log.Info("image found : %s", signSchema.Critical.Identity.DockerReference)
+			o.Log.Debug("image found : %s", signSchema.Critical.Identity.DockerReference)
 			// o.Log.Info("public Key : %s", strings.ToUpper(fmt.Sprintf("%x", md.SignedBy.PublicKey.Fingerprint)))
 
 			// write signature to cache


### PR DESCRIPTION
# Description

This PR removes the concurrency when calling containers/image copy.Image (details about why [here](https://hackmd.io/@aguidi/BJYubb3lR)). 

Also this PR adds a progress bar when mirroring / deleting images and improves the logs on the output to make it more user friendly.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

With the following ImageSetConfiguration:

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  platform:
    channels:
    - name: stable-4.13
      minVersion: 4.13.10
      maxVersion: 4.13.10
    graph: true
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15
      packages:
       - name: aws-load-balancer-operator
       - name: 3scale-operator
       - name: node-observability-operator
  additionalImages: 
   - name: registry.redhat.io/ubi8/ubi:latest
   - name: registry.redhat.io/ubi9/ubi@sha256:20f695d2a91352d4eaa25107535126727b5945bff38ed36a3e59590f495046f0
```

I ran all the workflows:

mirrorToDisk
```
./bin/oc-mirror -c ./alex-tests/alex-isc/isc.yaml file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-95 --v2
```

diskToMirror
```
./bin/oc-mirror -c ./alex-tests/alex-isc/isc.yaml --from file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-95 docker://localhost:6000 --v2
```

mirrorToMirror
```
./bin/oc-mirror -c ./alex-tests/alex-isc/isc.yaml --workspace file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-95 docker://localhost:6000 --v2
```

delete --generate
```
./bin/oc-mirror delete -c ./alex-tests/alex-isc/clid-20-delete.yaml --generate --workspace file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-20 --delete-id alex-test docker://localhost:6000 --v2
```

delete
```
./bin/oc-mirror delete --delete-yaml-file /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-20/working-dir/delete/delete-images-alex-test.yaml docker://localhost:6000 --v2
```

## Expected Outcome

Improvements on the command line output for all phases of the workflows mentioned above + progress bar during delete/mirroring.