### PR TITLE
[release-4.16] OCPBUGS-36498: Fix to ensure invalid catalogs are skipped

### DIFF
--- a/v2/internal/pkg/additional/local_stored_collector.go
+++ b/v2/internal/pkg/additional/local_stored_collector.go
@@ -67,7 +67,7 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 			// OCPBUGS-33196 - check source image for tag and digest
 			// skip mirroring
 			if imgSpec.IsImageByTagAndDigest() {
-				o.Log.Warn(collectorPrefix + "%s has both tag and digest : SKIPPING", imgSpec.Reference)
+				o.Log.Warn(collectorPrefix+"%s has both tag and digest : SKIPPING", imgSpec.Reference)
 			} else {
 				allImages = append(allImages, v2alpha1.CopyImageSchema{Source: src, Destination: dest, Origin: src, Type: v2alpha1.TypeGeneric})
 			}

--- a/v2/internal/pkg/batch/worker.go
+++ b/v2/internal/pkg/batch/worker.go
@@ -93,7 +93,7 @@ func (o *Batch) Worker(ctx context.Context, collectorSchema v2alpha1.CollectorSc
 				o.CopiedImages.TotalOperatorImages++
 			}
 		case img.Type != v2alpha1.TypeOCPRelease && img.Type != v2alpha1.TypeOCPReleaseContent:
-			// error occured on anything other than release images, continue mirroring
+			// error occurred on anything other than release images, continue mirroring
 			errArray = append(errArray, mirrorErrorSchema{image: img, err: err})
 
 		default:

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -991,10 +991,8 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 // closeAll - utility to close any open files
 func (o *ExecutorSchema) closeAll() {
 	// close registry log file
-	err := o.registryLogFile.Close()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error closing log file %s: %v\n", registryLogFilename, err)
-	}
+	// ignore errors here
+	_ = o.registryLogFile.Close()
 }
 
 func withMaxNestedPaths(in []v2alpha1.CopyImageSchema, maxNestedPaths int) ([]v2alpha1.CopyImageSchema, error) {

--- a/v2/internal/pkg/operator/local_stored_collector.go
+++ b/v2/internal/pkg/operator/local_stored_collector.go
@@ -78,10 +78,11 @@ func (o *LocalStorageCollector) OperatorImageCollector(ctx context.Context) ([]v
 			return nil, err
 		}
 
+		// OCPBUGS-36498 (manifest unknown)
 		catalogDigest, err := o.Manifest.GetDigest(ctx, sourceCtx, imgSpec.ReferenceWithTransport)
 		if err != nil {
-			o.Log.Error(errMsg, err.Error())
-			return []v2alpha1.CopyImageSchema{}, err
+			o.Log.Warn(collectorPrefix+"catalog %s : SKIPPING", err.Error())
+			continue
 		}
 
 		imageIndexDir := filepath.Join(imgSpec.ComponentName(), catalogDigest)
@@ -214,19 +215,16 @@ func (o *LocalStorageCollector) OperatorImageCollector(ctx context.Context) ([]v
 		fromDir := strings.Join([]string{dir, blobsDir}, "/")
 		err = o.Manifest.ExtractLayersOCI(fromDir, cacheDir, label, oci)
 		if err != nil {
-			o.Log.Error(errMsg, err.Error())
 			return []v2alpha1.CopyImageSchema{}, err
 		}
 
 		operatorCatalog, err := o.Manifest.GetCatalog(filepath.Join(cacheDir, label))
 		if err != nil {
-			o.Log.Error(errMsg, err.Error())
 			return []v2alpha1.CopyImageSchema{}, err
 		}
 
 		ri, err := o.Manifest.GetRelatedImagesFromCatalog(operatorCatalog, op)
 		if err != nil {
-			o.Log.Error(errMsg, err.Error())
 			return []v2alpha1.CopyImageSchema{}, err
 		}
 		for k, v := range ri {

--- a/v2/sonar-project.properties
+++ b/v2/sonar-project.properties
@@ -11,12 +11,12 @@ sonar.language=go
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
 
-sonar.exclusions=cmd/**,vendor/**,pkg/**/*_test.go,tests/**,internal/**,pkg/api/**, pkg/mirror/unshare*,*.json,*.txt,*.yml,*.xml,*.sh,Dockerfile,*.properties,*.html
+sonar.exclusions=cmd/**,vendor/**,internal/pkg/**/*_test.go,tests/**,internal/e2e/**,internal/testutils/**,internal/pkg/api/**, internal/pkg/mirror/unshare*,*.json,*.txt,*.yml,*.xml,*.sh,Dockerfile,*.properties,*.html
 
 sonar.go.coverage.reportPaths=tests/results/cover.out
 
 sonar.projectKey=oc-mirror
 
 # internal sonarqube url 
-sonar.host.url=http://192.168.0.22:9000
-sonar.login=sqa_07d32b831bde0c31c3eddb66d6d45fc67b58332f
+sonar.host.url=http://192.168.1.25:9000
+sonar.login=sqp_351dee0c3ea64b865bb8b38aef81aef4434dde06

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/additional/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/additional/local_stored_collector.go
@@ -67,7 +67,7 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 			// OCPBUGS-33196 - check source image for tag and digest
 			// skip mirroring
 			if imgSpec.IsImageByTagAndDigest() {
-				o.Log.Warn(collectorPrefix + "%s has both tag and digest : SKIPPING", imgSpec.Reference)
+				o.Log.Warn(collectorPrefix+"%s has both tag and digest : SKIPPING", imgSpec.Reference)
 			} else {
 				allImages = append(allImages, v2alpha1.CopyImageSchema{Source: src, Destination: dest, Origin: src, Type: v2alpha1.TypeGeneric})
 			}

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/worker.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/worker.go
@@ -93,7 +93,7 @@ func (o *Batch) Worker(ctx context.Context, collectorSchema v2alpha1.CollectorSc
 				o.CopiedImages.TotalOperatorImages++
 			}
 		case img.Type != v2alpha1.TypeOCPRelease && img.Type != v2alpha1.TypeOCPReleaseContent:
-			// error occured on anything other than release images, continue mirroring
+			// error occurred on anything other than release images, continue mirroring
 			errArray = append(errArray, mirrorErrorSchema{image: img, err: err})
 
 		default:

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
@@ -991,10 +991,8 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 // closeAll - utility to close any open files
 func (o *ExecutorSchema) closeAll() {
 	// close registry log file
-	err := o.registryLogFile.Close()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error closing log file %s: %v\n", registryLogFilename, err)
-	}
+	// ignore errors here
+	_ = o.registryLogFile.Close()
 }
 
 func withMaxNestedPaths(in []v2alpha1.CopyImageSchema, maxNestedPaths int) ([]v2alpha1.CopyImageSchema, error) {

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/operator/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/operator/local_stored_collector.go
@@ -78,10 +78,11 @@ func (o *LocalStorageCollector) OperatorImageCollector(ctx context.Context) ([]v
 			return nil, err
 		}
 
+		// OCPBUGS-36498 (manifest unknown)
 		catalogDigest, err := o.Manifest.GetDigest(ctx, sourceCtx, imgSpec.ReferenceWithTransport)
 		if err != nil {
-			o.Log.Error(errMsg, err.Error())
-			return []v2alpha1.CopyImageSchema{}, err
+			o.Log.Warn(collectorPrefix+"catalog %s : SKIPPING", err.Error())
+			continue
 		}
 
 		imageIndexDir := filepath.Join(imgSpec.ComponentName(), catalogDigest)
@@ -214,19 +215,16 @@ func (o *LocalStorageCollector) OperatorImageCollector(ctx context.Context) ([]v
 		fromDir := strings.Join([]string{dir, blobsDir}, "/")
 		err = o.Manifest.ExtractLayersOCI(fromDir, cacheDir, label, oci)
 		if err != nil {
-			o.Log.Error(errMsg, err.Error())
 			return []v2alpha1.CopyImageSchema{}, err
 		}
 
 		operatorCatalog, err := o.Manifest.GetCatalog(filepath.Join(cacheDir, label))
 		if err != nil {
-			o.Log.Error(errMsg, err.Error())
 			return []v2alpha1.CopyImageSchema{}, err
 		}
 
 		ri, err := o.Manifest.GetRelatedImagesFromCatalog(operatorCatalog, op)
 		if err != nil {
-			o.Log.Error(errMsg, err.Error())
 			return []v2alpha1.CopyImageSchema{}, err
 		}
 		for k, v := range ri {


### PR DESCRIPTION
# Description

This fix addresses the SIGSEGV violation error (causing oc-mirror to crash). 

The root cause is the handling of invalid catalogs for oc-mirror v2 (only oci file base catalogs are valid and not SQLite (database) type catalogs

Fixes # reference to OCPBUGS-36445 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Verified locally using the following imagesetconfig (from case 03862148)

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
  - catalog: icr.io/cpopen/noi-operator-catalog@sha256:ae39015ec2161a982c85d66456f23883dc19f85c00d5f3b2058f385fc5eacd50
    packages:
    - name: noi
  - catalog: icr.io/cpopen/ibm-netcool-integrations-operator-catalog@sha256:f913349f3c05f02fb48b2faaa9959927266947b64be5884e49e64f8d1e0788a5
    packages:
    - name: netcool-integrations-operator
  - catalog: icr.io/cpopen/tncp-catalog@sha256:dcf3a021269f7900cac8e2e8dd51cd32e087c35b68cf956d8d14565a4b9e7c55
    packages:
    - name: ibm-tncp-bundle
  - catalog: icr.io/cpopen/ibm-cpd-cloud-native-postgresql-operator-catalog@sha256:b5debd3c4b129a67f30ffdd774a385c96b8d33fd9ced8baad4835dd8913eb177
    packages:
    - name: cloud-native-postgresql

```

Using the following command line

```
bin/oc-mirror --v2 -c ocpbugs-36445.yaml --dry-run file://ocpbugs-36445 --loglevel info
```


## Expected Outcome

Before this fix we would get this panic output

```
panic: runtime error: 
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3ccf3de]goroutine 1 [running]:
github.com/openshift/oc-mirror/v2/internal/pkg/manifest.Manifest.GetCatalog({{0x7c?, 0x2?}}, {0xc000d10a80?, 0x1?})
        /go/src/github.com/openshift/oc-mirror/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/manifest/oci-manifest.go:204 +0x9e
github.com/openshift/oc-mirror/v2/internal/pkg/operator.(*LocalStorageCollector).OperatorImageCollector(0xc000004300, {0x54978a8, 0x76b6180})
        /go/src/github.com/openshift/oc-mirror/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/operator/local_stored_collector.go:221 +0x1092
github.com/openshift/oc-mirror/v2/internal/pkg/cli.(*ExecutorSchema).CollectAll(0xc000afe480, {0x54978a8, 0x76b6180})
        /go/src/github.com/openshift/oc-mirror/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go:923 +0x323
github.com/openshift/oc-mirror/v2/internal/pkg/cli.(*ExecutorSchema).RunMirrorToDisk(0xc000afe480, 0xc000ae6300, {0x0?, 0xc000ec9058?, 0x17d7f85?})
        /go/src/github.com/openshift/oc-mirror/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go:694 +0x1a5
github.com/openshift/oc-mirror/v2/internal/pkg/cli.(*ExecutorSchema).Run(0xc000afe480, 0xc000aacd20?, {0xc000aacd20?, 0x0?, 0x0?})
        /go/src/github.com/openshift/oc-mirror/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go:439 +0x149
github.com/openshift/oc-mirror/v2/internal/pkg/cli.NewMirrorCmd.func1(0xc000a7b200?, {0xc000aacd20, 0x1, 0x5})
        /go/src/github.com/openshift/oc-mirror/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go:203 +0x32a
github.com/spf13/cobra.(*Command).execute(0xc000ae6300, {0xc0000521f0, 0x5, 0x5})
        /go/src/github.com/openshift/oc-mirror/vendor/github.com/spf13/cobra/command.go:987 +0xaa3
github.com/spf13/cobra.(*Command).ExecuteC(0xc000ae6300)
        /go/src/github.com/openshift/oc-mirror/vendor/github.com/spf13/cobra/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(0x74be758?)
        /go/src/github.com/openshift/oc-mirror/vendor/github.com/spf13/cobra/command.go:1039 +0x13
main.main()
        /go/src/github.com/openshift/oc-mirror/cmd/oc-mirror/main.go:10 +0x18
```

With this fix  oc-mirror  v2 should not crash, expected output should show invalid catalogs as warning

```
$ bin/oc-mirror --v2 -c verizon.yaml --dry-run file://verizon --loglevel info

2024/07/03 11:24:42  [WARN]   : ⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.
2024/07/03 11:24:42  [INFO]   : 👋 Hello, welcome to oc-mirror
2024/07/03 11:24:42  [INFO]   : ⚙️  setting up the environment for you...
2024/07/03 11:24:42  [INFO]   : 🔀 workflow mode: mirrorToDisk 
2024/07/03 11:24:42  [INFO]   : 🕵️  going to discover the necessary images...
2024/07/03 11:24:42  [INFO]   : 🔍 collecting release images...
2024/07/03 11:24:42  [INFO]   : 🔍 collecting operator images...
2024/07/03 11:24:46  [WARN]   : [GetCatalog] invalid catalog verizon/working-dir/hold-operator/tncp-catalog/dcf3a021269f7900cac8e2e8dd51cd32e087c35b68cf956d8d14565a4b9e7c55 : SKIPPING
2024/07/03 11:24:46  [WARN]   : [OperatorImageCollector] package ibm-tncp-bundle not found in catalog icr.io/cpopen/tncp-catalog@sha256:dcf3a021269f7900cac8e2e8dd51cd32e087c35b68cf956d8d14565a4b9e7c55
2024/07/03 11:24:47  [WARN]   : [GetCatalog] invalid catalog verizon/working-dir/hold-operator/ibm-cpd-cloud-native-postgresql-operator-catalog/b5debd3c4b129a67f30ffdd774a385c96b8d33fd9ced8baad4835dd8913eb177 : SKIPPING
2024/07/03 11:24:47  [WARN]   : [OperatorImageCollector] package cloud-native-postgresql not found in catalog icr.io/cpopen/ibm-cpd-cloud-native-postgresql-operator-catalog@sha256:b5debd3c4b129a67f30ffdd774a385c96b8d33fd9ced8baad4835dd8913eb177
2024/07/03 11:24:47  [INFO]   : 🔍 collecting additional images...
2024/07/03 11:24:47  [WARN]   : ⚠️  12/12 images necessary for mirroring are not available in the cache.
2024/07/03 11:24:47  [WARN]   : List of missing images in : verizon/working-dir/dry-run/missing.txt.
please re-run the mirror to disk process
2024/07/03 11:24:47  [INFO]   : 📄 list of all images for mirroring in : verizon/working-dir/dry-run/mapping.txt
2024/07/03 11:24:47  [INFO]   : mirror time     : 5.429137541s
2024/07/03 11:24:47  [INFO]   : 👋 Goodbye, thank you for using oc-mirror
```
