### PR TITLE
OCPBUGS-33196: skip images with both tag and digest

### DIFF
--- a/v2/internal/pkg/additional/local_stored_collector.go
+++ b/v2/internal/pkg/additional/local_stored_collector.go
@@ -61,8 +61,14 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 
 			o.Log.Debug(collectorPrefix+"source %s", src)
 			o.Log.Debug(collectorPrefix+"destination %s", dest)
-			allImages = append(allImages, v2alpha1.CopyImageSchema{Source: src, Destination: dest, Origin: src, Type: v2alpha1.TypeGeneric})
 
+			// OCPBUGS-33196 - check source image for tag and digest
+			// skip mirroring
+			if imgSpec.IsImageByTagAndDigest() {
+				o.Log.Warn(collectorPrefix + "%s has both tag and digest : SKIPPING", imgSpec.Reference)
+			} else {
+				allImages = append(allImages, v2alpha1.CopyImageSchema{Source: src, Destination: dest, Origin: src, Type: v2alpha1.TypeGeneric})
+			}
 		}
 	}
 

--- a/v2/internal/pkg/image/image.go
+++ b/v2/internal/pkg/image/image.go
@@ -50,6 +50,7 @@ const (
 // Otherwise, it will return an error.
 func ParseRef(imgRef string) (ImageSpec, error) {
 	var imgSpec ImageSpec
+
 	if strings.Contains(imgRef, "://") {
 		imgSpec.ReferenceWithTransport = imgRef
 		imgSplit := strings.Split(imgRef, "://")
@@ -111,6 +112,14 @@ func (i ImageSpec) IsImageByDigest() bool {
 
 func (i ImageSpec) IsImageByDigestOnly() bool {
 	return i.Tag == "" && i.Digest != ""
+}
+
+// OCPBUGS-33196
+// check to see if we have both tag and digest
+// this is really bad practice on the part of the image creator
+// we need to handle this edge case
+func (i ImageSpec) IsImageByTagAndDigest() bool {
+	return len(strings.Split(i.Reference, ":")) > 2 && strings.Contains(i.Reference, "@")
 }
 
 func WithMaxNestedPaths(imageRef string, maxNestedPaths int) (string, error) {

--- a/v2/internal/pkg/mirror/mirror.go
+++ b/v2/internal/pkg/mirror/mirror.go
@@ -3,6 +3,7 @@ package mirror
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -170,7 +171,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 		SignBySigstorePrivateKeyFile:     opts.SignBySigstorePrivateKey,
 		SignSigstorePrivateKeyPassphrase: []byte(passphrase),
 		SignIdentity:                     signIdentity,
-		ReportWriter:                     opts.Stdout,
+		ReportWriter:                     io.Discard,
 		SourceCtx:                        sourceCtx,
 		DestinationCtx:                   destinationCtx,
 		ForceManifestMIMEType:            manifestType,

--- a/v2/internal/pkg/operator/local_stored_collector.go
+++ b/v2/internal/pkg/operator/local_stored_collector.go
@@ -373,7 +373,14 @@ func (o LocalStorageCollector) prepareM2DCopyBatch(log clog.PluggableLoggerInter
 
 			o.Log.Debug("source %s", src)
 			o.Log.Debug("destination %s", dest)
-			result = append(result, v2alpha1.CopyImageSchema{Source: src, Destination: dest, Origin: src, Type: img.Type})
+
+			// OCPBUGS-33196 - check source image for tag and digest
+			// skip mirroring
+			if imgSpec.IsImageByTagAndDigest() {
+				o.Log.Warn(collectorPrefix+"%s has both tag and digest : SKIPPING", imgSpec.Reference)
+			} else {
+				result = append(result, v2alpha1.CopyImageSchema{Source: src, Destination: dest, Origin: src, Type: img.Type})
+			}
 
 		}
 	}

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/additional/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/additional/local_stored_collector.go
@@ -61,8 +61,14 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 
 			o.Log.Debug(collectorPrefix+"source %s", src)
 			o.Log.Debug(collectorPrefix+"destination %s", dest)
-			allImages = append(allImages, v2alpha1.CopyImageSchema{Source: src, Destination: dest, Origin: src, Type: v2alpha1.TypeGeneric})
 
+			// OCPBUGS-33196 - check source image for tag and digest
+			// skip mirroring
+			if imgSpec.IsImageByTagAndDigest() {
+				o.Log.Warn(collectorPrefix + "%s has both tag and digest : SKIPPING", imgSpec.Reference)
+			} else {
+				allImages = append(allImages, v2alpha1.CopyImageSchema{Source: src, Destination: dest, Origin: src, Type: v2alpha1.TypeGeneric})
+			}
 		}
 	}
 

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/image/image.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/image/image.go
@@ -50,6 +50,7 @@ const (
 // Otherwise, it will return an error.
 func ParseRef(imgRef string) (ImageSpec, error) {
 	var imgSpec ImageSpec
+
 	if strings.Contains(imgRef, "://") {
 		imgSpec.ReferenceWithTransport = imgRef
 		imgSplit := strings.Split(imgRef, "://")
@@ -111,6 +112,14 @@ func (i ImageSpec) IsImageByDigest() bool {
 
 func (i ImageSpec) IsImageByDigestOnly() bool {
 	return i.Tag == "" && i.Digest != ""
+}
+
+// OCPBUGS-33196
+// check to see if we have both tag and digest
+// this is really bad practice on the part of the image creator
+// we need to handle this edge case
+func (i ImageSpec) IsImageByTagAndDigest() bool {
+	return len(strings.Split(i.Reference, ":")) > 2 && strings.Contains(i.Reference, "@")
 }
 
 func WithMaxNestedPaths(imageRef string, maxNestedPaths int) (string, error) {

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/mirror/mirror.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/mirror/mirror.go
@@ -3,6 +3,7 @@ package mirror
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -170,7 +171,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 		SignBySigstorePrivateKeyFile:     opts.SignBySigstorePrivateKey,
 		SignSigstorePrivateKeyPassphrase: []byte(passphrase),
 		SignIdentity:                     signIdentity,
-		ReportWriter:                     opts.Stdout,
+		ReportWriter:                     io.Discard,
 		SourceCtx:                        sourceCtx,
 		DestinationCtx:                   destinationCtx,
 		ForceManifestMIMEType:            manifestType,

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/operator/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/operator/local_stored_collector.go
@@ -373,7 +373,14 @@ func (o LocalStorageCollector) prepareM2DCopyBatch(log clog.PluggableLoggerInter
 
 			o.Log.Debug("source %s", src)
 			o.Log.Debug("destination %s", dest)
-			result = append(result, v2alpha1.CopyImageSchema{Source: src, Destination: dest, Origin: src, Type: img.Type})
+
+			// OCPBUGS-33196 - check source image for tag and digest
+			// skip mirroring
+			if imgSpec.IsImageByTagAndDigest() {
+				o.Log.Warn(collectorPrefix+"%s has both tag and digest : SKIPPING", imgSpec.Reference)
+			} else {
+				result = append(result, v2alpha1.CopyImageSchema{Source: src, Destination: dest, Origin: src, Type: img.Type})
+			}
 
 		}
 	}


### PR DESCRIPTION
# Description

This addresses the issue when images being mirrored, having both tag and digest would cause the mirror execution to fail, the fix ensures these type images will be skipped with an appropriate warning message.

Fixes #  OCPBUGS-33196

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I used the following imagesetconfig for testing

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
   additionalImages:
   - name: quay.io/cilium/cilium-etcd-operator:v2.0.7@sha256:04b8327f7f992693c2cb483b999041ed8f92efc8e14f2a5f3ab95574a65ea2dc
   - name: quay.io/coreos/etcd:v3.5.4@sha256:a67fb152d4c53223e96e818420c37f11d05c2d92cf62c05ca5604066c37295e9

```

Executed the following mirror to disk workflow

```
bin/oc-mirror --config ocpbugs-33196.yaml file://taganddigest --v2
```

## Expected Outcome

```
2024/05/14 14:18:35  [WARN]   : ⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.
2024/05/14 14:18:35  [INFO]   : 👋 Hello, welcome to oc-mirror
2024/05/14 14:18:35  [INFO]   : ⚙️  setting up the environment for you...
2024/05/14 14:18:35  [INFO]   : 🔀 workflow mode: mirrorToDisk 
2024/05/14 14:18:35  [INFO]   : 🕵️  going to discover the necessary images...
2024/05/14 14:18:35  [INFO]   : 🔍 collecting release images...
2024/05/14 14:18:35  [INFO]   : 🔍 collecting operator images...
2024/05/14 14:18:35  [INFO]   : 🔍 collecting additional images...
2024/05/14 14:18:35  [WARN]   : [AdditionalImagesCollector] mirroring skipped : source image quay.io/cilium/cilium-etcd-operator:v2.0.7@sha256:04b8327f7f992693c2cb483b999041ed8f92efc8e14f2a5f3ab95574a65ea2dc has both tag and digest
2024/05/14 14:18:35  [WARN]   : [AdditionalImagesCollector] mirroring skipped : source image quay.io/coreos/etcd:v3.5.4@sha256:a67fb152d4c53223e96e818420c37f11d05c2d92cf62c05ca5604066c37295e9 has both tag and digest
2024/05/14 14:18:35  [INFO]   : 🚀 Start copying the images...
2024/05/14 14:18:35  [INFO]   : === Results ===
2024/05/14 14:18:35  [INFO]   : All release images mirrored successfully 0 / 0 ✅
2024/05/14 14:18:35  [INFO]   : All operator images mirrored successfully 0 / 0 ✅
2024/05/14 14:18:35  [INFO]   : All additional images mirrored successfully 0 / 0 ✅
2024/05/14 14:18:35  [INFO]   : 📦 Preparing the tarball archive...
2024/05/14 14:18:35  [INFO]   : mirror time     : 1.770588ms
2024/05/14 14:18:35  [INFO]   : 👋 Goodbye, thank you for using oc-mirror

```
