### PR TITLE
[release-4.16] OCPBUGS-37040: use current working-dir for fetching release content f…

### DIFF
--- a/v2/internal/pkg/release/local_stored_collector.go
+++ b/v2/internal/pkg/release/local_stored_collector.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	digest "github.com/opencontainers/go-digest"
@@ -327,8 +328,9 @@ func (o LocalStorageCollector) identifyReleases() ([]v2alpha1.RelatedImage, []st
 	for _, copy := range releaseImageCopies {
 		releasePath := strings.TrimPrefix(copy.Destination, ociProtocol)
 		releasePath = strings.TrimPrefix(releasePath, ociProtocolTrimmed)
-		releaseHoldPath := strings.Replace(releasePath, releaseImageDir, releaseImageExtractDir, 1)
-		releaseFolders = append(releaseFolders, releaseHoldPath)
+		re := regexp.MustCompile("^.*/" + releaseImageDir)
+		releaseHoldPath := re.ReplaceAll([]byte(releasePath), []byte(filepath.Join(o.Opts.Global.WorkingDir, releaseImageExtractDir)))
+		releaseFolders = append(releaseFolders, string(releaseHoldPath))
 		releaseImages = append(releaseImages, v2alpha1.RelatedImage{Name: copy.Source, Image: copy.Source, Type: v2alpha1.TypeOCPRelease})
 	}
 	return releaseImages, releaseFolders, nil

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/local_stored_collector.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	digest "github.com/opencontainers/go-digest"
@@ -327,8 +328,9 @@ func (o LocalStorageCollector) identifyReleases() ([]v2alpha1.RelatedImage, []st
 	for _, copy := range releaseImageCopies {
 		releasePath := strings.TrimPrefix(copy.Destination, ociProtocol)
 		releasePath = strings.TrimPrefix(releasePath, ociProtocolTrimmed)
-		releaseHoldPath := strings.Replace(releasePath, releaseImageDir, releaseImageExtractDir, 1)
-		releaseFolders = append(releaseFolders, releaseHoldPath)
+		re := regexp.MustCompile("^.*/" + releaseImageDir)
+		releaseHoldPath := re.ReplaceAll([]byte(releasePath), []byte(filepath.Join(o.Opts.Global.WorkingDir, releaseImageExtractDir)))
+		releaseFolders = append(releaseFolders, string(releaseHoldPath))
 		releaseImages = append(releaseImages, v2alpha1.RelatedImage{Name: copy.Source, Image: copy.Source, Type: v2alpha1.TypeOCPRelease})
 	}
 	return releaseImages, releaseFolders, nil


### PR DESCRIPTION
…or disk to mirror

# Description

This bug only affect 4.16: in 4.17 release filters were removed by #883.


Fixes # OCPBUGS-37040

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. git checkout release-4.16
2. make build
3. ./bin/oc-mirror --v2 -c ec2-demo/isc_resources.yaml file:///home/skhoury/demo1 
4. mkdir ~/OCPBUGS-37040;cp ~/demo1/mirror_000001.tar  ~/OCPBUGS-37040
5. mv ~/demo1 ~/demo2
6. ./bin/oc-mirror --v2 -c ec2-demo/isc_resources.yaml --from file:///home/skhoury/OCPBUGS-37040 docker://localhost:5000 --dest-tls-verify=false # this step fails
7. git checkout OCPBUGS-37040
8. make build
9. ./bin/oc-mirror --v2 -c ec2-demo/isc_resources.yaml --from file:///home/skhoury/OCPBUGS-37040 docker://localhost:5000 --dest-tls-verify=false # success

## Expected Outcome
see above