### PR TITLE
OCPBUGS-36214: Fix V2 DiskToMirror should not require internet access

### DIFF
--- a/v2/internal/pkg/operator/local_stored_collector_test.go
+++ b/v2/internal/pkg/operator/local_stored_collector_test.go
@@ -38,7 +38,7 @@ var (
 			Mirror: v2alpha1.Mirror{
 				Operators: []v2alpha1.Operator{
 					{
-						Catalog: "redhat-operator-index:v4.14",
+						Catalog: "registry.redhat.io/redhat/redhat-operator-index:v4.14",
 					},
 					{
 						Catalog: "oci://" + common.TestFolder + "simple-test-bundle",
@@ -294,7 +294,7 @@ func TestOperatorLocalStoredCollectorM2D(t *testing.T) {
 				},
 				{
 					Source:      "oci://" + common.TestFolder + "simple-test-bundle",
-					Destination: "docker://localhost:9999/simple-test-bundle:3ef0b0141abd1548f60c4f3b23ecfc415142b0e842215f38e98610a3b2e52419",
+					Destination: "docker://localhost:9999/simple-test-bundle:latest",
 					Origin:      "oci://" + common.TestFolder + "simple-test-bundle",
 					Type:        v2alpha1.TypeOperatorCatalog,
 				},
@@ -422,7 +422,7 @@ func TestOperatorLocalStoredCollectorD2M(t *testing.T) {
 	os.RemoveAll(common.TestFolder + "tmp/")
 
 	//copy tests/hold-test-fake to working-dir
-	err := copy.Copy(common.TestFolder+"working-dir-fake/hold-operator/redhat-operator-index/v4.14", filepath.Join(tempDir, "working-dir", operatorImageExtractDir, "ocp-release/4.13.9-x86_64"))
+	err := copy.Copy(common.TestFolder+"working-dir-fake/hold-operator/redhat-operator-index/v4.14", filepath.Join(tempDir, "working-dir", operatorImageExtractDir, "redhat-operator-index/f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"))
 	if err != nil {
 		t.Fatalf("should not fail")
 	}
@@ -446,15 +446,15 @@ func TestOperatorLocalStoredCollectorD2M(t *testing.T) {
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
-					Source:      "docker://localhost:9999/simple-test-bundle:3ef0b0141abd1548f60c4f3b23ecfc415142b0e842215f38e98610a3b2e52419",
-					Destination: "docker://localhost:5000/test/simple-test-bundle:3ef0b0141abd1548f60c4f3b23ecfc415142b0e842215f38e98610a3b2e52419",
+					Source:      "docker://localhost:9999/simple-test-bundle:latest",
+					Destination: "docker://localhost:5000/test/simple-test-bundle:latest",
 					Origin:      "oci://" + common.TestFolder + "simple-test-bundle",
 					Type:        v2alpha1.TypeOperatorCatalog,
 				},
 				{
-					Source:      "docker://localhost:9999/redhat-operator-index:v4.14",
-					Destination: "docker://localhost:5000/test/redhat-operator-index:v4.14",
-					Origin:      "docker://redhat-operator-index:v4.14",
+					Source:      "docker://localhost:9999/redhat/redhat-operator-index:v4.14",
+					Destination: "docker://localhost:5000/test/redhat/redhat-operator-index:v4.14",
+					Origin:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.14",
 					Type:        v2alpha1.TypeOperatorCatalog,
 				},
 			},
@@ -679,7 +679,7 @@ func (o MockManifest) ConvertIndexToSingleManifest(dir string, oci *v2alpha1.OCI
 }
 
 func (o MockManifest) GetDigest(ctx context.Context, sourceCtx *types.SystemContext, imgRef string) (string, error) {
-	return "", nil
+	return "f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", nil
 }
 
 func (ex *LocalStorageCollector) withConfig(cfg v2alpha1.ImageSetConfiguration) *LocalStorageCollector {


### PR DESCRIPTION
# Description
This PR fixes the errors encountered while DiskToMirror in a disconnected environment.
The issue arises because
* when in MirrorToDisk, the catalog image(working-dir/operator-images) and contents (working-dir/hold-images) are stored under a subfolder corresponding to the digest of the image. 
* Then, while doing diskToMirror, oc-mirror attempts to call the source registry to resolve the image tag to a digest in order to find the corresponding subfolder on disk.

When diskToMirror is happening on a fully disconnected environment, there is no access to the source registry. This is why the error was happening.

With this fix, oc-mirror interrogates the local cache in order to determine this digest.

Fixes # [OCPBUGS-36214](https://issues.redhat.com/browse/OCPBUGS-36214)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
**Use cases**:
* catalog is a remote reference
  * without targetCatalog nor targetTag
  * with TargetCatalog
  * with TargetTag
  * with both TargetCatalog and TargetTag
* catalog is a OCI local reference
  * without targetCatalog nor targetTag
  * with TargetCatalog
  * with TargetTag
  * with both TargetCatalog and TargetTag

For each of the above use cases the 3 workflows were performed:
- mirror to disk twice: 
  - first time starting by `rm -fr $WORKING_DIR/hold-operator/* $WORKING_DIR/operator-images/*` (forcing redownload) 
  - and second time without (using cached image)
- disk to mirror without internet
- mirror to mirror

## Expected Outcome
All workflows should pass.