### PR TITLE
OCPBUGS-36548: Skip catalogs that are non existing

### DIFF
--- a/v2/internal/pkg/manifest/oci-manifest.go
+++ b/v2/internal/pkg/manifest/oci-manifest.go
@@ -28,7 +28,6 @@ import (
 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/otiai10/copy"
-	"k8s.io/klog/v2"
 )
 
 type OperatorCatalog struct {
@@ -189,7 +188,6 @@ func untar(gzipStream io.Reader, path string, cfgDirName string) error {
 
 			default:
 				// just ignore errors as we are only interested in the FB configs layer
-				klog.Warningf("untar: unknown type: %v in %s", header.Typeflag, header.Name)
 			}
 		}
 	}

--- a/v2/internal/pkg/operator/local_stored_collector.go
+++ b/v2/internal/pkg/operator/local_stored_collector.go
@@ -87,9 +87,10 @@ func (o *LocalStorageCollector) OperatorImageCollector(ctx context.Context) ([]v
 				return []v2alpha1.CopyImageSchema{}, err
 			}
 			d, err := o.Manifest.GetDigest(ctx, sourceCtx, imgSpec.ReferenceWithTransport)
+			// OCPBUGS-36548 (manifest unknown)
 			if err != nil {
-				o.Log.Error(errMsg, err.Error())
-				return []v2alpha1.CopyImageSchema{}, err
+				o.Log.Warn(collectorPrefix+"catalog %s : SKIPPING", err.Error())
+				continue
 			}
 			catalogDigest = d
 		}

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/manifest/oci-manifest.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/manifest/oci-manifest.go
@@ -28,7 +28,6 @@ import (
 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/otiai10/copy"
-	"k8s.io/klog/v2"
 )
 
 type OperatorCatalog struct {
@@ -189,7 +188,6 @@ func untar(gzipStream io.Reader, path string, cfgDirName string) error {
 
 			default:
 				// just ignore errors as we are only interested in the FB configs layer
-				klog.Warningf("untar: unknown type: %v in %s", header.Typeflag, header.Name)
 			}
 		}
 	}

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/operator/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/operator/local_stored_collector.go
@@ -87,9 +87,10 @@ func (o *LocalStorageCollector) OperatorImageCollector(ctx context.Context) ([]v
 				return []v2alpha1.CopyImageSchema{}, err
 			}
 			d, err := o.Manifest.GetDigest(ctx, sourceCtx, imgSpec.ReferenceWithTransport)
+			// OCPBUGS-36548 (manifest unknown)
 			if err != nil {
-				o.Log.Error(errMsg, err.Error())
-				return []v2alpha1.CopyImageSchema{}, err
+				o.Log.Warn(collectorPrefix+"catalog %s : SKIPPING", err.Error())
+				continue
 			}
 			catalogDigest = d
 		}


### PR DESCRIPTION
# Description

If a catalog is non existing oc-mirror should log a warning to the console  , skip the catalog and continue

Fixes # OCPBUGS-36548

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Use the following imagesetconfig

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.17
    packages:
    - name: windows-machine-config-operator
```

## Expected Outcome
Console output 

```
2024/07/04 12:30:51  [WARN]   : ⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.
2024/07/04 12:30:51  [INFO]   : 👋 Hello, welcome to oc-mirror
2024/07/04 12:30:51  [INFO]   : ⚙️  setting up the environment for you...
2024/07/04 12:30:51  [INFO]   : 🔀 workflow mode: mirrorToDisk 
2024/07/04 12:30:51  [INFO]   : 🕵️  going to discover the necessary images...
2024/07/04 12:30:51  [INFO]   : 🔍 collecting release images...
2024/07/04 12:30:51  [INFO]   : 🔍 collecting operator images...
2024/07/04 12:30:52  [WARN]   : [OperatorImageCollector] catalog reading manifest v4.17 in registry.redhat.io/redhat/redhat-operator-index: manifest unknown : SKIPPING
```