### PR TITLE
CLID-101: Fix TlsVerify always set to false

### DIFF
--- a/v2/pkg/additional/local_stored_collector_test.go
+++ b/v2/pkg/additional/local_stored_collector_test.go
@@ -22,7 +22,7 @@ type MockManifest struct {
 func TestAdditionalImageCollector(t *testing.T) {
 	log := clog.New("trace")
 
-	global := &mirror.GlobalOptions{TlsVerify: false, SecurePolicy: false}
+	global := &mirror.GlobalOptions{SecurePolicy: false}
 	_, sharedOpts := mirror.SharedImageFlags()
 	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
 	_, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")

--- a/v2/pkg/archive/archive_test.go
+++ b/v2/pkg/archive/archive_test.go
@@ -331,7 +331,6 @@ func assertContents(t *testing.T, archiveFile string, expectedTarContents []stri
 
 func newMirrorArchiveWithMocks(testFolder string, maxArchiveSize int64, permissive bool) (*MirrorArchive, error) {
 	global := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 		Force:        true,
 		WorkingDir:   "tests",

--- a/v2/pkg/archive/image-blob-gatherer.go
+++ b/v2/pkg/archive/image-blob-gatherer.go
@@ -39,7 +39,8 @@ func (o *ImageBlobGatherer) GatherBlobs(ctx context.Context, imgRef string) (blo
 	if err != nil {
 		return nil, fmt.Errorf("invalid source name %s: %v", imgRef, err)
 	}
-	sourceCtx, err := o.opts.SrcImage.NewSystemContext()
+	// we are always gathering blobs from the local cache registry - skipping tls verification
+	sourceCtx, err := o.opts.SrcImage.NewSystemContextWithTLSVerificationOverride(false)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/pkg/archive/image-blob-gatherer_test.go
+++ b/v2/pkg/archive/image-blob-gatherer_test.go
@@ -15,18 +15,19 @@ import (
 func TestImageBlobGatherer_GatherBlobs(t *testing.T) {
 	ctx := context.Background()
 	global := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 		Force:        true,
 		WorkingDir:   "tests",
 	}
-	global.TlsVerify = false
 
 	_, sharedOpts := mirror.SharedImageFlags()
 	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
-	_, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
-	_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
+	srcFlags, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
+	destFlags, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 	_, retryOpts := mirror.RetryFlags()
+
+	srcFlags.Set("src-tls-verify", "false")
+	destFlags.Set("dest-tls-verify", "false")
 
 	opts := mirror.CopyOptions{
 		Global:              global,
@@ -76,12 +77,10 @@ func TestImageBlobGatherer_GatherBlobs(t *testing.T) {
 func TestImageBlobGatherer_ImgRefError(t *testing.T) {
 	ctx := context.Background()
 	global := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 		Force:        true,
 		WorkingDir:   "tests",
 	}
-	global.TlsVerify = false
 
 	_, sharedOpts := mirror.SharedImageFlags()
 	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
@@ -108,18 +107,19 @@ func TestImageBlobGatherer_ImgRefError(t *testing.T) {
 func TestImageBlobGatherer_SrcContextError(t *testing.T) {
 	ctx := context.Background()
 	global := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 		Force:        true,
 		WorkingDir:   "tests",
 	}
-	global.TlsVerify = false
 
 	_, sharedOpts := mirror.SharedImageFlags()
 	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
-	_, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, nil, "src-", "screds")
-	_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
+	srcFlags, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, nil, "src-", "screds")
+	destFlags, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 	_, retryOpts := mirror.RetryFlags()
+
+	srcFlags.Set("src-tls-verify", "false")
+	destFlags.Set("dest-tls-verify", "false")
 
 	opts := mirror.CopyOptions{
 		Global:              global,
@@ -140,18 +140,19 @@ func TestImageBlobGatherer_SrcContextError(t *testing.T) {
 func TestImageBlobGatherer_ImageSourceError(t *testing.T) {
 	ctx := context.Background()
 	global := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 		Force:        true,
 		WorkingDir:   "tests",
 	}
-	global.TlsVerify = false
 
 	_, sharedOpts := mirror.SharedImageFlags()
 	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
-	_, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
-	_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
+	srcFlags, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
+	destFlags, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 	_, retryOpts := mirror.RetryFlags()
+
+	srcFlags.Set("src-tls-verify", "false")
+	destFlags.Set("dest-tls-verify", "false")
 
 	opts := mirror.CopyOptions{
 		Global:              global,

--- a/v2/pkg/batch/worker_test.go
+++ b/v2/pkg/batch/worker_test.go
@@ -16,7 +16,7 @@ func TestWorker(t *testing.T) {
 
 	log := clog.New("trace")
 
-	global := &mirror.GlobalOptions{TlsVerify: false, SecurePolicy: false, Quiet: false}
+	global := &mirror.GlobalOptions{SecurePolicy: false, Quiet: false}
 
 	_, sharedOpts := mirror.SharedImageFlags()
 	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()

--- a/v2/pkg/cli/additional_integration_test.go
+++ b/v2/pkg/cli/additional_integration_test.go
@@ -131,7 +131,7 @@ func (suite *TestEnvironmentAddditional) runMirror2Disk(t *testing.T) {
 	assert.NoError(t, err, "should not fail creating a temp folder for results")
 
 	os.Setenv("OC_MIRROR_CACHE", suite.tempFolder+"/.cacheM2D")
-	ocmirror.SetArgs([]string{"-c", suite.tempFolder + "/isc.yaml", "--v2", "-p", "55001", "file://" + resultFolder})
+	ocmirror.SetArgs([]string{"-c", suite.tempFolder + "/isc.yaml", "--v2", "-p", "55001", "--src-tls-verify=false", "--dest-tls-verify=false", "file://" + resultFolder})
 	err = ocmirror.Execute()
 	assert.NoError(t, err, "should not fail executing oc-mirror")
 
@@ -143,7 +143,7 @@ func (suite *TestEnvironmentAddditional) runDisk2Mirror(t *testing.T) {
 	ocmirror := NewMirrorCmd(clog.New("trace"))
 	resultFolder := filepath.Join(suite.tempFolder, "additional", d2mSubFolder)
 	os.Setenv("OC_MIRROR_CACHE", suite.tempFolder+"/.cacheD2M")
-	ocmirror.SetArgs([]string{"-c", suite.tempFolder + "/isc.yaml", "--v2", "-p", "55002", "--from", "file://" + resultFolder, "docker://" + suite.destinationRegistryDomain + "/additional"})
+	ocmirror.SetArgs([]string{"-c", suite.tempFolder + "/isc.yaml", "--v2", "-p", "55002", "--from", "file://" + resultFolder, "--src-tls-verify=false", "--dest-tls-verify=false", "docker://" + suite.destinationRegistryDomain + "/additional"})
 	err := ocmirror.Execute()
 	assert.NoError(t, err, "should not fail executing oc-mirror")
 
@@ -168,7 +168,7 @@ func (suite *TestEnvironmentAddditional) runMirror2Mirror(t *testing.T) {
 	err := os.MkdirAll(resultFolder, 0755)
 	assert.NoError(t, err, "should not fail creating a temp folder for results")
 
-	ocmirror.SetArgs([]string{"-c", suite.tempFolder + "/isc.yaml", "--v2", "-p", "55003", "--workspace", "file://" + resultFolder, "docker://" + suite.destinationRegistryDomain + "/additional"})
+	ocmirror.SetArgs([]string{"-c", suite.tempFolder + "/isc.yaml", "--v2", "-p", "55003", "--src-tls-verify=false", "--dest-tls-verify=false", "--workspace", "file://" + resultFolder, "docker://" + suite.destinationRegistryDomain + "/additional"})
 	err = ocmirror.Execute()
 	assert.NoError(t, err, "should not fail executing oc-mirror")
 

--- a/v2/pkg/cli/delete.go
+++ b/v2/pkg/cli/delete.go
@@ -42,7 +42,6 @@ const (
 func NewDeleteCommand(log clog.PluggableLoggerInterface) *cobra.Command {
 
 	global := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 	}
 
@@ -192,6 +191,7 @@ func (o *ExecutorSchema) CompleteDelete(args []string) error {
 		// fake a diskToMirror Mode
 		o.Opts.Mode = mirror.DiskToMirror
 		o.Opts.RemoveSignatures = true
+		o.srcFlagSet.Set("src-tls-verify", "false")
 	}
 
 	// update all dependant modules

--- a/v2/pkg/cli/delete_test.go
+++ b/v2/pkg/cli/delete_test.go
@@ -22,7 +22,6 @@ func TestExecutorValidateDelete(t *testing.T) {
 		log := clog.New("trace")
 
 		global := &mirror.GlobalOptions{
-			TlsVerify:    false,
 			SecurePolicy: false,
 		}
 
@@ -104,7 +103,6 @@ func TestExecutorCompleteDelete(t *testing.T) {
 		log := clog.New("trace")
 
 		global := &mirror.GlobalOptions{
-			TlsVerify:    false,
 			SecurePolicy: false,
 		}
 
@@ -161,7 +159,6 @@ func TestExecutorRunDelete(t *testing.T) {
 		log := clog.New("trace")
 
 		global := &mirror.GlobalOptions{
-			TlsVerify:    false,
 			SecurePolicy: false,
 			WorkingDir:   "../../tests/temp-dir/tests/",
 		}

--- a/v2/pkg/cli/dryrun_test.go
+++ b/v2/pkg/cli/dryrun_test.go
@@ -30,7 +30,6 @@ func TestDryRun(t *testing.T) {
 	log := clog.New("trace")
 
 	global := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 	}
 

--- a/v2/pkg/cli/executor.go
+++ b/v2/pkg/cli/executor.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openshift/oc-mirror/v2/pkg/release"
 	"github.com/openshift/oc-mirror/v2/pkg/version"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var (
@@ -85,6 +86,8 @@ type ExecutorSchema struct {
 	MirrorUnArchiver             archive.UnArchiver
 	MakeDir                      MakeDirInterface
 	Delete                       delete.DeleteInterface
+	srcFlagSet                   pflag.FlagSet // this is used so that we can set tlsVerify for the cache registry based on Mode (which is initialized in Complete func)
+	destFlagSet                  pflag.FlagSet // this is used so that we can set tlsVerify for the cache registry based on Mode (which is initialized in Complete func)
 }
 
 type MakeDirInterface interface {
@@ -102,7 +105,6 @@ func (o MakeDir) makeDirAll(dir string, mode os.FileMode) error {
 func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 
 	global := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 	}
 
@@ -125,9 +127,11 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 
 	mkd := MakeDir{}
 	ex := &ExecutorSchema{
-		Log:     log,
-		Opts:    opts,
-		MakeDir: mkd,
+		srcFlagSet:  flagSrcOpts,
+		destFlagSet: flagDestOpts,
+		Log:         log,
+		Opts:        opts,
+		MakeDir:     mkd,
 	}
 
 	cmd := &cobra.Command{
@@ -294,9 +298,13 @@ func (o *ExecutorSchema) Complete(args []string) error {
 		o.Opts.Mode = mirror.MirrorToDisk
 		rootDir = strings.TrimPrefix(args[0], fileProtocol)
 		o.Log.Debug("destination %s ", rootDir)
+		// destination is the local cache, which is HTTP
+		o.destFlagSet.Set("dest-tls-verify", "false")
 	} else if strings.Contains(args[0], dockerProtocol) && o.Opts.Global.From != "" {
 		rootDir = strings.TrimPrefix(o.Opts.Global.From, fileProtocol)
 		o.Opts.Mode = mirror.DiskToMirror
+		// source is the local cache, which is HTTP
+		o.srcFlagSet.Set("src-tls-verify", "false")
 	} else if strings.Contains(args[0], dockerProtocol) && o.Opts.Global.From == "" {
 		o.Opts.Mode = mirror.MirrorToMirror
 		if o.Opts.Global.WorkingDir == "" { // this should have been caught by Validate function. Nevertheless...

--- a/v2/pkg/cli/executor_test.go
+++ b/v2/pkg/cli/executor_test.go
@@ -39,7 +39,6 @@ func TestExecutorMirroring(t *testing.T) {
 	log := clog.New("trace")
 
 	global := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 		Force:        true,
 		WorkingDir:   workDir,
@@ -281,7 +280,6 @@ func TestRunMirrorToMirror(t *testing.T) {
 	log := clog.New("trace")
 
 	global := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 		Force:        true,
 		WorkingDir:   workDir,
@@ -423,7 +421,6 @@ func TestExecutorValidate(t *testing.T) {
 		log := clog.New("trace")
 
 		global := &mirror.GlobalOptions{
-			TlsVerify:    false,
 			SecurePolicy: false,
 		}
 
@@ -522,7 +519,6 @@ func TestExecutorComplete(t *testing.T) {
 		log := clog.New("trace")
 
 		global := &mirror.GlobalOptions{
-			TlsVerify:    false,
 			SecurePolicy: false,
 		}
 
@@ -604,7 +600,6 @@ func TestExecutorSetupLocalStorage(t *testing.T) {
 		log := clog.New("trace")
 
 		global := &mirror.GlobalOptions{
-			TlsVerify:    false,
 			SecurePolicy: false,
 			Port:         7777,
 		}
@@ -644,7 +639,6 @@ func TestExecutorSetupWorkingDir(t *testing.T) {
 		log := clog.New("trace")
 
 		global := &mirror.GlobalOptions{
-			TlsVerify:    false,
 			SecurePolicy: false,
 			WorkingDir:   "/root",
 		}
@@ -695,7 +689,6 @@ func TestExecutorSetupLogsLevelAndDir(t *testing.T) {
 		log := clog.New("trace")
 
 		global := &mirror.GlobalOptions{
-			TlsVerify:    false,
 			SecurePolicy: false,
 		}
 
@@ -729,7 +722,6 @@ func TestExecutorCollectAll(t *testing.T) {
 	t.Run("Testing Executor : collect all should pass", func(t *testing.T) {
 		log := clog.New("trace")
 		global := &mirror.GlobalOptions{
-			TlsVerify:    false,
 			SecurePolicy: false,
 			Force:        true,
 		}

--- a/v2/pkg/cli/release_integration_test.go
+++ b/v2/pkg/cli/release_integration_test.go
@@ -163,7 +163,7 @@ func (suite *TestEnvironmentRelease) runMirror2Disk(t *testing.T) {
 	err := os.MkdirAll(resultFolder, 0755)
 	assert.NoError(t, err, "should not fail creating a temp folder for results")
 
-	ocmirror.SetArgs([]string{"-c", suite.tempFolder + "/isc.yaml", "--v2", "-p", "56001", "file://" + resultFolder})
+	ocmirror.SetArgs([]string{"-c", suite.tempFolder + "/isc.yaml", "--v2", "-p", "56001", "--src-tls-verify=false", "--dest-tls-verify=false", "file://" + resultFolder})
 	err = ocmirror.Execute()
 	assert.NoError(t, err, "should not fail executing oc-mirror")
 
@@ -179,7 +179,7 @@ func (suite *TestEnvironmentRelease) runDisk2Mirror(t *testing.T) {
 	ocmirror := NewMirrorCmd(clog.New("trace"))
 	resultFolder := filepath.Join(suite.tempFolder, "release", d2mSubFolder)
 
-	ocmirror.SetArgs([]string{"-c", suite.tempFolder + "/isc.yaml", "--v2", "-p", "56002", "--from", "file://" + resultFolder, "docker://" + suite.destinationRegistryDomain + "/release"})
+	ocmirror.SetArgs([]string{"-c", suite.tempFolder + "/isc.yaml", "--v2", "-p", "56002", "--from", "file://" + resultFolder, "--src-tls-verify=false", "--dest-tls-verify=false", "docker://" + suite.destinationRegistryDomain + "/release"})
 	err := ocmirror.Execute()
 	assert.NoError(t, err, "should not fail executing oc-mirror")
 
@@ -207,7 +207,7 @@ func (suite *TestEnvironmentRelease) runMirror2Mirror(t *testing.T) {
 	err := os.MkdirAll(resultFolder, 0755)
 	assert.NoError(t, err, "should not fail creating a temp folder for results")
 
-	ocmirror.SetArgs([]string{"-c", suite.tempFolder + "/isc.yaml", "--v2", "-p", "56003", "--workspace", "file://" + resultFolder, "docker://" + suite.destinationRegistryDomain + "/release"})
+	ocmirror.SetArgs([]string{"-c", suite.tempFolder + "/isc.yaml", "--v2", "-p", "56003", "--src-tls-verify=false", "--dest-tls-verify=false", "--workspace", "file://" + resultFolder, "docker://" + suite.destinationRegistryDomain + "/release"})
 	err = ocmirror.Execute()
 	assert.NoError(t, err, "should not fail executing oc-mirror")
 

--- a/v2/pkg/delete/delete_images_test.go
+++ b/v2/pkg/delete/delete_images_test.go
@@ -19,7 +19,6 @@ func TestAllDeleteImages(t *testing.T) {
 	log := clog.New("trace")
 
 	global := &mirror.GlobalOptions{
-		TlsVerify:         false,
 		SecurePolicy:      false,
 		Quiet:             false,
 		WorkingDir:        "../../tests/",
@@ -131,7 +130,6 @@ func TestWriteMetaData(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	global := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 		Quiet:        false,
 		WorkingDir:   tempDir,
@@ -176,7 +174,6 @@ func TestFilterReleasesForDelete(t *testing.T) {
 	log := clog.New("trace")
 
 	globalM2D := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 		WorkingDir:   "../../tests/release-semver-test/",
 	}

--- a/v2/pkg/imagebuilder/builder_test.go
+++ b/v2/pkg/imagebuilder/builder_test.go
@@ -29,7 +29,6 @@ func TestImageBuilder(t *testing.T) {
 	tempDir := t.TempDir()
 
 	global := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 		WorkingDir:   tempDir + "/working-dir",
 		From:         tempDir,
@@ -37,9 +36,12 @@ func TestImageBuilder(t *testing.T) {
 
 	_, sharedOpts := mirror.SharedImageFlags()
 	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
-	_, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
-	_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
+	srcFlags, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
+	destFlags, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 	_, retryOpts := mirror.RetryFlags()
+
+	srcFlags.Set("src-tls-verify", "false")
+	destFlags.Set("dest-tls-verify", "false")
 
 	opts := mirror.CopyOptions{
 		Global:              global,
@@ -56,7 +58,8 @@ func TestImageBuilder(t *testing.T) {
 	t.Run("Testing NewImageBuilder : should pass", func(t *testing.T) {
 
 		_ = NewBuilder(log, opts)
-		opts.Global.TlsVerify = true
+		srcFlags.Set("src-tls-verify", "true")
+		destFlags.Set("dest-tls-verify", "true")
 		_ = NewBuilder(log, opts)
 
 		e := ErrInvalidReference{image: "broken"}
@@ -74,7 +77,8 @@ func TestImageBuilder(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		opts.Global.TlsVerify = false
+		srcFlags.Set("src-tls-verify", "false")
+		destFlags.Set("dest-tls-verify", "false")
 		ex := NewBuilder(log, opts)
 		ctx := context.Background()
 
@@ -149,15 +153,17 @@ func TestProcessImageIndex(t *testing.T) {
 		log := clog.New("debug")
 
 		global := &mirror.GlobalOptions{
-			TlsVerify:    false,
 			SecurePolicy: false,
 		}
 
 		_, sharedOpts := mirror.SharedImageFlags()
 		_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
-		_, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
-		_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
+		srcFlags, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
+		destFlags, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 		_, retryOpts := mirror.RetryFlags()
+
+		srcFlags.Set("src-tls-verify", "false")
+		destFlags.Set("dest-tls-verify", "false")
 
 		opts := mirror.CopyOptions{
 			Global:              global,
@@ -185,7 +191,6 @@ func TestProcessImageIndex(t *testing.T) {
 		}
 
 		v2format := false
-		opts.Global.TlsVerify = false
 
 		// cover the mediatype as list
 		idx, err := layout.ImageIndexFromPath("../../tests/test-process-image-list/")

--- a/v2/pkg/mirror/mirror_test.go
+++ b/v2/pkg/mirror/mirror_test.go
@@ -21,7 +21,7 @@ func TestMirrorCopy(t *testing.T) {
 	testFile := testFolder + "/testDigest.txt"
 	defer os.RemoveAll(testFolder)
 
-	global := &GlobalOptions{TlsVerify: false, SecurePolicy: false}
+	global := &GlobalOptions{SecurePolicy: false}
 
 	_, sharedOpts := SharedImageFlags()
 	_, deprecatedTLSVerifyOpt := DeprecatedTLSVerifyFlags()
@@ -101,14 +101,15 @@ func TestMirrorCopy(t *testing.T) {
 
 func TestMirrorCheck(t *testing.T) {
 
-	global := &GlobalOptions{TlsVerify: false, SecurePolicy: false}
+	global := &GlobalOptions{SecurePolicy: false}
 
 	_, sharedOpts := SharedImageFlags()
 	_, deprecatedTLSVerifyOpt := DeprecatedTLSVerifyFlags()
-	_, srcOpts := ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
-	_, destOpts := ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
+	srcFlags, srcOpts := ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
+	dstFlags, destOpts := ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 	_, retryOpts := RetryFlags()
-
+	srcFlags.Set("src-tls-verify", "false")
+	dstFlags.Set("dest-tls-verify", "false")
 	opts := CopyOptions{
 		Global:              global,
 		DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
@@ -162,13 +163,16 @@ func TestMirrorCheck(t *testing.T) {
 // TestMirrorDelete
 func TestMirrorDelete(t *testing.T) {
 
-	global := &GlobalOptions{TlsVerify: false, SecurePolicy: false}
+	global := &GlobalOptions{SecurePolicy: false}
 
 	_, sharedOpts := SharedImageFlags()
 	_, deprecatedTLSVerifyOpt := DeprecatedTLSVerifyFlags()
-	_, srcOpts := ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
-	_, destOpts := ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
+	srcFlags, srcOpts := ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
+	dstFlags, destOpts := ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 	_, retryOpts := RetryFlags()
+
+	srcFlags.Set("src-tls-verify", "false")
+	dstFlags.Set("dest-tls-verify", "false")
 
 	opts := CopyOptions{
 		Global:              global,

--- a/v2/pkg/mirror/options_test.go
+++ b/v2/pkg/mirror/options_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestOptionsNewContext(t *testing.T) {
 
-	global := &GlobalOptions{TlsVerify: false, SecurePolicy: false}
+	global := &GlobalOptions{SecurePolicy: false}
 
 	_, sharedOpts := SharedImageFlags()
 	_, deprecatedTLSVerifyOpt := DeprecatedTLSVerifyFlags()

--- a/v2/pkg/operator/local_stored_collector_test.go
+++ b/v2/pkg/operator/local_stored_collector_test.go
@@ -508,7 +508,6 @@ func setupCollector_DiskToMirror(tempDir string, log clog.PluggableLoggerInterfa
 	manifest := &MockManifest{Log: log}
 
 	globalD2M := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 		WorkingDir:   tempDir + "/working-dir",
 		From:         tempDir,
@@ -546,7 +545,6 @@ func setupCollector_DiskToMirror(tempDir string, log clog.PluggableLoggerInterfa
 func setupCollector_MirrorToDisk(tempDir string, log clog.PluggableLoggerInterface, manifest *MockManifest) *LocalStorageCollector {
 
 	globalM2D := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 		WorkingDir:   tempDir + "/working-dir",
 	}

--- a/v2/pkg/release/cincinnati_test.go
+++ b/v2/pkg/release/cincinnati_test.go
@@ -21,7 +21,7 @@ func TestGetReleaseReferenceImages(t *testing.T) {
 
 	log := clog.New("trace")
 
-	global := &mirror.GlobalOptions{TlsVerify: false, SecurePolicy: false}
+	global := &mirror.GlobalOptions{SecurePolicy: false}
 
 	_, sharedOpts := mirror.SharedImageFlags()
 	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()

--- a/v2/pkg/release/graph_test.go
+++ b/v2/pkg/release/graph_test.go
@@ -20,7 +20,6 @@ func TestCreateGraphImage(t *testing.T) {
 
 	log := clog.New("trace")
 	globalM2D := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 		WorkingDir:   t.TempDir(),
 	}

--- a/v2/pkg/release/local_stored_collector_test.go
+++ b/v2/pkg/release/local_stored_collector_test.go
@@ -172,7 +172,6 @@ func setupCollector_DiskToMirror(tempDir string, log clog.PluggableLoggerInterfa
 	manifest := &MockManifest{Log: log}
 
 	globalD2M := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 		WorkingDir:   tempDir + "/working-dir",
 		From:         tempDir,
@@ -230,7 +229,6 @@ func setupCollector_DiskToMirror(tempDir string, log clog.PluggableLoggerInterfa
 func setupCollector_MirrorToDisk(tempDir string, log clog.PluggableLoggerInterface, manifest *MockManifest) *LocalStorageCollector {
 
 	globalM2D := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 		WorkingDir:   tempDir,
 	}

--- a/v2/pkg/release/signature_test.go
+++ b/v2/pkg/release/signature_test.go
@@ -19,7 +19,6 @@ func TestReleaseSignature(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	global := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 		WorkingDir:   tempDir,
 	}

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/archive/image-blob-gatherer.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/archive/image-blob-gatherer.go
@@ -39,7 +39,8 @@ func (o *ImageBlobGatherer) GatherBlobs(ctx context.Context, imgRef string) (blo
 	if err != nil {
 		return nil, fmt.Errorf("invalid source name %s: %v", imgRef, err)
 	}
-	sourceCtx, err := o.opts.SrcImage.NewSystemContext()
+	// we are always gathering blobs from the local cache registry - skipping tls verification
+	sourceCtx, err := o.opts.SrcImage.NewSystemContextWithTLSVerificationOverride(false)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/cli/delete.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/cli/delete.go
@@ -42,7 +42,6 @@ const (
 func NewDeleteCommand(log clog.PluggableLoggerInterface) *cobra.Command {
 
 	global := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 	}
 
@@ -192,6 +191,7 @@ func (o *ExecutorSchema) CompleteDelete(args []string) error {
 		// fake a diskToMirror Mode
 		o.Opts.Mode = mirror.DiskToMirror
 		o.Opts.RemoveSignatures = true
+		o.srcFlagSet.Set("src-tls-verify", "false")
 	}
 
 	// update all dependant modules

--- a/vendor/github.com/openshift/oc-mirror/v2/pkg/cli/executor.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/pkg/cli/executor.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openshift/oc-mirror/v2/pkg/release"
 	"github.com/openshift/oc-mirror/v2/pkg/version"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var (
@@ -85,6 +86,8 @@ type ExecutorSchema struct {
 	MirrorUnArchiver             archive.UnArchiver
 	MakeDir                      MakeDirInterface
 	Delete                       delete.DeleteInterface
+	srcFlagSet                   pflag.FlagSet // this is used so that we can set tlsVerify for the cache registry based on Mode (which is initialized in Complete func)
+	destFlagSet                  pflag.FlagSet // this is used so that we can set tlsVerify for the cache registry based on Mode (which is initialized in Complete func)
 }
 
 type MakeDirInterface interface {
@@ -102,7 +105,6 @@ func (o MakeDir) makeDirAll(dir string, mode os.FileMode) error {
 func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 
 	global := &mirror.GlobalOptions{
-		TlsVerify:    false,
 		SecurePolicy: false,
 	}
 
@@ -125,9 +127,11 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 
 	mkd := MakeDir{}
 	ex := &ExecutorSchema{
-		Log:     log,
-		Opts:    opts,
-		MakeDir: mkd,
+		srcFlagSet:  flagSrcOpts,
+		destFlagSet: flagDestOpts,
+		Log:         log,
+		Opts:        opts,
+		MakeDir:     mkd,
 	}
 
 	cmd := &cobra.Command{
@@ -294,9 +298,13 @@ func (o *ExecutorSchema) Complete(args []string) error {
 		o.Opts.Mode = mirror.MirrorToDisk
 		rootDir = strings.TrimPrefix(args[0], fileProtocol)
 		o.Log.Debug("destination %s ", rootDir)
+		// destination is the local cache, which is HTTP
+		o.destFlagSet.Set("dest-tls-verify", "false")
 	} else if strings.Contains(args[0], dockerProtocol) && o.Opts.Global.From != "" {
 		rootDir = strings.TrimPrefix(o.Opts.Global.From, fileProtocol)
 		o.Opts.Mode = mirror.DiskToMirror
+		// source is the local cache, which is HTTP
+		o.srcFlagSet.Set("src-tls-verify", "false")
 	} else if strings.Contains(args[0], dockerProtocol) && o.Opts.Global.From == "" {
 		o.Opts.Mode = mirror.MirrorToMirror
 		if o.Opts.Global.WorkingDir == "" { // this should have been caught by Validate function. Nevertheless...


### PR DESCRIPTION
# Description

This PR removes the field `TlsVerify` from the `CopyOptions.Global` which was bypassing TLS handshake completely for all registries involved. 
This field was added there when some code was copied from the skopeo code base, where it was already marked deprecated.

Fixes # [CLID-101](https://issues.redhat.com//browse/CLID-101)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Implementation details

Instead of a global `TlsVerify`, one should set tls verification under either `CopyOptions.SrcImage` or `CopyOptions.DestImage`. The exact field can be found under type `dockerImageOptions`, and its type is `commonFlag.OptionalBool`. 

This makes it impossible to set the field directly. Instead, we use the flags associated with the options to set the value. 
Example:
```
srcFlags, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
destFlags, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")

srcFlags.Set("src-tls-verify", "false")
destFlags.Set("dest-tls-verify", "false")
```

#### Fixing unit tests
Most unit tests don't really call a registry. The fix here is easy: simply remove field `TlsVerify` when initializing the Global structure. 
For some unit tests, where a HTTPMock is used as the registry (image-blob-gatherer_test.go for instance), the flags need to be set. This is because the containers/image code is by default now going to make a TLS handshake, unless we set --src-tls-verify and --dest-tls-verify to false.

#### Fixing executor.go + delete.go
Here we use the same technique (using the flagSet.Set) to force the value of the flags as follows:
* When DiskToMirror, the source registry is the cache, and therefore ONLY `src-tls-verify` should be set
* When MirrorToDisk, the destination registry is the cache, and therefore ONLY `dest-tls-verify` should be set

The problem here is that the Mode (m2d, d2m or m2m) is determined at the `Complete` method. At this point, the flagsets are unreachable (flags and options were initialized in func `NewMirrorCmd`. That is why I had to declare, in the `ExecutorSchema` type, a private `srcFlagSet` and `destFlagSet`, in order to be able to later use them.

#### Fixing image-blob-gatherer.go

ImageBlobGatherer is used during delete and MirrorToDisk, where:
* dest-tls-verify should be set to false (because we target the cache)
* but src-tls-verify should not be set: it should do TLS handshake with the origin registries

From the ImageBlobGatherer's perspective though, the local cache is considered a source registry.
In order not to disturb TLS handshake for the mirroring, but still be able to gather blobs from cache during archive generation, I added this extra method `imageOptions.NewSystemContextWithTLSVerificationOverride` : calling it with tlsVerify=false as an input, creates a source system context specific for this use case that bypasses TLS.

# How Has This Been Tested?

All Unit and E2E tests pass. 
With an imageSetConfig containing just an additional image, I tested workflows:
* mirrorToDisk
* diskToMirror
* mirrorToMirror
* Delete
:warning: graph image generation not tested. This is tricky because the graph image is built using go-containerregistry, and we need to take the tlsVerify from the context and create new setup for go-containerregistry with it. I'm not sure if this is working. 
Operator mirroring and release mirroring shouldn't be impacted.

## Expected Outcome
No errors related to HTTP such as
```
2024/04/23 17:42:53  [ERROR]  : unable to add image blobs to the archive : unable to find blobs corresponding to docker://localhost:55000/ubi8/ubi:latest: pinging container registry localhost:55000: Get "https://localhost:55000/v2/": http: server gave HTTP response to HTTPS client 
```