### PR TITLE
OCPBUGS-34521: Fix DiskToMirror without internet connection without r…

### DIFF
--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -194,10 +194,12 @@ func (o *OperatorOptions) run(
 		} else if targetCtlg.Ref.Tag != "" {
 			ctlgSrcDir = filepath.Join(ctlgSrcDir, targetCtlg.Ref.Tag)
 		}
-		err = extractOPMAndCache(ctx, ctlgRef, ctlgSrcDir, o.SourceSkipTLS)
-		if err != nil {
-			reg.Destroy()
-			return nil, fmt.Errorf("unable to extract OPM binary from catalog %s: %v", targetName, err)
+		if o.RebuildCatalogs {
+			err = extractOPMAndCache(ctx, ctlgRef, ctlgSrcDir, o.SourceSkipTLS)
+			if err != nil {
+				reg.Destroy()
+				return nil, fmt.Errorf("unable to extract OPM binary from catalog %s: %v", targetName, err)
+			}
 		}
 
 		mappings, err := o.plan(ctx, dc, ic, ctlgRef, targetCtlg)

--- a/pkg/image/builder/image_builder.go
+++ b/pkg/image/builder/image_builder.go
@@ -236,19 +236,21 @@ func (b *ImageBuilder) processImageIndex(ctx context.Context, idx v1.ImageIndex,
 
 		// Add new layers to image.
 		// Ensure they have the right media type.
-		var mt types.MediaType
-		if *v2format {
-			mt = types.DockerLayer
-		} else {
-			mt = types.OCILayer
-		}
-		additions := make([]mutate.Addendum, 0, len(layers))
-		for _, layer := range layers {
-			additions = append(additions, mutate.Addendum{Layer: layer, MediaType: mt})
-		}
-		img, err = mutate.Append(img, additions...)
-		if err != nil {
-			return nil, err
+		if len(layers) > 0 {
+			var mt types.MediaType
+			if *v2format {
+				mt = types.DockerLayer
+			} else {
+				mt = types.OCILayer
+			}
+			additions := make([]mutate.Addendum, 0, len(layers))
+			for _, layer := range layers {
+				additions = append(additions, mutate.Addendum{Layer: layer, MediaType: mt})
+			}
+			img, err = mutate.Append(img, additions...)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		if update != nil {


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #OCPBUGS-34521

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using the following ImageSetConfig:
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2

mirror:
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.14
    targetCatalog: hij/redhat-operator-index
    packages:
    - name: aws-load-balancer-operator
  - catalog: oci:///home/skhoury/clid20/working-dir/operator-images/redhat-operator-index/008c9fedc8ca8103203166a959515a383d694039b29670a596c99e3a78f46c5f
    targetCatalog: def/redhat-operator-index
    targetTag: v4.14
    packages:
    - name: external-dns-operator
 ```
First run a Mirror to disk, with internet connection on:
```bash
$ ./bin/oc-mirror -c configs_logs/isc_34521.yaml file:///home/skhoury/ocpbugs34521
```
Next cut your internet connection, and perform a Disk To Mirror to a local registry:
```bash
$ ./bin/oc-mirror --from /home/skhoury/ocpbugs34521 docker://localhost:5000 --dest-use-http --dest-skip-tls
```
## Expected Outcome
```bash
-$ curl http://localhost:5000/v2/hij/redhat-operator-index/tags/list
{"name":"hij/redhat-operator-index","tags":["v4.14"]}
-$ curl http://localhost:5000/v2/def/redhat-operator-index/tags/list
{"name":"def/redhat-operator-index","tags":["v4.14"]}
```

We should also be able to apply the catalog source to a cluster accessing this mirror registry, and the pods should not fail.