### PR TITLE
OCPBUGS-35279: Fix spelling error in delete console message

### DIFF
--- a/v2/internal/pkg/cli/delete.go
+++ b/v2/internal/pkg/cli/delete.go
@@ -340,7 +340,7 @@ func (o *ExecutorSchema) RunDelete(cmd *cobra.Command) error {
 	}
 
 	if !o.Opts.Global.DeleteGenerate {
-		o.Log.Info("📝 Rememeber to execute a garbage collect (or similar) on your remote repository")
+		o.Log.Info("📝 Remember to execute a garbage collect (or similar) on your remote repository")
 	}
 	o.Log.Info("👋 Goodbye, thank you for using oc-mirror")
 

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/delete.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/delete.go
@@ -340,7 +340,7 @@ func (o *ExecutorSchema) RunDelete(cmd *cobra.Command) error {
 	}
 
 	if !o.Opts.Global.DeleteGenerate {
-		o.Log.Info("📝 Rememeber to execute a garbage collect (or similar) on your remote repository")
+		o.Log.Info("📝 Remember to execute a garbage collect (or similar) on your remote repository")
 	}
 	o.Log.Info("👋 Goodbye, thank you for using oc-mirror")
 


### PR DESCRIPTION
# Description

Fix spelling error in console message (delete functionality)

Fixes # OCPBUGS-35279

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

NA

## Expected Outcome
Console log output for delete should show  the following (Rememeber changed to Remember)

```
2024/06/11 14:18:05  [INFO]   : === Results ===
2024/06/11 14:18:05  [INFO]   : All images deleted successfully 196 / 196 ✅
2024/06/11 14:18:05  [INFO]   : delete time     : 804.724285ms
2024/06/11 14:18:05  [INFO]   : 📝 Remember to execute a garbage collect (or similar) on your remote repository
2024/06/11 14:18:05  [INFO]   : 👋 Goodbye, thank you for using oc-mirror
```