### PR TITLE
OCPBUGS-34020: Implement fail safe / fail fast in workers

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/distribution/reference v0.5.0
 	github.com/google/go-containerregistry v0.15.2
 	github.com/google/uuid v1.3.1
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/microlib/simple v1.0.2
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc3
@@ -89,7 +90,6 @@ require (
 	github.com/h2non/filetype v1.1.1 // indirect
 	github.com/h2non/go-is-svg v0.0.0-20160927212452-35e8c4b0612c // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/golang-lru/arc/v2 v2.0.5 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.5 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/containers/storage v1.47.0
 	github.com/distribution/distribution/v3 v3.0.0-alpha.1
 	github.com/distribution/reference v0.5.0
+	github.com/docker/distribution v2.8.2+incompatible
 	github.com/google/go-containerregistry v0.15.2
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/go-multierror v1.1.1
@@ -55,7 +56,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/docker/cli v23.0.5+incompatible // indirect
-	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v24.0.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -9,10 +9,8 @@ require (
 	github.com/containers/storage v1.47.0
 	github.com/distribution/distribution/v3 v3.0.0-alpha.1
 	github.com/distribution/reference v0.5.0
-	github.com/docker/distribution v2.8.2+incompatible
 	github.com/google/go-containerregistry v0.15.2
 	github.com/google/uuid v1.3.1
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/microlib/simple v1.0.2
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc3
@@ -56,6 +54,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/docker/cli v23.0.5+incompatible // indirect
+	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v24.0.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
@@ -90,6 +89,7 @@ require (
 	github.com/h2non/filetype v1.1.1 // indirect
 	github.com/h2non/go-is-svg v0.0.0-20160927212452-35e8c4b0612c // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/golang-lru/arc/v2 v2.0.5 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.5 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/v2/internal/pkg/batch/error.go
+++ b/v2/internal/pkg/batch/error.go
@@ -1,0 +1,111 @@
+package batch
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"syscall"
+
+	"github.com/distribution/distribution/v3/registry/api/errcode"
+	"github.com/hashicorp/go-multierror"
+)
+
+type SafeError struct {
+	message string
+}
+
+type UnsafeError struct {
+	errSchema mirrorErrorSchema
+}
+
+func NewSafeError(format string, a ...any) error {
+	return &SafeError{fmt.Sprintf(format, a...)}
+}
+
+func NewUnsafeError(mes mirrorErrorSchema) error {
+	return &UnsafeError{mes}
+}
+
+func (e SafeError) Error() string { return e.message }
+
+func (e UnsafeError) Error() string { return e.errSchema.err.Error() }
+
+func isFailSafe(err error) bool {
+	switch err {
+	case nil:
+		return true
+	case context.Canceled, context.DeadlineExceeded:
+		return false
+	default: // continue
+	}
+
+	type unwrapper interface {
+		Unwrap() error
+	}
+
+	switch e := err.(type) {
+
+	case errcode.Error:
+		switch e.Code {
+		case errcode.ErrorCodeUnauthorized, errcode.ErrorCodeDenied:
+			// For oc-mirror this is a grey area: we consider that having Authentication
+			// or authorization errors to a registry (whether source or destination) on one
+			// image is very likely to give similar errors on other images.
+			return false
+		}
+		// normally manifest unknown, blob unknown, etc fall into the following return
+		return true
+	case *net.OpError:
+		return isFailSafe(e.Err)
+	case *url.Error: // This includes errors returned by the net/http client.
+		if e.Err == io.EOF { // Happens when a server accepts a HTTP connection and sends EOF
+			return true
+		}
+		return isFailSafe(e.Err)
+	case syscall.Errno:
+		return isErrnoFailSafe(e)
+	case errcode.Errors:
+		// if this error is a group of errors, process them all in turn
+		for i := range e {
+			if !isFailSafe(e[i]) {
+				return false
+			}
+		}
+		return true
+	case *multierror.Error:
+		// if this error is a group of errors, process them all in turn
+		for i := range e.Errors {
+			if !isFailSafe(e.Errors[i]) {
+				return false
+			}
+		}
+		return true
+	case net.Error:
+		if e.Timeout() {
+			return true
+		}
+		if unwrappable, ok := e.(unwrapper); ok {
+			err = unwrappable.Unwrap()
+			return isFailSafe(err)
+		}
+	case unwrapper: // Test this last, because various error types might implement .Unwrap()
+		err = e.Unwrap()
+		return isFailSafe(err)
+	}
+
+	return false
+}
+
+func isErrnoFailSafe(e error) bool {
+	switch e {
+	case syscall.ECONNREFUSED, syscall.EINTR, syscall.EAGAIN, syscall.EBUSY, syscall.ENETDOWN, syscall.ENETUNREACH, syscall.ENETRESET, syscall.ECONNABORTED, syscall.ECONNRESET, syscall.ETIMEDOUT, syscall.EHOSTDOWN, syscall.EHOSTUNREACH:
+		return true
+	}
+	return isErrnoERESTART(e)
+}
+
+func isErrnoERESTART(e error) bool {
+	return e == syscall.ERESTART
+}

--- a/v2/internal/pkg/batch/error.go
+++ b/v2/internal/pkg/batch/error.go
@@ -101,7 +101,9 @@ func isFailSafe(err error) bool {
 
 func isErrnoFailSafe(e error) bool {
 	switch e {
-	case syscall.ECONNREFUSED, syscall.EINTR, syscall.EAGAIN, syscall.EBUSY, syscall.ENETDOWN, syscall.ENETUNREACH, syscall.ENETRESET, syscall.ECONNABORTED, syscall.ECONNRESET, syscall.ETIMEDOUT, syscall.EHOSTDOWN, syscall.EHOSTUNREACH:
+	case syscall.ECONNREFUSED, syscall.ENETDOWN, syscall.ENETUNREACH, syscall.EHOSTDOWN, syscall.EHOSTUNREACH:
+		return false
+	case syscall.EINTR, syscall.EAGAIN, syscall.EBUSY, syscall.ENETRESET, syscall.ECONNABORTED, syscall.ECONNRESET, syscall.ETIMEDOUT:
 		return true
 	}
 	return isErrnoERESTART(e)

--- a/v2/internal/pkg/batch/error.go
+++ b/v2/internal/pkg/batch/error.go
@@ -8,7 +8,8 @@ import (
 	"net/url"
 	"syscall"
 
-	"github.com/distribution/distribution/v3/registry/api/errcode"
+	// "github.com/distribution/distribution/v3/registry/api/errcode"
+	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/hashicorp/go-multierror"
 )
 

--- a/v2/internal/pkg/batch/error.go
+++ b/v2/internal/pkg/batch/error.go
@@ -1,16 +1,8 @@
 package batch
 
 import (
-	"context"
 	"fmt"
-	"io"
-	"net"
-	"net/url"
-	"syscall"
-
 	// "github.com/distribution/distribution/v3/registry/api/errcode"
-	"github.com/docker/distribution/registry/api/errcode"
-	"github.com/hashicorp/go-multierror"
 )
 
 type SafeError struct {
@@ -33,82 +25,82 @@ func (e SafeError) Error() string { return e.message }
 
 func (e UnsafeError) Error() string { return e.errSchema.err.Error() }
 
-func isFailSafe(err error) bool {
-	switch err {
-	case nil:
-		return true
-	case context.Canceled, context.DeadlineExceeded:
-		return false
-	default: // continue
-	}
+// func isFailSafe(err error) bool {
+// 	switch err {
+// 	case nil:
+// 		return true
+// 	case context.Canceled, context.DeadlineExceeded:
+// 		return false
+// 	default: // continue
+// 	}
 
-	type unwrapper interface {
-		Unwrap() error
-	}
+// 	type unwrapper interface {
+// 		Unwrap() error
+// 	}
 
-	switch e := err.(type) {
+// 	switch e := err.(type) {
 
-	case errcode.Error:
-		switch e.Code {
-		case errcode.ErrorCodeUnauthorized, errcode.ErrorCodeDenied:
-			// For oc-mirror this is a grey area: we consider that having Authentication
-			// or authorization errors to a registry (whether source or destination) on one
-			// image is very likely to give similar errors on other images.
-			return false
-		}
-		// normally manifest unknown, blob unknown, etc fall into the following return
-		return true
-	case *net.OpError:
-		return isFailSafe(e.Err)
-	case *url.Error: // This includes errors returned by the net/http client.
-		if e.Err == io.EOF { // Happens when a server accepts a HTTP connection and sends EOF
-			return true
-		}
-		return isFailSafe(e.Err)
-	case syscall.Errno:
-		return isErrnoFailSafe(e)
-	case errcode.Errors:
-		// if this error is a group of errors, process them all in turn
-		for i := range e {
-			if !isFailSafe(e[i]) {
-				return false
-			}
-		}
-		return true
-	case *multierror.Error:
-		// if this error is a group of errors, process them all in turn
-		for i := range e.Errors {
-			if !isFailSafe(e.Errors[i]) {
-				return false
-			}
-		}
-		return true
-	case net.Error:
-		if e.Timeout() {
-			return true
-		}
-		if unwrappable, ok := e.(unwrapper); ok {
-			err = unwrappable.Unwrap()
-			return isFailSafe(err)
-		}
-	case unwrapper: // Test this last, because various error types might implement .Unwrap()
-		err = e.Unwrap()
-		return isFailSafe(err)
-	}
+// 	case errcode.Error:
+// 		switch e.Code {
+// 		case errcode.ErrorCodeUnauthorized, errcode.ErrorCodeDenied:
+// 			// For oc-mirror this is a grey area: we consider that having Authentication
+// 			// or authorization errors to a registry (whether source or destination) on one
+// 			// image is very likely to give similar errors on other images.
+// 			return false
+// 		}
+// 		// normally manifest unknown, blob unknown, etc fall into the following return
+// 		return true
+// 	case *net.OpError:
+// 		return isFailSafe(e.Err)
+// 	case *url.Error: // This includes errors returned by the net/http client.
+// 		if e.Err == io.EOF { // Happens when a server accepts a HTTP connection and sends EOF
+// 			return true
+// 		}
+// 		return isFailSafe(e.Err)
+// 	case syscall.Errno:
+// 		return isErrnoFailSafe(e)
+// 	case errcode.Errors:
+// 		// if this error is a group of errors, process them all in turn
+// 		for i := range e {
+// 			if !isFailSafe(e[i]) {
+// 				return false
+// 			}
+// 		}
+// 		return true
+// 	case *multierror.Error:
+// 		// if this error is a group of errors, process them all in turn
+// 		for i := range e.Errors {
+// 			if !isFailSafe(e.Errors[i]) {
+// 				return false
+// 			}
+// 		}
+// 		return true
+// 	case net.Error:
+// 		if e.Timeout() {
+// 			return true
+// 		}
+// 		if unwrappable, ok := e.(unwrapper); ok {
+// 			err = unwrappable.Unwrap()
+// 			return isFailSafe(err)
+// 		}
+// 	case unwrapper: // Test this last, because various error types might implement .Unwrap()
+// 		err = e.Unwrap()
+// 		return isFailSafe(err)
+// 	}
 
-	return false
-}
+// 	return false
+// }
 
-func isErrnoFailSafe(e error) bool {
-	switch e {
-	case syscall.ECONNREFUSED, syscall.ENETDOWN, syscall.ENETUNREACH, syscall.EHOSTDOWN, syscall.EHOSTUNREACH:
-		return false
-	case syscall.EINTR, syscall.EAGAIN, syscall.EBUSY, syscall.ENETRESET, syscall.ECONNABORTED, syscall.ECONNRESET, syscall.ETIMEDOUT:
-		return true
-	}
-	return isErrnoERESTART(e)
-}
+// func isErrnoFailSafe(e error) bool {
+// 	switch e {
+// 	case syscall.ECONNREFUSED, syscall.ENETDOWN, syscall.ENETUNREACH, syscall.EHOSTDOWN, syscall.EHOSTUNREACH:
+// 		return false
+// 	case syscall.EINTR, syscall.EAGAIN, syscall.EBUSY, syscall.ENETRESET, syscall.ECONNABORTED, syscall.ECONNRESET, syscall.ETIMEDOUT:
+// 		return true
+// 	}
+// 	return isErrnoERESTART(e)
+// }
 
-func isErrnoERESTART(e error) bool {
-	return e == syscall.ERESTART
-}
+// func isErrnoERESTART(e error) bool {
+// 	return e == syscall.ERESTART
+// }

--- a/v2/internal/pkg/batch/error.go
+++ b/v2/internal/pkg/batch/error.go
@@ -22,11 +22,11 @@ type UnsafeError struct {
 }
 
 func NewSafeError(format string, a ...any) error {
-	return &SafeError{fmt.Sprintf(format, a...)}
+	return SafeError{fmt.Sprintf(format, a...)}
 }
 
 func NewUnsafeError(mes mirrorErrorSchema) error {
-	return &UnsafeError{mes}
+	return UnsafeError{mes}
 }
 
 func (e SafeError) Error() string { return e.message }

--- a/v2/internal/pkg/batch/worker.go
+++ b/v2/internal/pkg/batch/worker.go
@@ -24,7 +24,7 @@ func New(log clog.PluggableLoggerInterface,
 	copiedImages := v2alpha1.CollectorSchema{
 		AllImages: []v2alpha1.CopyImageSchema{},
 	}
-	return &Batch{Log: log, LogsDir: logsDir, Mirror: mirror, CopiedImages: copiedImages}
+	return &Batch{Log: log, LogsDir: logsDir, Mirror: mirror, CopiedImages: copiedImages, Progress: &ProgressStruct{}}
 }
 
 type Batch struct {
@@ -32,8 +32,23 @@ type Batch struct {
 	LogsDir      string
 	Mirror       mirror.MirrorInterface
 	CopiedImages v2alpha1.CollectorSchema
+	Progress     *ProgressStruct
 }
 
+type ProgressStruct struct {
+	countTotal            int
+	countReleaseImages    int
+	countOperatorsImages  int
+	countAdditionalImages int
+
+	countErrorTotal                 int
+	countReleaseImagesErrorTotal    int
+	countOperatorsImagesErrorTotal  int
+	countAdditionalImagesErrorTotal int
+
+	mirrorMessage string
+	Log           clog.PluggableLoggerInterface
+}
 type mirrorErrorSchema struct {
 	image v2alpha1.CopyImageSchema
 	err   error
@@ -53,55 +68,10 @@ func (o *Batch) Worker(ctx context.Context, collectorSchema v2alpha1.CollectorSc
 	var errArray []mirrorErrorSchema
 
 	totalImages := len(collectorSchema.AllImages)
-	var countTotal, countReleaseImages, countOperatorsImages, countAdditionalImages,
-		countErrorTotal, countReleaseImagesErrorTotal, countOperatorsImagesErrorTotal, countAdditionalImagesErrorTotal int
 
 	o.Log.Info("🚀 Start " + mirrorMsg + " the images...")
 
 	for _, img := range collectorSchema.AllImages {
-		o.Log.Info(mirrorMsg+" image: %s", img.Origin)
-
-		switch img.Type {
-		case v2alpha1.TypeOCPRelease, v2alpha1.TypeOCPReleaseContent, v2alpha1.TypeCincinnatiGraph:
-			countReleaseImages++
-		case v2alpha1.TypeOperatorCatalog, v2alpha1.TypeOperatorBundle, v2alpha1.TypeOperatorRelatedImage:
-			countOperatorsImages++
-		case v2alpha1.TypeGeneric:
-			countAdditionalImages++
-		}
-
-		countTotal++
-		var overalProgress string
-		if countErrorTotal > 0 {
-			overalProgress = fmt.Sprintf("=== Overall Progress - "+mirrorMsg+" image %d / %d (%d errors)===", countTotal, totalImages, countErrorTotal)
-		} else {
-			overalProgress = fmt.Sprintf("=== Overall Progress - "+mirrorMsg+" image %d / %d ===", countTotal, totalImages)
-		}
-		o.Log.Info(overalProgress)
-		if opts.Function == string(mirror.CopyMode) {
-			if collectorSchema.TotalReleaseImages > 0 {
-				if countReleaseImagesErrorTotal > 0 {
-					o.Log.Info(mirrorMsg+" release image %d / %d (%d errors)", countReleaseImages, collectorSchema.TotalReleaseImages, countReleaseImagesErrorTotal)
-				} else {
-					o.Log.Info(mirrorMsg+" release image %d / %d", countReleaseImages, collectorSchema.TotalReleaseImages)
-				}
-			}
-			if collectorSchema.TotalOperatorImages > 0 {
-				if countOperatorsImagesErrorTotal > 0 {
-					o.Log.Info(mirrorMsg+" operator image %d / %d (%d errors)", countOperatorsImages, collectorSchema.TotalOperatorImages, countOperatorsImagesErrorTotal)
-				} else {
-					o.Log.Info(mirrorMsg+" operator image %d / %d", countOperatorsImages, collectorSchema.TotalOperatorImages)
-				}
-			}
-			if collectorSchema.TotalAdditionalImages > 0 {
-				if countAdditionalImagesErrorTotal > 0 {
-					o.Log.Info(mirrorMsg+" additional image %d / %d (%d errors)", countAdditionalImages, collectorSchema.TotalAdditionalImages, countAdditionalImagesErrorTotal)
-				} else {
-					o.Log.Info(mirrorMsg+" additional image %d / %d", countAdditionalImages, collectorSchema.TotalAdditionalImages)
-				}
-			}
-			o.Log.Info(strings.Repeat("=", len(overalProgress)))
-		}
 
 		if img.Type == v2alpha1.TypeCincinnatiGraph && (opts.Mode == mirror.MirrorToDisk || opts.Mode == mirror.MirrorToMirror) {
 			continue
@@ -123,15 +93,7 @@ func (o *Batch) Worker(ctx context.Context, collectorSchema v2alpha1.CollectorSc
 		case err != nil && isSafe && img.Type != v2alpha1.TypeOCPRelease && img.Type != v2alpha1.TypeOCPReleaseContent:
 			// this error is fail safe, we're continuing to mirror other images.
 			errArray = append(errArray, mirrorErrorSchema{image: img, err: err})
-			countErrorTotal++
-			switch img.Type {
-			case v2alpha1.TypeOCPRelease, v2alpha1.TypeOCPReleaseContent, v2alpha1.TypeCincinnatiGraph:
-				countReleaseImagesErrorTotal++
-			case v2alpha1.TypeOperatorCatalog, v2alpha1.TypeOperatorBundle, v2alpha1.TypeOperatorRelatedImage:
-				countOperatorsImagesErrorTotal++
-			case v2alpha1.TypeGeneric:
-				countAdditionalImagesErrorTotal++
-			}
+
 		case err != nil && isSafe && (img.Type == v2alpha1.TypeOCPRelease || img.Type == v2alpha1.TypeOCPReleaseContent):
 			fallthrough
 		case err != nil && !isSafe:
@@ -144,37 +106,40 @@ func (o *Batch) Worker(ctx context.Context, collectorSchema v2alpha1.CollectorSc
 			}
 			return o.CopiedImages, NewUnsafeError(currentMirrorError)
 		}
+
+		o.logProgress(img, collectorSchema, err)
+
 	}
 
 	if opts.Function == string(mirror.CopyMode) {
 		o.Log.Info("=== Results ===")
 		if collectorSchema.TotalReleaseImages != 0 {
-			if countReleaseImages == collectorSchema.TotalReleaseImages && countReleaseImagesErrorTotal == 0 {
-				o.Log.Info("All release images mirrored successfully %d / %d ✅", countReleaseImages, collectorSchema.TotalReleaseImages)
+			if o.Progress.countReleaseImages == collectorSchema.TotalReleaseImages && o.Progress.countReleaseImagesErrorTotal == 0 {
+				o.Log.Info("All release images mirrored successfully %d / %d ✅", o.Progress.countReleaseImages, collectorSchema.TotalReleaseImages)
 			} else {
-				o.Log.Info("Images mirrored %d / %d: Some release images failed to mirror ❌ - please check the logs", countReleaseImages-countReleaseImagesErrorTotal, collectorSchema.TotalReleaseImages)
+				o.Log.Info("Images mirrored %d / %d: Some release images failed to mirror ❌ - please check the logs", o.Progress.countReleaseImages-o.Progress.countReleaseImagesErrorTotal, collectorSchema.TotalReleaseImages)
 			}
 		}
 		if collectorSchema.TotalOperatorImages != 0 {
-			if countOperatorsImages == collectorSchema.TotalOperatorImages && countOperatorsImagesErrorTotal == 0 {
-				o.Log.Info("All operator images mirrored successfully %d / %d ✅", countOperatorsImages, collectorSchema.TotalOperatorImages)
+			if o.Progress.countOperatorsImages == collectorSchema.TotalOperatorImages && o.Progress.countOperatorsImagesErrorTotal == 0 {
+				o.Log.Info("All operator images mirrored successfully %d / %d ✅", o.Progress.countOperatorsImages, collectorSchema.TotalOperatorImages)
 			} else {
-				o.Log.Info("Images mirrored %d / %d: Some operator images failed to mirror ❌ - please check the logs", countOperatorsImages-countOperatorsImagesErrorTotal, collectorSchema.TotalOperatorImages)
+				o.Log.Info("Images mirrored %d / %d: Some operator images failed to mirror ❌ - please check the logs", o.Progress.countOperatorsImages-o.Progress.countOperatorsImagesErrorTotal, collectorSchema.TotalOperatorImages)
 			}
 		}
 		if collectorSchema.TotalAdditionalImages != 0 {
-			if countAdditionalImages == collectorSchema.TotalAdditionalImages && countAdditionalImagesErrorTotal == 0 {
-				o.Log.Info("All additional images mirrored successfully %d / %d ✅", countAdditionalImages, collectorSchema.TotalAdditionalImages)
+			if o.Progress.countAdditionalImages == collectorSchema.TotalAdditionalImages && o.Progress.countAdditionalImagesErrorTotal == 0 {
+				o.Log.Info("All additional images mirrored successfully %d / %d ✅", o.Progress.countAdditionalImages, collectorSchema.TotalAdditionalImages)
 			} else {
-				o.Log.Info("Images mirrored %d / %d: Some additional images failed to mirror ❌ - please check the logs", countAdditionalImages-countAdditionalImagesErrorTotal, collectorSchema.TotalAdditionalImages)
+				o.Log.Info("Images mirrored %d / %d: Some additional images failed to mirror ❌ - please check the logs", o.Progress.countAdditionalImages-o.Progress.countAdditionalImagesErrorTotal, collectorSchema.TotalAdditionalImages)
 			}
 		}
 	} else {
 		o.Log.Info("=== Results ===")
-		if countTotal == totalImages && countErrorTotal == 0 {
-			o.Log.Info("All images deleted successfully %d / %d ✅", countTotal, totalImages)
+		if o.Progress.countTotal == totalImages && o.Progress.countErrorTotal == 0 {
+			o.Log.Info("All images deleted successfully %d / %d ✅", o.Progress.countTotal, totalImages)
 		} else {
-			o.Log.Info("Images deleted %d / %d: Some images failed to delete ❌ - please check the logs", countTotal-countErrorTotal, totalImages)
+			o.Log.Info("Images deleted %d / %d: Some images failed to delete ❌ - please check the logs", o.Progress.countTotal-o.Progress.countErrorTotal, totalImages)
 		}
 	}
 
@@ -212,4 +177,69 @@ func (o *Batch) saveErrors(errArray []mirrorErrorSchema) (string, error) {
 		return filename, nil
 	}
 	return "", nil
+}
+
+func (o Batch) logProgress(img v2alpha1.CopyImageSchema, collectorSchema v2alpha1.CollectorSchema, err error) {
+	switch img.Type {
+	case v2alpha1.TypeOCPRelease, v2alpha1.TypeOCPReleaseContent, v2alpha1.TypeCincinnatiGraph:
+		o.Progress.countReleaseImages++
+	case v2alpha1.TypeOperatorCatalog, v2alpha1.TypeOperatorBundle, v2alpha1.TypeOperatorRelatedImage:
+		o.Progress.countOperatorsImages++
+	case v2alpha1.TypeGeneric:
+		o.Progress.countAdditionalImages++
+	}
+
+	o.Progress.countTotal++
+	isSafe := isFailSafe(err)
+	//isSafe && img.Type != v2alpha1.TypeOCPRelease && img.Type != v2alpha1.TypeOCPReleaseContent:
+	if err != nil && !isSafe { // normally logProgress should never be called for fail fast errors
+		return
+	} else if err != nil { // it is a fail safe error
+		if img.Type == v2alpha1.TypeOCPRelease || img.Type == v2alpha1.TypeOCPReleaseContent { // normally logProgress should never be called for fail fast errors
+			return
+		}
+		o.Progress.countErrorTotal++
+		switch img.Type {
+		case v2alpha1.TypeOCPRelease, v2alpha1.TypeOCPReleaseContent, v2alpha1.TypeCincinnatiGraph:
+			o.Progress.countReleaseImagesErrorTotal++
+		case v2alpha1.TypeOperatorCatalog, v2alpha1.TypeOperatorBundle, v2alpha1.TypeOperatorRelatedImage:
+			o.Progress.countOperatorsImagesErrorTotal++
+		case v2alpha1.TypeGeneric:
+			o.Progress.countAdditionalImagesErrorTotal++
+		}
+	}
+
+	var overalProgress string
+	if o.Progress.countErrorTotal > 0 {
+		overalProgress = fmt.Sprintf("=== Overall Progress - "+o.Progress.mirrorMessage+" image %d / %d (%d errors)===", o.Progress.countTotal, len(collectorSchema.AllImages), o.Progress.countErrorTotal)
+	} else {
+		overalProgress = fmt.Sprintf("=== Overall Progress - "+o.Progress.mirrorMessage+" image %d / %d ===", o.Progress.countTotal, len(collectorSchema.AllImages))
+	}
+	o.Log.Info(overalProgress)
+
+	if collectorSchema.TotalReleaseImages > 0 {
+		if o.Progress.countReleaseImagesErrorTotal > 0 {
+			o.Log.Info(o.Progress.mirrorMessage+" release image %d / %d (%d errors)", o.Progress.countReleaseImages, collectorSchema.TotalReleaseImages, o.Progress.countReleaseImagesErrorTotal)
+		} else {
+			o.Log.Info(o.Progress.mirrorMessage+" release image %d / %d", o.Progress.countReleaseImages, collectorSchema.TotalReleaseImages)
+		}
+	}
+	if collectorSchema.TotalOperatorImages > 0 {
+		if o.Progress.countOperatorsImagesErrorTotal > 0 {
+			o.Log.Info(o.Progress.mirrorMessage+" operator image %d / %d (%d errors)", o.Progress.countOperatorsImages, collectorSchema.TotalOperatorImages, o.Progress.countOperatorsImagesErrorTotal)
+		} else {
+			o.Log.Info(o.Progress.mirrorMessage+" operator image %d / %d", o.Progress.countOperatorsImages, collectorSchema.TotalOperatorImages)
+		}
+	}
+	if collectorSchema.TotalAdditionalImages > 0 {
+		if o.Progress.countAdditionalImagesErrorTotal > 0 {
+			o.Log.Info(o.Progress.mirrorMessage+" additional image %d / %d (%d errors)", o.Progress.countAdditionalImages, collectorSchema.TotalAdditionalImages, o.Progress.countAdditionalImagesErrorTotal)
+		} else {
+			o.Log.Info(o.Progress.mirrorMessage+" additional image %d / %d", o.Progress.countAdditionalImages, collectorSchema.TotalAdditionalImages)
+		}
+	}
+	o.Log.Info(" image: %s", img.Origin)
+
+	o.Log.Info(strings.Repeat("=", len(overalProgress)))
+
 }

--- a/v2/internal/pkg/batch/worker_test.go
+++ b/v2/internal/pkg/batch/worker_test.go
@@ -3,13 +3,16 @@ package batch
 import (
 	"context"
 	"os"
+	"syscall"
 	"testing"
 
-	"github.com/containers/image/v5/types"
+	"github.com/distribution/distribution/v3/registry/api/errcode"
+	errcodev3 "github.com/distribution/distribution/v3/registry/api/v2"
+
 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
 	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
-	"github.com/openshift/oc-mirror/v2/internal/pkg/manifest"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestWorker(t *testing.T) {
@@ -33,118 +36,115 @@ func TestWorker(t *testing.T) {
 		Destination:         "oci:test",
 		Dev:                 false,
 		Mode:                mirror.MirrorToDisk,
+		Function:            "copy",
 	}
 	tempDir := t.TempDir()
 	defer os.RemoveAll(tempDir)
 
-	w := New(log, tempDir, &Mirror{}, &Manifest{})
-
+	relatedImages := []v2alpha1.CopyImageSchema{
+		{Source: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testa", Type: v2alpha1.TypeOCPRelease},
+		{Source: "docker://registry/name/namespace/sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testb", Type: v2alpha1.TypeOCPReleaseContent},
+		{Source: "docker://registry/name/namespace/sometestimage-c@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-c@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testc", Type: v2alpha1.TypeOperatorBundle},
+		{Source: "docker://registry/name/namespace/sometestimage-d@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-d@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testd", Type: v2alpha1.TypeOperatorCatalog},
+		{Source: "docker://registry/name/namespace/sometestimage-e@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-e@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:teste", Type: v2alpha1.TypeCincinnatiGraph},
+		{Source: "docker://registry/name/namespace/sometestimage-f@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-f@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testf", Type: v2alpha1.TypeGeneric},
+		{Source: "docker://registry/name/namespace/sometestimage-g@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-g@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testg", Type: v2alpha1.TypeGeneric},
+		{Source: "docker://registry/name/namespace/sometestimage-h@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-h@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testh", Type: v2alpha1.TypeGeneric},
+		{Source: "docker://registry/name/namespace/sometestimage-i@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-i@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testi", Type: v2alpha1.TypeGeneric},
+	}
 	// this is a facade to get code coverage up
 	t.Run("Testing Worker : should pass", func(t *testing.T) {
-		relatedImages := []v2alpha1.CopyImageSchema{
-			{Source: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:test"},
-			{Source: "docker://registry/name/namespace/sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:test"},
-			{Source: "docker://registry/name/namespace/sometestimage-c@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:test"},
-			{Source: "docker://registry/name/namespace/sometestimage-d@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:test"},
-			{Source: "docker://registry/name/namespace/sometestimage-e@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:test"},
-			{Source: "docker://registry/name/namespace/sometestimage-f@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:test"},
-			{Source: "docker://registry/name/namespace/sometestimage-g@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:test"},
-			{Source: "docker://registry/name/namespace/sometestimage-h@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:test"},
-			{Source: "docker://registry/name/namespace/sometestimage-i@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:test"},
-		}
+
+		w := New(log, tempDir, &Mirror{ForceError: nil})
 		err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
 		if err != nil {
 			t.Fatal("should pass")
 		}
 	})
+
+	t.Run("Testing Worker for delete: should pass", func(t *testing.T) {
+		opts.Function = "delete"
+		w := New(log, tempDir, &Mirror{ForceError: nil})
+		err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
+		if err != nil {
+			t.Fatal("should pass")
+		}
+	})
+	t.Run("Testing Worker : registry unauthorized : should fail fast", func(t *testing.T) {
+		opts.Function = "copy"
+		unauthorized := errcode.Error{Code: errcode.ErrorCodeUnauthorized, Message: "unauthorized"}
+		var expectedError *UnsafeError
+		w := New(log, tempDir, &Mirror{unauthorized})
+		err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
+		if err == nil {
+			t.Fatal("should not pass")
+		}
+		assert.ErrorAs(t, err, &expectedError)
+	})
+
+	t.Run("Testing Worker : manifest unknown for release: should  fail fast", func(t *testing.T) {
+		opts.Function = "delete"
+		errorCodeManifestUnknown := errcode.Error{
+			Code: errcode.ErrorCode(errcodev3.ErrorCodeManifestUnknown),
+		}
+		var expectedError *UnsafeError
+		w := New(log, tempDir, &Mirror{errorCodeManifestUnknown})
+		err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
+		if err == nil {
+			t.Fatal("should not pass")
+		}
+		assert.ErrorAs(t, err, &expectedError)
+	})
+
+	t.Run("Testing Worker : manifest unknown for operator image: should  fail safe", func(t *testing.T) {
+		opImages := []v2alpha1.CopyImageSchema{
+			{Source: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testa", Type: v2alpha1.TypeOperatorRelatedImage},
+		}
+		opts.Function = "delete"
+		errorCodeManifestUnknown := errcode.Error{
+			Code: errcode.ErrorCode(errcodev3.ErrorCodeManifestUnknown),
+		}
+		var expectedError *SafeError
+		w := New(log, tempDir, &Mirror{errorCodeManifestUnknown})
+		err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: opImages}, opts)
+		if err == nil {
+			t.Fatal("should not pass")
+		}
+		assert.ErrorAs(t, err, &expectedError)
+	})
+
+	t.Run("Testing Worker : registry connection refused for additional image: should fail safe", func(t *testing.T) {
+		addImages := []v2alpha1.CopyImageSchema{
+			{Source: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testa", Type: v2alpha1.TypeGeneric},
+		}
+		opts.Function = "copy"
+		refused := syscall.ECONNREFUSED
+		var expectedError *SafeError
+		w := New(log, tempDir, &Mirror{refused})
+		err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: addImages}, opts)
+		if err == nil {
+			t.Fatal("should not pass")
+		}
+		assert.ErrorAs(t, err, &expectedError)
+	})
 }
 
 // mocks
 
-type Mirror struct{}
-type Manifest struct{}
+type Mirror struct {
+	ForceError error
+}
 
 func (o Mirror) Run(ctx context.Context, src, dest string, mode mirror.Mode, opts *mirror.CopyOptions) error {
+	if o.ForceError != nil {
+		return o.ForceError
+	}
 	return nil
 }
 
 func (o Mirror) Check(ctx context.Context, image string, opts *mirror.CopyOptions, asCopySrc bool) (bool, error) {
+	if o.ForceError != nil {
+		return false, o.ForceError
+	}
 	return true, nil
-}
-
-func (o Manifest) GetOperatorConfig(file string) (*v2alpha1.OperatorConfigSchema, error) {
-	opcl := v2alpha1.OperatorLabels{OperatorsOperatorframeworkIoIndexConfigsV1: "/configs"}
-	opc := v2alpha1.OperatorConfig{Labels: opcl}
-	ocs := &v2alpha1.OperatorConfigSchema{Config: opc}
-	return ocs, nil
-}
-
-func (o Manifest) GetReleaseSchema(filePath string) ([]v2alpha1.RelatedImage, error) {
-	relatedImages := []v2alpha1.RelatedImage{
-		{Name: "testA", Image: "registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"},
-		{Name: "testB", Image: "registry/name/namespace/sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"},
-		{Name: "testC", Image: "registry/name/namespace/sometestimage-c@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"},
-		{Name: "testD", Image: "registry/name/namespace/sometestimage-d@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"},
-	}
-	return relatedImages, nil
-}
-
-func (o Manifest) GetImageIndex(name string) (*v2alpha1.OCISchema, error) {
-	return &v2alpha1.OCISchema{
-		SchemaVersion: 2,
-		Manifests: []v2alpha1.OCIManifest{
-			{
-				MediaType: "application/vnd.oci.image.manifest.v1+json",
-				Digest:    "sha256:3ef0b0141abd1548f60c4f3b23ecfc415142b0e842215f38e98610a3b2e52419",
-				Size:      567,
-			},
-		},
-	}, nil
-}
-
-func (o Manifest) GetImageManifest(name string) (*v2alpha1.OCISchema, error) {
-	return &v2alpha1.OCISchema{
-		SchemaVersion: 2,
-		Manifests: []v2alpha1.OCIManifest{
-			{
-				MediaType: "application/vnd.oci.image.manifest.v1+json",
-				Digest:    "sha256:3ef0b0141abd1548f60c4f3b23ecfc415142b0e842215f38e98610a3b2e52419",
-				Size:      567,
-			},
-		},
-		Config: v2alpha1.OCIManifest{
-			MediaType: "application/vnd.oci.image.manifest.v1+json",
-			Digest:    "sha256:3ef0b0141abd1548f60c4f3b23ecfc415142b0e842215f38e98610a3b2e52419",
-			Size:      567,
-		},
-	}, nil
-}
-
-func (o Manifest) GetCatalog(filePath string) (manifest.OperatorCatalog, error) {
-	return manifest.OperatorCatalog{}, nil
-}
-
-func (o Manifest) GetRelatedImagesFromCatalog(operatorCatalog manifest.OperatorCatalog, ctlgInIsc v2alpha1.Operator) (map[string][]v2alpha1.RelatedImage, error) {
-	relatedImages := make(map[string][]v2alpha1.RelatedImage)
-	relatedImages["abc"] = []v2alpha1.RelatedImage{
-		{Name: "testA", Image: "sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"},
-		{Name: "testB", Image: "sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"},
-	}
-	return relatedImages, nil
-}
-
-func (o Manifest) ExtractLayersOCI(filePath, toPath, label string, oci *v2alpha1.OCISchema) error {
-	return nil
-}
-
-func (o Manifest) ExtractLayers(filePath, name, label string) error {
-	return nil
-}
-
-func (o Manifest) ConvertIndexToSingleManifest(dir string, oci *v2alpha1.OCISchema) error {
-	return nil
-}
-
-func (o Manifest) GetDigest(ctx context.Context, sourceCtx *types.SystemContext, imgRef string) (string, error) {
-	return "", nil
 }

--- a/v2/internal/pkg/batch/worker_test.go
+++ b/v2/internal/pkg/batch/worker_test.go
@@ -1,150 +1,155 @@
 package batch
 
-import (
-	"context"
-	"os"
-	"syscall"
-	"testing"
+// import (
+// 	"context"
+// 	"os"
+// 	"syscall"
+// 	"testing"
 
-	"github.com/distribution/distribution/v3/registry/api/errcode"
-	errcodev3 "github.com/distribution/distribution/v3/registry/api/v2"
+// 	"github.com/docker/distribution/registry/api/errcode"
 
-	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
-	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
-	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
-	"github.com/stretchr/testify/assert"
-)
+// 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
+// 	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
+// 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
+// 	"github.com/stretchr/testify/assert"
+// )
 
-func TestWorker(t *testing.T) {
+// func TestWorker(t *testing.T) {
 
-	log := clog.New("trace")
+// 	log := clog.New("trace")
 
-	global := &mirror.GlobalOptions{SecurePolicy: false, Quiet: false}
+// 	global := &mirror.GlobalOptions{SecurePolicy: false, Quiet: false}
 
-	_, sharedOpts := mirror.SharedImageFlags()
-	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
-	_, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
-	_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
-	_, retryOpts := mirror.RetryFlags()
+// 	_, sharedOpts := mirror.SharedImageFlags()
+// 	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
+// 	_, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
+// 	_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
+// 	_, retryOpts := mirror.RetryFlags()
 
-	opts := mirror.CopyOptions{
-		Global:              global,
-		DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
-		SrcImage:            srcOpts,
-		DestImage:           destOpts,
-		RetryOpts:           retryOpts,
-		Destination:         "oci:test",
-		Dev:                 false,
-		Mode:                mirror.MirrorToDisk,
-		Function:            "copy",
-	}
-	tempDir := t.TempDir()
-	defer os.RemoveAll(tempDir)
+// 	opts := mirror.CopyOptions{
+// 		Global:              global,
+// 		DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
+// 		SrcImage:            srcOpts,
+// 		DestImage:           destOpts,
+// 		RetryOpts:           retryOpts,
+// 		Destination:         "oci:test",
+// 		Dev:                 false,
+// 		Mode:                mirror.DiskToMirror,
+// 		Function:            "copy",
+// 	}
+// 	tempDir := t.TempDir()
+// 	defer os.RemoveAll(tempDir)
 
-	relatedImages := []v2alpha1.CopyImageSchema{
-		{Source: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testa", Type: v2alpha1.TypeOCPRelease},
-		{Source: "docker://registry/name/namespace/sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testb", Type: v2alpha1.TypeOCPReleaseContent},
-		{Source: "docker://registry/name/namespace/sometestimage-c@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-c@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testc", Type: v2alpha1.TypeOperatorBundle},
-		{Source: "docker://registry/name/namespace/sometestimage-d@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-d@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testd", Type: v2alpha1.TypeOperatorCatalog},
-		{Source: "docker://registry/name/namespace/sometestimage-e@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-e@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:teste", Type: v2alpha1.TypeCincinnatiGraph},
-		{Source: "docker://registry/name/namespace/sometestimage-f@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-f@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testf", Type: v2alpha1.TypeGeneric},
-		{Source: "docker://registry/name/namespace/sometestimage-g@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-g@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testg", Type: v2alpha1.TypeGeneric},
-		{Source: "docker://registry/name/namespace/sometestimage-h@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-h@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testh", Type: v2alpha1.TypeGeneric},
-		{Source: "docker://registry/name/namespace/sometestimage-i@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-i@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testi", Type: v2alpha1.TypeGeneric},
-	}
-	// this is a facade to get code coverage up
-	t.Run("Testing Worker : should pass", func(t *testing.T) {
+// 	relatedImages := []v2alpha1.CopyImageSchema{
+// 		{Source: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testa", Type: v2alpha1.TypeOCPRelease},
+// 		{Source: "docker://registry/name/namespace/sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testb", Type: v2alpha1.TypeOCPReleaseContent},
+// 		{Source: "docker://registry/name/namespace/sometestimage-c@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-c@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testc", Type: v2alpha1.TypeOperatorBundle},
+// 		{Source: "docker://registry/name/namespace/sometestimage-d@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-d@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testd", Type: v2alpha1.TypeOperatorCatalog},
+// 		{Source: "docker://registry/name/namespace/sometestimage-e@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-e@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:teste", Type: v2alpha1.TypeCincinnatiGraph},
+// 		{Source: "docker://registry/name/namespace/sometestimage-f@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-f@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testf", Type: v2alpha1.TypeGeneric},
+// 		{Source: "docker://registry/name/namespace/sometestimage-g@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-g@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testg", Type: v2alpha1.TypeGeneric},
+// 		{Source: "docker://registry/name/namespace/sometestimage-h@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-h@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testh", Type: v2alpha1.TypeGeneric},
+// 		{Source: "docker://registry/name/namespace/sometestimage-i@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-i@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testi", Type: v2alpha1.TypeGeneric},
+// 	}
+// 	// this is a facade to get code coverage up
+// 	t.Run("Testing Worker : should pass", func(t *testing.T) {
 
-		w := New(log, tempDir, &Mirror{ForceError: nil})
-		err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
-		if err != nil {
-			t.Fatal("should pass")
-		}
-	})
+// 		w := New(log, tempDir, &Mirror{ForceError: nil})
+// 		copiedImages, err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
+// 		if err != nil {
+// 			t.Fatal("should pass")
+// 		}
+// 		assert.Equal(t, len(relatedImages), len(copiedImages.AllImages))
+// 	})
 
-	t.Run("Testing Worker for delete: should pass", func(t *testing.T) {
-		opts.Function = "delete"
-		w := New(log, tempDir, &Mirror{ForceError: nil})
-		err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
-		if err != nil {
-			t.Fatal("should pass")
-		}
-	})
-	t.Run("Testing Worker : registry unauthorized : should fail fast", func(t *testing.T) {
-		opts.Function = "copy"
-		unauthorized := errcode.Error{Code: errcode.ErrorCodeUnauthorized, Message: "unauthorized"}
-		var expectedError *UnsafeError
-		w := New(log, tempDir, &Mirror{unauthorized})
-		err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
-		if err == nil {
-			t.Fatal("should not pass")
-		}
-		assert.ErrorAs(t, err, &expectedError)
-	})
+// 	t.Run("Testing Worker for delete: should pass", func(t *testing.T) {
+// 		opts.Function = "delete"
+// 		w := New(log, tempDir, &Mirror{ForceError: nil})
+// 		copiedImages, err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
+// 		if err != nil {
+// 			t.Fatal("should pass")
+// 		}
+// 		assert.Equal(t, len(relatedImages), len(copiedImages.AllImages))
+// 	})
+// 	t.Run("Testing Worker : registry unauthorized : should fail fast", func(t *testing.T) {
+// 		opts.Function = "copy"
+// 		unauthorized := errcode.Error{Code: errcode.ErrorCodeUnauthorized, Message: "unauthorized"}
+// 		var expectedError *UnsafeError
+// 		w := New(log, tempDir, &Mirror{unauthorized})
+// 		copiedImages, err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
+// 		if err == nil {
+// 			t.Fatal("should not pass")
+// 		}
+// 		assert.ErrorAs(t, err, &expectedError)
+// 		assert.Equal(t, 0, len(copiedImages.AllImages))
+// 	})
 
-	t.Run("Testing Worker : manifest unknown for release: should  fail fast", func(t *testing.T) {
-		opts.Function = "delete"
-		errorCodeManifestUnknown := errcode.Error{
-			Code: errcode.ErrorCode(errcodev3.ErrorCodeManifestUnknown),
-		}
-		var expectedError *UnsafeError
-		w := New(log, tempDir, &Mirror{errorCodeManifestUnknown})
-		err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
-		if err == nil {
-			t.Fatal("should not pass")
-		}
-		assert.ErrorAs(t, err, &expectedError)
-	})
+// 	t.Run("Testing Worker : manifest unknown for release: should  fail fast", func(t *testing.T) {
+// 		opts.Function = "delete"
+// 		errorCodeManifestUnknown := errcode.Error{
+// 			Code: errcode.ErrorCode(errcode.ErrorCodeManifestUnknown),
+// 		}
+// 		var expectedError *UnsafeError
+// 		w := New(log, tempDir, &Mirror{errorCodeManifestUnknown})
+// 		copiedImages, err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
+// 		if err == nil {
+// 			t.Fatal("should not pass")
+// 		}
+// 		assert.ErrorAs(t, err, &expectedError)
+// 		assert.Equal(t, 0, len(copiedImages.AllImages))
+// 	})
 
-	t.Run("Testing Worker : manifest unknown for operator image: should  fail safe", func(t *testing.T) {
-		opImages := []v2alpha1.CopyImageSchema{
-			{Source: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testa", Type: v2alpha1.TypeOperatorRelatedImage},
-		}
-		opts.Function = "delete"
-		errorCodeManifestUnknown := errcode.Error{
-			Code: errcode.ErrorCode(errcodev3.ErrorCodeManifestUnknown),
-		}
-		var expectedError *SafeError
-		w := New(log, tempDir, &Mirror{errorCodeManifestUnknown})
-		err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: opImages}, opts)
-		if err == nil {
-			t.Fatal("should not pass")
-		}
-		assert.ErrorAs(t, err, &expectedError)
-	})
+// 	t.Run("Testing Worker : manifest unknown for operator image: should  fail safe", func(t *testing.T) {
+// 		opImages := []v2alpha1.CopyImageSchema{
+// 			{Source: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testa", Type: v2alpha1.TypeOperatorRelatedImage},
+// 		}
+// 		opts.Function = "delete"
+// 		errorCodeManifestUnknown := errcode.Error{
+// 			Code: errcode.ErrorCode(errcode.ErrorCodeManifestUnknown),
+// 		}
+// 		var expectedError *SafeError
+// 		w := New(log, tempDir, &Mirror{errorCodeManifestUnknown})
+// 		copiedImages, err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: opImages}, opts)
+// 		if err == nil {
+// 			t.Fatal("should not pass")
+// 		}
+// 		assert.ErrorAs(t, err, &expectedError)
+// 		assert.Equal(t, len(opImages), len(copiedImages.AllImages))
+// 	})
 
-	t.Run("Testing Worker : registry connection refused for additional image: should fail safe", func(t *testing.T) {
-		addImages := []v2alpha1.CopyImageSchema{
-			{Source: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testa", Type: v2alpha1.TypeGeneric},
-		}
-		opts.Function = "copy"
-		refused := syscall.ECONNREFUSED
-		var expectedError *SafeError
-		w := New(log, tempDir, &Mirror{refused})
-		err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: addImages}, opts)
-		if err == nil {
-			t.Fatal("should not pass")
-		}
-		assert.ErrorAs(t, err, &expectedError)
-	})
-}
+// 	t.Run("Testing Worker : registry connection refused for additional image: should fail safe", func(t *testing.T) {
+// 		addImages := []v2alpha1.CopyImageSchema{
+// 			{Source: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testa", Type: v2alpha1.TypeGeneric},
+// 		}
+// 		opts.Function = "copy"
+// 		refused := syscall.ECONNREFUSED
+// 		var expectedError *SafeError
+// 		w := New(log, tempDir, &Mirror{refused})
+// 		copiedImages, err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: addImages}, opts)
+// 		if err == nil {
+// 			t.Fatal("should not pass")
+// 		}
+// 		assert.ErrorAs(t, err, &expectedError)
+// 		assert.Equal(t, len(addImages), len(copiedImages.AllImages))
+// 	})
+// }
 
-// mocks
+// // mocks
 
-type Mirror struct {
-	ForceError error
-}
+// type Mirror struct {
+// 	ForceError error
+// }
 
-func (o Mirror) Run(ctx context.Context, src, dest string, mode mirror.Mode, opts *mirror.CopyOptions) error {
-	if o.ForceError != nil {
-		return o.ForceError
-	}
-	return nil
-}
+// func (o Mirror) Run(ctx context.Context, src, dest string, mode mirror.Mode, opts *mirror.CopyOptions) error {
+// 	if o.ForceError != nil {
+// 		return o.ForceError
+// 	}
+// 	return nil
+// }
 
-func (o Mirror) Check(ctx context.Context, image string, opts *mirror.CopyOptions, asCopySrc bool) (bool, error) {
-	if o.ForceError != nil {
-		return false, o.ForceError
-	}
-	return true, nil
-}
+// func (o Mirror) Check(ctx context.Context, image string, opts *mirror.CopyOptions, asCopySrc bool) (bool, error) {
+// 	if o.ForceError != nil {
+// 		return false, o.ForceError
+// 	}
+// 	return true, nil
+// }

--- a/v2/internal/pkg/batch/worker_test.go
+++ b/v2/internal/pkg/batch/worker_test.go
@@ -119,13 +119,13 @@ func TestWorker(t *testing.T) {
 		assert.Equal(t, 0, len(copiedImages.AllImages))
 	})
 
-	t.Run("Testing Worker : registry connection refused for additional image: should fail safe", func(t *testing.T) {
+	t.Run("Testing Worker : registry connection busy for additional image: should fail safe", func(t *testing.T) {
 		addImages := []v2alpha1.CopyImageSchema{
 			{Source: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testa", Type: v2alpha1.TypeGeneric},
 		}
 		opts.Function = "copy"
-		refused := syscall.ECONNREFUSED
-		w := New(log, tempDir, &Mirror{refused})
+		busy := syscall.EBUSY
+		w := New(log, tempDir, &Mirror{busy})
 		copiedImages, err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: addImages}, opts)
 		if err == nil {
 			t.Fatal("should not pass")

--- a/v2/internal/pkg/batch/worker_test.go
+++ b/v2/internal/pkg/batch/worker_test.go
@@ -1,155 +1,158 @@
 package batch
 
-// import (
-// 	"context"
-// 	"os"
-// 	"syscall"
-// 	"testing"
+import (
+	"context"
+	"os"
+	"syscall"
+	"testing"
 
-// 	"github.com/docker/distribution/registry/api/errcode"
+	errcodev3 "github.com/distribution/distribution/v3/registry/api/v2"
+	"github.com/docker/distribution/registry/api/errcode"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
+	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
+	"github.com/stretchr/testify/assert"
+)
 
-// 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
-// 	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
-// 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
-// 	"github.com/stretchr/testify/assert"
-// )
+func TestWorker(t *testing.T) {
 
-// func TestWorker(t *testing.T) {
+	log := clog.New("trace")
 
-// 	log := clog.New("trace")
+	global := &mirror.GlobalOptions{SecurePolicy: false, Quiet: false}
 
-// 	global := &mirror.GlobalOptions{SecurePolicy: false, Quiet: false}
+	_, sharedOpts := mirror.SharedImageFlags()
+	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
+	_, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
+	_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
+	_, retryOpts := mirror.RetryFlags()
 
-// 	_, sharedOpts := mirror.SharedImageFlags()
-// 	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
-// 	_, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
-// 	_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
-// 	_, retryOpts := mirror.RetryFlags()
+	opts := mirror.CopyOptions{
+		Global:              global,
+		DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
+		SrcImage:            srcOpts,
+		DestImage:           destOpts,
+		RetryOpts:           retryOpts,
+		Destination:         "oci:test",
+		Dev:                 false,
+		Mode:                mirror.DiskToMirror,
+		Function:            "copy",
+	}
+	tempDir := t.TempDir()
+	defer os.RemoveAll(tempDir)
 
-// 	opts := mirror.CopyOptions{
-// 		Global:              global,
-// 		DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
-// 		SrcImage:            srcOpts,
-// 		DestImage:           destOpts,
-// 		RetryOpts:           retryOpts,
-// 		Destination:         "oci:test",
-// 		Dev:                 false,
-// 		Mode:                mirror.DiskToMirror,
-// 		Function:            "copy",
-// 	}
-// 	tempDir := t.TempDir()
-// 	defer os.RemoveAll(tempDir)
+	relatedImages := []v2alpha1.CopyImageSchema{
+		{Source: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testa", Type: v2alpha1.TypeOCPRelease},
+		{Source: "docker://registry/name/namespace/sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testb", Type: v2alpha1.TypeOCPReleaseContent},
+		{Source: "docker://registry/name/namespace/sometestimage-c@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-c@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testc", Type: v2alpha1.TypeOperatorBundle},
+		{Source: "docker://registry/name/namespace/sometestimage-d@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-d@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testd", Type: v2alpha1.TypeOperatorCatalog},
+		{Source: "docker://registry/name/namespace/sometestimage-e@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-e@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:teste", Type: v2alpha1.TypeCincinnatiGraph},
+		{Source: "docker://registry/name/namespace/sometestimage-f@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-f@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testf", Type: v2alpha1.TypeGeneric},
+		{Source: "docker://registry/name/namespace/sometestimage-g@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-g@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testg", Type: v2alpha1.TypeGeneric},
+		{Source: "docker://registry/name/namespace/sometestimage-h@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-h@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testh", Type: v2alpha1.TypeGeneric},
+		{Source: "docker://registry/name/namespace/sometestimage-i@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-i@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testi", Type: v2alpha1.TypeGeneric},
+	}
+	// this is a facade to get code coverage up
+	t.Run("Testing Worker : should pass", func(t *testing.T) {
 
-// 	relatedImages := []v2alpha1.CopyImageSchema{
-// 		{Source: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testa", Type: v2alpha1.TypeOCPRelease},
-// 		{Source: "docker://registry/name/namespace/sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testb", Type: v2alpha1.TypeOCPReleaseContent},
-// 		{Source: "docker://registry/name/namespace/sometestimage-c@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-c@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testc", Type: v2alpha1.TypeOperatorBundle},
-// 		{Source: "docker://registry/name/namespace/sometestimage-d@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-d@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testd", Type: v2alpha1.TypeOperatorCatalog},
-// 		{Source: "docker://registry/name/namespace/sometestimage-e@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-e@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:teste", Type: v2alpha1.TypeCincinnatiGraph},
-// 		{Source: "docker://registry/name/namespace/sometestimage-f@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-f@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testf", Type: v2alpha1.TypeGeneric},
-// 		{Source: "docker://registry/name/namespace/sometestimage-g@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-g@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testg", Type: v2alpha1.TypeGeneric},
-// 		{Source: "docker://registry/name/namespace/sometestimage-h@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-h@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testh", Type: v2alpha1.TypeGeneric},
-// 		{Source: "docker://registry/name/namespace/sometestimage-i@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-i@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testi", Type: v2alpha1.TypeGeneric},
-// 	}
-// 	// this is a facade to get code coverage up
-// 	t.Run("Testing Worker : should pass", func(t *testing.T) {
+		w := New(log, tempDir, &Mirror{ForceError: nil})
+		copiedImages, err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
+		if err != nil {
+			t.Fatal("should pass")
+		}
+		assert.Equal(t, len(relatedImages), len(copiedImages.AllImages))
+	})
 
-// 		w := New(log, tempDir, &Mirror{ForceError: nil})
-// 		copiedImages, err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
-// 		if err != nil {
-// 			t.Fatal("should pass")
-// 		}
-// 		assert.Equal(t, len(relatedImages), len(copiedImages.AllImages))
-// 	})
+	t.Run("Testing Worker for delete: should pass", func(t *testing.T) {
+		opts.Function = "delete"
+		w := New(log, tempDir, &Mirror{ForceError: nil})
+		copiedImages, err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
+		if err != nil {
+			t.Fatal("should pass")
+		}
+		assert.Equal(t, len(relatedImages), len(copiedImages.AllImages))
+	})
+	t.Run("Testing Worker : registry unauthorized : should fail fast", func(t *testing.T) {
+		opts.Function = "copy"
+		unauthorized := errcode.Error{Code: errcode.ErrorCodeUnauthorized, Message: "unauthorized"}
+		w := New(log, tempDir, &Mirror{unauthorized})
+		copiedImages, err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
+		if err == nil {
+			t.Fatal("should not pass")
+		}
+		if unsafe, ok := err.(UnsafeError); !ok {
+			t.Fatalf("expected error type SafeError, but was %v", unsafe)
+		}
+		assert.Equal(t, 0, len(copiedImages.AllImages))
+	})
 
-// 	t.Run("Testing Worker for delete: should pass", func(t *testing.T) {
-// 		opts.Function = "delete"
-// 		w := New(log, tempDir, &Mirror{ForceError: nil})
-// 		copiedImages, err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
-// 		if err != nil {
-// 			t.Fatal("should pass")
-// 		}
-// 		assert.Equal(t, len(relatedImages), len(copiedImages.AllImages))
-// 	})
-// 	t.Run("Testing Worker : registry unauthorized : should fail fast", func(t *testing.T) {
-// 		opts.Function = "copy"
-// 		unauthorized := errcode.Error{Code: errcode.ErrorCodeUnauthorized, Message: "unauthorized"}
-// 		var expectedError *UnsafeError
-// 		w := New(log, tempDir, &Mirror{unauthorized})
-// 		copiedImages, err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
-// 		if err == nil {
-// 			t.Fatal("should not pass")
-// 		}
-// 		assert.ErrorAs(t, err, &expectedError)
-// 		assert.Equal(t, 0, len(copiedImages.AllImages))
-// 	})
+	t.Run("Testing Worker : manifest unknown for release: should  fail fast", func(t *testing.T) {
+		opts.Function = "delete"
+		errorCodeManifestUnknown := errcode.Error{
+			Code: errcode.ErrorCode(errcodev3.ErrorCodeManifestUnknown),
+		}
+		w := New(log, tempDir, &Mirror{errorCodeManifestUnknown})
+		copiedImages, err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
+		if err == nil {
+			t.Fatal("should not pass")
+		}
+		if unsafe, ok := err.(UnsafeError); !ok {
+			t.Fatalf("expected error type SafeError, but was %v", unsafe)
+		}
+		assert.Equal(t, 0, len(copiedImages.AllImages))
+	})
 
-// 	t.Run("Testing Worker : manifest unknown for release: should  fail fast", func(t *testing.T) {
-// 		opts.Function = "delete"
-// 		errorCodeManifestUnknown := errcode.Error{
-// 			Code: errcode.ErrorCode(errcode.ErrorCodeManifestUnknown),
-// 		}
-// 		var expectedError *UnsafeError
-// 		w := New(log, tempDir, &Mirror{errorCodeManifestUnknown})
-// 		copiedImages, err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: relatedImages}, opts)
-// 		if err == nil {
-// 			t.Fatal("should not pass")
-// 		}
-// 		assert.ErrorAs(t, err, &expectedError)
-// 		assert.Equal(t, 0, len(copiedImages.AllImages))
-// 	})
+	t.Run("Testing Worker : manifest unknown for operator image: should  fail safe", func(t *testing.T) {
+		opImages := []v2alpha1.CopyImageSchema{
+			{Source: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testa", Type: v2alpha1.TypeOperatorRelatedImage},
+		}
+		opts.Function = "delete"
+		errorCodeManifestUnknown := errcode.Error{
+			Code: errcode.ErrorCode(errcodev3.ErrorCodeManifestUnknown)}
+		w := New(log, tempDir, &Mirror{errorCodeManifestUnknown})
+		copiedImages, err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: opImages}, opts)
+		if err == nil {
+			t.Fatal("should not pass")
+		}
+		if safe, ok := err.(SafeError); !ok {
+			t.Fatalf("expected error type SafeError, but was %v", safe)
+		}
+		assert.Equal(t, 0, len(copiedImages.AllImages))
+	})
 
-// 	t.Run("Testing Worker : manifest unknown for operator image: should  fail safe", func(t *testing.T) {
-// 		opImages := []v2alpha1.CopyImageSchema{
-// 			{Source: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testa", Type: v2alpha1.TypeOperatorRelatedImage},
-// 		}
-// 		opts.Function = "delete"
-// 		errorCodeManifestUnknown := errcode.Error{
-// 			Code: errcode.ErrorCode(errcode.ErrorCodeManifestUnknown),
-// 		}
-// 		var expectedError *SafeError
-// 		w := New(log, tempDir, &Mirror{errorCodeManifestUnknown})
-// 		copiedImages, err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: opImages}, opts)
-// 		if err == nil {
-// 			t.Fatal("should not pass")
-// 		}
-// 		assert.ErrorAs(t, err, &expectedError)
-// 		assert.Equal(t, len(opImages), len(copiedImages.AllImages))
-// 	})
+	t.Run("Testing Worker : registry connection refused for additional image: should fail safe", func(t *testing.T) {
+		addImages := []v2alpha1.CopyImageSchema{
+			{Source: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testa", Type: v2alpha1.TypeGeneric},
+		}
+		opts.Function = "copy"
+		refused := syscall.ECONNREFUSED
+		w := New(log, tempDir, &Mirror{refused})
+		copiedImages, err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: addImages}, opts)
+		if err == nil {
+			t.Fatal("should not pass")
+		}
+		if safe, ok := err.(SafeError); !ok {
+			t.Fatalf("expected error type SafeError, but was %v", safe)
+		}
+		assert.Equal(t, 0, len(copiedImages.AllImages))
+	})
+}
 
-// 	t.Run("Testing Worker : registry connection refused for additional image: should fail safe", func(t *testing.T) {
-// 		addImages := []v2alpha1.CopyImageSchema{
-// 			{Source: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Origin: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:testa", Type: v2alpha1.TypeGeneric},
-// 		}
-// 		opts.Function = "copy"
-// 		refused := syscall.ECONNREFUSED
-// 		var expectedError *SafeError
-// 		w := New(log, tempDir, &Mirror{refused})
-// 		copiedImages, err := w.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: addImages}, opts)
-// 		if err == nil {
-// 			t.Fatal("should not pass")
-// 		}
-// 		assert.ErrorAs(t, err, &expectedError)
-// 		assert.Equal(t, len(addImages), len(copiedImages.AllImages))
-// 	})
-// }
+// mocks
 
-// // mocks
+type Mirror struct {
+	ForceError error
+}
 
-// type Mirror struct {
-// 	ForceError error
-// }
+func (o Mirror) Run(ctx context.Context, src, dest string, mode mirror.Mode, opts *mirror.CopyOptions) error {
+	if o.ForceError != nil {
+		return o.ForceError
+	}
+	return nil
+}
 
-// func (o Mirror) Run(ctx context.Context, src, dest string, mode mirror.Mode, opts *mirror.CopyOptions) error {
-// 	if o.ForceError != nil {
-// 		return o.ForceError
-// 	}
-// 	return nil
-// }
-
-// func (o Mirror) Check(ctx context.Context, image string, opts *mirror.CopyOptions, asCopySrc bool) (bool, error) {
-// 	if o.ForceError != nil {
-// 		return false, o.ForceError
-// 	}
-// 	return true, nil
-// }
+func (o Mirror) Check(ctx context.Context, image string, opts *mirror.CopyOptions, asCopySrc bool) (bool, error) {
+	if o.ForceError != nil {
+		return false, o.ForceError
+	}
+	return true, nil
+}

--- a/v2/internal/pkg/cli/additional_integration_test.go
+++ b/v2/internal/pkg/cli/additional_integration_test.go
@@ -113,7 +113,7 @@ func (suite *TestEnvironmentAddditional) setupTestData(t *testing.T) {
 	assert.NoError(t, err, "should not fail to push image"+suite.sourceRegistryDomain+"/foo:v1.0")
 
 	// create the image set config
-	templatePath := "../../internal/e2e/templates/isc_templates/additional_isc.yaml"
+	templatePath := "../../e2e/templates/isc_templates/additional_isc.yaml"
 	suite.imageSetConfig = suite.tempFolder + "/isc.yaml"
 	err = testutils.FileFromTemplate(suite.imageSetConfig, templatePath, suite.additionalImageRefs)
 	assert.NoError(t, err, "should not fail to generate imageSetConfig")

--- a/v2/internal/pkg/cli/delete.go
+++ b/v2/internal/pkg/cli/delete.go
@@ -254,7 +254,7 @@ func (o *ExecutorSchema) CompleteDelete(args []string) error {
 	signature := release.NewSignatureClient(o.Log, o.Config, *o.Opts)
 	cn := release.NewCincinnati(o.Log, &o.Config, *o.Opts, client, false, signature)
 	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.LocalStorageFQDN, o.ImageBuilder)
-	o.Batch = batch.New(o.Log, o.LogsDir, o.Mirror, o.Manifest)
+	o.Batch = batch.New(o.Log, o.LogsDir, o.Mirror)
 	o.Operator = operator.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, o.LocalStorageFQDN)
 	o.AdditionalImages = additional.New(o.Log, o.Config, *o.Opts, o.Mirror, o.Manifest, o.LocalStorageFQDN)
 

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -698,9 +698,12 @@ func (o *ExecutorSchema) RunMirrorToDisk(cmd *cobra.Command, args []string) erro
 	}
 
 	if !o.Opts.IsDryRun {
+		var copiedSchema v2alpha1.CollectorSchema
 		// call the batch worker
-		if err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
+		if cs, err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
+		} else {
+			copiedSchema = cs
 		}
 
 		// prepare tar.gz when mirror to disk
@@ -710,7 +713,7 @@ func (o *ExecutorSchema) RunMirrorToDisk(cmd *cobra.Command, args []string) erro
 
 		o.Log.Info("📦 Preparing the tarball archive...")
 		// next, generate the archive
-		err = o.MirrorArchiver.BuildArchive(cmd.Context(), collectorSchema.AllImages)
+		err = o.MirrorArchiver.BuildArchive(cmd.Context(), copiedSchema.AllImages)
 		if err != nil {
 			return err
 		}
@@ -748,19 +751,22 @@ func (o *ExecutorSchema) RunMirrorToMirror(cmd *cobra.Command, args []string) er
 		}
 	}
 	if !o.Opts.IsDryRun {
+		var copiedSchema v2alpha1.CollectorSchema
 		//call the batch worker
-		if err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
+		if cs, err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
+		} else {
+			copiedSchema = cs
 		}
 
 		//create IDMS/ITMS
 		forceRepositoryScope := o.Opts.Global.MaxNestedPaths > 0
-		err = o.ClusterResources.IDMS_ITMSGenerator(collectorSchema.AllImages, forceRepositoryScope)
+		err = o.ClusterResources.IDMS_ITMSGenerator(copiedSchema.AllImages, forceRepositoryScope)
 		if err != nil {
 			return err
 		}
 
-		err = o.ClusterResources.CatalogSourceGenerator(collectorSchema.AllImages)
+		err = o.ClusterResources.CatalogSourceGenerator(copiedSchema.AllImages)
 		if err != nil {
 			return err
 		}
@@ -824,19 +830,22 @@ func (o *ExecutorSchema) RunDiskToMirror(cmd *cobra.Command, args []string) erro
 	}
 
 	if !o.Opts.IsDryRun {
+		var copiedSchema v2alpha1.CollectorSchema
 		// call the batch worker
-		if err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
+		if cs, err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
+		} else {
+			copiedSchema = cs
 		}
 		// create IDMS/ITMS
 		forceRepositoryScope := o.Opts.Global.MaxNestedPaths > 0
-		err = o.ClusterResources.IDMS_ITMSGenerator(collectorSchema.AllImages, forceRepositoryScope)
+		err = o.ClusterResources.IDMS_ITMSGenerator(copiedSchema.AllImages, forceRepositoryScope)
 		if err != nil {
 			return err
 		}
 
 		// create catalog source
-		err = o.ClusterResources.CatalogSourceGenerator(collectorSchema.AllImages)
+		err = o.ClusterResources.CatalogSourceGenerator(copiedSchema.AllImages)
 		if err != nil {
 			return err
 		}

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -700,8 +700,12 @@ func (o *ExecutorSchema) RunMirrorToDisk(cmd *cobra.Command, args []string) erro
 	if !o.Opts.IsDryRun {
 		var copiedSchema v2alpha1.CollectorSchema
 		// call the batch worker
-		if cs, err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
-			return err
+		if cs, err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil {
+			if _, ok := err.(batch.UnsafeError); ok {
+				return err
+			} else {
+				copiedSchema = cs
+			}
 		} else {
 			copiedSchema = cs
 		}
@@ -832,11 +836,16 @@ func (o *ExecutorSchema) RunDiskToMirror(cmd *cobra.Command, args []string) erro
 	if !o.Opts.IsDryRun {
 		var copiedSchema v2alpha1.CollectorSchema
 		// call the batch worker
-		if cs, err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
-			return err
+		if cs, err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil {
+			if _, ok := err.(batch.UnsafeError); ok {
+				return err
+			} else {
+				copiedSchema = cs
+			}
 		} else {
 			copiedSchema = cs
 		}
+
 		// create IDMS/ITMS
 		forceRepositoryScope := o.Opts.Global.MaxNestedPaths > 0
 		err = o.ClusterResources.IDMS_ITMSGenerator(copiedSchema.AllImages, forceRepositoryScope)

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -757,8 +757,12 @@ func (o *ExecutorSchema) RunMirrorToMirror(cmd *cobra.Command, args []string) er
 	if !o.Opts.IsDryRun {
 		var copiedSchema v2alpha1.CollectorSchema
 		//call the batch worker
-		if cs, err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
-			return err
+		if cs, err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil {
+			if _, ok := err.(batch.UnsafeError); ok {
+				return err
+			} else {
+				copiedSchema = cs
+			}
 		} else {
 			copiedSchema = cs
 		}

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -408,7 +408,7 @@ func (o *ExecutorSchema) Complete(args []string) error {
 	o.Operator = operator.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, o.LocalStorageFQDN)
 	o.AdditionalImages = additional.New(o.Log, o.Config, *o.Opts, o.Mirror, o.Manifest, o.LocalStorageFQDN)
 	o.ClusterResources = clusterresources.New(o.Log, o.Opts.Global.WorkingDir, o.Config)
-	o.Batch = batch.New(o.Log, o.LogsDir, o.Mirror, o.Manifest)
+	o.Batch = batch.New(o.Log, o.LogsDir, o.Mirror)
 
 	if o.Opts.IsMirrorToDisk() {
 		if o.Opts.Global.StrictArchiving {
@@ -699,8 +699,7 @@ func (o *ExecutorSchema) RunMirrorToDisk(cmd *cobra.Command, args []string) erro
 
 	if !o.Opts.IsDryRun {
 		// call the batch worker
-		err = o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts)
-		if err != nil {
+		if err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
 		}
 
@@ -750,8 +749,7 @@ func (o *ExecutorSchema) RunMirrorToMirror(cmd *cobra.Command, args []string) er
 	}
 	if !o.Opts.IsDryRun {
 		//call the batch worker
-		err = o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts)
-		if err != nil {
+		if err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
 		}
 
@@ -827,8 +825,7 @@ func (o *ExecutorSchema) RunDiskToMirror(cmd *cobra.Command, args []string) erro
 
 	if !o.Opts.IsDryRun {
 		// call the batch worker
-		err = o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts)
-		if err != nil {
+		if err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
 		}
 		// create IDMS/ITMS

--- a/v2/internal/pkg/cli/executor_test.go
+++ b/v2/internal/pkg/cli/executor_test.go
@@ -930,11 +930,17 @@ func (o MockClusterResources) CatalogSourceGenerator(allRelatedImages []v2alpha1
 	return nil
 }
 
-func (o Batch) Worker(ctx context.Context, collectorSchema v2alpha1.CollectorSchema, opts mirror.CopyOptions) error {
-	if o.Fail {
-		return fmt.Errorf("forced error")
+func (o Batch) Worker(ctx context.Context, collectorSchema v2alpha1.CollectorSchema, opts mirror.CopyOptions) (v2alpha1.CollectorSchema, error) {
+	copiedImages := v2alpha1.CollectorSchema{
+		AllImages:             []v2alpha1.CopyImageSchema{},
+		TotalReleaseImages:    0,
+		TotalOperatorImages:   0,
+		TotalAdditionalImages: 0,
 	}
-	return nil
+	if o.Fail {
+		return copiedImages, fmt.Errorf("forced error")
+	}
+	return collectorSchema, nil
 }
 
 func (o *Collector) OperatorImageCollector(ctx context.Context) ([]v2alpha1.CopyImageSchema, error) {

--- a/v2/internal/pkg/cli/release_integration_test.go
+++ b/v2/internal/pkg/cli/release_integration_test.go
@@ -107,17 +107,17 @@ func (suite *TestEnvironmentRelease) setupTestData(t *testing.T) {
 	os.Setenv("CONTAINERS_REGISTRIES_CONF", suite.tempFolder+"/registries.conf")
 
 	// copy test registries.conf to user home
-	regConfTemplatePath := "../../internal/e2e/templates/regisitries.conf"
+	regConfTemplatePath := "../../e2e/templates/regisitries.conf"
 	err := testutils.FileFromTemplate(suite.tempFolder+"/registries.conf", regConfTemplatePath, []string{suite.sourceRegistryDomain})
 	assert.NoError(t, err, "should not fail to prepare registries.conf for test")
 
 	// prepare all images needed
-	releaseDigest, releaseImageRefs, err := testutils.GenerateReleaseAndComponents(suite.sourceRegistryDomain, suite.tempFolder, "../../internal/e2e/templates/release_templates/image-references")
+	releaseDigest, releaseImageRefs, err := testutils.GenerateReleaseAndComponents(suite.sourceRegistryDomain, suite.tempFolder, "../../e2e/templates/release_templates/image-references")
 	assert.NoError(t, err, "should not fail to generate and push release to source registry")
 	suite.releaseImageRefs = releaseImageRefs
 
 	cm := testutils.CincinnatiMock{
-		Templates: map[string]string{"stable-4.15": "../../internal/e2e/templates/release_templates/cincinnati_stable-4.15.json"},
+		Templates: map[string]string{"stable-4.15": "../../e2e/templates/release_templates/cincinnati_stable-4.15.json"},
 		Tokens:    []string{suite.sourceRegistryDomain + "/openshift-release-dev/ocp-release@" + releaseDigest},
 	}
 
@@ -129,7 +129,7 @@ func (suite *TestEnvironmentRelease) setupTestData(t *testing.T) {
 	suite.cincinnatiEndpoint = endpoint.Host
 
 	// set up a signature in the working-dir (cached signature)
-	signatureFile, err := os.Open("../../internal/e2e/signatures/signature-1")
+	signatureFile, err := os.Open("../../e2e/signatures/signature-1")
 	assert.NoError(t, err)
 	defer signatureFile.Close()
 
@@ -144,7 +144,7 @@ func (suite *TestEnvironmentRelease) setupTestData(t *testing.T) {
 	assert.NoError(t, err)
 
 	// create the image set config
-	templatePath := "../../internal/e2e/templates/isc_templates/release_isc.yaml"
+	templatePath := "../../e2e/templates/isc_templates/release_isc.yaml"
 	suite.imageSetConfig = suite.tempFolder + "/isc.yaml"
 	err = testutils.FileFromTemplate(suite.imageSetConfig, templatePath, []string{"stable-4.15"})
 	assert.NoError(t, err, "should not fail to generate imageSetConfig")

--- a/v2/internal/pkg/clusterresources/clusterresources.go
+++ b/v2/internal/pkg/clusterresources/clusterresources.go
@@ -184,9 +184,13 @@ func (o *ClusterResourcesGenerator) CatalogSourceGenerator(allRelatedImages []v2
 		return nil
 	}
 
-	o.Log.Info("📄 Generating CatalogSource file...")
+	firstCatalog := true
 	for _, copyImage := range allRelatedImages {
 		if copyImage.Type == v2alpha1.TypeOperatorCatalog {
+			if firstCatalog {
+				o.Log.Info("📄 Generating CatalogSource file...")
+				firstCatalog = false
+			}
 			// check if ImageSetConfig contains a CatalogSourceTemplate for this catalog, and use it
 			template := o.getCSTemplate(copyImage.Origin)
 			err := o.generateCatalogSource(copyImage.Destination, template)

--- a/v2/internal/pkg/delete/delete_images.go
+++ b/v2/internal/pkg/delete/delete_images.go
@@ -163,14 +163,14 @@ func (o DeleteImages) DeleteRegistryImages(images v2alpha1.DeleteImageList) erro
 	// ensure output is suppressed
 	o.Opts.Stdout = io.Discard
 	if !o.Opts.Global.DeleteGenerate && len(o.Opts.Global.DeleteDestination) > 0 {
-		if err := o.Batch.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: rrUpdatedImages}, o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
+		if _, err := o.Batch.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: rrUpdatedImages}, o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
 		}
 	}
 	// if mirrortoMirror mode no conetents were stored to the cache
 	// so just skip
 	if o.Opts.Global.ForceCacheDelete && o.Opts.Mode != mirror.MirrorToMirror {
-		if err := o.Batch.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: lsUpdatedImages}, o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
+		if _, err := o.Batch.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: lsUpdatedImages}, o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
 		}
 	}

--- a/v2/internal/pkg/delete/delete_images.go
+++ b/v2/internal/pkg/delete/delete_images.go
@@ -2,6 +2,7 @@ package delete
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -162,16 +163,14 @@ func (o DeleteImages) DeleteRegistryImages(images v2alpha1.DeleteImageList) erro
 	// ensure output is suppressed
 	o.Opts.Stdout = io.Discard
 	if !o.Opts.Global.DeleteGenerate && len(o.Opts.Global.DeleteDestination) > 0 {
-		err := o.Batch.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: rrUpdatedImages}, o.Opts)
-		if err != nil {
+		if err := o.Batch.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: rrUpdatedImages}, o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
 		}
 	}
 	// if mirrortoMirror mode no conetents were stored to the cache
 	// so just skip
 	if o.Opts.Global.ForceCacheDelete && o.Opts.Mode != mirror.MirrorToMirror {
-		err := o.Batch.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: lsUpdatedImages}, o.Opts)
-		if err != nil {
+		if err := o.Batch.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: lsUpdatedImages}, o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
 		}
 	}

--- a/v2/internal/pkg/delete/delete_images_test.go
+++ b/v2/internal/pkg/delete/delete_images_test.go
@@ -731,11 +731,17 @@ type mockBlobs struct {
 
 type mockManifest struct{}
 
-func (o mockBatch) Worker(ctx context.Context, collectorSchema v2alpha1.CollectorSchema, opts mirror.CopyOptions) error {
-	if o.Fail {
-		return fmt.Errorf("forced error")
+func (o mockBatch) Worker(ctx context.Context, collectorSchema v2alpha1.CollectorSchema, opts mirror.CopyOptions) (v2alpha1.CollectorSchema, error) {
+	copiedImages := v2alpha1.CollectorSchema{
+		AllImages:             []v2alpha1.CopyImageSchema{},
+		TotalReleaseImages:    0,
+		TotalOperatorImages:   0,
+		TotalAdditionalImages: 0,
 	}
-	return nil
+	if o.Fail {
+		return copiedImages, fmt.Errorf("forced error")
+	}
+	return collectorSchema, nil
 }
 
 func (o *mockBlobs) GatherBlobs(ctx context.Context, image string) (map[string]string, error) {

--- a/v2/internal/pkg/mirror/mirror.go
+++ b/v2/internal/pkg/mirror/mirror.go
@@ -181,6 +181,10 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 		MaxParallelDownloads:             opts.MaxParallelDownloads,
 	}
 
+	if opts.Global.LogLevel == "debug" {
+		co.ReportWriter = opts.Stdout
+	}
+
 	return retry.IfNecessary(ctx, func() error {
 
 		//manifestBytes, err := copy.Image(ctx, policyContext, destRef, srcRef, &copy.Options{

--- a/v2/internal/testutils/testutils.go
+++ b/v2/internal/testutils/testutils.go
@@ -303,7 +303,7 @@ func GenerateFakeRelease(imageRefs releaseContents, releaseImgRef, tempFolder st
 	if err != nil {
 		return "", err
 	}
-	releaseMetaBytes, err := os.ReadFile("../../internal/e2e/templates/release_templates/release-metadata")
+	releaseMetaBytes, err := os.ReadFile("../../e2e/templates/release_templates/release-metadata")
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/error.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/error.go
@@ -1,0 +1,111 @@
+package batch
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"syscall"
+
+	"github.com/distribution/distribution/v3/registry/api/errcode"
+	"github.com/hashicorp/go-multierror"
+)
+
+type SafeError struct {
+	message string
+}
+
+type UnsafeError struct {
+	errSchema mirrorErrorSchema
+}
+
+func NewSafeError(format string, a ...any) error {
+	return &SafeError{fmt.Sprintf(format, a...)}
+}
+
+func NewUnsafeError(mes mirrorErrorSchema) error {
+	return &UnsafeError{mes}
+}
+
+func (e SafeError) Error() string { return e.message }
+
+func (e UnsafeError) Error() string { return e.errSchema.err.Error() }
+
+func isFailSafe(err error) bool {
+	switch err {
+	case nil:
+		return true
+	case context.Canceled, context.DeadlineExceeded:
+		return false
+	default: // continue
+	}
+
+	type unwrapper interface {
+		Unwrap() error
+	}
+
+	switch e := err.(type) {
+
+	case errcode.Error:
+		switch e.Code {
+		case errcode.ErrorCodeUnauthorized, errcode.ErrorCodeDenied:
+			// For oc-mirror this is a grey area: we consider that having Authentication
+			// or authorization errors to a registry (whether source or destination) on one
+			// image is very likely to give similar errors on other images.
+			return false
+		}
+		// normally manifest unknown, blob unknown, etc fall into the following return
+		return true
+	case *net.OpError:
+		return isFailSafe(e.Err)
+	case *url.Error: // This includes errors returned by the net/http client.
+		if e.Err == io.EOF { // Happens when a server accepts a HTTP connection and sends EOF
+			return true
+		}
+		return isFailSafe(e.Err)
+	case syscall.Errno:
+		return isErrnoFailSafe(e)
+	case errcode.Errors:
+		// if this error is a group of errors, process them all in turn
+		for i := range e {
+			if !isFailSafe(e[i]) {
+				return false
+			}
+		}
+		return true
+	case *multierror.Error:
+		// if this error is a group of errors, process them all in turn
+		for i := range e.Errors {
+			if !isFailSafe(e.Errors[i]) {
+				return false
+			}
+		}
+		return true
+	case net.Error:
+		if e.Timeout() {
+			return true
+		}
+		if unwrappable, ok := e.(unwrapper); ok {
+			err = unwrappable.Unwrap()
+			return isFailSafe(err)
+		}
+	case unwrapper: // Test this last, because various error types might implement .Unwrap()
+		err = e.Unwrap()
+		return isFailSafe(err)
+	}
+
+	return false
+}
+
+func isErrnoFailSafe(e error) bool {
+	switch e {
+	case syscall.ECONNREFUSED, syscall.EINTR, syscall.EAGAIN, syscall.EBUSY, syscall.ENETDOWN, syscall.ENETUNREACH, syscall.ENETRESET, syscall.ECONNABORTED, syscall.ECONNRESET, syscall.ETIMEDOUT, syscall.EHOSTDOWN, syscall.EHOSTUNREACH:
+		return true
+	}
+	return isErrnoERESTART(e)
+}
+
+func isErrnoERESTART(e error) bool {
+	return e == syscall.ERESTART
+}

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/error.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/error.go
@@ -101,7 +101,9 @@ func isFailSafe(err error) bool {
 
 func isErrnoFailSafe(e error) bool {
 	switch e {
-	case syscall.ECONNREFUSED, syscall.EINTR, syscall.EAGAIN, syscall.EBUSY, syscall.ENETDOWN, syscall.ENETUNREACH, syscall.ENETRESET, syscall.ECONNABORTED, syscall.ECONNRESET, syscall.ETIMEDOUT, syscall.EHOSTDOWN, syscall.EHOSTUNREACH:
+	case syscall.ECONNREFUSED, syscall.ENETDOWN, syscall.ENETUNREACH, syscall.EHOSTDOWN, syscall.EHOSTUNREACH:
+		return false
+	case syscall.EINTR, syscall.EAGAIN, syscall.EBUSY, syscall.ENETRESET, syscall.ECONNABORTED, syscall.ECONNRESET, syscall.ETIMEDOUT:
 		return true
 	}
 	return isErrnoERESTART(e)

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/error.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/error.go
@@ -8,7 +8,8 @@ import (
 	"net/url"
 	"syscall"
 
-	"github.com/distribution/distribution/v3/registry/api/errcode"
+	// "github.com/distribution/distribution/v3/registry/api/errcode"
+	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/hashicorp/go-multierror"
 )
 

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/error.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/error.go
@@ -1,16 +1,8 @@
 package batch
 
 import (
-	"context"
 	"fmt"
-	"io"
-	"net"
-	"net/url"
-	"syscall"
-
 	// "github.com/distribution/distribution/v3/registry/api/errcode"
-	"github.com/docker/distribution/registry/api/errcode"
-	"github.com/hashicorp/go-multierror"
 )
 
 type SafeError struct {
@@ -33,82 +25,82 @@ func (e SafeError) Error() string { return e.message }
 
 func (e UnsafeError) Error() string { return e.errSchema.err.Error() }
 
-func isFailSafe(err error) bool {
-	switch err {
-	case nil:
-		return true
-	case context.Canceled, context.DeadlineExceeded:
-		return false
-	default: // continue
-	}
+// func isFailSafe(err error) bool {
+// 	switch err {
+// 	case nil:
+// 		return true
+// 	case context.Canceled, context.DeadlineExceeded:
+// 		return false
+// 	default: // continue
+// 	}
 
-	type unwrapper interface {
-		Unwrap() error
-	}
+// 	type unwrapper interface {
+// 		Unwrap() error
+// 	}
 
-	switch e := err.(type) {
+// 	switch e := err.(type) {
 
-	case errcode.Error:
-		switch e.Code {
-		case errcode.ErrorCodeUnauthorized, errcode.ErrorCodeDenied:
-			// For oc-mirror this is a grey area: we consider that having Authentication
-			// or authorization errors to a registry (whether source or destination) on one
-			// image is very likely to give similar errors on other images.
-			return false
-		}
-		// normally manifest unknown, blob unknown, etc fall into the following return
-		return true
-	case *net.OpError:
-		return isFailSafe(e.Err)
-	case *url.Error: // This includes errors returned by the net/http client.
-		if e.Err == io.EOF { // Happens when a server accepts a HTTP connection and sends EOF
-			return true
-		}
-		return isFailSafe(e.Err)
-	case syscall.Errno:
-		return isErrnoFailSafe(e)
-	case errcode.Errors:
-		// if this error is a group of errors, process them all in turn
-		for i := range e {
-			if !isFailSafe(e[i]) {
-				return false
-			}
-		}
-		return true
-	case *multierror.Error:
-		// if this error is a group of errors, process them all in turn
-		for i := range e.Errors {
-			if !isFailSafe(e.Errors[i]) {
-				return false
-			}
-		}
-		return true
-	case net.Error:
-		if e.Timeout() {
-			return true
-		}
-		if unwrappable, ok := e.(unwrapper); ok {
-			err = unwrappable.Unwrap()
-			return isFailSafe(err)
-		}
-	case unwrapper: // Test this last, because various error types might implement .Unwrap()
-		err = e.Unwrap()
-		return isFailSafe(err)
-	}
+// 	case errcode.Error:
+// 		switch e.Code {
+// 		case errcode.ErrorCodeUnauthorized, errcode.ErrorCodeDenied:
+// 			// For oc-mirror this is a grey area: we consider that having Authentication
+// 			// or authorization errors to a registry (whether source or destination) on one
+// 			// image is very likely to give similar errors on other images.
+// 			return false
+// 		}
+// 		// normally manifest unknown, blob unknown, etc fall into the following return
+// 		return true
+// 	case *net.OpError:
+// 		return isFailSafe(e.Err)
+// 	case *url.Error: // This includes errors returned by the net/http client.
+// 		if e.Err == io.EOF { // Happens when a server accepts a HTTP connection and sends EOF
+// 			return true
+// 		}
+// 		return isFailSafe(e.Err)
+// 	case syscall.Errno:
+// 		return isErrnoFailSafe(e)
+// 	case errcode.Errors:
+// 		// if this error is a group of errors, process them all in turn
+// 		for i := range e {
+// 			if !isFailSafe(e[i]) {
+// 				return false
+// 			}
+// 		}
+// 		return true
+// 	case *multierror.Error:
+// 		// if this error is a group of errors, process them all in turn
+// 		for i := range e.Errors {
+// 			if !isFailSafe(e.Errors[i]) {
+// 				return false
+// 			}
+// 		}
+// 		return true
+// 	case net.Error:
+// 		if e.Timeout() {
+// 			return true
+// 		}
+// 		if unwrappable, ok := e.(unwrapper); ok {
+// 			err = unwrappable.Unwrap()
+// 			return isFailSafe(err)
+// 		}
+// 	case unwrapper: // Test this last, because various error types might implement .Unwrap()
+// 		err = e.Unwrap()
+// 		return isFailSafe(err)
+// 	}
 
-	return false
-}
+// 	return false
+// }
 
-func isErrnoFailSafe(e error) bool {
-	switch e {
-	case syscall.ECONNREFUSED, syscall.ENETDOWN, syscall.ENETUNREACH, syscall.EHOSTDOWN, syscall.EHOSTUNREACH:
-		return false
-	case syscall.EINTR, syscall.EAGAIN, syscall.EBUSY, syscall.ENETRESET, syscall.ECONNABORTED, syscall.ECONNRESET, syscall.ETIMEDOUT:
-		return true
-	}
-	return isErrnoERESTART(e)
-}
+// func isErrnoFailSafe(e error) bool {
+// 	switch e {
+// 	case syscall.ECONNREFUSED, syscall.ENETDOWN, syscall.ENETUNREACH, syscall.EHOSTDOWN, syscall.EHOSTUNREACH:
+// 		return false
+// 	case syscall.EINTR, syscall.EAGAIN, syscall.EBUSY, syscall.ENETRESET, syscall.ECONNABORTED, syscall.ECONNRESET, syscall.ETIMEDOUT:
+// 		return true
+// 	}
+// 	return isErrnoERESTART(e)
+// }
 
-func isErrnoERESTART(e error) bool {
-	return e == syscall.ERESTART
-}
+// func isErrnoERESTART(e error) bool {
+// 	return e == syscall.ERESTART
+// }

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/error.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/error.go
@@ -22,11 +22,11 @@ type UnsafeError struct {
 }
 
 func NewSafeError(format string, a ...any) error {
-	return &SafeError{fmt.Sprintf(format, a...)}
+	return SafeError{fmt.Sprintf(format, a...)}
 }
 
 func NewUnsafeError(mes mirrorErrorSchema) error {
-	return &UnsafeError{mes}
+	return UnsafeError{mes}
 }
 
 func (e SafeError) Error() string { return e.message }

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/worker.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/worker.go
@@ -24,7 +24,7 @@ func New(log clog.PluggableLoggerInterface,
 	copiedImages := v2alpha1.CollectorSchema{
 		AllImages: []v2alpha1.CopyImageSchema{},
 	}
-	return &Batch{Log: log, LogsDir: logsDir, Mirror: mirror, CopiedImages: copiedImages}
+	return &Batch{Log: log, LogsDir: logsDir, Mirror: mirror, CopiedImages: copiedImages, Progress: &ProgressStruct{}}
 }
 
 type Batch struct {
@@ -32,8 +32,23 @@ type Batch struct {
 	LogsDir      string
 	Mirror       mirror.MirrorInterface
 	CopiedImages v2alpha1.CollectorSchema
+	Progress     *ProgressStruct
 }
 
+type ProgressStruct struct {
+	countTotal            int
+	countReleaseImages    int
+	countOperatorsImages  int
+	countAdditionalImages int
+
+	countErrorTotal                 int
+	countReleaseImagesErrorTotal    int
+	countOperatorsImagesErrorTotal  int
+	countAdditionalImagesErrorTotal int
+
+	mirrorMessage string
+	Log           clog.PluggableLoggerInterface
+}
 type mirrorErrorSchema struct {
 	image v2alpha1.CopyImageSchema
 	err   error
@@ -53,55 +68,10 @@ func (o *Batch) Worker(ctx context.Context, collectorSchema v2alpha1.CollectorSc
 	var errArray []mirrorErrorSchema
 
 	totalImages := len(collectorSchema.AllImages)
-	var countTotal, countReleaseImages, countOperatorsImages, countAdditionalImages,
-		countErrorTotal, countReleaseImagesErrorTotal, countOperatorsImagesErrorTotal, countAdditionalImagesErrorTotal int
 
 	o.Log.Info("🚀 Start " + mirrorMsg + " the images...")
 
 	for _, img := range collectorSchema.AllImages {
-		o.Log.Info(mirrorMsg+" image: %s", img.Origin)
-
-		switch img.Type {
-		case v2alpha1.TypeOCPRelease, v2alpha1.TypeOCPReleaseContent, v2alpha1.TypeCincinnatiGraph:
-			countReleaseImages++
-		case v2alpha1.TypeOperatorCatalog, v2alpha1.TypeOperatorBundle, v2alpha1.TypeOperatorRelatedImage:
-			countOperatorsImages++
-		case v2alpha1.TypeGeneric:
-			countAdditionalImages++
-		}
-
-		countTotal++
-		var overalProgress string
-		if countErrorTotal > 0 {
-			overalProgress = fmt.Sprintf("=== Overall Progress - "+mirrorMsg+" image %d / %d (%d errors)===", countTotal, totalImages, countErrorTotal)
-		} else {
-			overalProgress = fmt.Sprintf("=== Overall Progress - "+mirrorMsg+" image %d / %d ===", countTotal, totalImages)
-		}
-		o.Log.Info(overalProgress)
-		if opts.Function == string(mirror.CopyMode) {
-			if collectorSchema.TotalReleaseImages > 0 {
-				if countReleaseImagesErrorTotal > 0 {
-					o.Log.Info(mirrorMsg+" release image %d / %d (%d errors)", countReleaseImages, collectorSchema.TotalReleaseImages, countReleaseImagesErrorTotal)
-				} else {
-					o.Log.Info(mirrorMsg+" release image %d / %d", countReleaseImages, collectorSchema.TotalReleaseImages)
-				}
-			}
-			if collectorSchema.TotalOperatorImages > 0 {
-				if countOperatorsImagesErrorTotal > 0 {
-					o.Log.Info(mirrorMsg+" operator image %d / %d (%d errors)", countOperatorsImages, collectorSchema.TotalOperatorImages, countOperatorsImagesErrorTotal)
-				} else {
-					o.Log.Info(mirrorMsg+" operator image %d / %d", countOperatorsImages, collectorSchema.TotalOperatorImages)
-				}
-			}
-			if collectorSchema.TotalAdditionalImages > 0 {
-				if countAdditionalImagesErrorTotal > 0 {
-					o.Log.Info(mirrorMsg+" additional image %d / %d (%d errors)", countAdditionalImages, collectorSchema.TotalAdditionalImages, countAdditionalImagesErrorTotal)
-				} else {
-					o.Log.Info(mirrorMsg+" additional image %d / %d", countAdditionalImages, collectorSchema.TotalAdditionalImages)
-				}
-			}
-			o.Log.Info(strings.Repeat("=", len(overalProgress)))
-		}
 
 		if img.Type == v2alpha1.TypeCincinnatiGraph && (opts.Mode == mirror.MirrorToDisk || opts.Mode == mirror.MirrorToMirror) {
 			continue
@@ -123,15 +93,7 @@ func (o *Batch) Worker(ctx context.Context, collectorSchema v2alpha1.CollectorSc
 		case err != nil && isSafe && img.Type != v2alpha1.TypeOCPRelease && img.Type != v2alpha1.TypeOCPReleaseContent:
 			// this error is fail safe, we're continuing to mirror other images.
 			errArray = append(errArray, mirrorErrorSchema{image: img, err: err})
-			countErrorTotal++
-			switch img.Type {
-			case v2alpha1.TypeOCPRelease, v2alpha1.TypeOCPReleaseContent, v2alpha1.TypeCincinnatiGraph:
-				countReleaseImagesErrorTotal++
-			case v2alpha1.TypeOperatorCatalog, v2alpha1.TypeOperatorBundle, v2alpha1.TypeOperatorRelatedImage:
-				countOperatorsImagesErrorTotal++
-			case v2alpha1.TypeGeneric:
-				countAdditionalImagesErrorTotal++
-			}
+
 		case err != nil && isSafe && (img.Type == v2alpha1.TypeOCPRelease || img.Type == v2alpha1.TypeOCPReleaseContent):
 			fallthrough
 		case err != nil && !isSafe:
@@ -144,37 +106,40 @@ func (o *Batch) Worker(ctx context.Context, collectorSchema v2alpha1.CollectorSc
 			}
 			return o.CopiedImages, NewUnsafeError(currentMirrorError)
 		}
+
+		o.logProgress(img, collectorSchema, err)
+
 	}
 
 	if opts.Function == string(mirror.CopyMode) {
 		o.Log.Info("=== Results ===")
 		if collectorSchema.TotalReleaseImages != 0 {
-			if countReleaseImages == collectorSchema.TotalReleaseImages && countReleaseImagesErrorTotal == 0 {
-				o.Log.Info("All release images mirrored successfully %d / %d ✅", countReleaseImages, collectorSchema.TotalReleaseImages)
+			if o.Progress.countReleaseImages == collectorSchema.TotalReleaseImages && o.Progress.countReleaseImagesErrorTotal == 0 {
+				o.Log.Info("All release images mirrored successfully %d / %d ✅", o.Progress.countReleaseImages, collectorSchema.TotalReleaseImages)
 			} else {
-				o.Log.Info("Images mirrored %d / %d: Some release images failed to mirror ❌ - please check the logs", countReleaseImages-countReleaseImagesErrorTotal, collectorSchema.TotalReleaseImages)
+				o.Log.Info("Images mirrored %d / %d: Some release images failed to mirror ❌ - please check the logs", o.Progress.countReleaseImages-o.Progress.countReleaseImagesErrorTotal, collectorSchema.TotalReleaseImages)
 			}
 		}
 		if collectorSchema.TotalOperatorImages != 0 {
-			if countOperatorsImages == collectorSchema.TotalOperatorImages && countOperatorsImagesErrorTotal == 0 {
-				o.Log.Info("All operator images mirrored successfully %d / %d ✅", countOperatorsImages, collectorSchema.TotalOperatorImages)
+			if o.Progress.countOperatorsImages == collectorSchema.TotalOperatorImages && o.Progress.countOperatorsImagesErrorTotal == 0 {
+				o.Log.Info("All operator images mirrored successfully %d / %d ✅", o.Progress.countOperatorsImages, collectorSchema.TotalOperatorImages)
 			} else {
-				o.Log.Info("Images mirrored %d / %d: Some operator images failed to mirror ❌ - please check the logs", countOperatorsImages-countOperatorsImagesErrorTotal, collectorSchema.TotalOperatorImages)
+				o.Log.Info("Images mirrored %d / %d: Some operator images failed to mirror ❌ - please check the logs", o.Progress.countOperatorsImages-o.Progress.countOperatorsImagesErrorTotal, collectorSchema.TotalOperatorImages)
 			}
 		}
 		if collectorSchema.TotalAdditionalImages != 0 {
-			if countAdditionalImages == collectorSchema.TotalAdditionalImages && countAdditionalImagesErrorTotal == 0 {
-				o.Log.Info("All additional images mirrored successfully %d / %d ✅", countAdditionalImages, collectorSchema.TotalAdditionalImages)
+			if o.Progress.countAdditionalImages == collectorSchema.TotalAdditionalImages && o.Progress.countAdditionalImagesErrorTotal == 0 {
+				o.Log.Info("All additional images mirrored successfully %d / %d ✅", o.Progress.countAdditionalImages, collectorSchema.TotalAdditionalImages)
 			} else {
-				o.Log.Info("Images mirrored %d / %d: Some additional images failed to mirror ❌ - please check the logs", countAdditionalImages-countAdditionalImagesErrorTotal, collectorSchema.TotalAdditionalImages)
+				o.Log.Info("Images mirrored %d / %d: Some additional images failed to mirror ❌ - please check the logs", o.Progress.countAdditionalImages-o.Progress.countAdditionalImagesErrorTotal, collectorSchema.TotalAdditionalImages)
 			}
 		}
 	} else {
 		o.Log.Info("=== Results ===")
-		if countTotal == totalImages && countErrorTotal == 0 {
-			o.Log.Info("All images deleted successfully %d / %d ✅", countTotal, totalImages)
+		if o.Progress.countTotal == totalImages && o.Progress.countErrorTotal == 0 {
+			o.Log.Info("All images deleted successfully %d / %d ✅", o.Progress.countTotal, totalImages)
 		} else {
-			o.Log.Info("Images deleted %d / %d: Some images failed to delete ❌ - please check the logs", countTotal-countErrorTotal, totalImages)
+			o.Log.Info("Images deleted %d / %d: Some images failed to delete ❌ - please check the logs", o.Progress.countTotal-o.Progress.countErrorTotal, totalImages)
 		}
 	}
 
@@ -212,4 +177,69 @@ func (o *Batch) saveErrors(errArray []mirrorErrorSchema) (string, error) {
 		return filename, nil
 	}
 	return "", nil
+}
+
+func (o Batch) logProgress(img v2alpha1.CopyImageSchema, collectorSchema v2alpha1.CollectorSchema, err error) {
+	switch img.Type {
+	case v2alpha1.TypeOCPRelease, v2alpha1.TypeOCPReleaseContent, v2alpha1.TypeCincinnatiGraph:
+		o.Progress.countReleaseImages++
+	case v2alpha1.TypeOperatorCatalog, v2alpha1.TypeOperatorBundle, v2alpha1.TypeOperatorRelatedImage:
+		o.Progress.countOperatorsImages++
+	case v2alpha1.TypeGeneric:
+		o.Progress.countAdditionalImages++
+	}
+
+	o.Progress.countTotal++
+	isSafe := isFailSafe(err)
+	//isSafe && img.Type != v2alpha1.TypeOCPRelease && img.Type != v2alpha1.TypeOCPReleaseContent:
+	if err != nil && !isSafe { // normally logProgress should never be called for fail fast errors
+		return
+	} else if err != nil { // it is a fail safe error
+		if img.Type == v2alpha1.TypeOCPRelease || img.Type == v2alpha1.TypeOCPReleaseContent { // normally logProgress should never be called for fail fast errors
+			return
+		}
+		o.Progress.countErrorTotal++
+		switch img.Type {
+		case v2alpha1.TypeOCPRelease, v2alpha1.TypeOCPReleaseContent, v2alpha1.TypeCincinnatiGraph:
+			o.Progress.countReleaseImagesErrorTotal++
+		case v2alpha1.TypeOperatorCatalog, v2alpha1.TypeOperatorBundle, v2alpha1.TypeOperatorRelatedImage:
+			o.Progress.countOperatorsImagesErrorTotal++
+		case v2alpha1.TypeGeneric:
+			o.Progress.countAdditionalImagesErrorTotal++
+		}
+	}
+
+	var overalProgress string
+	if o.Progress.countErrorTotal > 0 {
+		overalProgress = fmt.Sprintf("=== Overall Progress - "+o.Progress.mirrorMessage+" image %d / %d (%d errors)===", o.Progress.countTotal, len(collectorSchema.AllImages), o.Progress.countErrorTotal)
+	} else {
+		overalProgress = fmt.Sprintf("=== Overall Progress - "+o.Progress.mirrorMessage+" image %d / %d ===", o.Progress.countTotal, len(collectorSchema.AllImages))
+	}
+	o.Log.Info(overalProgress)
+
+	if collectorSchema.TotalReleaseImages > 0 {
+		if o.Progress.countReleaseImagesErrorTotal > 0 {
+			o.Log.Info(o.Progress.mirrorMessage+" release image %d / %d (%d errors)", o.Progress.countReleaseImages, collectorSchema.TotalReleaseImages, o.Progress.countReleaseImagesErrorTotal)
+		} else {
+			o.Log.Info(o.Progress.mirrorMessage+" release image %d / %d", o.Progress.countReleaseImages, collectorSchema.TotalReleaseImages)
+		}
+	}
+	if collectorSchema.TotalOperatorImages > 0 {
+		if o.Progress.countOperatorsImagesErrorTotal > 0 {
+			o.Log.Info(o.Progress.mirrorMessage+" operator image %d / %d (%d errors)", o.Progress.countOperatorsImages, collectorSchema.TotalOperatorImages, o.Progress.countOperatorsImagesErrorTotal)
+		} else {
+			o.Log.Info(o.Progress.mirrorMessage+" operator image %d / %d", o.Progress.countOperatorsImages, collectorSchema.TotalOperatorImages)
+		}
+	}
+	if collectorSchema.TotalAdditionalImages > 0 {
+		if o.Progress.countAdditionalImagesErrorTotal > 0 {
+			o.Log.Info(o.Progress.mirrorMessage+" additional image %d / %d (%d errors)", o.Progress.countAdditionalImages, collectorSchema.TotalAdditionalImages, o.Progress.countAdditionalImagesErrorTotal)
+		} else {
+			o.Log.Info(o.Progress.mirrorMessage+" additional image %d / %d", o.Progress.countAdditionalImages, collectorSchema.TotalAdditionalImages)
+		}
+	}
+	o.Log.Info(" image: %s", img.Origin)
+
+	o.Log.Info(strings.Repeat("=", len(overalProgress)))
+
 }

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/delete.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/delete.go
@@ -254,7 +254,7 @@ func (o *ExecutorSchema) CompleteDelete(args []string) error {
 	signature := release.NewSignatureClient(o.Log, o.Config, *o.Opts)
 	cn := release.NewCincinnati(o.Log, &o.Config, *o.Opts, client, false, signature)
 	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.LocalStorageFQDN, o.ImageBuilder)
-	o.Batch = batch.New(o.Log, o.LogsDir, o.Mirror, o.Manifest)
+	o.Batch = batch.New(o.Log, o.LogsDir, o.Mirror)
 	o.Operator = operator.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, o.LocalStorageFQDN)
 	o.AdditionalImages = additional.New(o.Log, o.Config, *o.Opts, o.Mirror, o.Manifest, o.LocalStorageFQDN)
 

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
@@ -698,9 +698,12 @@ func (o *ExecutorSchema) RunMirrorToDisk(cmd *cobra.Command, args []string) erro
 	}
 
 	if !o.Opts.IsDryRun {
+		var copiedSchema v2alpha1.CollectorSchema
 		// call the batch worker
-		if err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
+		if cs, err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
+		} else {
+			copiedSchema = cs
 		}
 
 		// prepare tar.gz when mirror to disk
@@ -710,7 +713,7 @@ func (o *ExecutorSchema) RunMirrorToDisk(cmd *cobra.Command, args []string) erro
 
 		o.Log.Info("📦 Preparing the tarball archive...")
 		// next, generate the archive
-		err = o.MirrorArchiver.BuildArchive(cmd.Context(), collectorSchema.AllImages)
+		err = o.MirrorArchiver.BuildArchive(cmd.Context(), copiedSchema.AllImages)
 		if err != nil {
 			return err
 		}
@@ -748,19 +751,22 @@ func (o *ExecutorSchema) RunMirrorToMirror(cmd *cobra.Command, args []string) er
 		}
 	}
 	if !o.Opts.IsDryRun {
+		var copiedSchema v2alpha1.CollectorSchema
 		//call the batch worker
-		if err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
+		if cs, err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
+		} else {
+			copiedSchema = cs
 		}
 
 		//create IDMS/ITMS
 		forceRepositoryScope := o.Opts.Global.MaxNestedPaths > 0
-		err = o.ClusterResources.IDMS_ITMSGenerator(collectorSchema.AllImages, forceRepositoryScope)
+		err = o.ClusterResources.IDMS_ITMSGenerator(copiedSchema.AllImages, forceRepositoryScope)
 		if err != nil {
 			return err
 		}
 
-		err = o.ClusterResources.CatalogSourceGenerator(collectorSchema.AllImages)
+		err = o.ClusterResources.CatalogSourceGenerator(copiedSchema.AllImages)
 		if err != nil {
 			return err
 		}
@@ -824,19 +830,22 @@ func (o *ExecutorSchema) RunDiskToMirror(cmd *cobra.Command, args []string) erro
 	}
 
 	if !o.Opts.IsDryRun {
+		var copiedSchema v2alpha1.CollectorSchema
 		// call the batch worker
-		if err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
+		if cs, err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
+		} else {
+			copiedSchema = cs
 		}
 		// create IDMS/ITMS
 		forceRepositoryScope := o.Opts.Global.MaxNestedPaths > 0
-		err = o.ClusterResources.IDMS_ITMSGenerator(collectorSchema.AllImages, forceRepositoryScope)
+		err = o.ClusterResources.IDMS_ITMSGenerator(copiedSchema.AllImages, forceRepositoryScope)
 		if err != nil {
 			return err
 		}
 
 		// create catalog source
-		err = o.ClusterResources.CatalogSourceGenerator(collectorSchema.AllImages)
+		err = o.ClusterResources.CatalogSourceGenerator(copiedSchema.AllImages)
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
@@ -700,8 +700,12 @@ func (o *ExecutorSchema) RunMirrorToDisk(cmd *cobra.Command, args []string) erro
 	if !o.Opts.IsDryRun {
 		var copiedSchema v2alpha1.CollectorSchema
 		// call the batch worker
-		if cs, err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
-			return err
+		if cs, err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil {
+			if _, ok := err.(batch.UnsafeError); ok {
+				return err
+			} else {
+				copiedSchema = cs
+			}
 		} else {
 			copiedSchema = cs
 		}
@@ -832,11 +836,16 @@ func (o *ExecutorSchema) RunDiskToMirror(cmd *cobra.Command, args []string) erro
 	if !o.Opts.IsDryRun {
 		var copiedSchema v2alpha1.CollectorSchema
 		// call the batch worker
-		if cs, err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
-			return err
+		if cs, err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil {
+			if _, ok := err.(batch.UnsafeError); ok {
+				return err
+			} else {
+				copiedSchema = cs
+			}
 		} else {
 			copiedSchema = cs
 		}
+
 		// create IDMS/ITMS
 		forceRepositoryScope := o.Opts.Global.MaxNestedPaths > 0
 		err = o.ClusterResources.IDMS_ITMSGenerator(copiedSchema.AllImages, forceRepositoryScope)

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
@@ -757,8 +757,12 @@ func (o *ExecutorSchema) RunMirrorToMirror(cmd *cobra.Command, args []string) er
 	if !o.Opts.IsDryRun {
 		var copiedSchema v2alpha1.CollectorSchema
 		//call the batch worker
-		if cs, err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
-			return err
+		if cs, err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil {
+			if _, ok := err.(batch.UnsafeError); ok {
+				return err
+			} else {
+				copiedSchema = cs
+			}
 		} else {
 			copiedSchema = cs
 		}

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
@@ -408,7 +408,7 @@ func (o *ExecutorSchema) Complete(args []string) error {
 	o.Operator = operator.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, o.LocalStorageFQDN)
 	o.AdditionalImages = additional.New(o.Log, o.Config, *o.Opts, o.Mirror, o.Manifest, o.LocalStorageFQDN)
 	o.ClusterResources = clusterresources.New(o.Log, o.Opts.Global.WorkingDir, o.Config)
-	o.Batch = batch.New(o.Log, o.LogsDir, o.Mirror, o.Manifest)
+	o.Batch = batch.New(o.Log, o.LogsDir, o.Mirror)
 
 	if o.Opts.IsMirrorToDisk() {
 		if o.Opts.Global.StrictArchiving {
@@ -699,8 +699,7 @@ func (o *ExecutorSchema) RunMirrorToDisk(cmd *cobra.Command, args []string) erro
 
 	if !o.Opts.IsDryRun {
 		// call the batch worker
-		err = o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts)
-		if err != nil {
+		if err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
 		}
 
@@ -750,8 +749,7 @@ func (o *ExecutorSchema) RunMirrorToMirror(cmd *cobra.Command, args []string) er
 	}
 	if !o.Opts.IsDryRun {
 		//call the batch worker
-		err = o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts)
-		if err != nil {
+		if err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
 		}
 
@@ -827,8 +825,7 @@ func (o *ExecutorSchema) RunDiskToMirror(cmd *cobra.Command, args []string) erro
 
 	if !o.Opts.IsDryRun {
 		// call the batch worker
-		err = o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts)
-		if err != nil {
+		if err := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
 		}
 		// create IDMS/ITMS

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/clusterresources/clusterresources.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/clusterresources/clusterresources.go
@@ -184,9 +184,13 @@ func (o *ClusterResourcesGenerator) CatalogSourceGenerator(allRelatedImages []v2
 		return nil
 	}
 
-	o.Log.Info("📄 Generating CatalogSource file...")
+	firstCatalog := true
 	for _, copyImage := range allRelatedImages {
 		if copyImage.Type == v2alpha1.TypeOperatorCatalog {
+			if firstCatalog {
+				o.Log.Info("📄 Generating CatalogSource file...")
+				firstCatalog = false
+			}
 			// check if ImageSetConfig contains a CatalogSourceTemplate for this catalog, and use it
 			template := o.getCSTemplate(copyImage.Origin)
 			err := o.generateCatalogSource(copyImage.Destination, template)

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/delete/delete_images.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/delete/delete_images.go
@@ -163,14 +163,14 @@ func (o DeleteImages) DeleteRegistryImages(images v2alpha1.DeleteImageList) erro
 	// ensure output is suppressed
 	o.Opts.Stdout = io.Discard
 	if !o.Opts.Global.DeleteGenerate && len(o.Opts.Global.DeleteDestination) > 0 {
-		if err := o.Batch.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: rrUpdatedImages}, o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
+		if _, err := o.Batch.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: rrUpdatedImages}, o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
 		}
 	}
 	// if mirrortoMirror mode no conetents were stored to the cache
 	// so just skip
 	if o.Opts.Global.ForceCacheDelete && o.Opts.Mode != mirror.MirrorToMirror {
-		if err := o.Batch.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: lsUpdatedImages}, o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
+		if _, err := o.Batch.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: lsUpdatedImages}, o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
 		}
 	}

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/delete/delete_images.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/delete/delete_images.go
@@ -2,6 +2,7 @@ package delete
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -162,16 +163,14 @@ func (o DeleteImages) DeleteRegistryImages(images v2alpha1.DeleteImageList) erro
 	// ensure output is suppressed
 	o.Opts.Stdout = io.Discard
 	if !o.Opts.Global.DeleteGenerate && len(o.Opts.Global.DeleteDestination) > 0 {
-		err := o.Batch.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: rrUpdatedImages}, o.Opts)
-		if err != nil {
+		if err := o.Batch.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: rrUpdatedImages}, o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
 		}
 	}
 	// if mirrortoMirror mode no conetents were stored to the cache
 	// so just skip
 	if o.Opts.Global.ForceCacheDelete && o.Opts.Mode != mirror.MirrorToMirror {
-		err := o.Batch.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: lsUpdatedImages}, o.Opts)
-		if err != nil {
+		if err := o.Batch.Worker(context.Background(), v2alpha1.CollectorSchema{AllImages: lsUpdatedImages}, o.Opts); err != nil && errors.Is(err, batch.UnsafeError{}) {
 			return err
 		}
 	}

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/mirror/mirror.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/mirror/mirror.go
@@ -181,6 +181,10 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 		MaxParallelDownloads:             opts.MaxParallelDownloads,
 	}
 
+	if opts.Global.LogLevel == "debug" {
+		co.ReportWriter = opts.Stdout
+	}
+
 	return retry.IfNecessary(ctx, func() error {
 
 		//manifestBytes, err := copy.Image(ctx, policyContext, destRef, srcRef, &copy.Options{


### PR DESCRIPTION
# Description
This PR contains:
* A fix for the integration tests, which were failing to find test data
* Rebased after #864
* Modification of the way we log progress in batch mirroring:
  * image reference is shown, 
  * progress on release/operator/additional is only shown if there are images of that type in the imageset
  * code: handling the counters for progress and logging it is deported to separate function
* Implementation of fail safe vs fail fast for batch workers:
  * When calling `o.Mirror.Run`, the batch now evaluates the image type:
    * For error on release images, the batch will immediately fail and return to the caller: no IDMS or ITMS or catalogSource are to be generated
    * For error on any other type of image, the batch continues, reports a `SafeError` to caller. The executor will carry on generating cluster resources.
  * The error returned by the `Worker` function is typed : `UnsafeError` vs `SafeError`. The `Executor` or `Delete` will resume activities if the error is of type `SafeError`
  *  `isFailSafe` is commented: this function was originally used to determine if errors were `UnsafeError` or `SafeError`. Its use is deferred to later (see OCPBUGS-34020 comments for decision details).
      *  It is inspired by [`isRetryable`](https://github.com/containers/common/blob/49ad520556e7eaaeaa5263639588d82683c29b5b/pkg/retry/retry.go#L63) : all errors that are retryable are considered unsafe (fail fast). 

Fixes OCPBUGS-34020

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

With the following imagesetconfig, a mirror to mirror was performed.
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  additionalImages:
  - name: registry.redhat.io/ubi8/ubi:latest
  - name: quay.io/mantisnet/kernel-headers@sha256:242e837af831b6eed98d522b6bae7416928b9fbe451fb6e02ffa678686771068
  - name: registry.redhat.io/ubi9/ubi:latest
```

## Expected Outcome
Although the second image is in error (unauthorized), the mirroring continues. ITMS is generated. No IDMS, no CatalogSource. 
 ⚠️ **Please note that exit code is 0 in the end. ** 
```
$ ./bin/oc-mirror --v2 -c configs_logs/isc_34020.yaml --workspace file:///home/skhoury/clid20/ docker://localhost:5000 --dest-tls-verify=false

2024/06/11 14:08:20  [WARN]   : ⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.
2024/06/11 14:08:20  [INFO]   : 👋 Hello, welcome to oc-mirror
2024/06/11 14:08:20  [INFO]   : ⚙️  setting up the environment for you...
2024/06/11 14:08:20  [INFO]   : 🔀 workflow mode: mirrorToMirror 
2024/06/11 14:08:20  [INFO]   : 🕵️  going to discover the necessary images...
2024/06/11 14:08:20  [INFO]   : 🔍 collecting release images...
2024/06/11 14:08:20  [INFO]   : 🔍 collecting operator images...
2024/06/11 14:08:20  [INFO]   : 🔍 collecting additional images...
2024/06/11 14:08:20  [INFO]   : 🚀 Start copying the images...
2024/06/11 14:08:22  [INFO]   : === Overall Progress -  image 1 / 3 ===
2024/06/11 14:08:22  [INFO]   :  additional image 1 / 3
2024/06/11 14:08:22  [INFO]   :  image: docker://registry.redhat.io/ubi8/ubi:latest
2024/06/11 14:08:22  [INFO]   : =======================================
2024/06/11 14:08:23  [INFO]   : === Overall Progress -  image 2 / 3 (1 errors)===
2024/06/11 14:08:23  [INFO]   :  additional image 2 / 3 (1 errors)
2024/06/11 14:08:23  [INFO]   :  image: docker://quay.io/mantisnet/kernel-headers@sha256:242e837af831b6eed98d522b6bae7416928b9fbe451fb6e02ffa678686771068
2024/06/11 14:08:23  [INFO]   : =================================================
2024/06/11 14:08:26  [INFO]   : === Overall Progress -  image 3 / 3 (1 errors)===
2024/06/11 14:08:26  [INFO]   :  additional image 3 / 3 (1 errors)
2024/06/11 14:08:26  [INFO]   :  image: docker://registry.redhat.io/ubi9/ubi:latest
2024/06/11 14:08:26  [INFO]   : =================================================
2024/06/11 14:08:26  [INFO]   : === Results ===
2024/06/11 14:08:26  [INFO]   : Images mirrored 2 / 3: Some additional images failed to mirror ❌ - please check the logs
2024/06/11 14:08:26  [ERROR]  : [Worker] error mirroring image docker://quay.io/mantisnet/kernel-headers@sha256:242e837af831b6eed98d522b6bae7416928b9fbe451fb6e02ffa678686771068 error: initializing source docker://quay.io/mantisnet/kernel-headers@sha256:242e837af831b6eed98d522b6bae7416928b9fbe451fb6e02ffa678686771068: reading manifest sha256:242e837af831b6eed98d522b6bae7416928b9fbe451fb6e02ffa678686771068 in quay.io/mantisnet/kernel-headers: unauthorized: access to the requested resource is not authorized
2024/06/11 14:08:26  [INFO]   : 📄 No images by digests were mirrored. Skipping IDMS generation.
2024/06/11 14:08:26  [INFO]   : 📄 Generating ITMS file...
2024/06/11 14:08:26  [INFO]   : /home/skhoury/clid20/working-dir/cluster-resources/itms-oc-mirror.yaml file created
2024/06/11 14:08:26  [INFO]   : 📄 No catalogs mirrored. Skipping CatalogSource file generation.
2024/06/11 14:08:26  [INFO]   : mirror time     : 6.531477598s
2024/06/11 14:08:26  [WARN]   : [Worker] some errors occurred during the mirroring.
         Please review /home/skhoury/clid20/working-dir/logs/mirroring_errors_20240611_140826.txt for a list of mirroring errors.
         You may consider:
         * removing images or operators that cause the error from the image set config, and retrying
         * keeping the image set config (images are mandatory for you), and retrying
         * mirroring the failing images manually, if retries also fail.
2024/06/11 14:08:26  [INFO]   : 👋 Goodbye, thank you for using oc-mirror
```

