### PR TITLE
OCPBUGS-31536: Change default behavior to not rebuild catalogs for V1

### DIFF
--- a/pkg/cli/mirror/fbc_operators.go
+++ b/pkg/cli/mirror/fbc_operators.go
@@ -523,7 +523,7 @@ func (o *MirrorOptions) copyImage(ctx context.Context, from, to string, funcs Re
 		SourceCtx:             sourceCtx,
 		DestinationCtx:        destinationCtx,
 		ForceManifestMIMEType: "",
-		ImageListSelection:    imagecopy.CopySystemImage,
+		ImageListSelection:    imagecopy.CopyAllImages,
 		OciDecryptConfig:      nil,
 		OciEncryptLayers:      nil,
 		OciEncryptConfig:      nil,

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	imagecopy "github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/types"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -340,6 +342,9 @@ func (o *MirrorOptions) Run(cmd *cobra.Command, f kcmdutil.Factory) (err error) 
 func (o *MirrorOptions) mirrorImages(ctx context.Context, cleanup cleanupFunc) error {
 
 	o.remoteRegFuncs = RemoteRegFuncs{
+		copy: func(ctx context.Context, policyContext *signature.PolicyContext, destRef types.ImageReference, srcRef types.ImageReference, options *imagecopy.Options) (copiedManifest []byte, retErr error) {
+			return imagecopy.Image(ctx, policyContext, destRef, srcRef, options)
+		},
 		newImageSource: func(ctx context.Context, sys *types.SystemContext, imgRef types.ImageReference) (types.ImageSource, error) {
 			return imgRef.NewImageSource(ctx, sys)
 		},
@@ -746,7 +751,7 @@ func (o *MirrorOptions) mirrorToMirrorWrapper(ctx context.Context, cfg v1alpha2.
 		return err
 	}
 	// process catalog FBC images
-	if len(cfg.Mirror.Operators) > 0 {
+	if o.RebuildCatalogs && len(cfg.Mirror.Operators) > 0 {
 		ctlgRefs, err := o.rebuildCatalogs(ctx, filepath.Join(o.Dir, config.SourceDir))
 		if err != nil {
 			return fmt.Errorf("error rebuilding catalog images from file-based catalogs: %v", err)

--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -194,16 +194,33 @@ func (o *OperatorOptions) run(
 		} else if targetCtlg.Ref.Tag != "" {
 			ctlgSrcDir = filepath.Join(ctlgSrcDir, targetCtlg.Ref.Tag)
 		}
-		err = extractOPMAndCache(ctx, ctlgRef, ctlgSrcDir, o.SourceSkipTLS)
-		if err != nil {
-			reg.Destroy()
-			return nil, fmt.Errorf("unable to extract OPM binary from catalog %s: %v", targetName, err)
+		if o.RebuildCatalogs {
+			err = extractOPMAndCache(ctx, ctlgRef, ctlgSrcDir, o.SourceSkipTLS)
+			if err != nil {
+				reg.Destroy()
+				return nil, fmt.Errorf("unable to extract OPM binary from catalog %s: %v", targetName, err)
+			}
 		}
 
 		mappings, err := o.plan(ctx, dc, ic, ctlgRef, targetCtlg)
 		if err != nil {
 			reg.Destroy()
 			return nil, err
+		}
+		if !o.RebuildCatalogs {
+			var destCatalogRef string
+			if o.ToMirror != "" { // mirror to mirror
+				destCatalogRef, err = prepareDestCatalogRef(ctlg, o.ToMirror, o.UserNamespace)
+				if err != nil {
+					return nil, err
+				}
+			} else { // mirror to disk
+				destCatalogRef = "oci://" + ctlgSrcDir + "/layout"
+			}
+			_, err = o.copyImage(ctx, ctlg.Catalog, destCatalogRef, o.remoteRegFuncs)
+			if err != nil {
+				return nil, err
+			}
 		}
 		mmapping.Merge(mappings)
 		reg.Destroy()
@@ -604,21 +621,23 @@ func (o *OperatorOptions) plan(ctx context.Context, dc *declcfg.DeclarativeConfi
 		return nil, err
 	}
 
-	// Remove the catalog image from mappings we are going to transfer this
-	// using an OCI layout.
-	var ctlgImg image.TypedImage
-	if ctlgRef.Type == "oci" {
-		ctlgImg, err = image.ParseTypedImage(ctlgRef.OCIFBCPath, v1alpha2.TypeOperatorBundle)
-		if err != nil {
-			return nil, err
+	if o.RebuildCatalogs {
+		// Remove the catalog image from mappings we are going to transfer this
+		// using an OCI layout.
+		var ctlgImg image.TypedImage
+		if ctlgRef.Type == "oci" {
+			ctlgImg, err = image.ParseTypedImage(ctlgRef.OCIFBCPath, v1alpha2.TypeOperatorBundle)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			ctlgImg, err = image.ParseTypedImage(ctlgRef.Ref.Exact(), v1alpha2.TypeOperatorBundle)
+			if err != nil {
+				return nil, err
+			}
 		}
-	} else {
-		ctlgImg, err = image.ParseTypedImage(ctlgRef.Ref.Exact(), v1alpha2.TypeOperatorBundle)
-		if err != nil {
-			return nil, err
-		}
+		mappings.Remove(ctlgImg)
 	}
-	mappings.Remove(ctlgImg)
 	// Write catalog OCI layout file to src so it is included in the archive
 	// at a path unique to the image.
 	if ctlgRef.Type != image.DestinationOCI {
@@ -655,15 +674,17 @@ func (o *OperatorOptions) plan(ctx context.Context, dc *declcfg.DeclarativeConfi
 	}
 	// Remove catalog namespace prefix from each mapping's destination, which is added by opts.Run().
 	for srcRef, dstRef := range mappings {
-		newRepoName := strings.TrimPrefix(dstRef.Ref.RepositoryName(), ctlgRef.Ref.RepositoryName())
-		newRepoName = strings.TrimPrefix(newRepoName, "/")
-		tmpRef, err := imgreference.Parse(newRepoName)
-		if err != nil {
-			return nil, err
+		if srcRef.Ref.String() != ctlgRef.Ref.String() || o.RebuildCatalogs { // OCPBUGS-31536: don't do this for catalog images unless they will be rebuilt
+			newRepoName := strings.TrimPrefix(dstRef.Ref.RepositoryName(), ctlgRef.Ref.RepositoryName())
+			newRepoName = strings.TrimPrefix(newRepoName, "/")
+			tmpRef, err := imgreference.Parse(newRepoName)
+			if err != nil {
+				return nil, err
+			}
+			dstRef.Ref.Namespace = tmpRef.Namespace
+			dstRef.Ref.Name = tmpRef.Name
+			mappings[srcRef] = dstRef
 		}
-		dstRef.Ref.Namespace = tmpRef.Namespace
-		dstRef.Ref.Name = tmpRef.Name
-		mappings[srcRef] = dstRef
 	}
 	return mappings, validateMapping(*dc, mappings)
 }

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -39,6 +39,7 @@ type MirrorOptions struct {
 	OCIRegistriesConfig        string // Registries config file location (it works only with local oci catalogs)
 	OCIInsecureSignaturePolicy bool   // If set, OCI catalog push will not try to push signatures
 	MaxNestedPaths             int
+	RebuildCatalogs            bool // If set, rebuilds catalogs based on filtered declarative config, and regenerates the cache of that catalog
 	// cancelCh is a channel listening for command cancellations
 	cancelCh                          <-chan struct{}
 	once                              sync.Once
@@ -76,6 +77,7 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.OCIInsecureSignaturePolicy, "oci-insecure-signature-policy", o.OCIInsecureSignaturePolicy, "If set, OCI catalog push will not try to push signatures")
 	fs.BoolVar(&o.SkipPruning, "skip-pruning", o.SkipPruning, "If set, will disable pruning globally")
 	fs.IntVar(&o.MaxNestedPaths, "max-nested-paths", 0, "Number of nested paths, for destination registries that limit nested paths")
+	fs.BoolVar(&o.RebuildCatalogs, "rebuild-catalogs", o.RebuildCatalogs, "If set (defaults to false), rebuilds catalogs based on filtered declarative config, and regenerates the cache of that catalog")
 }
 
 func (o *MirrorOptions) init() {

--- a/pkg/cli/mirror/publish.go
+++ b/pkg/cli/mirror/publish.go
@@ -336,7 +336,7 @@ func (o *MirrorOptions) processMirroredImages(ctx context.Context, assocs image.
 // processCustomImages builds custom images for operator catalogs or Cincinnati graph data if data is present in the archive
 func (o *MirrorOptions) processCustomImages(ctx context.Context, dir string, filesInArchive map[string]string) (image.TypedImageMapping, error) {
 	allMappings := image.TypedImageMapping{}
-	// process catalogs
+	// process catalogs only when --rebuild-catalogs flag is on
 	klog.V(2).Infof("rebuilding catalog images")
 	found, err := o.unpackCatalog(dir, filesInArchive)
 	if err != nil {
@@ -344,11 +344,18 @@ func (o *MirrorOptions) processCustomImages(ctx context.Context, dir string, fil
 	}
 
 	if found {
-		ctlgRefs, err := o.rebuildCatalogs(ctx, dir)
-		if err != nil {
-			return allMappings, fmt.Errorf("error rebuilding catalog images from file-based catalogs: %v", err)
+		if o.RebuildCatalogs {
+			ctlgRefs, err := o.rebuildCatalogs(ctx, dir)
+			if err != nil {
+				return allMappings, fmt.Errorf("error rebuilding catalog images from file-based catalogs: %v", err)
+			}
+			allMappings.Merge(ctlgRefs)
+		} else {
+			err := o.copyCatalogs(ctx, dir)
+			if err != nil {
+				return allMappings, fmt.Errorf("error rebuilding catalog images from file-based catalogs: %v", err)
+			}
 		}
-		allMappings.Merge(ctlgRefs)
 	}
 
 	klog.V(2).Infof("building cincinnati graph data image")

--- a/test/e2e/lib/workflow.sh
+++ b/test/e2e/lib/workflow.sh
@@ -140,7 +140,7 @@ function workflow_m2d2m_oci_catalog() {
   if !$DIFF; then
     cleanup_conn
   fi
-  run_cmd --from "${CREATE_FULL_DIR}/mirror_seq1_000000.tar" "docker://${remote_image}"
+  run_cmd --from "${CREATE_FULL_DIR}/mirror_seq1_000000.tar" "docker://${remote_image}" $PUBLISH_FLAGS
 
   popd
 }

--- a/test/e2e/testcases.sh
+++ b/test/e2e/testcases.sh
@@ -24,13 +24,13 @@ TESTCASES[18]="no_updates_exist"
 TESTCASES[19]="m2m_oci_catalog"
 TESTCASES[20]="m2m_release_with_oci_catalog"
 TESTCASES[21]="headsonly_diff_with_target"
-TESTCASES[22]="m2d2m_oci_catalog"
-TESTCASES[23]="helm_repository"
+TESTCASES[22]="helm_repository"
+TESTCASES[23]="m2d2m_oci_catalog"
 
 
 # Test full catalog mode.
 function full_catalog() {
-    workflow_full imageset-config-full.yaml "test-catalog-latest" -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-full.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.0.0 baz.v1.0.1 baz.v1.1.0 foo.v0.1.0 foo.v0.2.0 foo.v0.3.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -38,7 +38,7 @@ function full_catalog() {
 
 # Test full catalog mode with digest.
 function full_catalog_with_digest() {
-    workflow_full imageset-config-full-digest.yaml "test-catalog-latest" -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-full-digest.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     TMPTAG=$(echo $CATALOGDIGEST | cut -d: -f 2)
     ## We default to 6 for the partial digest length to get unique tags per repo
     TMPTAG=${TMPTAG:0:6}
@@ -49,12 +49,12 @@ function full_catalog_with_digest() {
 
 # Test heads-only mode
 function headsonly_diff () {
-    workflow_full imageset-config-headsonly.yaml "test-catalog-latest" --diff -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-headsonly.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
 
-    workflow_diff imageset-config-headsonly.yaml "test-catalog-diff" -c="--source-use-http --source-skip-tls"
+    workflow_diff imageset-config-headsonly.yaml "test-catalog-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -62,13 +62,13 @@ function headsonly_diff () {
 
 # Test heads-only mode with target
 function headsonly_diff_with_target () {
-    workflow_full imageset-config-headsonly-newtarget.yaml "test-catalog-latest" --diff -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-headsonly-newtarget.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     # shellcheck disable=SC2086
     check_bundles localhost.localdomain:"${REGISTRY_DISCONN_PORT}"/"${CATALOGORG}"/${TARGET_CATALOG_NAME}:${TARGET_CATALOG_TAG} \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
 
-    workflow_diff imageset-config-headsonly-newtarget.yaml "test-catalog-diff" -c="--source-use-http --source-skip-tls"
+    workflow_diff imageset-config-headsonly-newtarget.yaml "test-catalog-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:"${REGISTRY_DISCONN_PORT}"/"${CATALOGORG}"/"${TARGET_CATALOG_NAME}":"${TARGET_CATALOG_TAG}" \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:"${REGISTRY_DISCONN_PORT}"
@@ -76,13 +76,13 @@ function headsonly_diff_with_target () {
 
 # Test heads-only mode with catalogs that prune bundles
 function pruned_catalogs() {
-    workflow_full imageset-config-headsonly.yaml "test-catalog-prune" --diff -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-headsonly.yaml "test-catalog-prune" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.1.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
     check_image_exists "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:${CATALOG_ID}"
 
-    workflow_diff imageset-config-headsonly.yaml "test-catalog-prune-diff" -c="--source-use-http --source-skip-tls"
+    workflow_diff imageset-config-headsonly.yaml "test-catalog-prune-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.2.0" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -92,13 +92,13 @@ function pruned_catalogs() {
 # Test heads-only mode with catalogs that prune with a custom target
 # name set
 function pruned_catalogs_with_target() {
-    workflow_full imageset-config-headsonly-newtarget.yaml "test-catalog-prune" --diff -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-headsonly-newtarget.yaml "test-catalog-prune" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGORG}/${TARGET_CATALOG_NAME}:${TARGET_CATALOG_TAG} \
     "bar.v0.1.0 foo.v0.1.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
     check_image_exists "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:${CATALOG_ID}"
 
-    workflow_diff imageset-config-headsonly-newtarget.yaml "test-catalog-prune-diff" -c="--source-use-http --source-skip-tls"
+    workflow_diff imageset-config-headsonly-newtarget.yaml "test-catalog-prune-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGORG}/${TARGET_CATALOG_NAME}:${TARGET_CATALOG_TAG} \
     "bar.v0.1.0 foo.v0.2.0" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -107,13 +107,13 @@ function pruned_catalogs_with_target() {
 
 # Test heads-only mode with catalogs that prune bundles
 function pruned_catalogs_with_include() {
-    workflow_full imageset-config-filter-multi-prune.yaml "test-catalog-prune" --diff -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-filter-multi-prune.yaml "test-catalog-prune" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.1.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
     check_image_exists "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:${CATALOG_ID}"
 
-    workflow_diff imageset-config-filter-multi-prune.yaml "test-catalog-prune-diff" -c="--source-use-http --source-skip-tls"
+    workflow_diff imageset-config-filter-multi-prune.yaml "test-catalog-prune-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.2.0" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -122,13 +122,13 @@ function pruned_catalogs_with_include() {
 
 # Test heads-only mode with catalogs that prune bundles
 function pruned_catalogs_mirror_to_mirror() {
-    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-prune" -c="--source-use-http --source-skip-tls"
+    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-prune" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.1.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
     check_image_exists "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:${CATALOG_ID}"
 
-    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-prune-diff" -c="--source-use-http --source-skip-tls"
+    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-prune-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.2.0" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -137,12 +137,12 @@ function pruned_catalogs_mirror_to_mirror() {
 
 # Test registry backend
 function registry_backend () {
-    workflow_full imageset-config-headsonly-backend-registry.yaml "test-catalog-latest" --diff -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-headsonly-backend-registry.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
 
-    workflow_diff imageset-config-headsonly-backend-registry.yaml "test-catalog-diff" -c="--source-use-http --source-skip-tls"
+    workflow_diff imageset-config-headsonly-backend-registry.yaml "test-catalog-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -150,7 +150,7 @@ function registry_backend () {
 
 # Test mirror to mirror with local backend
 function mirror_to_mirror() {
-    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-latest" -c="--source-use-http --source-skip-tls"
+    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-latest" -c="--source-use-http --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -158,7 +158,7 @@ function mirror_to_mirror() {
 
 # Test mirror to mirror no backend
 function mirror_to_mirror_nostorage() {
-    workflow_mirror2mirror imageset-config-full.yaml "test-catalog-latest" -c="--source-use-http --source-skip-tls"
+    workflow_mirror2mirror imageset-config-full.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.0.0 baz.v1.0.1 baz.v1.1.0 foo.v0.1.0 foo.v0.2.0 foo.v0.3.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -166,12 +166,12 @@ function mirror_to_mirror_nostorage() {
 
 # Test registry backend with custom namespace
 function custom_namespace {
-    workflow_full imageset-config-headsonly-backend-registry.yaml "test-catalog-latest" --diff -n="custom" -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-headsonly-backend-registry.yaml "test-catalog-latest" --diff -n="custom" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles "localhost.localdomain:${REGISTRY_DISCONN_PORT}/custom/${CATALOGNAMESPACE}:test-catalog-latest" \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT} "custom"
 
-    workflow_diff imageset-config-headsonly-backend-registry.yaml "test-catalog-diff" -n="custom" -c="--source-use-http --source-skip-tls"
+    workflow_diff imageset-config-headsonly-backend-registry.yaml "test-catalog-diff" -n="custom" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles "localhost.localdomain:${REGISTRY_DISCONN_PORT}/custom/${CATALOGNAMESPACE}:test-catalog-latest" \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT} "custom"
@@ -180,12 +180,12 @@ function custom_namespace {
 
 # Test package filtering
 function package_filtering {
-    workflow_full imageset-config-filter.yaml "test-catalog-latest" --diff -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-filter.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest" \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 foo.v0.1.0 foo.v0.2.0 foo.v0.3.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
 
-    workflow_diff imageset-config-filter-multi.yaml "test-catalog-diff" -c="--source-use-http --source-skip-tls"
+    workflow_diff imageset-config-filter-multi.yaml "test-catalog-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest" \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.0.1 baz.v1.1.0 foo.v0.1.0 foo.v0.2.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -193,7 +193,7 @@ function package_filtering {
 
 # Test catalog with one version in a package specified
 function single_version () {
-    workflow_full imageset-config-filter-single.yaml "test-catalog-latest" -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-filter-single.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "baz.v1.0.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -201,7 +201,7 @@ function single_version () {
 
 # Test catalog with a version range in a package specified
 function version_range () {
-    workflow_full imageset-config-filter-range.yaml "test-catalog-latest" -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-filter-range.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "foo.v0.2.0 foo.v0.3.0" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -209,7 +209,7 @@ function version_range () {
 
 # Test catalog with a max version in a package specified
 function max_version () {
-    workflow_full imageset-config-filter-max.yaml "test-catalog-latest" -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-filter-max.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "foo.v0.1.0 foo.v0.2.0 foo.v0.3.0" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -218,7 +218,7 @@ function max_version () {
 
 # Test skip deps
 function skip_deps {
-    workflow_full imageset-config-skip-deps.yaml "test-catalog-latest" --diff -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-skip-deps.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest" \
     "bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -240,7 +240,7 @@ function helm_repository {
 
 # Test no updates
 function no_updates_exist {
-    workflow_no_updates imageset-config-headsonly.yaml "test-catalog-latest" --diff -c="--source-use-http --source-skip-tls"
+    workflow_no_updates imageset-config-headsonly.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -255,7 +255,7 @@ function no_updates_exist {
 # Test OCI local catalog
 function m2m_oci_catalog {
     rm -fr olm_artifacts
-    workflow_m2m_oci_catalog imageset-config-oci-mirror.yaml "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}" -c="--dest-skip-tls --oci-insecure-signature-policy"
+    workflow_m2m_oci_catalog imageset-config-oci-mirror.yaml "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}" -c="--dest-skip-tls --oci-insecure-signature-policy --rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${OCI_REGISTRY_NAMESPACE}/oc-mirror-dev:test-catalog-latest \
     "baz.v1.0.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -276,7 +276,7 @@ function m2m_release_with_oci_catalog {
     test/e2e/graph/main & PID_GO=$!
     echo -e "go cincinnatti web service PID: ${PID_GO}"
     # copy relevant files and start the mirror process
-    workflow_oci_mirror_all imageset-config-oci-mirror-all.yaml "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}/test-catalog-latest" -c="--dest-skip-tls --oci-insecure-signature-policy"
+    workflow_oci_mirror_all imageset-config-oci-mirror-all.yaml "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}/test-catalog-latest" -c="--dest-skip-tls --oci-insecure-signature-policy --rebuild-catalogs"
 
     # use crane digest to verify
     crane digest --insecure localhost.localdomain:${REGISTRY_DISCONN_PORT}/test-catalog-latest/${OCI_REGISTRY_NAMESPACE}/oc-mirror-dev:bar-v0.1.0
@@ -293,7 +293,7 @@ function m2m_release_with_oci_catalog {
 # Test full catalog mode.
 function m2d2m_oci_catalog() {
     rm -fr olm_artifacts
-    workflow_m2d2m_oci_catalog imageset-config-oci-mirror.yaml "localhost.localdomain:${REGISTRY_DISCONN_PORT}" -c="--source-use-http  --source-skip-tls"
+    workflow_m2d2m_oci_catalog imageset-config-oci-mirror.yaml "localhost.localdomain:${REGISTRY_DISCONN_PORT}" -c="--source-use-http   --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${OCI_REGISTRY_NAMESPACE}/oc-mirror-dev:test-catalog-latest \
     "baz.v1.0.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}


### PR DESCRIPTION
# Description

Introduces flag `--rebuild-catalogs` (default false). 
By default, oc-mirror v1 will not rebuild catalogs (nor generate their cache). 
When `--rebuild-catalogs` is explicitly set  in the command line, this rebuilding will be done, without changes to the current implementation. In other words, if the OS on which oc-mirror is running is not a match to the opm binary extracted from the catalog, the cache generation may fail during mirroring, or may fail during deployment of the catalogSource on the cluster. 
The user can also use the environment variable `OPM_BINARY` in order to force oc-mirror to use a custom opm binary for cache generation. See tests section below for samples of use. 

PS: you can download the opm binary from https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/opm-linux.tar.gz :warning: rhel8 only I think.
Fixes # OCPBUGS-31536

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

With the following 2 imageSetConfigs, the following tests were performed successfully
-  M2M with registry based catalog
- M2D + D2M registry based catalog
- M2M with oci catalog
- M2D + D2M with oci catalog
-  M2M with registry based catalog and --rebuild-catalogs
```
./bin/oc-mirror -c /home/skhoury/go/src/github.com/openshift/oc-mirror/isc_31536.yaml  docker://localhost:5000/31536r --dest-skip-tls --dest-use-http --rebuild-catalogs
```
- M2D + D2M registry based catalog with --rebuild-catalogs
```bash
./bin/oc-mirror -c /home/skhoury/go/src/github.com/openshift/oc-mirror/isc_31536.yaml file:///home/skhoury/31536r --rebuild-catalogs
./bin/oc-mirror -c /home/skhoury/go/src/github.com/openshift/oc-mirror/isc_31536.yaml --from /home/skhoury/31536r docker://localhost:5000/31536r --dest-skip-tls --dest-use-http --rebuild-catalogs
curl http://localhost:5000/v2/31536r/redhat/redhat-operator-index/tags/list
{"name":"31536r/redhat/redhat-operator-index","tags":["v4.14"]}
```
- M2D + D2M file based catalog with --rebuild-catalogs and variable OPM_BINARY
```bash
export OPM_BINARY=/home/skhoury/opm-linux/opm
./bin/oc-mirror -c /home/skhoury/go/src/github.com/openshift/oc-mirror/isc_31536.yaml file:///home/skhoury/31536re --rebuild-catalogs
./bin/oc-mirror -c /home/skhoury/go/src/github.com/openshift/oc-mirror/isc_31536.yaml --from /home/skhoury/31536re docker://localhost:5000/31536re --dest-skip-tls --dest-use-http --rebuild-catalogs
curl http://localhost:5000/v2/31536re/oci/redhat-operator-index/tags/list
{"name":"31536re/oci/redhat-operator-index","tags":["v4.14"]}
```
_ImageSetConfig for registry catalogs_
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.14
    packages:
      - name: external-dns-operator
```
_ImageSetConfig for file based catalogs_
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
  - catalog: oci:///home/skhoury/redhat-index-all
    targetCatalog: oci/redhat-operator-index:v4.14
    packages:
      - name: external-dns-operator
```
All the E2E tests use `--rebuild-catalogs` and ensure that all workflows m2m or m2d+d2m (oci or registry based) are passing. 

## Expected Outcome
Curl command outcome should show the v4.14 tag as for example:
```
curl http://localhost:5000/v2/31536/redhat/redhat-operator-index/tags/list
{"name":"31536/redhat/redhat-operator-index","tags":["v4.14"]}
```
If you get `MANIFEST_UNKNOWN` then, this means the catalog was not mirrored.