### PR TITLE
OCPBUGS-33081: Skip images that don't follow standards, semver and na…

### DIFF
--- a/v2/internal/pkg/additional/local_stored_collector.go
+++ b/v2/internal/pkg/additional/local_stored_collector.go
@@ -46,9 +46,11 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 		for _, img := range o.Config.ImageSetConfigurationSpec.Mirror.AdditionalImages {
 			imgSpec, err := image.ParseRef(img.Name)
 			if err != nil {
-				o.Log.Error(errMsg, err.Error())
-				return nil, err
+				// OCPBUGS-33081 - skip if parse error (i.e semver and other)
+				o.Log.Warn("%v : SKIPPING", err)
+				continue
 			}
+
 			var src string
 			var dest string
 			src = imgSpec.ReferenceWithTransport

--- a/v2/internal/pkg/additional/local_stored_collector_test.go
+++ b/v2/internal/pkg/additional/local_stored_collector_test.go
@@ -89,10 +89,10 @@ func TestAdditionalImageCollector(t *testing.T) {
 	opts.Mode = mirror.MirrorToDisk
 	ex = New(log, cfg, opts, mockmirror, manifest, localstorageFQDN)
 
-	t.Run("Testing AdditionalImagesCollector : mirrorToDisk should fail", func(t *testing.T) {
+	t.Run("Testing AdditionalImagesCollector : mirrorToDisk should not fail (skipped)", func(t *testing.T) {
 		_, err := ex.AdditionalImagesCollector(ctx)
-		if err == nil {
-			t.Fatalf("should fail")
+		if err != nil {
+			t.Fatalf("should not fail")
 		}
 	})
 

--- a/v2/internal/pkg/image/image.go
+++ b/v2/internal/pkg/image/image.go
@@ -43,13 +43,14 @@ type ImageSpec struct {
 
 const (
 	dockerProtocol  = "docker://"
-	errMessageImage = "unable to parse image %s correctly"
+	errMessageImage = "%s unable to parse image correctly"
 )
 
 // It expects the image reference not to have the transport prefix.
 // Otherwise, it will return an error.
 func ParseRef(imgRef string) (ImageSpec, error) {
 	var imgSpec ImageSpec
+
 	if strings.Contains(imgRef, "://") {
 		imgSpec.ReferenceWithTransport = imgRef
 		imgSplit := strings.Split(imgRef, "://")
@@ -69,7 +70,7 @@ func ParseRef(imgRef string) (ImageSpec, error) {
 		if len(imgSplit) > 1 {
 			validDigest, err := digest.Parse(imgSplit[1])
 			if err != nil {
-				return ImageSpec{}, fmt.Errorf("unable to parse image %s correctly, invalid digest: %v", imgRef, err)
+				return ImageSpec{}, fmt.Errorf("%s unable to parse image correctly : invalid digest", imgRef)
 			}
 			imgSpec.Digest = validDigest.Encoded()
 			imgSpec.Algorithm = validDigest.Algorithm().String()
@@ -82,10 +83,10 @@ func ParseRef(imgRef string) (ImageSpec, error) {
 	}
 
 	if imgSpec.Name == "" {
-		return ImageSpec{}, fmt.Errorf(errMessageImage, imgRef)
+		return ImageSpec{}, fmt.Errorf("unknown image : reference name is empty")
 	}
 	if imgSpec.Transport == dockerProtocol && imgSpec.Tag == "" && imgSpec.Digest == "" {
-		return ImageSpec{}, fmt.Errorf(errMessageImage, imgRef)
+		return ImageSpec{}, fmt.Errorf(errMessageImage+" : tag and digest are empty", imgRef)
 	}
 
 	if imgSpec.Transport == dockerProtocol {

--- a/v2/internal/pkg/image/image_test.go
+++ b/v2/internal/pkg/image/image_test.go
@@ -201,7 +201,7 @@ func TestImage_TestParseRef(t *testing.T) {
 			caseName:        "invalid docker reference fails",
 			imgRef:          "whatever",
 			expectedImgSpec: ImageSpec{},
-			expectedError:   "unable to parse image whatever correctly",
+			expectedError:   "whatever unable to parse image correctly : tag and digest are empty",
 		},
 	}
 
@@ -279,7 +279,7 @@ func TestImage_TestWithMaxNestedPaths(t *testing.T) {
 			imgRef:         "whatever",
 			maxNestedPaths: 2,
 			expectedOutRef: "",
-			expectedError:  "unable to parse image whatever correctly",
+			expectedError:  "whatever unable to parse image correctly : tag and digest are empty",
 		},
 	}
 	for _, aTestCase := range testCases {

--- a/v2/internal/pkg/mirror/mirror.go
+++ b/v2/internal/pkg/mirror/mirror.go
@@ -3,6 +3,7 @@ package mirror
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -170,7 +171,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 		SignBySigstorePrivateKeyFile:     opts.SignBySigstorePrivateKey,
 		SignSigstorePrivateKeyPassphrase: []byte(passphrase),
 		SignIdentity:                     signIdentity,
-		ReportWriter:                     opts.Stdout,
+		ReportWriter:                     io.Discard,
 		SourceCtx:                        sourceCtx,
 		DestinationCtx:                   destinationCtx,
 		ForceManifestMIMEType:            manifestType,

--- a/v2/internal/pkg/operator/local_stored_collector.go
+++ b/v2/internal/pkg/operator/local_stored_collector.go
@@ -303,8 +303,9 @@ func (o LocalStorageCollector) prepareD2MCopyBatch(log clog.PluggableLoggerInter
 
 			imgSpec, err := image.ParseRef(img.Image)
 			if err != nil {
-				o.Log.Error("%s", err.Error())
-				return nil, err
+				// OCPBUGS-33081 - skip if parse error (i.e semver and other)
+				o.Log.Warn("mirroring skipped : %v", err)
+				continue
 			}
 
 			// prepare the src and dest references
@@ -352,7 +353,9 @@ func (o LocalStorageCollector) prepareM2DCopyBatch(log clog.PluggableLoggerInter
 			var dest string
 			imgSpec, err := image.ParseRef(img.Image)
 			if err != nil {
-				return nil, err
+				// OCPBUGS-33081 - skip if parse error (i.e semver and other)
+				o.Log.Warn("%v : SKIPPING", err)
+				continue
 			}
 
 			src = imgSpec.ReferenceWithTransport

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/additional/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/additional/local_stored_collector.go
@@ -46,9 +46,11 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 		for _, img := range o.Config.ImageSetConfigurationSpec.Mirror.AdditionalImages {
 			imgSpec, err := image.ParseRef(img.Name)
 			if err != nil {
-				o.Log.Error(errMsg, err.Error())
-				return nil, err
+				// OCPBUGS-33081 - skip if parse error (i.e semver and other)
+				o.Log.Warn("%v : SKIPPING", err)
+				continue
 			}
+
 			var src string
 			var dest string
 			src = imgSpec.ReferenceWithTransport

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/image/image.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/image/image.go
@@ -43,13 +43,14 @@ type ImageSpec struct {
 
 const (
 	dockerProtocol  = "docker://"
-	errMessageImage = "unable to parse image %s correctly"
+	errMessageImage = "%s unable to parse image correctly"
 )
 
 // It expects the image reference not to have the transport prefix.
 // Otherwise, it will return an error.
 func ParseRef(imgRef string) (ImageSpec, error) {
 	var imgSpec ImageSpec
+
 	if strings.Contains(imgRef, "://") {
 		imgSpec.ReferenceWithTransport = imgRef
 		imgSplit := strings.Split(imgRef, "://")
@@ -69,7 +70,7 @@ func ParseRef(imgRef string) (ImageSpec, error) {
 		if len(imgSplit) > 1 {
 			validDigest, err := digest.Parse(imgSplit[1])
 			if err != nil {
-				return ImageSpec{}, fmt.Errorf("unable to parse image %s correctly, invalid digest: %v", imgRef, err)
+				return ImageSpec{}, fmt.Errorf("%s unable to parse image correctly : invalid digest", imgRef)
 			}
 			imgSpec.Digest = validDigest.Encoded()
 			imgSpec.Algorithm = validDigest.Algorithm().String()
@@ -82,10 +83,10 @@ func ParseRef(imgRef string) (ImageSpec, error) {
 	}
 
 	if imgSpec.Name == "" {
-		return ImageSpec{}, fmt.Errorf(errMessageImage, imgRef)
+		return ImageSpec{}, fmt.Errorf("unknown image : reference name is empty")
 	}
 	if imgSpec.Transport == dockerProtocol && imgSpec.Tag == "" && imgSpec.Digest == "" {
-		return ImageSpec{}, fmt.Errorf(errMessageImage, imgRef)
+		return ImageSpec{}, fmt.Errorf(errMessageImage+" : tag and digest are empty", imgRef)
 	}
 
 	if imgSpec.Transport == dockerProtocol {

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/mirror/mirror.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/mirror/mirror.go
@@ -3,6 +3,7 @@ package mirror
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -170,7 +171,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 		SignBySigstorePrivateKeyFile:     opts.SignBySigstorePrivateKey,
 		SignSigstorePrivateKeyPassphrase: []byte(passphrase),
 		SignIdentity:                     signIdentity,
-		ReportWriter:                     opts.Stdout,
+		ReportWriter:                     io.Discard,
 		SourceCtx:                        sourceCtx,
 		DestinationCtx:                   destinationCtx,
 		ForceManifestMIMEType:            manifestType,

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/operator/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/operator/local_stored_collector.go
@@ -303,8 +303,9 @@ func (o LocalStorageCollector) prepareD2MCopyBatch(log clog.PluggableLoggerInter
 
 			imgSpec, err := image.ParseRef(img.Image)
 			if err != nil {
-				o.Log.Error("%s", err.Error())
-				return nil, err
+				// OCPBUGS-33081 - skip if parse error (i.e semver and other)
+				o.Log.Warn("mirroring skipped : %v", err)
+				continue
 			}
 
 			// prepare the src and dest references
@@ -352,7 +353,9 @@ func (o LocalStorageCollector) prepareM2DCopyBatch(log clog.PluggableLoggerInter
 			var dest string
 			imgSpec, err := image.ParseRef(img.Image)
 			if err != nil {
-				return nil, err
+				// OCPBUGS-33081 - skip if parse error (i.e semver and other)
+				o.Log.Warn("%v : SKIPPING", err)
+				continue
 			}
 
 			src = imgSpec.ReferenceWithTransport


### PR DESCRIPTION
…ming

# Description

This fix addresses the issues when image names are missing as well as incorrect semver usage. The images will be skipped and not mirrored, the console will output a warning with relevant image (in semver case only).

Fixes # OCPBUGS-33081

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I used the following imagesetconfiguration 

```
apiVersion: mirror.openshift.io/v2alpha1
kind: ImageSetConfiguration
archiveSize: 4
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15
      packages:
      - name: aws-load-balancer-operator
  - catalog: registry.redhat.io/redhat/community-operator-index:v4.15
    full: false

```

Executed with the following command

```
bin/oc-mirror --config ocpbugs-33081.yaml --v2 docker://localhost:5000/m2m  --workspace file://ocpbugs-33081 --dest-tls-verify=false --loglevel info
```

## Expected Outcome
As this was a fairly large mirroring (+ 880) images I had issues with mirroring the whole catalog.
I have included a  truncated console output

```
2024/05/15 16:50:25  [WARN]   : ⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.
2024/05/15 16:50:25  [INFO]   : 👋 Hello, welcome to oc-mirror
2024/05/15 16:50:25  [INFO]   : ⚙️  setting up the environment for you...
2024/05/15 16:50:25  [INFO]   : 🔀 workflow mode: mirrorToMirror 
2024/05/15 16:50:25  [INFO]   : 🕵️  going to discover the necessary images...
2024/05/15 16:50:25  [INFO]   : 🔍 collecting release images...
2024/05/15 16:50:25  [INFO]   : 🔍 collecting operator images...
2024/05/15 16:51:37  [WARN]   : mirroring skipped : reference name is empty
2024/05/15 16:51:37  [WARN]   : mirroring skipped : unable to parse image centos/postgresql-10-centos7 correctly : tag and digest are empty
2024/05/15 16:51:37  [WARN]   : mirroring skipped : unable to parse image registry.redhat.io/openshift4/ose-kube-rbac-proxy correctly : tag and digest are empty
2024/05/15 16:51:37  [WARN]   : mirroring skipped : unable to parse image quay.io/noobaa/pause correctly : tag and digest are empty
2024/05/15 16:51:37  [WARN]   : mirroring skipped : unable to parse image registry.redhat.io/openshift4/ose-kube-rbac-proxy correctly : tag and digest are empty
2024/05/15 16:51:37  [INFO]   : 🔍 collecting additional images...
2024/05/15 16:51:37  [INFO]   : 🚀 Start copying the images...
2024/05/15 16:51:37  [INFO]   : === Overall Progress - copying image 1 / 882 ===
2024/05/15 16:51:37  [INFO]   : copying release image 0 / 0
2024/05/15 16:51:37  [INFO]   : copying operator image 1 / 882
2024/05/15 16:51:37  [INFO]   : copying additional image 0 / 0
2024/05/15 16:51:37  [INFO]   : ================================================
2024/05/15 16:51:37  [INFO]   : copying image: docker://public.ecr.aws/aws-controllers-k8s/organizations-controller:0.0.6

``` 
