### PR TITLE
OCPBUGS-31622: Fix operator related image has empty reference

### DIFF
--- a/v2/internal/pkg/operator/local_stored_collector.go
+++ b/v2/internal/pkg/operator/local_stored_collector.go
@@ -300,7 +300,9 @@ func (o LocalStorageCollector) prepareD2MCopyBatch(log clog.PluggableLoggerInter
 		for _, img := range relatedImgs {
 			var src string
 			var dest string
-
+			if img.Image == "" { // OCPBUGS-31622 skipping empty related images
+				continue
+			}
 			imgSpec, err := image.ParseRef(img.Image)
 			if err != nil {
 				o.Log.Error("%s", err.Error())
@@ -350,6 +352,9 @@ func (o LocalStorageCollector) prepareM2DCopyBatch(log clog.PluggableLoggerInter
 		for _, img := range relatedImgs {
 			var src string
 			var dest string
+			if img.Image == "" { // OCPBUGS-31622 skipping empty related images
+				continue
+			}
 			imgSpec, err := image.ParseRef(img.Image)
 			if err != nil {
 				return nil, err

--- a/v2/internal/pkg/operator/local_stored_collector_test.go
+++ b/v2/internal/pkg/operator/local_stored_collector_test.go
@@ -662,6 +662,7 @@ func (o MockManifest) GetRelatedImagesFromCatalog(operatorCatalog manifest.Opera
 	relatedImages["abc"] = []v2alpha1.RelatedImage{
 		{Name: "testA", Image: "sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"},
 		{Name: "testB", Image: "sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"},
+		{Name: "", Image: ""}, // OCPBUGS-31622
 	}
 	return relatedImages, nil
 }

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/operator/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/operator/local_stored_collector.go
@@ -300,7 +300,9 @@ func (o LocalStorageCollector) prepareD2MCopyBatch(log clog.PluggableLoggerInter
 		for _, img := range relatedImgs {
 			var src string
 			var dest string
-
+			if img.Image == "" { // OCPBUGS-31622 skipping empty related images
+				continue
+			}
 			imgSpec, err := image.ParseRef(img.Image)
 			if err != nil {
 				o.Log.Error("%s", err.Error())
@@ -350,6 +352,9 @@ func (o LocalStorageCollector) prepareM2DCopyBatch(log clog.PluggableLoggerInter
 		for _, img := range relatedImgs {
 			var src string
 			var dest string
+			if img.Image == "" { // OCPBUGS-31622 skipping empty related images
+				continue
+			}
 			imgSpec, err := image.ParseRef(img.Image)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
# Description

Fixes # OCPBUGS-31622
This was specific to seldon-operator (community catalog)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Additional unit test covering the use case.
Successfully performed M2D + D2M with the following imagesetconfig
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
    - catalog: oci:///home/skhoury/redhat-index-all
      packages:
        - name: aws-load-balancer-operator
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15
      packages:
       - name: elasticsearch-operator
    - catalog: registry.redhat.io/redhat/redhat-marketplace-index:v4.15
      packages:
      - name: datadog-operator-certified-rhmp
    - catalog: registry.redhat.io/redhat/certified-operator-index:v4.15
      packages:
      - name: portworx-certified
    - catalog: registry.redhat.io/redhat/community-operator-index:v4.15
      packages:
      - name: seldon-operator
```

## Expected Outcome
Both M2D and D2M successfully complete