### PR TITLE
CLID-66,CLID-81: refines v2 --help

### DIFF
--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -148,7 +148,7 @@ func buildV2Cmd() *cobra.Command {
 	log := clog.New("info")
 
 	fmt.Println()
-	log.Info("⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.")
+	log.Warn("⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.")
 
 	cmd := cliV2.NewMirrorCmd(log)
 	return cmd


### PR DESCRIPTION
# Description

This PR changes the --help for v2 (description, usage and examples).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
./bin/oc-mirror --help --v2
```

## Expected Outcome
A different --help output from the main branch