### PR TITLE
OCPBUGS-31343: Display warning if package not found

### DIFF
--- a/v2/internal/pkg/manifest/oci-manifest.go
+++ b/v2/internal/pkg/manifest/oci-manifest.go
@@ -258,10 +258,17 @@ func (o Manifest) GetRelatedImagesFromCatalog(operatorCatalog OperatorCatalog, c
 	} else {
 		for _, iscOperator := range ctlgInIsc.Packages {
 			operatorConfig := parseOperatorCatalogByOperator(iscOperator.Name, operatorCatalog)
-
+			if operatorConfig.BundlesByPkgAndName[iscOperator.Name] == nil {
+				o.Log.Warn("[OperatorImageCollector] package %s not found in catalog %s", iscOperator.Name, ctlgInIsc.Catalog)
+				continue
+			}
 			ri, err := getRelatedImages(o.Log, iscOperator.Name, operatorConfig, iscOperator, ctlgInIsc.Full)
 			if err != nil {
 				return relatedImages, err
+			}
+			if ri == nil || len(ri) == 0 { // no matching bundles
+				o.Log.Warn("[OperatorImageCollector] no bundles matching filtering for %s in catalog %s", iscOperator.Name, ctlgInIsc.Catalog)
+				continue
 			}
 
 			//TODO GOLANG 1.21 required - replace the for loop with maps.Copy

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/manifest/oci-manifest.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/manifest/oci-manifest.go
@@ -258,10 +258,17 @@ func (o Manifest) GetRelatedImagesFromCatalog(operatorCatalog OperatorCatalog, c
 	} else {
 		for _, iscOperator := range ctlgInIsc.Packages {
 			operatorConfig := parseOperatorCatalogByOperator(iscOperator.Name, operatorCatalog)
-
+			if operatorConfig.BundlesByPkgAndName[iscOperator.Name] == nil {
+				o.Log.Warn("[OperatorImageCollector] package %s not found in catalog %s", iscOperator.Name, ctlgInIsc.Catalog)
+				continue
+			}
 			ri, err := getRelatedImages(o.Log, iscOperator.Name, operatorConfig, iscOperator, ctlgInIsc.Full)
 			if err != nil {
 				return relatedImages, err
+			}
+			if ri == nil || len(ri) == 0 { // no matching bundles
+				o.Log.Warn("[OperatorImageCollector] no bundles matching filtering for %s in catalog %s", iscOperator.Name, ctlgInIsc.Catalog)
+				continue
 			}
 
 			//TODO GOLANG 1.21 required - replace the for loop with maps.Copy


### PR DESCRIPTION
# Description
Displays warnings if the operator package is not found in the catalog, but doesn't stop mirroring.

Fixes #OCPBUGS-31343

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests added.

Mirror to disk performed successfully with:
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15
      packages:
      - name: chocolate-factory-operator
      - name: external-dns-operator
      - name: aws-load-balancer-operator
        minVersion: "77.77.77"
        maxVersion: "77.77.99"
```

## Expected Outcome
The above mirroring should show in logs:
```
2024/05/16 17:38:55  [INFO]   : 🔍 collecting operator images...
2024/05/16 17:39:02  [WARN]   : [OperatorImageCollector] package chocolate-factory-operator not found in catalog registry.redhat.io/redhat/redhat-operator-index:v4.15
2024/05/16 17:39:02  [WARN]   : [OperatorImageCollector] no bundles matching filtering for aws-load-balancer-operator in catalog registry.redhat.io/redhat/redhat-operator-index:v4.15
2024/05/16 17:39:02  [INFO]   : 🔍 collecting additional images...
2024/05/16 17:39:02  [INFO]   : 🚀 Start copying the images...
```