### PR TITLE
OCPBUGS-33575: Change default behavior to not rebuild catalogs for V1

### DIFF
--- a/pkg/cli/mirror/catalog_images.go
+++ b/pkg/cli/mirror/catalog_images.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -22,6 +24,7 @@ import (
 	"github.com/openshift/oc/pkg/cli/image/imagesource"
 	"github.com/operator-framework/operator-registry/pkg/containertools"
 	"github.com/operator-framework/operator-registry/pkg/image/containerdregistry"
+	"github.com/otiai10/copy"
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/oc-mirror/pkg/api/v1alpha2"
@@ -35,6 +38,7 @@ const (
 	opmBinarySuffix = "opm"
 	cacheFolderUID  = 1001
 	cacheFolderGID  = 0
+	tempFolder      = "/tmp/temp_folder"
 )
 
 type NoCacheArgsErrorType struct{}
@@ -61,7 +65,7 @@ func (o *MirrorOptions) unpackCatalog(dstDir string, filesInArchive map[string]s
 }
 
 /*
-rebuildCatalogs will modify an OCI catalog in <some path>/src/catalogs/<repoPath>/layout with
+rebuildOrCopyCatalogs will modify an OCI catalog in <some path>/src/catalogs/<repoPath>/layout with
 the index.json files found in <some path>/src/catalogs/<repoPath>/index/index.json
 
 # Arguments
@@ -76,7 +80,7 @@ the index.json files found in <some path>/src/catalogs/<repoPath>/index/index.js
 
 • error: non-nil if error occurs, nil otherwise
 */
-func (o *MirrorOptions) rebuildCatalogs(ctx context.Context, dstDir string) (image.TypedImageMapping, error) {
+func (o *MirrorOptions) rebuildOrCopyCatalogs(ctx context.Context, dstDir string) (image.TypedImageMapping, error) {
 	refs := image.TypedImageMapping{}
 	var err error
 
@@ -88,80 +92,171 @@ func (o *MirrorOptions) rebuildCatalogs(ctx context.Context, dstDir string) (ima
 
 	dstDir = filepath.Clean(dstDir)
 	catalogsByImage := map[image.TypedImage]string{}
-	if err := filepath.Walk(dstDir, func(fpath string, info fs.FileInfo, err error) error {
+	if o.RebuildCatalogs {
+		if err := filepath.Walk(dstDir, func(fpath string, info fs.FileInfo, err error) error {
 
-		// Skip the layouts dir because we only need
-		// to process the parent directory one time
-		if filepath.Base(fpath) == config.LayoutsDir {
-			return filepath.SkipDir
-		}
-
-		if err != nil || info == nil {
-			return err
-		}
-
-		// From the index path determine the artifacts (index and layout) directory.
-		// Using that path to determine the corresponding catalog image for processing.
-		slashPath := filepath.ToSlash(fpath)
-		if base := path.Base(slashPath); base == "index.json" {
-			// remove the index.json from the path
-			// results in <some path>/src/catalogs/<repoPath>/index
-			slashPath = path.Dir(slashPath)
-			// remove the index folder from the path
-			// results in <some path>/src/catalogs/<repoPath>
-			slashPath = strings.TrimSuffix(slashPath, config.IndexDir)
-
-			// remove the <some path>/src/catalogs from the path to arrive at <repoPath>
-			repoPath := strings.TrimPrefix(slashPath, fmt.Sprintf("%s/%s/", dstDir, config.CatalogsDir))
-			// get the repo namespace and id (where ID is a SHA or tag)
-			// example: foo.com/foo/bar/<id>
-			regRepoNs, id := path.Split(path.Dir(repoPath))
-			regRepoNs = path.Clean(regRepoNs)
-			// reconstitute the path into a valid docker ref
-			var img string
-			if strings.Contains(id, ":") {
-				// Digest.
-				img = fmt.Sprintf("%s@%s", regRepoNs, id)
-			} else {
-				// Tag.
-				img = fmt.Sprintf("%s:%s", regRepoNs, id)
+			// Skip the layouts dir because we only need
+			// to process the parent directory one time
+			if filepath.Base(fpath) == config.LayoutsDir {
+				return filepath.SkipDir
 			}
-			ctlgRef := image.TypedImage{}
-			ctlgRef.Type = imagesource.DestinationRegistry
-			sourceRef, err := image.ParseReference(img)
-			// since we can't really tell if the "img" reference originated from an actual docker
-			// reference or from an OCI file path that approximates a docker reference, ParseReference
-			// might not lowercase the name and namespace values which is required by the
-			// docker reference spec (see https://github.com/distribution/distribution/blob/main/reference/reference.go).
-			// Therefore we lower case name and namespace here to make sure it's done.
-			sourceRef.Ref.Name = strings.ToLower(sourceRef.Ref.Name)
-			sourceRef.Ref.Namespace = strings.ToLower(sourceRef.Ref.Namespace)
 
-			if err != nil {
-				return fmt.Errorf("error parsing index dir path %q as image %q: %v", fpath, img, err)
+			if err != nil || info == nil {
+				return err
 			}
-			ctlgRef.Ref = sourceRef.Ref
-			// Update registry so the existing catalog image can be pulled.
-			ctlgRef.Ref.Registry = mirrorRef.Ref.Registry
-			ctlgRef.Ref.Namespace = path.Join(o.UserNamespace, ctlgRef.Ref.Namespace)
-			ctlgRef = ctlgRef.SetDefaults()
-			// Unset the ID when passing to the image builder.
-			// Tags are needed here since the digest will be recalculated.
-			ctlgRef.Ref.ID = ""
 
-			catalogsByImage[ctlgRef] = slashPath
+			// From the index path determine the artifacts (index and layout) directory.
+			// Using that path to determine the corresponding catalog image for processing.
+			slashPath := filepath.ToSlash(fpath)
+			if base := path.Base(slashPath); base == "index.json" {
+				// remove the index.json from the path
+				// results in <some path>/src/catalogs/<repoPath>/index
+				slashPath = path.Dir(slashPath)
+				// remove the index folder from the path
+				// results in <some path>/src/catalogs/<repoPath>
+				slashPath = strings.TrimSuffix(slashPath, config.IndexDir)
 
-			// Add to mapping for ICSP generation
-			refs.Add(sourceRef, ctlgRef.TypedImageReference, v1alpha2.TypeOperatorCatalog)
+				// remove the <some path>/src/catalogs from the path to arrive at <repoPath>
+				repoPath := strings.TrimPrefix(slashPath, fmt.Sprintf("%s/%s/", dstDir, config.CatalogsDir))
+				// get the repo namespace and id (where ID is a SHA or tag)
+				// example: foo.com/foo/bar/<id>
+				regRepoNs, id := path.Split(path.Dir(repoPath))
+				regRepoNs = path.Clean(regRepoNs)
+				// reconstitute the path into a valid docker ref
+				var img string
+				if strings.Contains(id, ":") {
+					// Digest.
+					img = fmt.Sprintf("%s@%s", regRepoNs, id)
+				} else {
+					// Tag.
+					img = fmt.Sprintf("%s:%s", regRepoNs, id)
+				}
+				ctlgRef := image.TypedImage{}
+				ctlgRef.Type = imagesource.DestinationRegistry
+				sourceRef, err := image.ParseReference(img)
+				// since we can't really tell if the "img" reference originated from an actual docker
+				// reference or from an OCI file path that approximates a docker reference, ParseReference
+				// might not lowercase the name and namespace values which is required by the
+				// docker reference spec (see https://github.com/distribution/distribution/blob/main/reference/reference.go).
+				// Therefore we lower case name and namespace here to make sure it's done.
+				sourceRef.Ref.Name = strings.ToLower(sourceRef.Ref.Name)
+				sourceRef.Ref.Namespace = strings.ToLower(sourceRef.Ref.Namespace)
+
+				if err != nil {
+					return fmt.Errorf("error parsing index dir path %q as image %q: %v", fpath, img, err)
+				}
+				ctlgRef.Ref = sourceRef.Ref
+				// Update registry so the existing catalog image can be pulled.
+				ctlgRef.Ref.Registry = mirrorRef.Ref.Registry
+				ctlgRef.Ref.Namespace = path.Join(o.UserNamespace, ctlgRef.Ref.Namespace)
+				ctlgRef = ctlgRef.SetDefaults()
+				// Unset the ID when passing to the image builder.
+				// Tags are needed here since the digest will be recalculated.
+				ctlgRef.Ref.ID = ""
+
+				catalogsByImage[ctlgRef] = slashPath
+
+				// Add to mapping for ICSP generation
+				refs.Add(sourceRef, ctlgRef.TypedImageReference, v1alpha2.TypeOperatorCatalog)
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
-		return nil
-	}); err != nil {
-		return nil, err
-	}
 
-	// update the catalogs in the OCI layout directory and push them to their destination
-	if err := o.processCatalogRefs(ctx, catalogsByImage); err != nil {
-		return nil, err
+		// update the catalogs in the OCI layout directory and push them to their destination
+		if err := o.processCatalogRefs(ctx, catalogsByImage); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := filepath.Walk(dstDir, func(fpath string, info fs.FileInfo, err error) error {
+			if err != nil || info == nil {
+				return err
+			}
+			slashPath := filepath.ToSlash(fpath)
+
+			if filepath.Base(fpath) == config.LayoutsDir {
+
+				// results in <some path>/src/catalogs/<repoPath>/layout
+				slashPath = path.Dir(slashPath)
+
+				// remove the <some path>/src/catalogs from the path to arrive at <repoPath>
+				repoPath := strings.TrimPrefix(slashPath, fmt.Sprintf("%s/%s/", dstDir, config.CatalogsDir))
+				// get the repo namespace and id (where ID is a SHA or tag)
+				// example: foo.com/foo/bar/<id>
+				regRepoNs, id := path.Split(repoPath)
+				regRepoNs = path.Clean(regRepoNs)
+				// reconstitute the path into a valid docker ref
+				var img string
+				if strings.Contains(id, ":") {
+					// Digest.
+					img = fmt.Sprintf("%s@%s", regRepoNs, id)
+				} else {
+					// Tag.
+					img = fmt.Sprintf("%s:%s", regRepoNs, id)
+				}
+
+				ctlgRef := image.TypedImage{}
+				ctlgRef.Type = imagesource.DestinationRegistry
+				originRef, err := image.ParseReference(img)
+				// since we can't really tell if the "img" reference originated from an actual docker
+				// reference or from an OCI file path that approximates a docker reference, ParseReference
+				// might not lowercase the name and namespace values which is required by the
+				// docker reference spec (see https://github.com/distribution/distribution/blob/main/reference/reference.go).
+				// Therefore we lower case name and namespace here to make sure it's done.
+				originRef.Ref.Name = strings.ToLower(originRef.Ref.Name)
+				originRef.Ref.Namespace = strings.ToLower(originRef.Ref.Namespace)
+
+				if err != nil {
+					return fmt.Errorf("error parsing index dir path %q as image %q: %v", fpath, img, err)
+				}
+				ctlgRef.Ref = originRef.Ref
+				// Update registry so the existing catalog image can be pulled.
+				ctlgRef.Ref.Registry = mirrorRef.Ref.Registry
+				ctlgRef.Ref.Namespace = path.Join(o.UserNamespace, ctlgRef.Ref.Namespace)
+				ctlgRef = ctlgRef.SetDefaults()
+				// Unset the ID when passing to the image builder.
+				// Tags are needed here since the digest will be recalculated.
+				ctlgRef.Ref.ID = ""
+
+				catalogOCIDir := fpath
+				isValid, err := isValidOCILayout(catalogOCIDir)
+				if err != nil {
+					klog.Warningf("unable to verify that the catalog layout is valid for image %s: %v", ctlgRef.Ref.String(), err)
+				}
+				if isValid && err == nil {
+					// Add to mapping for ICSP generation
+					if strings.Contains(fpath, "sha256:") {
+						randomNumber := strconv.Itoa(rand.Int())
+						catalogOCIDir = tempFolder + randomNumber
+						err := os.Mkdir(catalogOCIDir, 0755)
+						if err != nil {
+							klog.Warningf("unable to create temp folder facilitating mirroring of catalog image %s: %v", fpath, err)
+						}
+						defer os.RemoveAll(catalogOCIDir)
+						err = copy.Copy(fpath, catalogOCIDir)
+						if err != nil {
+							klog.Warningf("unable to copy catalog to temp folder while mirroring of catalog image %s: %v", fpath, err)
+						}
+					}
+					_, err = o.copyImage(ctx, "oci://"+catalogOCIDir, "docker://"+ctlgRef.Ref.String(), o.remoteRegFuncs)
+					if err != nil {
+						return fmt.Errorf("error copying image %s to %s: %v", fpath, "docker://"+ctlgRef.Ref.String(), err)
+					}
+
+				} else {
+					_, err = o.copyImage(ctx, "docker://"+originRef.Ref.String(), "docker://"+ctlgRef.Ref.String(), o.remoteRegFuncs)
+					if err != nil {
+						return fmt.Errorf("error copying image %s to %s: %v", "docker://"+originRef.Ref.String(), "docker://"+ctlgRef.Ref.String(), err)
+					}
+				}
+				// Add to mapping for ICSP generation
+				refs.Add(originRef, ctlgRef.TypedImageReference, v1alpha2.TypeOperatorCatalog)
+			}
+			return nil
+		}); err != nil {
+			return nil, err
+		}
 	}
 
 	// use the resolver to obtain the digests of the newly pushed images
@@ -241,11 +336,17 @@ func (o *MirrorOptions) processCatalogRefs(ctx context.Context, catalogsByImage 
 
 		if withCacheRegeneration {
 
-			opmCmdPath := filepath.Join(artifactDir, config.OpmBinDir, "opm")
+			opmCmdPath := ""
+			if opmBinary := os.Getenv("OPM_BINARY"); opmBinary != "" {
+				opmCmdPath = opmBinary
+			} else {
+				opmCmdPath = filepath.Join(artifactDir, config.OpmBinDir, "opm")
+			}
 			_, err = os.Stat(opmCmdPath)
 			if err != nil {
 				return fmt.Errorf("cannot find opm in the extracted catalog %v for %s on %s: %v", ctlgRef, runtime.GOOS, runtime.GOARCH, err)
 			}
+
 			absConfigPath, err := filepath.Abs(filepath.Join(artifactDir, config.IndexDir))
 			if err != nil {
 				return fmt.Errorf("error getting absolute path for catalog's index %v: %v", filepath.Join(artifactDir, config.IndexDir), err)
@@ -641,4 +742,25 @@ func extractCatalog(img v1.Image, destFolder string, opmBin string) error {
 	}
 
 	return nil
+}
+
+func isValidOCILayout(folder string) (bool, error) {
+	_, err := os.Stat(folder)
+	if err != nil {
+		return false, err
+	}
+	indexFile := filepath.Join(folder, "index.json")
+	_, err = os.Stat(indexFile)
+	if err != nil {
+		return false, err
+	}
+	indexData, err := os.ReadFile(indexFile)
+	if err != nil {
+		return false, err
+	}
+	if strings.Contains(string(indexData), "application/vnd.oci") {
+		return true, nil
+	} else {
+		return false, nil
+	}
 }

--- a/pkg/cli/mirror/fbc_operators.go
+++ b/pkg/cli/mirror/fbc_operators.go
@@ -478,6 +478,7 @@ func (o *MirrorOptions) copyImage(ctx context.Context, from, to string, funcs Re
 		// find absolute path if from is a relative path
 		fromPath := v1alpha2.TrimProtocol(from)
 		if !strings.HasPrefix(fromPath, "/") {
+
 			absolutePath, err := filepath.Abs(fromPath)
 			if err != nil {
 				return digest.Digest(""), fmt.Errorf("unable to get absolute path of oci image %s: %v", from, err)

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -38,6 +38,7 @@ type MirrorOptions struct {
 	OCIRegistriesConfig        string // Registries config file location (it works only with local oci catalogs)
 	OCIInsecureSignaturePolicy bool   // If set, OCI catalog push will not try to push signatures
 	MaxNestedPaths             int
+	RebuildCatalogs            bool // If set, rebuilds catalogs based on filtered declarative config, and regenerates the cache of that catalog
 	// cancelCh is a channel listening for command cancellations
 	cancelCh                          <-chan struct{}
 	once                              sync.Once
@@ -74,6 +75,7 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.OCIInsecureSignaturePolicy, "oci-insecure-signature-policy", o.OCIInsecureSignaturePolicy, "If set, OCI catalog push will not try to push signatures")
 	fs.BoolVar(&o.SkipPruning, "skip-pruning", o.SkipPruning, "If set, will disable pruning globally")
 	fs.IntVar(&o.MaxNestedPaths, "max-nested-paths", 0, "Number of nested paths, for destination registries that limit nested paths")
+	fs.BoolVar(&o.RebuildCatalogs, "rebuild-catalogs", o.RebuildCatalogs, "If set (defaults to false), rebuilds catalogs based on filtered declarative config, and regenerates the cache of that catalog")
 }
 
 func (o *MirrorOptions) init() {

--- a/pkg/cli/mirror/publish.go
+++ b/pkg/cli/mirror/publish.go
@@ -342,7 +342,7 @@ func (o *MirrorOptions) processCustomImages(ctx context.Context, dir string, fil
 	}
 
 	if found {
-		ctlgRefs, err := o.rebuildCatalogs(ctx, dir)
+		ctlgRefs, err := o.rebuildOrCopyCatalogs(ctx, dir)
 		if err != nil {
 			return allMappings, fmt.Errorf("error rebuilding catalog images from file-based catalogs: %v", err)
 		}

--- a/test/e2e/lib/workflow.sh
+++ b/test/e2e/lib/workflow.sh
@@ -125,7 +125,7 @@ function workflow_m2d2m_oci_catalog() {
   if !$DIFF; then
     cleanup_conn
   fi
-  run_cmd --from "${CREATE_FULL_DIR}/mirror_seq1_000000.tar" "docker://${remote_image}"
+  run_cmd --from "${CREATE_FULL_DIR}/mirror_seq1_000000.tar" "docker://${remote_image}" $PUBLISH_FLAGS
 
   popd
 }

--- a/test/e2e/testcases.sh
+++ b/test/e2e/testcases.sh
@@ -29,7 +29,7 @@ TESTCASES[22]="m2d2m_oci_catalog"
 
 # Test full catalog mode.
 function full_catalog() {
-    workflow_full imageset-config-full.yaml "test-catalog-latest" -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-full.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.0.0 baz.v1.0.1 baz.v1.1.0 foo.v0.1.0 foo.v0.2.0 foo.v0.3.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -37,7 +37,7 @@ function full_catalog() {
 
 # Test full catalog mode with digest.
 function full_catalog_with_digest() {
-    workflow_full imageset-config-full-digest.yaml "test-catalog-latest" -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-full-digest.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     TMPTAG=$(echo $CATALOGDIGEST | cut -d: -f 2)
     ## We default to 6 for the partial digest length to get unique tags per repo
     TMPTAG=${TMPTAG:0:6}
@@ -48,12 +48,12 @@ function full_catalog_with_digest() {
 
 # Test heads-only mode
 function headsonly_diff () {
-    workflow_full imageset-config-headsonly.yaml "test-catalog-latest" --diff -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-headsonly.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
 
-    workflow_diff imageset-config-headsonly.yaml "test-catalog-diff" -c="--source-use-http --source-skip-tls"
+    workflow_diff imageset-config-headsonly.yaml "test-catalog-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -61,13 +61,13 @@ function headsonly_diff () {
 
 # Test heads-only mode with target
 function headsonly_diff_with_target () {
-    workflow_full imageset-config-headsonly-newtarget.yaml "test-catalog-latest" --diff -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-headsonly-newtarget.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     # shellcheck disable=SC2086
     check_bundles localhost.localdomain:"${REGISTRY_DISCONN_PORT}"/"${CATALOGORG}"/${TARGET_CATALOG_NAME}:${TARGET_CATALOG_TAG} \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
 
-    workflow_diff imageset-config-headsonly-newtarget.yaml "test-catalog-diff" -c="--source-use-http --source-skip-tls"
+    workflow_diff imageset-config-headsonly-newtarget.yaml "test-catalog-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:"${REGISTRY_DISCONN_PORT}"/"${CATALOGORG}"/"${TARGET_CATALOG_NAME}":"${TARGET_CATALOG_TAG}" \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:"${REGISTRY_DISCONN_PORT}"
@@ -75,13 +75,13 @@ function headsonly_diff_with_target () {
 
 # Test heads-only mode with catalogs that prune bundles
 function pruned_catalogs() {
-    workflow_full imageset-config-headsonly.yaml "test-catalog-prune" --diff -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-headsonly.yaml "test-catalog-prune" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.1.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
     check_image_exists "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:86fa1b12"
 
-    workflow_diff imageset-config-headsonly.yaml "test-catalog-prune-diff" -c="--source-use-http --source-skip-tls"
+    workflow_diff imageset-config-headsonly.yaml "test-catalog-prune-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.2.0" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -91,13 +91,13 @@ function pruned_catalogs() {
 # Test heads-only mode with catalogs that prune with a custom target
 # name set
 function pruned_catalogs_with_target() {
-    workflow_full imageset-config-headsonly-newtarget.yaml "test-catalog-prune" --diff -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-headsonly-newtarget.yaml "test-catalog-prune" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGORG}/${TARGET_CATALOG_NAME}:${TARGET_CATALOG_TAG} \
     "bar.v0.1.0 foo.v0.1.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
     check_image_exists "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:86fa1b12"
 
-    workflow_diff imageset-config-headsonly-newtarget.yaml "test-catalog-prune-diff" -c="--source-use-http --source-skip-tls"
+    workflow_diff imageset-config-headsonly-newtarget.yaml "test-catalog-prune-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGORG}/${TARGET_CATALOG_NAME}:${TARGET_CATALOG_TAG} \
     "bar.v0.1.0 foo.v0.2.0" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -106,13 +106,13 @@ function pruned_catalogs_with_target() {
 
 # Test heads-only mode with catalogs that prune bundles
 function pruned_catalogs_with_include() {
-    workflow_full imageset-config-filter-multi-prune.yaml "test-catalog-prune" --diff -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-filter-multi-prune.yaml "test-catalog-prune" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.1.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
     check_image_exists "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:86fa1b12"
 
-    workflow_diff imageset-config-filter-multi-prune.yaml "test-catalog-prune-diff" -c="--source-use-http --source-skip-tls"
+    workflow_diff imageset-config-filter-multi-prune.yaml "test-catalog-prune-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.2.0" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -121,13 +121,13 @@ function pruned_catalogs_with_include() {
 
 # Test heads-only mode with catalogs that prune bundles
 function pruned_catalogs_mirror_to_mirror() {
-    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-prune" -c="--source-use-http --source-skip-tls"
+    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-prune" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.1.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
     check_image_exists "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:86fa1b12"
 
-    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-prune-diff" -c="--source-use-http --source-skip-tls"
+    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-prune-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.2.0" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -136,12 +136,12 @@ function pruned_catalogs_mirror_to_mirror() {
 
 # Test registry backend
 function registry_backend () {
-    workflow_full imageset-config-headsonly-backend-registry.yaml "test-catalog-latest" --diff -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-headsonly-backend-registry.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
 
-    workflow_diff imageset-config-headsonly-backend-registry.yaml "test-catalog-diff" -c="--source-use-http --source-skip-tls"
+    workflow_diff imageset-config-headsonly-backend-registry.yaml "test-catalog-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -149,7 +149,7 @@ function registry_backend () {
 
 # Test mirror to mirror with local backend
 function mirror_to_mirror() {
-    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-latest" -c="--source-use-http --source-skip-tls"
+    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-latest" -c="--source-use-http --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -157,7 +157,7 @@ function mirror_to_mirror() {
 
 # Test mirror to mirror no backend
 function mirror_to_mirror_nostorage() {
-    workflow_mirror2mirror imageset-config-full.yaml "test-catalog-latest" -c="--source-use-http --source-skip-tls"
+    workflow_mirror2mirror imageset-config-full.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.0.0 baz.v1.0.1 baz.v1.1.0 foo.v0.1.0 foo.v0.2.0 foo.v0.3.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -165,12 +165,12 @@ function mirror_to_mirror_nostorage() {
 
 # Test registry backend with custom namespace
 function custom_namespace {
-    workflow_full imageset-config-headsonly-backend-registry.yaml "test-catalog-latest" --diff -n="custom" -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-headsonly-backend-registry.yaml "test-catalog-latest" --diff -n="custom" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles "localhost.localdomain:${REGISTRY_DISCONN_PORT}/custom/${CATALOGNAMESPACE}:test-catalog-latest" \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT} "custom"
 
-    workflow_diff imageset-config-headsonly-backend-registry.yaml "test-catalog-diff" -n="custom" -c="--source-use-http --source-skip-tls"
+    workflow_diff imageset-config-headsonly-backend-registry.yaml "test-catalog-diff" -n="custom" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles "localhost.localdomain:${REGISTRY_DISCONN_PORT}/custom/${CATALOGNAMESPACE}:test-catalog-latest" \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT} "custom"
@@ -179,12 +179,12 @@ function custom_namespace {
 
 # Test package filtering
 function package_filtering {
-    workflow_full imageset-config-filter.yaml "test-catalog-latest" --diff -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-filter.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest" \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 foo.v0.1.0 foo.v0.2.0 foo.v0.3.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
 
-    workflow_diff imageset-config-filter-multi.yaml "test-catalog-diff" -c="--source-use-http --source-skip-tls"
+    workflow_diff imageset-config-filter-multi.yaml "test-catalog-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest" \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.0.1 baz.v1.1.0 foo.v0.1.0 foo.v0.2.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -192,7 +192,7 @@ function package_filtering {
 
 # Test catalog with one version in a package specified
 function single_version () {
-    workflow_full imageset-config-filter-single.yaml "test-catalog-latest" -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-filter-single.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "baz.v1.0.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -200,7 +200,7 @@ function single_version () {
 
 # Test catalog with a version range in a package specified
 function version_range () {
-    workflow_full imageset-config-filter-range.yaml "test-catalog-latest" -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-filter-range.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "foo.v0.2.0 foo.v0.3.0" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -208,7 +208,7 @@ function version_range () {
 
 # Test catalog with a max version in a package specified
 function max_version () {
-    workflow_full imageset-config-filter-max.yaml "test-catalog-latest" -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-filter-max.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "foo.v0.1.0 foo.v0.2.0 foo.v0.3.0" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -217,7 +217,7 @@ function max_version () {
 
 # Test skip deps
 function skip_deps {
-    workflow_full imageset-config-skip-deps.yaml "test-catalog-latest" --diff -c="--source-use-http --source-skip-tls"
+    workflow_full imageset-config-skip-deps.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest" \
     "bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -232,7 +232,7 @@ function helm_local {
 
 # Test no updates
 function no_updates_exist {
-    workflow_no_updates imageset-config-headsonly.yaml "test-catalog-latest" --diff -c="--source-use-http --source-skip-tls"
+    workflow_no_updates imageset-config-headsonly.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -247,7 +247,7 @@ function no_updates_exist {
 # Test OCI local catalog
 function m2m_oci_catalog {
     rm -fr olm_artifacts
-    workflow_m2m_oci_catalog imageset-config-oci-mirror.yaml "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}" -c="--dest-skip-tls --oci-insecure-signature-policy"
+    workflow_m2m_oci_catalog imageset-config-oci-mirror.yaml "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}" -c="--dest-skip-tls --oci-insecure-signature-policy --rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/redhatgov/oc-mirror-dev:test-catalog-latest \
     "baz.v1.0.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -268,7 +268,7 @@ function m2m_release_with_oci_catalog {
     test/e2e/graph/main & PID_GO=$! 
     echo -e "go cincinnatti web service PID: ${PID_GO}"
     # copy relevant files and start the mirror process
-    workflow_oci_mirror_all imageset-config-oci-mirror-all.yaml "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}/test-catalog-latest" -c="--dest-skip-tls --oci-insecure-signature-policy"
+    workflow_oci_mirror_all imageset-config-oci-mirror-all.yaml "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}/test-catalog-latest" -c="--dest-skip-tls --oci-insecure-signature-policy --rebuild-catalogs"
 
     # use crane digest to verify
     crane digest --insecure localhost.localdomain:${REGISTRY_DISCONN_PORT}/test-catalog-latest/redhatgov/oc-mirror-dev:bar-v0.1.0
@@ -285,7 +285,7 @@ function m2m_release_with_oci_catalog {
 # Test full catalog mode.
 function m2d2m_oci_catalog() {
     rm -fr olm_artifacts
-    workflow_m2d2m_oci_catalog imageset-config-oci-mirror.yaml "localhost.localdomain:${REGISTRY_DISCONN_PORT}" -c="--source-use-http  --source-skip-tls"
+    workflow_m2d2m_oci_catalog imageset-config-oci-mirror.yaml "localhost.localdomain:${REGISTRY_DISCONN_PORT}" -c="--source-use-http   --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/redhatgov/oc-mirror-dev:test-catalog-latest \
     "baz.v1.0.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}


### PR DESCRIPTION
# Description

This PR is a cherrypick of #847 and fixes OCPBUGS-33575. 
Mirroring M2M and M2D for registry based catalogs was failing with error :
```
oc adm catalog mirror [file://rhceph-dev/ocs-registry:4.16.0-92](file:///ocs-registry:4.16.0-92) REGISTRY/REPOSITORY
error: lstat /home/jenkins/quay.io: no such file or directory
```
Fixes OCPBUGS-33575

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using the following imageSetConfig:
```yaml
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
  - catalog: quay.io/skhoury/oc-mirror-dev:test-catalog-latest
    packages: 
    - name: foo
  
  - catalog: oci:///home/skhoury/testcatalog
    # targetCatalog: oc-mirror-dev:oci
    packages: 
    - name: bar
```

Test matrix
|Test|workflow|catalog type|rebuildCatalogs|use OPM_BINARY| result|
|---|---|---|---|---|---|
|1|MirrorToMirror|registry based|no|NA|OK|
|2|MirrorToMirror|OCI file based|no|NA|OK|
|3|MirrorToMirror|registry based|yes|no|OK|
|4|MirrorToMirror|OCI file based|yes|no|not tested|
|5|MirrorToMirror|registry based|yes|yes|OK|
|6|MirrorToMirror|OCI file based|yes|yes|OK|
|7|MirrorToDisk|registry based|NA|NA|OK|
|8|MirrorToDisk|OCI file based|NA|NA|OK|
|9|DiskToMirror|registry based|no|NA|OK|
|10|DiskToMirror|OCI file based|no|NA|OK|
|11|DiskToMirror|registry based|yes|no|not tested|
|12|DiskToMirror|OCI file based|yes|no|not tested|
|13|DiskToMirror|registry based|yes|yes|OK|
|14|DiskToMirror|OCI file based|yes|yes|OK|

## Expected Outcome
The mirroring completes without errors, and the catalog is available on the mirror registry.
**Not tested:**
- For catalogs mirrored without --rebuild-catalogs
  - The catalogsource should be deployable on the cluster, regardless of the catalog version (v4.15 or v4.14, etc)
  - oc-mirror should work on rhel8 and rhel9 systems
- For catalogs mirrored with --rebuild-catalogs and OPM_BINARY defined
  - The catalogsource should be deployable on the cluster, regardless of the catalog version (v4.15 or v4.14, etc)
  - oc-mirror should work on rhel8 and rhel9 systems provided that the OPM_BINARY chosen corresponds to the os.