### PR TITLE
CLID-101: Fix graph image mirroring after TLS verification enabling

### DIFF
--- a/v2/internal/pkg/release/local_stored_collector.go
+++ b/v2/internal/pkg/release/local_stored_collector.go
@@ -58,12 +58,11 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v2
 	o.Log.Debug(collectorPrefix+"setting copy option o.Opts.MultiArch=%s when collecting releases image", o.Opts.MultiArch)
 	var allImages []v2alpha1.CopyImageSchema
 	var imageIndexDir string
-	filterCopy := o.Config.Mirror.Platform.DeepCopy()
 	if o.Opts.IsMirrorToDisk() || o.Opts.IsMirrorToMirror() || o.Opts.IsPrepare() {
 		releases := o.Cincinnati.GetReleaseReferenceImages(ctx)
 
 		releasesForFilter := releasesForFilter{
-			Filter: filterCopy,
+			Filter: o.Config.Mirror.Platform,
 			//cannot directly use the array releases here as the Destinations are still empty
 			Releases: []v2alpha1.CopyImageSchema{},
 		}
@@ -172,6 +171,7 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v2
 			}
 			o.Log.Debug(collectorPrefix + "graph image created and pushed to cache.")
 			// still add the graph image to the `allImages` so that we later can add it in the tar.gz archive
+			// or copied to the destination registry (case of mirror to mirror)
 			graphCopy := v2alpha1.CopyImageSchema{
 				Source:      graphImgRef,
 				Destination: graphImgRef,

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/local_stored_collector.go
@@ -58,12 +58,11 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v2
 	o.Log.Debug(collectorPrefix+"setting copy option o.Opts.MultiArch=%s when collecting releases image", o.Opts.MultiArch)
 	var allImages []v2alpha1.CopyImageSchema
 	var imageIndexDir string
-	filterCopy := o.Config.Mirror.Platform.DeepCopy()
 	if o.Opts.IsMirrorToDisk() || o.Opts.IsMirrorToMirror() || o.Opts.IsPrepare() {
 		releases := o.Cincinnati.GetReleaseReferenceImages(ctx)
 
 		releasesForFilter := releasesForFilter{
-			Filter: filterCopy,
+			Filter: o.Config.Mirror.Platform,
 			//cannot directly use the array releases here as the Destinations are still empty
 			Releases: []v2alpha1.CopyImageSchema{},
 		}
@@ -172,6 +171,7 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v2
 			}
 			o.Log.Debug(collectorPrefix + "graph image created and pushed to cache.")
 			// still add the graph image to the `allImages` so that we later can add it in the tar.gz archive
+			// or copied to the destination registry (case of mirror to mirror)
 			graphCopy := v2alpha1.CopyImageSchema{
 				Source:      graphImgRef,
 				Destination: graphImgRef,


### PR DESCRIPTION
# Description

* Fix graph image mirroring during MirrorToDisk and MirrorToMirror: 
  * The error that was encountered was because in the specific case of the graph image, src of the image is localhost:55000/graph:latest. Therefore we were attempting to mirror from the cache registry (tls-verify not forced to false) . 
  * The graph image is already built and pushed to the destination registry during the collection phase (graph.go)
    * destination registry is the cache for the case of mirrorToDisk
    * destination registry is the remote mirror for the case of mirrorToMirror
  * The fix is to exclude the graph image from the batch mirroring for the case of MirrorToDisk and MirrorToMirror.
* Fix the generation of UpdateService.yaml file for MirrorToMirror workflow. 
  * The root cause was that the imageSetConfig (o.Opts.Config) was getting modified by the collector (more exactly cincinnati's `GetReleaseReferenceImages` which was adding minVersion and maxVersion for releases).  This made the executor fail while `GetRelease` to prepare for UpdateService.yaml generation. The modified filter did not match the one saved previously by the collector
  * The fix consisted of using a copy of the Config for `GetReleaseReferenceImages`, instead of using the original one.
* Fix the way we count errors during the batch phase, by creating error counters for release, operator and additional images.
Example of what is displayed in logs in case of errors during mirroring:
```yaml
2024/04/25 14:54:05  [INFO]   : === Results ===
2024/04/25 14:54:05  [INFO]   : Some release images failed to mirror: mirrored 185 / 185 (185 failures) ❌ - please check the logs
2024/04/25 14:54:05  [INFO]   : Some operator images failed to mirror: mirrored 11 / 11 (11 failures) ❌ - please check the logs
2024/04/25 14:54:05  [INFO]   : Some additional images failed to mirror: mirrored 1 / 1 (1 failures) ❌ - please check the logs
```

Fixes # [CLID-101](https://issues.redhat.com//browse/CLID-101)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Successfully perform MirrorToDisk, DiskToMirror and MirrorToMirror with the following imageSetConfiguration:
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  platform:
    channels:
    - name: stable-4.13
    graph: true
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.14
    packages:
    - name: aws-load-balancer-operator
    - name: external-dns-operator
  additionalImages:
  - name: registry.redhat.io/ubi8/ubi:latest
```

## Expected Outcome
Please describe the outcome expected from the tests