### PR TITLE
OCPBUGS-31092: Fix archive tar file size to respect the archiveSize s…

### DIFF
--- a/v2/internal/pkg/archive/archive.go
+++ b/v2/internal/pkg/archive/archive.go
@@ -46,7 +46,7 @@ func NewMirrorArchive(opts *mirror.CopyOptions, destination, iscPath, workingDir
 	if maxSize == 0 {
 		maxSize = defaultSegSize
 	}
-	maxSize *= maxSize * segMultiplier
+	maxSize = maxSize * segMultiplier
 
 	a, err := newStrictAdder(maxSize, destination, logg)
 	if err != nil {
@@ -80,7 +80,7 @@ func NewPermissiveMirrorArchive(opts *mirror.CopyOptions, destination, iscPath, 
 	if maxSize == 0 {
 		maxSize = defaultSegSize
 	}
-	maxSize *= maxSize * segMultiplier
+	maxSize = maxSize * segMultiplier
 
 	a, err := newPermissiveAdder(maxSize, destination, logg)
 	if err != nil {

--- a/v2/internal/pkg/archive/permissive_adder_test.go
+++ b/v2/internal/pkg/archive/permissive_adder_test.go
@@ -119,6 +119,7 @@ func TestPermissiveAdder_AddFile_BiggerThanMax(t *testing.T) {
 		assertContents(t, firstArchive, []string{"file1", "file2"})
 		// assert that the second archive is saved to disk
 		assert.FileExists(t, ma.archiveFile.Name(), "archive2 should exist")
+		assertContents(t, ma.archiveFile.Name(), []string{"file3"})
 	})
 }
 

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/archive/archive.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/archive/archive.go
@@ -46,7 +46,7 @@ func NewMirrorArchive(opts *mirror.CopyOptions, destination, iscPath, workingDir
 	if maxSize == 0 {
 		maxSize = defaultSegSize
 	}
-	maxSize *= maxSize * segMultiplier
+	maxSize = maxSize * segMultiplier
 
 	a, err := newStrictAdder(maxSize, destination, logg)
 	if err != nil {
@@ -80,7 +80,7 @@ func NewPermissiveMirrorArchive(opts *mirror.CopyOptions, destination, iscPath, 
 	if maxSize == 0 {
 		maxSize = defaultSegSize
 	}
-	maxSize *= maxSize * segMultiplier
+	maxSize = maxSize * segMultiplier
 
 	a, err := newPermissiveAdder(maxSize, destination, logg)
 	if err != nil {


### PR DESCRIPTION
# Description

Fix archive tar file size to respect the archiveSize setting when mirror with V2 format

Fixes # OCPBUGS-31092

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Mirror to disk with the following ISC should pass 
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
archiveSize: 8
mirror:
  # platform:
  #   channels:
  #   - name: stable-4.13
  #   graph: true
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15
    packages:
    - name: advanced-cluster-management                                  
      channels:
      - name: release-2.9             
    - name: compliance-operator
      channels:
      - name: stable
    - name: multicluster-engine
      channels:
      - name: stable-2.4
      - name: stable-2.5
  additionalImages:
  - name: registry.redhat.io/ubi8/ubi:latest                        
  - name: registry.redhat.io/rhel8/support-tools:latest
  - name: registry.access.redhat.com/ubi8/nginx-120:latest
  - name: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
  - name: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
```

## Expected Outcome
```bash
$ ls -lh  ~/clid20/
total 12G
-rw-r--r--. 1 skhoury skhoury 7.9G Apr 29 15:57 mirror_000001.tar
-rw-r--r--. 1 skhoury skhoury 3.8G Apr 29 15:57 mirror_000002.tar
drwxr-xr-x. 1 skhoury skhoury  262 Apr 29 15:50 working-dir
```