### PR TITLE
OCPBUGS-37055: Use proxy for HTTP request release signatures

### DIFF
--- a/v2/internal/pkg/release/signature.go
+++ b/v2/internal/pkg/release/signature.go
@@ -55,6 +55,7 @@ func (o SignatureSchema) GenerateReleaseSignatures(ctx context.Context, images [
 	// set up http object
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: false},
+		Proxy:           http.ProxyFromEnvironment,
 	}
 	httpClient := &http.Client{Transport: tr}
 

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/signature.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/signature.go
@@ -55,6 +55,7 @@ func (o SignatureSchema) GenerateReleaseSignatures(ctx context.Context, images [
 	// set up http object
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: false},
+		Proxy:           http.ProxyFromEnvironment,
 	}
 	httpClient := &http.Client{Transport: tr}
 


### PR DESCRIPTION
# Description

This fixes the error encountered when running oc-mirror behind proxy for mirroring releases: signature API was called without respecting proxy setup

Fixes #OCPBUGS-37055

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. Install tinyproxy (`sudo dnf install tinyproxy -y`)
2. Create tinyproxy.conf
```
Port 8888
Listen 127.0.0.1
Timeout 600
Allow 127.0.0.1
```
3. run tinyproxy (`tinyproxy -d -c tinyproxy.conf`)
4. in separate window, run oc-mirror with proxy env vars set:
```
 export http_proxy=localhost:8888
 export HTTP_PROXY=localhost:8888
export HTTPS_PROXY=localhost:8888
export https_proxy=localhost:8888
./bin/oc-mirror --v2 -c ec2-demo/isc_resources.yaml file:///home/skhoury/demo1
```
5. look at logs of tinyproxy, call to `mirror.openshift.com` (as well as quay.io for images, and api.openshift.io for cincinnati) should be visible in the logs.

## Expected Outcome
see above