### PR TITLE
OCPBUGS-33775: Do not generate idms & itms if nothing has been mirrored

### DIFF
--- a/v2/internal/pkg/clusterresources/clusterresources_test.go
+++ b/v2/internal/pkg/clusterresources/clusterresources_test.go
@@ -462,6 +462,17 @@ func TestCatalogSourceGenerator(t *testing.T) {
 		cr := &ClusterResourcesGenerator{
 			Log:        log,
 			WorkingDir: workingDir,
+			Config: v2alpha1.ImageSetConfiguration{
+				ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+					Mirror: v2alpha1.Mirror{
+						Operators: []v2alpha1.Operator{
+							{
+								Catalog: "registry.redhat.io/redhat/redhat-operator-index:v4.15",
+							},
+						},
+					},
+				},
+			},
 		}
 		err := cr.CatalogSourceGenerator(imageList)
 		if err != nil {
@@ -723,6 +734,17 @@ func TestCatalogSourceGenerator(t *testing.T) {
 		cr := &ClusterResourcesGenerator{
 			Log:        log,
 			WorkingDir: workingDir,
+			Config: v2alpha1.ImageSetConfiguration{
+				ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+					Mirror: v2alpha1.Mirror{
+						Operators: []v2alpha1.Operator{
+							{
+								Catalog: "registry.redhat.io/redhat/redhat-operator-index@sha256:7c4ef7434c97c8aaf6cd310874790b915b3c61fc902eea255f9177058ea9aff3",
+							},
+						},
+					},
+				},
+			},
 		}
 		err := cr.CatalogSourceGenerator(listCatalogDigestAsTag)
 		if err != nil {


### PR DESCRIPTION
# Description

This PR skips the generation of an empty itms/idms/catalogsource when no images corresponding are available.

Fixes #OCPBUGS-33775

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Using this imagesetconfiguration, only itms is generated
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  # operators:
  # - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15
  #   targetCatalog: hij/redhat-operator-index
  #   packages:
  #   - name: aws-load-balancer-operator
  additionalImages:
  - name: registry.redhat.io/ubi8/ubi:latest
 ```

## Expected Outcome
idms file is not generated