### PR TITLE
OCPBUGS-34211: docker.io registry/2 is pulled with a platform argument

### DIFF
--- a/test/e2e/lib/util.sh
+++ b/test/e2e/lib/util.sh
@@ -77,7 +77,7 @@ function install_deps() {
     then
       crane export --platform linux/arm64/v8 registry:2 registry2.tar
     else
-      crane export ${ARCH}/registry:2 registry2.tar
+      crane export --platform linux/${ARCH} ${ARCH}/registry:2 registry2.tar
     fi
     tar xvf registry2.tar bin/registry
     mv bin/registry $GOBIN


### PR DESCRIPTION
# Description

- docker.io updated to a  manifest listed image.
- the code accounts for this change.

Fixes # https://issues.redhat.com/browse/OCPBUGS-34211

## Type of change
Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run on Z

## Expected Outcome
e2e tests run on z/power