### PR TITLE
OCPBUGS-32547: Fix delete generation for mirror to mirror flow

### DIFF
--- a/v2/docs/delete-functionality.md
+++ b/v2/docs/delete-functionality.md
@@ -142,6 +142,15 @@ before executing the local cache delete.**
 
 ### Troubleshooting and Recovery
 
+**We highly recommend using the mirror to disk and disk to mirror workflows**
+
+The mirror to mirror workflow was added to be backward compatible with the current v1 version. Use it when you have a small amout of images to mirror or for testing in a lab environment.
+No images are cached when using the mirror to mirror workflow. 
+
+**NB If you did use the mirror to mirror workflow in previous executions and consequenlty changed to the other worklfows, and then execute the delete generation and registry delete, it will fail**
+
+To circumvent this issue, create a file called "mode.txt" as well as a folder called "info" in the "working-dir" main folder (i.e "working-dir/info/mode.txt"), with the content "mirrorToMirror" (without the quotes), this will ensure that the delete functionality will work correctly for non-cached images. Also don't use the --force-cache-delete flag.
+
 The delete functionality is split into 2 stages (as mentioned in the overview), a typical workflow would be to use the --generate flag first, this will create the delete yaml file, this file can be used to validate the images/blobs that will be deleted.
 
 We highly recommend making backup of each tar.gz file that gets created in the "work-directory" folder. You could also create a tar.gz using the --since flag (see the oc-mirror command help for more information).
@@ -157,6 +166,7 @@ If by accident the local cache is deleted, untar all the relevant <work-director
 (default is ~/.oc-mirror/.cache), the local cache directory can be configured using the envar "OC_MIRROR_CACHE"
 
 If the remote registry is also deleted by accident, re-run the oc-mirror command using the --from flag (disk to mirror mode, it will use the contents of all the relevant .tar.gz files), this will ensure your remote registry is back to the original state.
+
 
 ### Conclusion
 

--- a/v2/internal/pkg/batch/worker.go
+++ b/v2/internal/pkg/batch/worker.go
@@ -104,7 +104,8 @@ func (o *Batch) Worker(ctx context.Context, collectorSchema v2alpha1.CollectorSc
 			}
 			o.Log.Info(strings.Repeat("=", len(overalProgress)))
 		}
-		o.Log.Info(mirrorMsg+" image: %s", img.Origin)
+
+		o.Log.Debug(mirrorMsg+" image: %s", img.Origin)
 
 		if img.Type == v2alpha1.TypeCincinnatiGraph && (opts.Mode == mirror.MirrorToDisk || opts.Mode == mirror.MirrorToMirror) {
 			continue
@@ -131,26 +132,26 @@ func (o *Batch) Worker(ctx context.Context, collectorSchema v2alpha1.CollectorSc
 		if countReleaseImages == collectorSchema.TotalReleaseImages && countReleaseImagesErrorTotal == 0 {
 			o.Log.Info("All release images mirrored successfully %d / %d ✅", countReleaseImages, collectorSchema.TotalReleaseImages)
 		} else {
-			o.Log.Info("Successfully mirrored %d / %d: Some release images failed to mirror ❌ - please check the logs", countReleaseImages-countReleaseImagesErrorTotal, collectorSchema.TotalReleaseImages)
+			o.Log.Info("Images mirrored %d / %d: Some release images failed to mirror ❌ - please check the logs", countReleaseImages-countReleaseImagesErrorTotal, collectorSchema.TotalReleaseImages)
 		}
 
 		if countOperatorsImages == collectorSchema.TotalOperatorImages && countOperatorsImagesErrorTotal == 0 {
 			o.Log.Info("All operator images mirrored successfully %d / %d ✅", countOperatorsImages, collectorSchema.TotalOperatorImages)
 		} else {
-			o.Log.Info("Successfully mirrored %d / %d: Some operator images failed to mirror ❌ - please check the logs", countOperatorsImages-countOperatorsImagesErrorTotal, collectorSchema.TotalOperatorImages)
+			o.Log.Info("Images mirrored %d / %d: Some operator images failed to mirror ❌ - please check the logs", countOperatorsImages-countOperatorsImagesErrorTotal, collectorSchema.TotalOperatorImages)
 		}
 
 		if countAdditionalImages == collectorSchema.TotalAdditionalImages && countAdditionalImagesErrorTotal == 0 {
 			o.Log.Info("All additional images mirrored successfully %d / %d ✅", countAdditionalImages, collectorSchema.TotalAdditionalImages)
 		} else {
-			o.Log.Info("Successfully mirrored %d / %d: Some additional images failed to mirror ❌ - please check the logs", countAdditionalImages-countAdditionalImagesErrorTotal, collectorSchema.TotalAdditionalImages)
+			o.Log.Info("Images mirrored %d / %d: Some additional images failed to mirror ❌ - please check the logs", countAdditionalImages-countAdditionalImagesErrorTotal, collectorSchema.TotalAdditionalImages)
 		}
 	} else {
 		o.Log.Info("=== Results ===")
 		if countTotal == totalImages && countErrorTotal == 0 {
 			o.Log.Info("All images deleted successfully %d / %d ✅", countTotal, totalImages)
 		} else {
-			o.Log.Info("Successfully deleted %d / %d: Some images failed to delete ❌ - please check the logs", countTotal-countErrorTotal, totalImages)
+			o.Log.Info("Images deleted %d / %d: Some images failed to delete ❌ - please check the logs", countTotal-countErrorTotal, totalImages)
 		}
 	}
 

--- a/v2/internal/pkg/cli/const.go
+++ b/v2/internal/pkg/cli/const.go
@@ -21,4 +21,6 @@ const (
 	dryRunOutDir            string = "dry-run"
 	mappingFile             string = "mapping.txt"
 	missingImgsFile         string = "missing.txt"
+	infoDir                 string = "info"
+	modeFile                string = "mode.txt"
 )

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -444,6 +444,13 @@ func (o *ExecutorSchema) Run(cmd *cobra.Command, args []string) error {
 		err = o.RunMirrorToMirror(cmd, args)
 	}
 
+	// track the workflow - used for delete
+	wfInfo := filepath.Join(o.Opts.Global.WorkingDir, infoDir, modeFile)
+	fileErr := os.WriteFile(wfInfo, []byte(o.Opts.Mode), 0755)
+	if fileErr != nil {
+		o.Log.Warn("unable to write workflow mode %v", err)
+	}
+
 	o.Log.Info("👋 Goodbye, thank you for using oc-mirror")
 
 	if err != nil {
@@ -498,7 +505,7 @@ http:
 		LocalStorageDisk: o.LocalStorageDisk,
 		LocalStoragePort: int(o.Opts.Global.Port),
 		LogLevel:         o.Opts.Global.LogLevel,
-		LogAccessOff:     o.Opts.Global.LogLevel != "debug",
+		LogAccessOff:     true,
 	}
 
 	if o.Opts.Global.LogLevel == "debug" || o.Opts.Global.LogLevel == "trace" {
@@ -626,7 +633,7 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 	o.Log.Trace("creating signatures directory %s ", o.Opts.Global.WorkingDir+"/"+signaturesDir)
 	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+signaturesDir, 0755)
 	if err != nil {
-		o.Log.Error(" setupWorkingDir %v ", err)
+		o.Log.Error(" setupWorkingDir for signatures %v ", err)
 		return err
 	}
 
@@ -634,7 +641,7 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 	o.Log.Trace("creating release images directory %s ", o.Opts.Global.WorkingDir+"/"+releaseImageDir)
 	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+releaseImageDir, 0755)
 	if err != nil {
-		o.Log.Error(" setupWorkingDir %v ", err)
+		o.Log.Error(" setupWorkingDir for release images %v ", err)
 		return err
 	}
 
@@ -642,7 +649,7 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 	o.Log.Trace("creating release cache directory %s ", o.Opts.Global.WorkingDir+"/"+releaseImageExtractDir)
 	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+releaseImageExtractDir, 0755)
 	if err != nil {
-		o.Log.Error(" setupWorkingDir %v ", err)
+		o.Log.Error(" setupWorkingDir for release cache %v ", err)
 		return err
 	}
 
@@ -650,7 +657,15 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 	o.Log.Trace("creating operator cache directory %s ", o.Opts.Global.WorkingDir+"/"+operatorImageExtractDir)
 	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+operatorImageExtractDir, 0755)
 	if err != nil {
-		o.Log.Error(" setupWorkingDir %v ", err)
+		o.Log.Error(" setupWorkingDir for operator cache %v ", err)
+		return err
+	}
+
+	// track the mode - this is important for delete functionality
+	o.Log.Trace("creating info directory %s ", o.Opts.Global.WorkingDir+"/"+infoDir)
+	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+infoDir, 0755)
+	if err != nil {
+		o.Log.Error(" setupWorkingDir for info %v ", err)
 		return err
 	}
 	return nil

--- a/v2/internal/pkg/log/logger.go
+++ b/v2/internal/pkg/log/logger.go
@@ -14,7 +14,8 @@ type PluggableLoggerInterface interface {
 	Debug(msg string, val ...interface{})
 	Trace(msg string, val ...interface{})
 	Warn(msg string, val ...interface{})
-	Level(levele string)
+	Level(level string)
+	GetLevel() string
 }
 
 // PluggableLogger
@@ -55,4 +56,8 @@ func (c *PluggableLogger) Warn(msg string, val ...interface{}) {
 // Level - ovveride log level
 func (c *PluggableLogger) Level(level string) {
 	c.Log.Level = level
+}
+
+func (c *PluggableLogger) GetLevel() string {
+	return c.Log.Level
 }

--- a/v2/internal/pkg/mirror/mirror.go
+++ b/v2/internal/pkg/mirror/mirror.go
@@ -3,6 +3,7 @@ package mirror
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -163,6 +164,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 		}
 	}
 
+	// hard coded ReportWriter to io.Discard
 	co := &copy.Options{
 		RemoveSignatures:                 opts.RemoveSignatures,
 		SignBy:                           opts.SignByFingerprint,
@@ -170,7 +172,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 		SignBySigstorePrivateKeyFile:     opts.SignBySigstorePrivateKey,
 		SignSigstorePrivateKeyPassphrase: []byte(passphrase),
 		SignIdentity:                     signIdentity,
-		ReportWriter:                     opts.Stdout,
+		ReportWriter:                     io.Discard,
 		SourceCtx:                        sourceCtx,
 		DestinationCtx:                   destinationCtx,
 		ForceManifestMIMEType:            manifestType,

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/worker.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/worker.go
@@ -104,7 +104,8 @@ func (o *Batch) Worker(ctx context.Context, collectorSchema v2alpha1.CollectorSc
 			}
 			o.Log.Info(strings.Repeat("=", len(overalProgress)))
 		}
-		o.Log.Info(mirrorMsg+" image: %s", img.Origin)
+
+		o.Log.Debug(mirrorMsg+" image: %s", img.Origin)
 
 		if img.Type == v2alpha1.TypeCincinnatiGraph && (opts.Mode == mirror.MirrorToDisk || opts.Mode == mirror.MirrorToMirror) {
 			continue
@@ -131,26 +132,26 @@ func (o *Batch) Worker(ctx context.Context, collectorSchema v2alpha1.CollectorSc
 		if countReleaseImages == collectorSchema.TotalReleaseImages && countReleaseImagesErrorTotal == 0 {
 			o.Log.Info("All release images mirrored successfully %d / %d ✅", countReleaseImages, collectorSchema.TotalReleaseImages)
 		} else {
-			o.Log.Info("Successfully mirrored %d / %d: Some release images failed to mirror ❌ - please check the logs", countReleaseImages-countReleaseImagesErrorTotal, collectorSchema.TotalReleaseImages)
+			o.Log.Info("Images mirrored %d / %d: Some release images failed to mirror ❌ - please check the logs", countReleaseImages-countReleaseImagesErrorTotal, collectorSchema.TotalReleaseImages)
 		}
 
 		if countOperatorsImages == collectorSchema.TotalOperatorImages && countOperatorsImagesErrorTotal == 0 {
 			o.Log.Info("All operator images mirrored successfully %d / %d ✅", countOperatorsImages, collectorSchema.TotalOperatorImages)
 		} else {
-			o.Log.Info("Successfully mirrored %d / %d: Some operator images failed to mirror ❌ - please check the logs", countOperatorsImages-countOperatorsImagesErrorTotal, collectorSchema.TotalOperatorImages)
+			o.Log.Info("Images mirrored %d / %d: Some operator images failed to mirror ❌ - please check the logs", countOperatorsImages-countOperatorsImagesErrorTotal, collectorSchema.TotalOperatorImages)
 		}
 
 		if countAdditionalImages == collectorSchema.TotalAdditionalImages && countAdditionalImagesErrorTotal == 0 {
 			o.Log.Info("All additional images mirrored successfully %d / %d ✅", countAdditionalImages, collectorSchema.TotalAdditionalImages)
 		} else {
-			o.Log.Info("Successfully mirrored %d / %d: Some additional images failed to mirror ❌ - please check the logs", countAdditionalImages-countAdditionalImagesErrorTotal, collectorSchema.TotalAdditionalImages)
+			o.Log.Info("Images mirrored %d / %d: Some additional images failed to mirror ❌ - please check the logs", countAdditionalImages-countAdditionalImagesErrorTotal, collectorSchema.TotalAdditionalImages)
 		}
 	} else {
 		o.Log.Info("=== Results ===")
 		if countTotal == totalImages && countErrorTotal == 0 {
 			o.Log.Info("All images deleted successfully %d / %d ✅", countTotal, totalImages)
 		} else {
-			o.Log.Info("Successfully deleted %d / %d: Some images failed to delete ❌ - please check the logs", countTotal-countErrorTotal, totalImages)
+			o.Log.Info("Images deleted %d / %d: Some images failed to delete ❌ - please check the logs", countTotal-countErrorTotal, totalImages)
 		}
 	}
 

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/const.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/const.go
@@ -21,4 +21,6 @@ const (
 	dryRunOutDir            string = "dry-run"
 	mappingFile             string = "mapping.txt"
 	missingImgsFile         string = "missing.txt"
+	infoDir                 string = "info"
+	modeFile                string = "mode.txt"
 )

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
@@ -444,6 +444,13 @@ func (o *ExecutorSchema) Run(cmd *cobra.Command, args []string) error {
 		err = o.RunMirrorToMirror(cmd, args)
 	}
 
+	// track the workflow - used for delete
+	wfInfo := filepath.Join(o.Opts.Global.WorkingDir, infoDir, modeFile)
+	fileErr := os.WriteFile(wfInfo, []byte(o.Opts.Mode), 0755)
+	if fileErr != nil {
+		o.Log.Warn("unable to write workflow mode %v", err)
+	}
+
 	o.Log.Info("👋 Goodbye, thank you for using oc-mirror")
 
 	if err != nil {
@@ -498,7 +505,7 @@ http:
 		LocalStorageDisk: o.LocalStorageDisk,
 		LocalStoragePort: int(o.Opts.Global.Port),
 		LogLevel:         o.Opts.Global.LogLevel,
-		LogAccessOff:     o.Opts.Global.LogLevel != "debug",
+		LogAccessOff:     true,
 	}
 
 	if o.Opts.Global.LogLevel == "debug" || o.Opts.Global.LogLevel == "trace" {
@@ -626,7 +633,7 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 	o.Log.Trace("creating signatures directory %s ", o.Opts.Global.WorkingDir+"/"+signaturesDir)
 	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+signaturesDir, 0755)
 	if err != nil {
-		o.Log.Error(" setupWorkingDir %v ", err)
+		o.Log.Error(" setupWorkingDir for signatures %v ", err)
 		return err
 	}
 
@@ -634,7 +641,7 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 	o.Log.Trace("creating release images directory %s ", o.Opts.Global.WorkingDir+"/"+releaseImageDir)
 	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+releaseImageDir, 0755)
 	if err != nil {
-		o.Log.Error(" setupWorkingDir %v ", err)
+		o.Log.Error(" setupWorkingDir for release images %v ", err)
 		return err
 	}
 
@@ -642,7 +649,7 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 	o.Log.Trace("creating release cache directory %s ", o.Opts.Global.WorkingDir+"/"+releaseImageExtractDir)
 	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+releaseImageExtractDir, 0755)
 	if err != nil {
-		o.Log.Error(" setupWorkingDir %v ", err)
+		o.Log.Error(" setupWorkingDir for release cache %v ", err)
 		return err
 	}
 
@@ -650,7 +657,15 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 	o.Log.Trace("creating operator cache directory %s ", o.Opts.Global.WorkingDir+"/"+operatorImageExtractDir)
 	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+operatorImageExtractDir, 0755)
 	if err != nil {
-		o.Log.Error(" setupWorkingDir %v ", err)
+		o.Log.Error(" setupWorkingDir for operator cache %v ", err)
+		return err
+	}
+
+	// track the mode - this is important for delete functionality
+	o.Log.Trace("creating info directory %s ", o.Opts.Global.WorkingDir+"/"+infoDir)
+	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+infoDir, 0755)
+	if err != nil {
+		o.Log.Error(" setupWorkingDir for info %v ", err)
 		return err
 	}
 	return nil

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/log/logger.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/log/logger.go
@@ -14,7 +14,8 @@ type PluggableLoggerInterface interface {
 	Debug(msg string, val ...interface{})
 	Trace(msg string, val ...interface{})
 	Warn(msg string, val ...interface{})
-	Level(levele string)
+	Level(level string)
+	GetLevel() string
 }
 
 // PluggableLogger
@@ -55,4 +56,8 @@ func (c *PluggableLogger) Warn(msg string, val ...interface{}) {
 // Level - ovveride log level
 func (c *PluggableLogger) Level(level string) {
 	c.Log.Level = level
+}
+
+func (c *PluggableLogger) GetLevel() string {
+	return c.Log.Level
 }

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/mirror/mirror.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/mirror/mirror.go
@@ -3,6 +3,7 @@ package mirror
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -163,6 +164,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 		}
 	}
 
+	// hard coded ReportWriter to io.Discard
 	co := &copy.Options{
 		RemoveSignatures:                 opts.RemoveSignatures,
 		SignBy:                           opts.SignByFingerprint,
@@ -170,7 +172,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 		SignBySigstorePrivateKeyFile:     opts.SignBySigstorePrivateKey,
 		SignSigstorePrivateKeyPassphrase: []byte(passphrase),
 		SignIdentity:                     signIdentity,
-		ReportWriter:                     opts.Stdout,
+		ReportWriter:                     io.Discard,
 		SourceCtx:                        sourceCtx,
 		DestinationCtx:                   destinationCtx,
 		ForceManifestMIMEType:            manifestType,


### PR DESCRIPTION
# Description

This a fix addresses the bug raised for delete images generation for the mirror to mirror flow

Fixes # OCPBUGS-32547

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Executed the following isc 

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  platform:
    channels:
    - name: stable-4.14
      minVersion: 4.14.22
      maxVersion: 4.14.22
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.14
      packages:
      - name: aws-load-balancer-operator
    - catalog: oci:///home/lzuccarelli/go/src/github.com/openshift/oc-mirror/rhopi4-14
      targetTag: "v14"
      targetCatalog: "lmz/catalog"
      packages:
      - name: windows-machine-config-operator
    - catalog: oci:///home/lzuccarelli/go/src/github.com/openshift/oc-mirror/rhopi4-14
      packages:
      - name: cincinnati-operator
```

Then ensured a mirror to mirror workflow using this command

```
bin/oc-mirror --config ocpbugs-32547.yaml --workspace file://ocpbugs-32547 --v2 docker://localhost:5000/ocpbugs-32547 --dest-tls-verify=false
```

Created a delete-isc.yaml from the isc as described above

Once completed I executed the following to generate the delete files.

```
bin/oc-mirror delete --config delete-32547.yaml --workspace file://ocpbugs-32547 --v2 --generate docker://localhost:5000/ocpbugs-32547 --dest-tls-verify=false
```

And finally actually doing a delete of the remote registry

```
bin/oc-mirror delete --config delete-32547.yaml --delete-yaml-file ocpbugs-32547/working-dir/delete/delete-images.yaml --v2 docker://localhost:5000/ocpbugs-32547 --dest-tls-verify=false --force-cache-delete
```

## Expected Outcome
- All indicated steps should **not** fail
- All unit and e2e should pass