### PR TITLE
OCPBUGS-33121: Fix problems with versions and verbose flags

### DIFF
--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -280,6 +280,9 @@ func (o *MirrorOptions) Validate() error {
 	if mirrorToMirror || mirrorToDisk {
 		cfg, err := config.ReadConfig(o.ConfigPath)
 		if err != nil {
+			if strings.Contains(err.Error(), "config GVK not recognized") && o.LogLevel == 2 {
+				return fmt.Errorf("detected a v2 ImageSetConfiguration, please use --v2 instead of -v2")
+			}
 			return fmt.Errorf("unable to read the configuration file provided with --config: %v", err)
 		}
 

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -26,7 +26,7 @@ type RootOptions struct {
 
 func (o *RootOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&o.Dir, "dir", "d", config.DefaultWorkspaceName, "Assets directory")
-	fs.IntVarP(&o.LogLevel, "verbose", "", o.LogLevel, "Number for the log level verbosity (valid 1-9, default is 0)")
+	fs.IntVarP(&o.LogLevel, "verbose", "v", o.LogLevel, "Number for the log level verbosity (valid 1-9, default is 0)")
 	if err := fs.MarkHidden("dir"); err != nil {
 		klog.Fatal(err.Error())
 	}

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -26,7 +26,7 @@ type RootOptions struct {
 
 func (o *RootOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&o.Dir, "dir", "d", config.DefaultWorkspaceName, "Assets directory")
-	fs.IntVarP(&o.LogLevel, "verbose", "v", o.LogLevel, "Number for the log level verbosity (valid 1-9, default is 0)")
+	fs.IntVarP(&o.LogLevel, "verbose", "", o.LogLevel, "Number for the log level verbosity (valid 1-9, default is 0)")
 	if err := fs.MarkHidden("dir"); err != nil {
 		klog.Fatal(err.Error())
 	}


### PR DESCRIPTION
# Description

This fix addresses the issue faced in using the --v2 (used to invoke v2 of oc mirror) and accidentally using -v2 (used for verbose logging)

This fix will only be for 4.17 onwards until we deprecate v1

Fixes # OCPBUGS-33121

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally and unit tests

## Expected Outcome
console message should show 

```
error: detected a v2 ImageSetConfiguration, please use --v2 instead of -v2
``` 