### PR TITLE
OCPBUGS-31608:OCPBUGS-33775: Fix source repository for IDMS/ITMS in case of empty namespace

### DIFF
--- a/v2/internal/pkg/additional/local_stored_collector_test.go
+++ b/v2/internal/pkg/additional/local_stored_collector_test.go
@@ -113,7 +113,7 @@ func (o MockMirror) Run(ctx context.Context, src, dest string, mode mirror.Mode,
 	return nil
 }
 
-func (o MockMirror) Check(ctx context.Context, image string, opts *mirror.CopyOptions) (bool, error) {
+func (o MockMirror) Check(ctx context.Context, image string, opts *mirror.CopyOptions, asCopySrc bool) (bool, error) {
 	return true, nil
 }
 

--- a/v2/internal/pkg/batch/worker_test.go
+++ b/v2/internal/pkg/batch/worker_test.go
@@ -68,7 +68,7 @@ func (o Mirror) Run(ctx context.Context, src, dest string, mode mirror.Mode, opt
 	return nil
 }
 
-func (o Mirror) Check(ctx context.Context, image string, opts *mirror.CopyOptions) (bool, error) {
+func (o Mirror) Check(ctx context.Context, image string, opts *mirror.CopyOptions, asCopySrc bool) (bool, error) {
 	return true, nil
 }
 

--- a/v2/internal/pkg/cli/const.go
+++ b/v2/internal/pkg/cli/const.go
@@ -22,5 +22,6 @@ const (
 	mappingFile             string = "mapping.txt"
 	missingImgsFile         string = "missing.txt"
 	infoDir                 string = "info"
+	clusterResourcesDir     string = "cluster-resources"
 	modeFile                string = "mode.txt"
 )

--- a/v2/internal/pkg/cli/dryrun.go
+++ b/v2/internal/pkg/cli/dryrun.go
@@ -35,7 +35,7 @@ func (o *ExecutorSchema) DryRun(ctx context.Context, allImages []v2alpha1.CopyIm
 	for _, img := range allImages {
 		buff.WriteString(img.Source + "=" + img.Destination + "\n")
 		if o.Opts.IsMirrorToDisk() {
-			exists, err := o.Mirror.Check(ctx, img.Destination, o.Opts)
+			exists, err := o.Mirror.Check(ctx, img.Destination, o.Opts, false)
 			if err != nil {
 				o.Log.Debug("unable to check existence of %s in local cache: %v", img.Destination, err)
 			}

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -668,6 +668,20 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 		o.Log.Error(" setupWorkingDir for info %v ", err)
 		return err
 	}
+
+	// create cluster-resources directory and clean it
+	o.Log.Trace("creating cluster-resources directory %s ", o.Opts.Global.WorkingDir+"/"+clusterResourcesDir)
+	err = os.RemoveAll(o.Opts.Global.WorkingDir + "/" + clusterResourcesDir)
+	if err != nil {
+		o.Log.Error(" setupWorkingDir for cluster resources: failed to clear folder %s: %v ", o.Opts.Global.WorkingDir+"/"+clusterResourcesDir, err)
+		return err
+	}
+	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+clusterResourcesDir, 0755)
+	if err != nil {
+		o.Log.Error(" setupWorkingDir for cluster resources %v ", err)
+		return err
+	}
+
 	return nil
 }
 

--- a/v2/internal/pkg/cli/executor_test.go
+++ b/v2/internal/pkg/cli/executor_test.go
@@ -636,12 +636,14 @@ func TestExecutorSetupLocalStorage(t *testing.T) {
 
 // TestExecutorSetupWorkingDir
 func TestExecutorSetupWorkingDir(t *testing.T) {
+	workingDir := t.TempDir()
+	defer os.RemoveAll(workingDir)
 	t.Run("Testing Executor : setup working dir should pass", func(t *testing.T) {
 		log := clog.New("trace")
 
 		global := &mirror.GlobalOptions{
 			SecurePolicy: false,
-			WorkingDir:   "/root",
+			WorkingDir:   workingDir,
 		}
 
 		opts := &mirror.CopyOptions{
@@ -837,7 +839,7 @@ func (o MockMakeDir) makeDirAll(dir string, mode os.FileMode) error {
 	return nil
 }
 
-func (o Mirror) Check(ctx context.Context, dest string, opts *mirror.CopyOptions) (bool, error) {
+func (o Mirror) Check(ctx context.Context, dest string, opts *mirror.CopyOptions, asCopySrc bool) (bool, error) {
 	if !o.Fail {
 		return true, nil
 	} else {

--- a/v2/internal/pkg/clusterresources/clusterresources.go
+++ b/v2/internal/pkg/clusterresources/clusterresources.go
@@ -511,7 +511,12 @@ func (o *ClusterResourcesGenerator) UpdateServiceGenerator(graphImageRef, releas
 func namespaceScope(imgSpec image.ImageSpec) string {
 	pathComponents := strings.Split(imgSpec.PathComponent, "/")
 	ns := strings.Join(pathComponents[:len(pathComponents)-1], "/")
-	return imgSpec.Domain + "/" + ns
+	if ns != "" {
+		return imgSpec.Domain + "/" + ns
+	} else {
+		return imgSpec.Domain
+	}
+
 }
 
 func repositoryScope(imgSpec image.ImageSpec) string {

--- a/v2/internal/pkg/clusterresources/clusterresources_test.go
+++ b/v2/internal/pkg/clusterresources/clusterresources_test.go
@@ -70,6 +70,12 @@ var (
 			Type:        v2alpha1.TypeOperatorCatalog,
 		},
 		{
+			Source:      "docker://localhost:55000/ubi8-minimal:b93deceb59a58588d5b16429fc47f98920f84740a1f2ed6454e33275f0701b59",
+			Destination: "docker://myregistry/mynamespace/ubi8-minimal@sha256:b93deceb59a58588d5b16429fc47f98920f84740a1f2ed6454e33275f0701b59",
+			Origin:      "docker://registry.redhat.io/ubi8-minimal@sha256:b93deceb59a58588d5b16429fc47f98920f84740a1f2ed6454e33275f0701b59",
+			Type:        v2alpha1.TypeOperatorRelatedImage,
+		},
+		{
 			Source:      "docker://localhost:5000/ubi8/ubi:latest",
 			Destination: "docker://myregistry/mynamespace/ubi8/ubi:latest",
 			Origin:      "docker://registry.redhat.io/ubi8/ubi:latest",
@@ -252,6 +258,10 @@ func TestGenerateIDMS(t *testing.T) {
 							{
 								Source:  "quay.io/openshift-community-operators",
 								Mirrors: []confv1.ImageMirror{"myregistry/mynamespace/openshift-community-operators"},
+							},
+							{
+								Source:  "registry.redhat.io",
+								Mirrors: []confv1.ImageMirror{"myregistry/mynamespace"},
 							},
 						},
 					},
@@ -828,7 +838,7 @@ func TestGenerateImageMirrors(t *testing.T) {
 			expectedCategorizedMirrors: []categorizedMirrors{
 				{
 					category: operatorCategory,
-					mirrors:  map[string][]confv1.ImageMirror{"quay.io/openshift-community-operators": {"myregistry/mynamespace/openshift-community-operators"}},
+					mirrors:  map[string][]confv1.ImageMirror{"quay.io/openshift-community-operators": {"myregistry/mynamespace/openshift-community-operators"}, "registry.redhat.io": {"myregistry/mynamespace"}},
 				},
 				{
 					category: releaseCategory,
@@ -847,7 +857,9 @@ func TestGenerateImageMirrors(t *testing.T) {
 					category: operatorCategory,
 					mirrors: map[string][]confv1.ImageMirror{
 						"quay.io/openshift-community-operators/cockroachdb": {
-							"myregistry/mynamespace/openshift-community-operators/cockroachdb"}},
+							"myregistry/mynamespace/openshift-community-operators/cockroachdb"},
+						"registry.redhat.io/ubi8-minimal": {
+							"myregistry/mynamespace/ubi8-minimal"}},
 				},
 				{
 					category: releaseCategory,

--- a/v2/internal/pkg/mirror/mirror_test.go
+++ b/v2/internal/pkg/mirror/mirror_test.go
@@ -150,14 +150,14 @@ func TestMirrorCheck(t *testing.T) {
 	}
 
 	t.Run("Testing Mirror : check should pass", func(t *testing.T) {
-		_, err := m.Check(context.Background(), dest, &opts)
+		_, err := m.Check(context.Background(), dest, &opts, false)
 		if err != nil {
 			t.Fatal("should pass")
 		}
 	})
 
 	t.Run("Testing Mirror : check should pass", func(t *testing.T) {
-		_, err := m.Check(context.Background(), "broken", &opts)
+		_, err := m.Check(context.Background(), "broken", &opts, false)
 		assert.Equal(t, "invalid source name broken: Invalid image name \"broken\", expected colon-separated transport:reference", err.Error())
 	})
 }

--- a/v2/internal/pkg/operator/local_stored_collector_test.go
+++ b/v2/internal/pkg/operator/local_stored_collector_test.go
@@ -587,7 +587,7 @@ func (o MockMirror) Run(ctx context.Context, src, dest string, mode mirror.Mode,
 	return nil
 }
 
-func (o MockMirror) Check(ctx context.Context, image string, opts *mirror.CopyOptions) (bool, error) {
+func (o MockMirror) Check(ctx context.Context, image string, opts *mirror.CopyOptions, asCopySrc bool) (bool, error) {
 	return true, nil
 }
 

--- a/v2/internal/pkg/release/local_stored_collector_test.go
+++ b/v2/internal/pkg/release/local_stored_collector_test.go
@@ -353,7 +353,7 @@ func (o MockMirror) Run(ctx context.Context, src, dest string, mode mirror.Mode,
 	return nil
 }
 
-func (o MockMirror) Check(ctx context.Context, image string, opts *mirror.CopyOptions) (bool, error) {
+func (o MockMirror) Check(ctx context.Context, image string, opts *mirror.CopyOptions, asCopySrc bool) (bool, error) {
 	return true, nil
 }
 

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/const.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/const.go
@@ -22,5 +22,6 @@ const (
 	mappingFile             string = "mapping.txt"
 	missingImgsFile         string = "missing.txt"
 	infoDir                 string = "info"
+	clusterResourcesDir     string = "cluster-resources"
 	modeFile                string = "mode.txt"
 )

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/dryrun.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/dryrun.go
@@ -35,7 +35,7 @@ func (o *ExecutorSchema) DryRun(ctx context.Context, allImages []v2alpha1.CopyIm
 	for _, img := range allImages {
 		buff.WriteString(img.Source + "=" + img.Destination + "\n")
 		if o.Opts.IsMirrorToDisk() {
-			exists, err := o.Mirror.Check(ctx, img.Destination, o.Opts)
+			exists, err := o.Mirror.Check(ctx, img.Destination, o.Opts, false)
 			if err != nil {
 				o.Log.Debug("unable to check existence of %s in local cache: %v", img.Destination, err)
 			}

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
@@ -668,6 +668,20 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 		o.Log.Error(" setupWorkingDir for info %v ", err)
 		return err
 	}
+
+	// create cluster-resources directory and clean it
+	o.Log.Trace("creating cluster-resources directory %s ", o.Opts.Global.WorkingDir+"/"+clusterResourcesDir)
+	err = os.RemoveAll(o.Opts.Global.WorkingDir + "/" + clusterResourcesDir)
+	if err != nil {
+		o.Log.Error(" setupWorkingDir for cluster resources: failed to clear folder %s: %v ", o.Opts.Global.WorkingDir+"/"+clusterResourcesDir, err)
+		return err
+	}
+	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+clusterResourcesDir, 0755)
+	if err != nil {
+		o.Log.Error(" setupWorkingDir for cluster resources %v ", err)
+		return err
+	}
+
 	return nil
 }
 

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/clusterresources/clusterresources.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/clusterresources/clusterresources.go
@@ -511,7 +511,12 @@ func (o *ClusterResourcesGenerator) UpdateServiceGenerator(graphImageRef, releas
 func namespaceScope(imgSpec image.ImageSpec) string {
 	pathComponents := strings.Split(imgSpec.PathComponent, "/")
 	ns := strings.Join(pathComponents[:len(pathComponents)-1], "/")
-	return imgSpec.Domain + "/" + ns
+	if ns != "" {
+		return imgSpec.Domain + "/" + ns
+	} else {
+		return imgSpec.Domain
+	}
+
 }
 
 func repositoryScope(imgSpec image.ImageSpec) string {


### PR DESCRIPTION
# Description

 Fix source repository for IDMS/ITMS in case of empty namespace

This also clears the cluster-resources folder while setting up the working-dir, so that old itms , catalogsrouce files don't stay stale in the folder, and get dragged into the tar file.

It also fixes dry-run for mirror-to-disk mode which was checking and not finding any of the images in the cache due to the fact that it was using a srcImage context (tls enabled) instead of the destImage context (tls disabled for the cache registry)

Fixes # OCPBUGS-31608

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Using the following imageSetConfig, perform a mirror to disk followed by disk to mirror as stated in the jira issue: 
```yaml
apiVersion: mirror.openshift.io/v2alpha1
kind: ImageSetConfiguration
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15
      packages:
        - name: devworkspace-operator
          minVersion: "0.23.0"
        - name: quay-operator
          maxVersion: "3.10.2"
        - name: cluster-logging
          minVersion: 5.8.3
          maxVersion: 5.8.5
```

## Expected Outcome
the working-dir/cluster-resources folder should contain 2 files only
* cs-redhat-operator-index-v4-15.yaml  
* idms-oc-mirror.yaml

The idms-oc-mirror.yaml file should contain the following imageDigestMirrors:
```yaml
  imageDigestMirrors:
  - mirrors:
    - localhost:5000/31608/devworkspace
    source: registry.redhat.io/devworkspace
  - mirrors:
    - localhost:5000/31608/openshift4
    source: registry.redhat.io/openshift4
  - mirrors:
    - localhost:5000/31608
    source: registry.redhat.io

```

The last `source` should be `registry.redhat.io`, and not `registry.redhat.io**/**`
