### PR TITLE
OCPBUGS-33580: Fix shortestPath returning 3 times the same imageSet

### DIFF
--- a/v2/internal/pkg/release/cincinnati.go
+++ b/v2/internal/pkg/release/cincinnati.go
@@ -298,18 +298,22 @@ func getCrossChannelDownloads(ctx context.Context, log clog.PluggableLoggerInter
 // gatherUpdates
 func gatherUpdates(log clog.PluggableLoggerInterface, current, newest Update, updates []Update) []v2alpha1.CopyImageSchema {
 	var allImages []v2alpha1.CopyImageSchema
+	uniqueImages := make(map[v2alpha1.CopyImageSchema]bool)
 	for _, update := range updates {
 		log.Debug("Found update %s", update.Version)
-		allImages = append(allImages, v2alpha1.CopyImageSchema{Source: update.Image, Destination: ""})
+		uniqueImages[v2alpha1.CopyImageSchema{Source: update.Image, Destination: ""}] = true
 	}
 
 	if current.Image != "" {
-		allImages = append(allImages, v2alpha1.CopyImageSchema{Source: current.Image, Destination: ""})
+		uniqueImages[v2alpha1.CopyImageSchema{Source: current.Image, Destination: ""}] = true
 	}
 
 	if newest.Image != "" {
-		allImages = append(allImages, v2alpha1.CopyImageSchema{Source: newest.Image, Destination: ""})
+		uniqueImages[v2alpha1.CopyImageSchema{Source: newest.Image, Destination: ""}] = true
 	}
 
+	for img := range uniqueImages {
+		allImages = append(allImages, img)
+	}
 	return allImages
 }

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/cincinnati.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/cincinnati.go
@@ -298,18 +298,22 @@ func getCrossChannelDownloads(ctx context.Context, log clog.PluggableLoggerInter
 // gatherUpdates
 func gatherUpdates(log clog.PluggableLoggerInterface, current, newest Update, updates []Update) []v2alpha1.CopyImageSchema {
 	var allImages []v2alpha1.CopyImageSchema
+	uniqueImages := make(map[v2alpha1.CopyImageSchema]bool)
 	for _, update := range updates {
 		log.Debug("Found update %s", update.Version)
-		allImages = append(allImages, v2alpha1.CopyImageSchema{Source: update.Image, Destination: ""})
+		uniqueImages[v2alpha1.CopyImageSchema{Source: update.Image, Destination: ""}] = true
 	}
 
 	if current.Image != "" {
-		allImages = append(allImages, v2alpha1.CopyImageSchema{Source: current.Image, Destination: ""})
+		uniqueImages[v2alpha1.CopyImageSchema{Source: current.Image, Destination: ""}] = true
 	}
 
 	if newest.Image != "" {
-		allImages = append(allImages, v2alpha1.CopyImageSchema{Source: newest.Image, Destination: ""})
+		uniqueImages[v2alpha1.CopyImageSchema{Source: newest.Image, Destination: ""}] = true
 	}
 
+	for img := range uniqueImages {
+		allImages = append(allImages, img)
+	}
 	return allImages
 }


### PR DESCRIPTION
# Description

When selecting the release nodes that correspond to the filtering, we were using a slice. duplicates nodes lead to mirroring the release content more than once. 
The fix consists of using a map in order to reduce the quantity of images.
PS: this is a practice that we should consider more overall for all collectors in the future, as some images (kube-rbac-proxy for one) is used in multiple components and operators. WDYT?

Fixes #OCPBUGS-33580

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

mirroring the following imagesetconfig with or without shortestPath: true should lead to the same number of mirrored images.
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
archiveSize: 8
mirror:
  platform:
    channels:
    - name: stable-4.15                                             
      type: ocp
      minVersion: '4.15.11'
      maxVersion: '4.15.11'
      shortestPath: true
```

## Expected Outcome
Success