### PR TITLE
OCPBUGS-31536:OCPBUGS-33554: Fix mirroring operators on fedora systems - no sig verification

### DIFF
--- a/pkg/cli/mirror/fbc_operators.go
+++ b/pkg/cli/mirror/fbc_operators.go
@@ -519,12 +519,11 @@ func (o *MirrorOptions) copyImage(ctx context.Context, from, to string, funcs Re
 	// call the copy.Image function with the set options
 	manifestBytes, err := funcs.copy(ctx, policyContext, destRef, srcRef, &imagecopy.Options{
 		RemoveSignatures:      true,
-		SignBy:                "",
 		ReportWriter:          os.Stdout,
 		SourceCtx:             sourceCtx,
 		DestinationCtx:        destinationCtx,
 		ForceManifestMIMEType: "",
-		ImageListSelection:    imagecopy.CopySystemImage,
+		ImageListSelection:    imagecopy.CopyAllImages,
 		OciDecryptConfig:      nil,
 		OciEncryptLayers:      nil,
 		OciEncryptConfig:      nil,

--- a/pkg/cli/mirror/fbc_operators.go
+++ b/pkg/cli/mirror/fbc_operators.go
@@ -493,13 +493,13 @@ func (o *MirrorOptions) copyImage(ctx context.Context, from, to string, funcs Re
 	// Pull the source image, and store it in the local storage, under the name main
 	var sigPolicy *signature.Policy
 	var err error
-	if o.OCIInsecureSignaturePolicy {
-		sigPolicy = &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
-	} else {
+	if o.EnableOperatorSignatureVerification && !o.OCIInsecureSignaturePolicy {
 		sigPolicy, err = signature.DefaultPolicy(nil)
 		if err != nil {
 			return digest.Digest(""), err
 		}
+	} else {
+		sigPolicy = &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
 	}
 	policyContext, err := signature.NewPolicyContext(sigPolicy)
 	if err != nil {

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -14,32 +14,33 @@ import (
 
 type MirrorOptions struct {
 	*cli.RootOptions
-	OutputDir                  string // directory path, whose value is dependent on how oc mirror was invoked
-	ConfigPath                 string // Path to imageset configuration file
-	SkipImagePin               bool   // Do not replace image tags with digest pins in operator catalogs
-	ManifestsOnly              bool   // Generate manifests and do not mirror
-	From                       string // Path to an input file (e.g. archived imageset)
-	ToMirror                   string // Final destination for the mirror operation
-	UserNamespace              string // The <namespace>/<image> portion of a docker reference only
-	DryRun                     bool   // Print actions without mirroring images
-	SourceSkipTLS              bool   // Disable TLS validation for source registry
-	DestSkipTLS                bool   // Disable TLS validation for destination registry
-	V2                         bool   // Redirect the flow to oc-mirror v2 - PLEASE DO NOT USE that. V2 is still under development and it is not ready to be used.
-	V1                         bool   // Redirect the flow to oc-mirror v1 - This flag is going to redirect the flow to v1 (legacy code) when v2 becomes the default (still under development).
-	SourcePlainHTTP            bool   // Use plain HTTP for source registry
-	DestPlainHTTP              bool   // Use plain HTTP for destination registry
-	SkipVerification           bool   // Skip verifying the integrity of the retrieved content.
-	SkipCleanup                bool   // Skip removal of artifact directories
-	SkipMissing                bool   // If an input image is not found, skip them.
-	SkipMetadataCheck          bool   // Skip metadata when publishing an imageset
-	SkipPruning                bool   // If set, will disable pruning globally
-	ContinueOnError            bool   // If an error occurs, keep going and attempt to complete operations if possible
-	IgnoreHistory              bool   // Ignore past mirrors when downloading images and packing layers
-	MaxPerRegistry             int    // Number of concurrent requests allowed per registry
-	OCIRegistriesConfig        string // Registries config file location (it works only with local oci catalogs)
-	OCIInsecureSignaturePolicy bool   // If set, OCI catalog push will not try to push signatures
-	MaxNestedPaths             int
-	RebuildCatalogs            bool // If set, rebuilds catalogs based on filtered declarative config, and regenerates the cache of that catalog
+	OutputDir                           string // directory path, whose value is dependent on how oc mirror was invoked
+	ConfigPath                          string // Path to imageset configuration file
+	SkipImagePin                        bool   // Do not replace image tags with digest pins in operator catalogs
+	ManifestsOnly                       bool   // Generate manifests and do not mirror
+	From                                string // Path to an input file (e.g. archived imageset)
+	ToMirror                            string // Final destination for the mirror operation
+	UserNamespace                       string // The <namespace>/<image> portion of a docker reference only
+	DryRun                              bool   // Print actions without mirroring images
+	SourceSkipTLS                       bool   // Disable TLS validation for source registry
+	DestSkipTLS                         bool   // Disable TLS validation for destination registry
+	V2                                  bool   // Redirect the flow to oc-mirror v2 - PLEASE DO NOT USE that. V2 is still under development and it is not ready to be used.
+	V1                                  bool   // Redirect the flow to oc-mirror v1 - This flag is going to redirect the flow to v1 (legacy code) when v2 becomes the default (still under development).
+	SourcePlainHTTP                     bool   // Use plain HTTP for source registry
+	DestPlainHTTP                       bool   // Use plain HTTP for destination registry
+	SkipVerification                    bool   // Skip verifying the integrity of the retrieved content.
+	SkipCleanup                         bool   // Skip removal of artifact directories
+	SkipMissing                         bool   // If an input image is not found, skip them.
+	SkipMetadataCheck                   bool   // Skip metadata when publishing an imageset
+	SkipPruning                         bool   // If set, will disable pruning globally
+	ContinueOnError                     bool   // If an error occurs, keep going and attempt to complete operations if possible
+	IgnoreHistory                       bool   // Ignore past mirrors when downloading images and packing layers
+	MaxPerRegistry                      int    // Number of concurrent requests allowed per registry
+	OCIRegistriesConfig                 string // Registries config file location (it works only with local oci catalogs)
+	OCIInsecureSignaturePolicy          bool   // If set, OCI catalog push will not try to push signatures
+	EnableOperatorSignatureVerification bool   // If set, verifies operator catalog signatures prior to mirroring
+	MaxNestedPaths                      int
+	RebuildCatalogs                     bool // If set, rebuilds catalogs based on filtered declarative config, and regenerates the cache of that catalog
 	// cancelCh is a channel listening for command cancellations
 	cancelCh                          <-chan struct{}
 	once                              sync.Once
@@ -75,9 +76,11 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&o.MaxPerRegistry, "max-per-registry", 6, "Number of concurrent requests allowed per registry")
 	fs.StringVar(&o.OCIRegistriesConfig, "oci-registries-config", o.OCIRegistriesConfig, "Registries config file location (it works only with local oci catalogs)")
 	fs.BoolVar(&o.OCIInsecureSignaturePolicy, "oci-insecure-signature-policy", o.OCIInsecureSignaturePolicy, "If set, OCI catalog push will not try to push signatures")
+	fs.BoolVar(&o.EnableOperatorSignatureVerification, "enable-operator-secure-policy", o.EnableOperatorSignatureVerification, "If set, verifies operator catalog signatures prior to mirroring")
 	fs.BoolVar(&o.SkipPruning, "skip-pruning", o.SkipPruning, "If set, will disable pruning globally")
 	fs.IntVar(&o.MaxNestedPaths, "max-nested-paths", 0, "Number of nested paths, for destination registries that limit nested paths")
 	fs.BoolVar(&o.RebuildCatalogs, "rebuild-catalogs", o.RebuildCatalogs, "If set (defaults to false), rebuilds catalogs based on filtered declarative config, and regenerates the cache of that catalog")
+	fs.MarkDeprecated("oci-insecure-signature-policy", "and will be removed in a future release. Use enable-operator-secure-policy instead.")
 }
 
 func (o *MirrorOptions) init() {


### PR DESCRIPTION
# Description
2 issues are fixed here:
* catalog images are mirrored as manifest lists
* catalog images are mirrored without signature verification by default
* to enable signature verification, one can use the new flag `--enable-operator-secure-policy`
* existing flag `oci-insecure-signature-policy` marked deprecated

Fixes # OCPBUGS-31536

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
```
$ ./bin/oc-mirror -c isc_31536.yaml file:///home/skhoury/31536 --enable-operator-secure-policy
```

## Expected Outcome
Above test is no proof of fix: this needs to be tested on a fedora system
* with no /etc/containers/policy.json 
* AND without using the flag
 to show that the mirroring is successful on systems that don't have the policy setup for checking image signatures from redhat.