### PR TITLE
[v2] CLID-133,CLID-98: feat: show operator on error logs and skip bundle when related image associated failed

### DIFF
--- a/v2/internal/pkg/additional/local_stored_collector_test.go
+++ b/v2/internal/pkg/additional/local_stored_collector_test.go
@@ -169,7 +169,7 @@ func (o MockManifest) GetCatalog(filePath string) (manifest.OperatorCatalog, err
 	return manifest.OperatorCatalog{}, nil
 }
 
-func (o MockManifest) GetRelatedImagesFromCatalog(operatorCatalog manifest.OperatorCatalog, op v2alpha1.Operator) (map[string][]v2alpha1.RelatedImage, error) {
+func (o MockManifest) GetRelatedImagesFromCatalog(operatorCatalog manifest.OperatorCatalog, op v2alpha1.Operator, copyImageSchemaMap *v2alpha1.CopyImageSchemaMap) (map[string][]v2alpha1.RelatedImage, error) {
 	relatedImages := make(map[string][]v2alpha1.RelatedImage)
 	relatedImages["abc"] = []v2alpha1.RelatedImage{
 		{Name: "testA", Image: "quay.io/name/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"},

--- a/v2/internal/pkg/api/v2alpha1/type_image.go
+++ b/v2/internal/pkg/api/v2alpha1/type_image.go
@@ -42,6 +42,18 @@ var imageStringsType = map[string]ImageType{
 	"generic":              TypeGeneric,
 }
 
+func (it ImageType) IsRelease() bool {
+	return it == TypeOCPRelease || it == TypeOCPReleaseContent
+}
+
+func (it ImageType) IsOperator() bool {
+	return it == TypeOperatorBundle || it == TypeOperatorCatalog || it == TypeOperatorRelatedImage
+}
+
+func (it ImageType) IsAdditionalImage() bool {
+	return it == TypeGeneric
+}
+
 // String returns the string representation
 // of an Image Type
 func (it ImageType) String() string {

--- a/v2/internal/pkg/api/v2alpha1/type_internal.go
+++ b/v2/internal/pkg/api/v2alpha1/type_internal.go
@@ -199,6 +199,12 @@ type CollectorSchema struct {
 	TotalOperatorImages   int
 	TotalAdditionalImages int
 	AllImages             []CopyImageSchema
+	CopyImageSchemaMap    CopyImageSchemaMap
+}
+
+type CopyImageSchemaMap struct {
+	OperatorsByImage map[string]map[string]struct{} //key is the origin image name and value is an array of operators' name
+	BundlesByImage   map[string]map[string]string   //key is the image name and value is the bundle name
 }
 
 // CopyImageSchema

--- a/v2/internal/pkg/batch/type.go
+++ b/v2/internal/pkg/batch/type.go
@@ -1,0 +1,30 @@
+package batch
+
+import (
+	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
+	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
+)
+
+type ProgressStruct struct {
+	countTotal            int
+	countReleaseImages    int
+	countOperatorsImages  int
+	countAdditionalImages int
+
+	countErrorTotal                 int
+	countReleaseImagesErrorTotal    int
+	countOperatorsImagesErrorTotal  int
+	countAdditionalImagesErrorTotal int
+
+	mirrorMessage string
+	Log           clog.PluggableLoggerInterface
+}
+
+type StringMap map[string]string
+
+type mirrorErrorSchema struct {
+	image     v2alpha1.CopyImageSchema
+	err       error
+	operators map[string]struct{}
+	bundles   StringMap
+}

--- a/v2/internal/pkg/cli/delete.go
+++ b/v2/internal/pkg/cli/delete.go
@@ -287,10 +287,11 @@ func (o *ExecutorSchema) RunDelete(cmd *cobra.Command) error {
 
 		o.Log.Info("🔍 collecting operator images...")
 		// collect operator images
-		oImgs, err := o.Operator.OperatorImageCollector(cmd.Context())
+		oCollector, err := o.Operator.OperatorImageCollector(cmd.Context())
 		if err != nil {
 			o.Log.Error(" %v", err)
 		}
+		oImgs := oCollector.AllImages
 		allImages = append(allImages, oImgs...)
 
 		o.Log.Info("🔍 collecting additional images...")

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -962,22 +962,22 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 
 	collectorSchema.TotalReleaseImages = len(rImgs)
 	o.Log.Debug(collecAllPrefix+"total release images to %s %d ", o.Opts.Function, collectorSchema.TotalReleaseImages)
-	o.Opts.ImageType = "release" //TODO ALEX ask to Sherine about it
 	allRelatedImages = append(allRelatedImages, rImgs...)
 
 	o.Log.Info("🔍 collecting operator images...")
 	// collect operators
-	oImgs, err := o.Operator.OperatorImageCollector(ctx)
+	oCollector, err := o.Operator.OperatorImageCollector(ctx)
 	if err != nil {
 		o.closeAll()
 		return v2alpha1.CollectorSchema{}, err
 	}
+	oImgs := oCollector.AllImages
 	// exclude blocked images
 	oImgs = excludeImages(oImgs, o.Config.Mirror.BlockedImages)
 	collectorSchema.TotalOperatorImages = len(oImgs)
 	o.Log.Debug(collecAllPrefix+"total operator images to %s %d ", o.Opts.Function, collectorSchema.TotalOperatorImages)
-	o.Opts.ImageType = "operator"
 	allRelatedImages = append(allRelatedImages, oImgs...)
+	collectorSchema.CopyImageSchemaMap = oCollector.CopyImageSchemaMap
 
 	o.Log.Info("🔍 collecting additional images...")
 	// collect additionalImages

--- a/v2/internal/pkg/cli/executor_test.go
+++ b/v2/internal/pkg/cli/executor_test.go
@@ -1113,9 +1113,9 @@ func (o Batch) Worker(ctx context.Context, collectorSchema v2alpha1.CollectorSch
 	return collectorSchema, nil
 }
 
-func (o *Collector) OperatorImageCollector(ctx context.Context) ([]v2alpha1.CopyImageSchema, error) {
+func (o *Collector) OperatorImageCollector(ctx context.Context) (v2alpha1.CollectorSchema, error) {
 	if o.Fail {
-		return []v2alpha1.CopyImageSchema{}, fmt.Errorf("forced error operator collector")
+		return v2alpha1.CollectorSchema{}, fmt.Errorf("forced error operator collector")
 	}
 	test := []v2alpha1.CopyImageSchema{
 		{Source: "docker://registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:test"},
@@ -1125,7 +1125,7 @@ func (o *Collector) OperatorImageCollector(ctx context.Context) ([]v2alpha1.Copy
 		{Source: "docker://registry/name/namespace/sometestimage-e@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:test"},
 		{Source: "docker://registry/name/namespace/sometestimage-f@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:test"},
 	}
-	return test, nil
+	return v2alpha1.CollectorSchema{AllImages: test}, nil
 }
 
 func (o *Collector) ReleaseImageCollector(ctx context.Context) ([]v2alpha1.CopyImageSchema, error) {

--- a/v2/internal/pkg/delete/delete_images_test.go
+++ b/v2/internal/pkg/delete/delete_images_test.go
@@ -201,7 +201,7 @@ func (o mockManifest) GetCatalog(filePath string) (manifest.OperatorCatalog, err
 	return manifest.OperatorCatalog{}, nil
 }
 
-func (o mockManifest) GetRelatedImagesFromCatalog(operatorCatalog manifest.OperatorCatalog, ctlgInIsc v2alpha1.Operator) (map[string][]v2alpha1.RelatedImage, error) {
+func (o mockManifest) GetRelatedImagesFromCatalog(operatorCatalog manifest.OperatorCatalog, ctlgInIsc v2alpha1.Operator, copyImageSchemaMap *v2alpha1.CopyImageSchemaMap) (map[string][]v2alpha1.RelatedImage, error) {
 	res := map[string][]v2alpha1.RelatedImage{}
 	ri := []v2alpha1.RelatedImage{
 		{

--- a/v2/internal/pkg/manifest/interface.go
+++ b/v2/internal/pkg/manifest/interface.go
@@ -12,7 +12,7 @@ type ManifestInterface interface {
 	GetImageManifest(file string) (*v2alpha1.OCISchema, error)
 	GetOperatorConfig(file string) (*v2alpha1.OperatorConfigSchema, error)
 	GetCatalog(filePath string) (OperatorCatalog, error)
-	GetRelatedImagesFromCatalog(operatorCatalog OperatorCatalog, ctlgInIsc v2alpha1.Operator) (map[string][]v2alpha1.RelatedImage, error)
+	GetRelatedImagesFromCatalog(operatorCatalog OperatorCatalog, ctlgInIsc v2alpha1.Operator, copyImageSchemaMap *v2alpha1.CopyImageSchemaMap) (map[string][]v2alpha1.RelatedImage, error)
 	ExtractLayersOCI(filePath, toPath, label string, oci *v2alpha1.OCISchema) error
 	GetReleaseSchema(filePath string) ([]v2alpha1.RelatedImage, error)
 	ConvertIndexToSingleManifest(dir string, oci *v2alpha1.OCISchema) error

--- a/v2/internal/pkg/manifest/oci-manifest_test.go
+++ b/v2/internal/pkg/manifest/oci-manifest_test.go
@@ -606,8 +606,9 @@ func TestGetRelatedImagesFromCatalog(t *testing.T) {
 
 			var res map[string][]v2alpha1.RelatedImage
 			var err error
+			copyImageSchemaMap := &v2alpha1.CopyImageSchemaMap{OperatorsByImage: make(map[string]map[string]struct{}), BundlesByImage: make(map[string]map[string]string)}
 
-			res, err = manifest.GetRelatedImagesFromCatalog(operatorCatalog, testCase.cfg)
+			res, err = manifest.GetRelatedImagesFromCatalog(operatorCatalog, testCase.cfg, copyImageSchemaMap)
 
 			if testCase.expectedError == nil {
 				assert.NoError(t, err)
@@ -668,8 +669,9 @@ func TestTypesOnRelatedImages(t *testing.T) {
 
 			var bundles map[string][]v2alpha1.RelatedImage
 			var err error
+			copyImageSchemaMap := &v2alpha1.CopyImageSchemaMap{OperatorsByImage: make(map[string]map[string]struct{}), BundlesByImage: make(map[string]map[string]string)}
 
-			bundles, err = manifest.GetRelatedImagesFromCatalog(operatorCatalog, testCase.cfg)
+			bundles, err = manifest.GetRelatedImagesFromCatalog(operatorCatalog, testCase.cfg, copyImageSchemaMap)
 
 			assert.NoError(t, err)
 

--- a/v2/internal/pkg/operator/interface.go
+++ b/v2/internal/pkg/operator/interface.go
@@ -7,5 +7,5 @@ import (
 )
 
 type CollectorInterface interface {
-	OperatorImageCollector(ctx context.Context) ([]v2alpha1.CopyImageSchema, error)
+	OperatorImageCollector(ctx context.Context) (v2alpha1.CollectorSchema, error)
 }

--- a/v2/internal/pkg/operator/local_stored_collector_test.go
+++ b/v2/internal/pkg/operator/local_stored_collector_test.go
@@ -393,7 +393,7 @@ func TestOperatorLocalStoredCollectorM2D(t *testing.T) {
 			if !testCase.expectedError && err != nil {
 				t.Fatal("should not fail")
 			}
-			assert.ElementsMatch(t, testCase.expectedResult, res)
+			assert.ElementsMatch(t, testCase.expectedResult, res.AllImages)
 		})
 	}
 
@@ -501,7 +501,7 @@ func TestOperatorLocalStoredCollectorD2M(t *testing.T) {
 			if !testCase.expectedError && err != nil {
 				t.Fatal("should not fail")
 			}
-			assert.ElementsMatch(t, testCase.expectedResult, res)
+			assert.ElementsMatch(t, testCase.expectedResult, res.AllImages)
 		})
 	}
 
@@ -657,7 +657,7 @@ func (o MockManifest) GetCatalog(filePath string) (manifest.OperatorCatalog, err
 	return manifest.OperatorCatalog{}, nil
 }
 
-func (o MockManifest) GetRelatedImagesFromCatalog(operatorCatalog manifest.OperatorCatalog, op v2alpha1.Operator) (map[string][]v2alpha1.RelatedImage, error) {
+func (o MockManifest) GetRelatedImagesFromCatalog(operatorCatalog manifest.OperatorCatalog, op v2alpha1.Operator, copyImageSchemaMap *v2alpha1.CopyImageSchemaMap) (map[string][]v2alpha1.RelatedImage, error) {
 	relatedImages := make(map[string][]v2alpha1.RelatedImage)
 	relatedImages["abc"] = []v2alpha1.RelatedImage{
 		{Name: "testA", Image: "sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"},

--- a/v2/internal/pkg/operator/sort.go
+++ b/v2/internal/pkg/operator/sort.go
@@ -1,0 +1,31 @@
+package operator
+
+import (
+	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
+)
+
+type ByTypePriority []v2alpha1.CopyImageSchema
+
+func (a ByTypePriority) Len() int      { return len(a) }
+func (a ByTypePriority) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a ByTypePriority) Less(i, j int) bool {
+	priority := map[string]int{
+		v2alpha1.TypeOperatorRelatedImage.String(): 1,
+		v2alpha1.TypeOperatorBundle.String():       2,
+		v2alpha1.TypeOperatorCatalog.String():      3,
+	}
+
+	defaultPriority := 0
+
+	priorityI, ok := priority[a[i].Type.String()]
+	if !ok {
+		priorityI = defaultPriority
+	}
+
+	priorityJ, ok := priority[a[j].Type.String()]
+	if !ok {
+		priorityJ = defaultPriority
+	}
+
+	return priorityI < priorityJ
+}

--- a/v2/internal/pkg/operator/sort_test.go
+++ b/v2/internal/pkg/operator/sort_test.go
@@ -1,0 +1,53 @@
+package operator
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSort(t *testing.T) {
+
+	type testCase struct {
+		caseName       string
+		allImages      []v2alpha1.CopyImageSchema
+		expectedOutput []v2alpha1.CopyImageSchema
+	}
+
+	testCases := []testCase{
+		{
+			caseName: "Sort - should sort the images based on the priority",
+			allImages: []v2alpha1.CopyImageSchema{
+				{
+					Type: v2alpha1.TypeOperatorCatalog,
+				},
+				{
+					Type: v2alpha1.TypeOperatorRelatedImage,
+				},
+				{
+					Type: v2alpha1.TypeOperatorBundle,
+				},
+			},
+			expectedOutput: []v2alpha1.CopyImageSchema{
+				{
+					Type: v2alpha1.TypeOperatorRelatedImage,
+				},
+				{
+					Type: v2alpha1.TypeOperatorBundle,
+				},
+				{
+					Type: v2alpha1.TypeOperatorCatalog,
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.caseName, func(t *testing.T) {
+			sort.Sort(ByTypePriority(testCase.allImages))
+			assert.Equal(t, testCase.expectedOutput, testCase.allImages)
+		})
+	}
+}

--- a/v2/internal/pkg/release/local_stored_collector_test.go
+++ b/v2/internal/pkg/release/local_stored_collector_test.go
@@ -439,7 +439,7 @@ func (o MockManifest) GetCatalog(filePath string) (manifest.OperatorCatalog, err
 	return manifest.OperatorCatalog{}, nil
 }
 
-func (o MockManifest) GetRelatedImagesFromCatalog(operatorCatalog manifest.OperatorCatalog, op v2alpha1.Operator) (map[string][]v2alpha1.RelatedImage, error) {
+func (o MockManifest) GetRelatedImagesFromCatalog(operatorCatalog manifest.OperatorCatalog, op v2alpha1.Operator, copyImageSchemaMap *v2alpha1.CopyImageSchemaMap) (map[string][]v2alpha1.RelatedImage, error) {
 	relatedImages := make(map[string][]v2alpha1.RelatedImage)
 	relatedImages["abc"] = []v2alpha1.RelatedImage{
 		{Name: "testA", Image: "sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"},

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1/type_image.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1/type_image.go
@@ -42,6 +42,18 @@ var imageStringsType = map[string]ImageType{
 	"generic":              TypeGeneric,
 }
 
+func (it ImageType) IsRelease() bool {
+	return it == TypeOCPRelease || it == TypeOCPReleaseContent
+}
+
+func (it ImageType) IsOperator() bool {
+	return it == TypeOperatorBundle || it == TypeOperatorCatalog || it == TypeOperatorRelatedImage
+}
+
+func (it ImageType) IsAdditionalImage() bool {
+	return it == TypeGeneric
+}
+
 // String returns the string representation
 // of an Image Type
 func (it ImageType) String() string {

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1/type_internal.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1/type_internal.go
@@ -199,6 +199,12 @@ type CollectorSchema struct {
 	TotalOperatorImages   int
 	TotalAdditionalImages int
 	AllImages             []CopyImageSchema
+	CopyImageSchemaMap    CopyImageSchemaMap
+}
+
+type CopyImageSchemaMap struct {
+	OperatorsByImage map[string]map[string]struct{} //key is the origin image name and value is an array of operators' name
+	BundlesByImage   map[string]map[string]string   //key is the image name and value is the bundle name
 }
 
 // CopyImageSchema

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/type.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/type.go
@@ -1,0 +1,30 @@
+package batch
+
+import (
+	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
+	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
+)
+
+type ProgressStruct struct {
+	countTotal            int
+	countReleaseImages    int
+	countOperatorsImages  int
+	countAdditionalImages int
+
+	countErrorTotal                 int
+	countReleaseImagesErrorTotal    int
+	countOperatorsImagesErrorTotal  int
+	countAdditionalImagesErrorTotal int
+
+	mirrorMessage string
+	Log           clog.PluggableLoggerInterface
+}
+
+type StringMap map[string]string
+
+type mirrorErrorSchema struct {
+	image     v2alpha1.CopyImageSchema
+	err       error
+	operators map[string]struct{}
+	bundles   StringMap
+}

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/delete.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/delete.go
@@ -287,10 +287,11 @@ func (o *ExecutorSchema) RunDelete(cmd *cobra.Command) error {
 
 		o.Log.Info("🔍 collecting operator images...")
 		// collect operator images
-		oImgs, err := o.Operator.OperatorImageCollector(cmd.Context())
+		oCollector, err := o.Operator.OperatorImageCollector(cmd.Context())
 		if err != nil {
 			o.Log.Error(" %v", err)
 		}
+		oImgs := oCollector.AllImages
 		allImages = append(allImages, oImgs...)
 
 		o.Log.Info("🔍 collecting additional images...")

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
@@ -962,22 +962,22 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 
 	collectorSchema.TotalReleaseImages = len(rImgs)
 	o.Log.Debug(collecAllPrefix+"total release images to %s %d ", o.Opts.Function, collectorSchema.TotalReleaseImages)
-	o.Opts.ImageType = "release" //TODO ALEX ask to Sherine about it
 	allRelatedImages = append(allRelatedImages, rImgs...)
 
 	o.Log.Info("🔍 collecting operator images...")
 	// collect operators
-	oImgs, err := o.Operator.OperatorImageCollector(ctx)
+	oCollector, err := o.Operator.OperatorImageCollector(ctx)
 	if err != nil {
 		o.closeAll()
 		return v2alpha1.CollectorSchema{}, err
 	}
+	oImgs := oCollector.AllImages
 	// exclude blocked images
 	oImgs = excludeImages(oImgs, o.Config.Mirror.BlockedImages)
 	collectorSchema.TotalOperatorImages = len(oImgs)
 	o.Log.Debug(collecAllPrefix+"total operator images to %s %d ", o.Opts.Function, collectorSchema.TotalOperatorImages)
-	o.Opts.ImageType = "operator"
 	allRelatedImages = append(allRelatedImages, oImgs...)
+	collectorSchema.CopyImageSchemaMap = oCollector.CopyImageSchemaMap
 
 	o.Log.Info("🔍 collecting additional images...")
 	// collect additionalImages

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/manifest/interface.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/manifest/interface.go
@@ -12,7 +12,7 @@ type ManifestInterface interface {
 	GetImageManifest(file string) (*v2alpha1.OCISchema, error)
 	GetOperatorConfig(file string) (*v2alpha1.OperatorConfigSchema, error)
 	GetCatalog(filePath string) (OperatorCatalog, error)
-	GetRelatedImagesFromCatalog(operatorCatalog OperatorCatalog, ctlgInIsc v2alpha1.Operator) (map[string][]v2alpha1.RelatedImage, error)
+	GetRelatedImagesFromCatalog(operatorCatalog OperatorCatalog, ctlgInIsc v2alpha1.Operator, copyImageSchemaMap *v2alpha1.CopyImageSchemaMap) (map[string][]v2alpha1.RelatedImage, error)
 	ExtractLayersOCI(filePath, toPath, label string, oci *v2alpha1.OCISchema) error
 	GetReleaseSchema(filePath string) ([]v2alpha1.RelatedImage, error)
 	ConvertIndexToSingleManifest(dir string, oci *v2alpha1.OCISchema) error

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/operator/interface.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/operator/interface.go
@@ -7,5 +7,5 @@ import (
 )
 
 type CollectorInterface interface {
-	OperatorImageCollector(ctx context.Context) ([]v2alpha1.CopyImageSchema, error)
+	OperatorImageCollector(ctx context.Context) (v2alpha1.CollectorSchema, error)
 }

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/operator/sort.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/operator/sort.go
@@ -1,0 +1,31 @@
+package operator
+
+import (
+	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
+)
+
+type ByTypePriority []v2alpha1.CopyImageSchema
+
+func (a ByTypePriority) Len() int      { return len(a) }
+func (a ByTypePriority) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a ByTypePriority) Less(i, j int) bool {
+	priority := map[string]int{
+		v2alpha1.TypeOperatorRelatedImage.String(): 1,
+		v2alpha1.TypeOperatorBundle.String():       2,
+		v2alpha1.TypeOperatorCatalog.String():      3,
+	}
+
+	defaultPriority := 0
+
+	priorityI, ok := priority[a[i].Type.String()]
+	if !ok {
+		priorityI = defaultPriority
+	}
+
+	priorityJ, ok := priority[a[j].Type.String()]
+	if !ok {
+		priorityJ = defaultPriority
+	}
+
+	return priorityI < priorityJ
+}


### PR DESCRIPTION
# Description

This implementation adds to the error log file which operators a related image that failed is associated with.

Also, it skips a bundle image in case one of its associated related images failed during the mirroring.

NOTE: There is no guarantee that the bundle image is going to be skipped all the times. There is a scenario with small chance of happening where the operator related image and the operator bundle image are in the same batch and the bundle image is executed first in the concurrent process, in this scenario if the related image fails, the bundle is not going to be skipped because it has been already mirrored. This scenario is going to be handled in the [CLID-181](https://issues.redhat.com/browse/CLID-181) and [CLID-204](https://issues.redhat.com/browse/CLID-204)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
### Automated test
[Unit test](https://github.com/openshift/oc-mirror/pull/895/files#diff-28004d00e63b0f2ddf92a150fc0742493540820521fb4130c32f9e0638f0abf0R187)

### Manual test
Step 1: MirrorToDisk and in the middle of the mirroring process (batch) I cut the internet access temporarily to make operator related images to fail (only to related images associated with 3scale-operator).

Step 2: DiskToMirror to check if the repo for 3scale bundle was not created

ImageSetConfig.yaml
```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15
      packages:
       - name: aws-load-balancer-operator
       - name: 3scale-operator
       - name: node-observability-operator
```

Step 1: mirror to disk:

```
rm -rf ./alex-tests/clid-133-debug/ && rm -rf ~/.oc-mirror/

./bin/oc-mirror -c /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-isc/isc.yaml file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-133-debug --v2
```
Log Output:
```
2024/07/25 14:49:52  [WARN]   : ⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.
2024/07/25 14:49:52  [INFO]   : 👋 Hello, welcome to oc-mirror
2024/07/25 14:49:52  [INFO]   : ⚙️  setting up the environment for you...
2024/07/25 14:49:52  [INFO]   : 🔀 workflow mode: mirrorToDisk 
2024/07/25 14:49:52  [INFO]   : 🕵️  going to discover the necessary images...
2024/07/25 14:49:52  [INFO]   : 🔍 collecting release images...
2024/07/25 14:49:52  [INFO]   : 🔍 collecting operator images...
2024/07/25 14:52:14  [INFO]   : 🔍 collecting additional images...
2024/07/25 14:52:14  [INFO]   : 🚀 Start copying the images...
2024/07/25 14:52:14  [INFO]   : images to copy 26 
 ✗   1/26 : (10m0s) docker://registry.redhat.io/3scale-amp2/system-rhel7@sha256:fe77272021867cc6b6d5d0c9bd06c99d4024ad53f1ab94ec0ab69d0fda74588e 
 ✓   2/26 : (57s) docker://registry.redhat.io/albo/aws-load-balancer-rhel8-operator@sha256:16e9ffed36107527a37713ac5bd34a7bc20f042269a81077429fb5884914c4d0 
 ✗   3/26 : (10m0s) docker://registry.redhat.io/3scale-amp2/zync-rhel9@sha256:8bb6b31e108d67476cc62622f20ff8db34efae5d58014de9502336fcc479d86d 
 ✓   4/26 : (2m24s) docker://registry.redhat.io/openshift4/ose-cli@sha256:1a8caae40be21f23ba3cb48b75809a73333907033a6041927aa568b5c9290f3c 
 ✓   5/26 : (2m55s) docker://registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:f11f71448986aa17abec9caadb568a6cc34ef1a7898e6dc20bc6a512830ba476 
 ✓   6/26 : (56s) docker://registry.redhat.io/albo/aws-load-balancer-controller-rhel8@sha256:2e0b9332a44d8d9c23e19c7accab0813a651f39210257820db508cac28876595 
 ✓   7/26 : (47s) docker://registry.redhat.io/3scale-amp2/3scale-rhel7-operator@sha256:6fca648c287cca3307921ce7c6b47ecfbfbd525caa8cad109402a459746874c8 
 ✓   8/26 : (29s) docker://registry.redhat.io/3scale-amp2/3scale-rhel7-operator@sha256:6fca648c287cca3307921ce7c6b47ecfbfbd525caa8cad109402a459746874c8 
2024/07/25 15:02:14  [WARN]   : Mirroring is ongoing. Total errors: 2.
2024/07/25 15:02:14 http: superfluous response.WriteHeader call from go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*respWriterWrapper).WriteHeader (wrap.go:98)
2024/07/25 15:02:14 http: superfluous response.WriteHeader call from go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*respWriterWrapper).WriteHeader (wrap.go:98)
2024/07/25 15:02:14 http: superfluous response.WriteHeader call from go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*respWriterWrapper).WriteHeader (wrap.go:98)
 ✓   9/26 : (2m55s) docker://registry.redhat.io/3scale-amp2/apicast-gateway-rhel8@sha256:f6a2a301ff3e1d7432378996c8a0d97a738f1193c5ad66c2d03cd03784a326c4 
 ✓   10/26 : (4m26s) docker://registry.redhat.io/3scale-amp2/backend-rhel8@sha256:129c8015195fdafa61ce6a3d9cd6f4c55059fc37b51620483726698d5d5933dc 
 ✓   11/26 : (1m0s) docker://registry.redhat.io/3scale-amp2/memcached-rhel7@sha256:0983ab0e30ef071f8e66eebb0ea7224fd3b0e9da43cf22f403ea06567c3f8da8 
 ✓   12/26 : (3m51s) docker://registry.redhat.io/3scale-amp2/searchd-rhel7@sha256:a3aeb4499d1b57e6b4ec04db0eea5737b5aba7f943601e74109fb8f27b259231 
 ✓   13/26 : (51s) docker://registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:e3dad360d0351237a16593ca0862652809c41a2127c2f98b9e0a559568efbd10 
 ✓   14/26 : (40s) docker://registry.redhat.io/noo/node-observability-rhel8-operator@sha256:53ba77f648154ac8aca1ae6c83815078dfde211dba1e42f597e69844e4954c01 
 ✓   15/26 : (4s) docker://registry.redhat.io/albo/aws-load-balancer-rhel8-operator@sha256:16e9ffed36107527a37713ac5bd34a7bc20f042269a81077429fb5884914c4d0 
 ✓   16/26 : (3m27s) docker://registry.redhat.io/rhel8/mysql-80@sha256:8b101afa8d7d6ac8a7ff6fde5a8f75721d5f94d2d8ba8b347bffee1b6fc8087b 
2024/07/25 15:06:41  [WARN]   : Mirroring is ongoing. Total errors: 2.
 ✓   17/26 : (17s) docker://registry.redhat.io/rhel8/redis-6@sha256:726bc80093a756d382024ac3e214b5dc3ed3dc2ee638f96e0fdead6b8fe2f612 
 ✓   18/26 : (19s) docker://registry.redhat.io/rhel8/redis-6@sha256:726bc80093a756d382024ac3e214b5dc3ed3dc2ee638f96e0fdead6b8fe2f612 
 ✓   19/26 : (19s) docker://registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:a95d09fc3b224f550dec3de3d23fd2dbfc0a220dc869b4ad9559ee2f85327daa 
 ✓   20/26 : (19s) docker://registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:a95d09fc3b224f550dec3de3d23fd2dbfc0a220dc869b4ad9559ee2f85327daa 
 ✓   21/26 : (1s) docker://registry.redhat.io/noo/node-observability-rhel8-operator@sha256:53ba77f648154ac8aca1ae6c83815078dfde211dba1e42f597e69844e4954c01 
 ✓   22/26 : (3s) docker://registry.redhat.io/noo/node-observability-agent-rhel8@sha256:a8e60d9f63e2ed0cf1e27309aac54014e3f1efc947b51ca0a99376338d220875 
 ✓   23/26 : (3s) docker://registry.redhat.io/noo/node-observability-operator-bundle-rhel8@sha256:0fbbb0b32adadc5746251103d25bba6bd365b2ff60e289e4694061fc92c3ce6e 
 ✓   24/26 : (3s) docker://registry.redhat.io/albo/aws-load-balancer-operator-bundle@sha256:01f2ca529d2486f113bcefc9fedce6a6fd07bcb48aaf534394b5b04c353f8853 
2024/07/25 15:07:00  [WARN]   : Mirroring is ongoing. Total errors: 2.
 ✗   25/26 : (2m21s) docker://registry.redhat.io/3scale-amp2/3scale-rhel7-operator-metadata@sha256:de0a70d1263a6a596d28bf376158056631afd0b6159865008a7263a8e9bf0c7d 
 ✓   26/26 : (2m21s) docker://registry.redhat.io/redhat/redhat-operator-index:v4.15 
2024/07/25 15:09:22  [INFO]   : === Results ===
2024/07/25 15:09:22  [INFO]   : ❌ 23 / 26 operator images mirrored: Some operator images failed to mirror - please check the logs
2024/07/25 15:09:22  [ERROR]  : [Worker] error mirroring image docker://registry.redhat.io/3scale-amp2/system-rhel7@sha256:fe77272021867cc6b6d5d0c9bd06c99d4024ad53f1ab94ec0ab69d0fda74588e (Operator bundles: [3scale-operator.v0.11.12] - Operators: [3scale-operator]) error: copying image 1/3 from manifest list: writing blob: Patch "http://localhost:55000/v2/3scale-amp2/system-rhel7/blobs/uploads/7c1a9be5-05c9-4007-b88d-96e215ebd5d0?_state=G2jKAUIQ-L95afv7wCB3AXhpDA6XCLWscv5N4vC1mEZ7Ik5hbWUiOiIzc2NhbGUtYW1wMi9zeXN0ZW0tcmhlbDciLCJVVUlEIjoiN2MxYTliZTUtMDVjOS00MDA3LWI4OGQtOTZlMjE1ZWJkNWQwIiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDI0LTA3LTI1VDEyOjUyOjE2LjI2NDAyNTYxM1oifQ%!D(MISSING)%!D(MISSING)": context deadline exceeded
2024/07/25 15:09:22  [ERROR]  : [Worker] error mirroring image docker://registry.redhat.io/3scale-amp2/zync-rhel9@sha256:8bb6b31e108d67476cc62622f20ff8db34efae5d58014de9502336fcc479d86d (Operator bundles: [3scale-operator.v0.11.12] - Operators: [3scale-operator]) error: copying image 3/3 from manifest list: writing blob: Patch "http://localhost:55000/v2/3scale-amp2/zync-rhel9/blobs/uploads/15197f69-8438-4379-b6fc-c5d90db3887d?_state=PAKwIsx5_kiWsF7Vb3B-NxCH8SqclrGx-idjLLqJF2d7Ik5hbWUiOiIzc2NhbGUtYW1wMi96eW5jLXJoZWw5IiwiVVVJRCI6IjE1MTk3ZjY5LTg0MzgtNDM3OS1iNmZjLWM1ZDkwZGIzODg3ZCIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyNC0wNy0yNVQxMjo1NTowMS4xMTMxNzkyNzVaIn0%!D(MISSING)": context deadline exceeded
2024/07/25 15:09:22  [ERROR]  : [Worker] error mirroring image docker://registry.redhat.io/3scale-amp2/3scale-rhel7-operator-metadata@sha256:de0a70d1263a6a596d28bf376158056631afd0b6159865008a7263a8e9bf0c7d error: skipping operator bundle docker://registry.redhat.io/3scale-amp2/3scale-rhel7-operator-metadata@sha256:de0a70d1263a6a596d28bf376158056631afd0b6159865008a7263a8e9bf0c7d because one of its related images failed to mirror
2024/07/25 15:09:22  [INFO]   : 📦 Preparing the tarball archive...
2024/07/25 15:09:37  [INFO]   : mirror time     : 19m44.47055938s
2024/07/25 15:09:37  [WARN]   : [Worker] some errors occurred during the mirroring.
         Please review /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-133-debug/working-dir/logs/mirroring_errors_20240725_150922.txt for a list of mirroring errors.
         You may consider:
         * removing images or operators that cause the error from the image set config, and retrying
         * keeping the image set config (images are mandatory for you), and retrying
         * mirroring the failing images manually, if retries also fail.
2024/07/25 15:09:37  [INFO]   : 👋 Goodbye, thank you for using oc-mirror

```

Log file mirroring_errors_20240725_150922.txt content:
```
error mirroring image docker://registry.redhat.io/3scale-amp2/system-rhel7@sha256:fe77272021867cc6b6d5d0c9bd06c99d4024ad53f1ab94ec0ab69d0fda74588e (Operator bundles: [3scale-operator.v0.11.12] - Operators: [3scale-operator]) error: copying image 1/3 from manifest list: writing blob: Patch "http://localhost:55000/v2/3scale-amp2/system-rhel7/blobs/uploads/7c1a9be5-05c9-4007-b88d-96e215ebd5d0?_state=G2jKAUIQ-L95afv7wCB3AXhpDA6XCLWscv5N4vC1mEZ7Ik5hbWUiOiIzc2NhbGUtYW1wMi9zeXN0ZW0tcmhlbDciLCJVVUlEIjoiN2MxYTliZTUtMDVjOS00MDA3LWI4OGQtOTZlMjE1ZWJkNWQwIiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDI0LTA3LTI1VDEyOjUyOjE2LjI2NDAyNTYxM1oifQ%3D%3D": context deadline exceeded
error mirroring image docker://registry.redhat.io/3scale-amp2/zync-rhel9@sha256:8bb6b31e108d67476cc62622f20ff8db34efae5d58014de9502336fcc479d86d (Operator bundles: [3scale-operator.v0.11.12] - Operators: [3scale-operator]) error: copying image 3/3 from manifest list: writing blob: Patch "http://localhost:55000/v2/3scale-amp2/zync-rhel9/blobs/uploads/15197f69-8438-4379-b6fc-c5d90db3887d?_state=PAKwIsx5_kiWsF7Vb3B-NxCH8SqclrGx-idjLLqJF2d7Ik5hbWUiOiIzc2NhbGUtYW1wMi96eW5jLXJoZWw5IiwiVVVJRCI6IjE1MTk3ZjY5LTg0MzgtNDM3OS1iNmZjLWM1ZDkwZGIzODg3ZCIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyNC0wNy0yNVQxMjo1NTowMS4xMTMxNzkyNzVaIn0%3D": context deadline exceeded
error mirroring image docker://registry.redhat.io/3scale-amp2/3scale-rhel7-operator-metadata@sha256:de0a70d1263a6a596d28bf376158056631afd0b6159865008a7263a8e9bf0c7d error: skipping operator bundle docker://registry.redhat.io/3scale-amp2/3scale-rhel7-operator-metadata@sha256:de0a70d1263a6a596d28bf376158056631afd0b6159865008a7263a8e9bf0c7d because one of its related images failed to mirror
```

Step 2: disk to mirror
```
./bin/oc-mirror -c /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-isc/isc.yaml --from file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-133-debug docker://localhost:6000 --v2
```

Log output:
```
2024/07/25 15:13:14  [WARN]   : ⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.
2024/07/25 15:13:14  [INFO]   : 👋 Hello, welcome to oc-mirror
2024/07/25 15:13:14  [INFO]   : ⚙️  setting up the environment for you...
2024/07/25 15:13:14  [INFO]   : 🔀 workflow mode: diskToMirror 
2024/07/25 15:13:34  [INFO]   : 🕵️  going to discover the necessary images...
2024/07/25 15:13:34  [INFO]   : 🔍 collecting release images...
2024/07/25 15:13:34  [INFO]   : 🔍 collecting operator images...
2024/07/25 15:13:43  [INFO]   : 🔍 collecting additional images...
2024/07/25 15:13:43  [INFO]   : 🚀 Start copying the images...
2024/07/25 15:13:43  [INFO]   : images to copy 26 
 ✗   1/26 : (13s) docker://registry.redhat.io/3scale-amp2/zync-rhel9@sha256:8bb6b31e108d67476cc62622f20ff8db34efae5d58014de9502336fcc479d86d 
 ✓   2/26 : (5s) docker://registry.redhat.io/noo/node-observability-rhel8-operator@sha256:53ba77f648154ac8aca1ae6c83815078dfde211dba1e42f597e69844e4954c01 
 ✓   3/26 : (10s) docker://registry.redhat.io/3scale-amp2/apicast-gateway-rhel8@sha256:f6a2a301ff3e1d7432378996c8a0d97a738f1193c5ad66c2d03cd03784a326c4 
 ✓   4/26 : (13s) docker://registry.redhat.io/3scale-amp2/backend-rhel8@sha256:129c8015195fdafa61ce6a3d9cd6f4c55059fc37b51620483726698d5d5933dc 
 ✓   5/26 : (10s) docker://registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:e3dad360d0351237a16593ca0862652809c41a2127c2f98b9e0a559568efbd10 
 ✓   6/26 : (5s) docker://registry.redhat.io/albo/aws-load-balancer-controller-rhel8@sha256:2e0b9332a44d8d9c23e19c7accab0813a651f39210257820db508cac28876595 
 ✓   7/26 : (8s) docker://registry.redhat.io/3scale-amp2/3scale-rhel7-operator@sha256:6fca648c287cca3307921ce7c6b47ecfbfbd525caa8cad109402a459746874c8 
 ✓   8/26 : (5s) docker://registry.redhat.io/albo/aws-load-balancer-rhel8-operator@sha256:16e9ffed36107527a37713ac5bd34a7bc20f042269a81077429fb5884914c4d0 
2024/07/25 15:13:56  [WARN]   : Mirroring is ongoing. Total errors: 1.
 ✓   9/26 : (0s) docker://registry.redhat.io/albo/aws-load-balancer-rhel8-operator@sha256:16e9ffed36107527a37713ac5bd34a7bc20f042269a81077429fb5884914c4d0 
 ✓   10/26 : (6s) docker://registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:f11f71448986aa17abec9caadb568a6cc34ef1a7898e6dc20bc6a512830ba476 
 ✓   11/26 : (5s) docker://registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:a95d09fc3b224f550dec3de3d23fd2dbfc0a220dc869b4ad9559ee2f85327daa 
 ✓   12/26 : (0s) docker://registry.redhat.io/3scale-amp2/3scale-rhel7-operator@sha256:6fca648c287cca3307921ce7c6b47ecfbfbd525caa8cad109402a459746874c8 
 ✓   13/26 : (5s) docker://registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:a95d09fc3b224f550dec3de3d23fd2dbfc0a220dc869b4ad9559ee2f85327daa 
 ✓   14/26 : (5s) docker://registry.redhat.io/rhel8/redis-6@sha256:726bc80093a756d382024ac3e214b5dc3ed3dc2ee638f96e0fdead6b8fe2f612 
 ✓   15/26 : (0s) docker://registry.redhat.io/noo/node-observability-rhel8-operator@sha256:53ba77f648154ac8aca1ae6c83815078dfde211dba1e42f597e69844e4954c01 
 ✓   16/26 : (5s) docker://registry.redhat.io/3scale-amp2/memcached-rhel7@sha256:0983ab0e30ef071f8e66eebb0ea7224fd3b0e9da43cf22f403ea06567c3f8da8 
2024/07/25 15:14:03  [WARN]   : Mirroring is ongoing. Total errors: 1.
 ✓   17/26 : (9s) docker://registry.redhat.io/3scale-amp2/searchd-rhel7@sha256:a3aeb4499d1b57e6b4ec04db0eea5737b5aba7f943601e74109fb8f27b259231 
 ✗   18/26 : (9s) docker://registry.redhat.io/3scale-amp2/system-rhel7@sha256:fe77272021867cc6b6d5d0c9bd06c99d4024ad53f1ab94ec0ab69d0fda74588e 
 ✓   19/26 : (0s) docker://registry.redhat.io/noo/node-observability-agent-rhel8@sha256:a8e60d9f63e2ed0cf1e27309aac54014e3f1efc947b51ca0a99376338d220875 
 ✓   20/26 : (4s) docker://registry.redhat.io/openshift4/ose-cli@sha256:1a8caae40be21f23ba3cb48b75809a73333907033a6041927aa568b5c9290f3c 
 ✓   21/26 : (7s) docker://registry.redhat.io/rhel8/mysql-80@sha256:8b101afa8d7d6ac8a7ff6fde5a8f75721d5f94d2d8ba8b347bffee1b6fc8087b 
 ✓   22/26 : (0s) docker://registry.redhat.io/rhel8/redis-6@sha256:726bc80093a756d382024ac3e214b5dc3ed3dc2ee638f96e0fdead6b8fe2f612 
 ✓ 23/26 : (0s) docker://registry.redhat.io/noo/node-observability-operator-bundle-rhel8@sha256:0fbbb0b32adadc5746251103d25bba6bd365b2ff60e289e4694061fc92c3ce6e 
 ✗   24/26 : (9s) docker://registry.redhat.io/3scale-amp2/3scale-rhel7-operator-metadata@sha256:de0a70d1263a6a596d28bf376158056631afd0b6159865008a7263a8e9bf0c7d 
2024/07/25 15:14:12  [WARN]   : Mirroring is ongoing. Total errors: 3.
 ✓   25/26 : (0s) docker://registry.redhat.io/albo/aws-load-balancer-operator-bundle@sha256:01f2ca529d2486f113bcefc9fedce6a6fd07bcb48aaf534394b5b04c353f8853 
 ✓   26/26 : (9s) docker://registry.redhat.io/redhat/redhat-operator-index:v4.15 
2024/07/25 15:14:22  [INFO]   : === Results ===
2024/07/25 15:14:22  [INFO]   : ❌ 23 / 26 operator images mirrored: Some operator images failed to mirror - please check the logs
2024/07/25 15:14:22  [ERROR]  : [Worker] error mirroring image docker://registry.redhat.io/3scale-amp2/zync-rhel9@sha256:8bb6b31e108d67476cc62622f20ff8db34efae5d58014de9502336fcc479d86d (Operator bundles: [3scale-operator.v0.11.12] - Operators: [3scale-operator]) error: initializing source docker://localhost:55000/3scale-amp2/zync-rhel9:8bb6b31e108d67476cc62622f20ff8db34efae5d58014de9502336fcc479d86d: reading manifest 8bb6b31e108d67476cc62622f20ff8db34efae5d58014de9502336fcc479d86d in localhost:55000/3scale-amp2/zync-rhel9: manifest unknown
2024/07/25 15:14:22  [ERROR]  : [Worker] error mirroring image docker://registry.redhat.io/3scale-amp2/3scale-rhel7-operator-metadata@sha256:de0a70d1263a6a596d28bf376158056631afd0b6159865008a7263a8e9bf0c7d error: skipping operator bundle docker://registry.redhat.io/3scale-amp2/3scale-rhel7-operator-metadata@sha256:de0a70d1263a6a596d28bf376158056631afd0b6159865008a7263a8e9bf0c7d because one of its related images failed to mirror
2024/07/25 15:14:22  [ERROR]  : [Worker] error mirroring image docker://registry.redhat.io/3scale-amp2/system-rhel7@sha256:fe77272021867cc6b6d5d0c9bd06c99d4024ad53f1ab94ec0ab69d0fda74588e (Operator bundles: [3scale-operator.v0.11.12] - Operators: [3scale-operator]) error: initializing source docker://localhost:55000/3scale-amp2/system-rhel7:fe77272021867cc6b6d5d0c9bd06c99d4024ad53f1ab94ec0ab69d0fda74588e: reading manifest fe77272021867cc6b6d5d0c9bd06c99d4024ad53f1ab94ec0ab69d0fda74588e in localhost:55000/3scale-amp2/system-rhel7: manifest unknown
2024/07/25 15:14:22  [INFO]   : 📄 Generating IDMS file...
2024/07/25 15:14:22  [INFO]   : /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-133-debug/working-dir/cluster-resources/idms-oc-mirror.yaml file created
2024/07/25 15:14:22  [INFO]   : 📄 No images by tag were mirrored. Skipping ITMS generation.
2024/07/25 15:14:22  [INFO]   : 📄 Generating CatalogSource file...
2024/07/25 15:14:22  [INFO]   : /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-133-debug/working-dir/cluster-resources/cs-redhat-operator-index-v4-15.yaml file created
2024/07/25 15:14:22  [INFO]   : mirror time     : 1m8.058885398s
2024/07/25 15:14:22  [WARN]   : [Worker] some errors occurred during the mirroring.
         Please review /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-133-debug/working-dir/logs/mirroring_errors_20240725_151422.txt for a list of mirroring errors.
         You may consider:
         * removing images or operators that cause the error from the image set config, and retrying
         * keeping the image set config (images are mandatory for you), and retrying
         * mirroring the failing images manually, if retries also fail.
2024/07/25 15:14:22  [INFO]   : 👋 Goodbye, thank you for using oc-mirror
```

Log file mirroring_errors_20240725_151422.txt content:
```
error mirroring image docker://registry.redhat.io/3scale-amp2/zync-rhel9@sha256:8bb6b31e108d67476cc62622f20ff8db34efae5d58014de9502336fcc479d86d (Operator bundles: [3scale-operator.v0.11.12] - Operators: [3scale-operator]) error: initializing source docker://localhost:55000/3scale-amp2/zync-rhel9:8bb6b31e108d67476cc62622f20ff8db34efae5d58014de9502336fcc479d86d: reading manifest 8bb6b31e108d67476cc62622f20ff8db34efae5d58014de9502336fcc479d86d in localhost:55000/3scale-amp2/zync-rhel9: manifest unknown
error mirroring image docker://registry.redhat.io/3scale-amp2/3scale-rhel7-operator-metadata@sha256:de0a70d1263a6a596d28bf376158056631afd0b6159865008a7263a8e9bf0c7d error: skipping operator bundle docker://registry.redhat.io/3scale-amp2/3scale-rhel7-operator-metadata@sha256:de0a70d1263a6a596d28bf376158056631afd0b6159865008a7263a8e9bf0c7d because one of its related images failed to mirror
error mirroring image docker://registry.redhat.io/3scale-amp2/system-rhel7@sha256:fe77272021867cc6b6d5d0c9bd06c99d4024ad53f1ab94ec0ab69d0fda74588e (Operator bundles: [3scale-operator.v0.11.12] - Operators: [3scale-operator]) error: initializing source docker://localhost:55000/3scale-amp2/system-rhel7:fe77272021867cc6b6d5d0c9bd06c99d4024ad53f1ab94ec0ab69d0fda74588e: reading manifest fe77272021867cc6b6d5d0c9bd06c99d4024ad53f1ab94ec0ab69d0fda74588e in localhost:55000/3scale-amp2/system-rhel7: manifest unknown
```

target registry after mirroring without 3scale-rhel7-operator-metadata (bundle) repo
```
[aguidi@fedora oc-mirror]$ curl http://localhost:6000/v2/_catalog | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   570  100   570    0     0   157k      0 --:--:-- --:--:-- --:--:--  185k
{
  "repositories": [
    "3scale-amp2/3scale-rhel7-operator",
    "3scale-amp2/apicast-gateway-rhel8",
    "3scale-amp2/backend-rhel8",
    "3scale-amp2/memcached-rhel7",
    "3scale-amp2/searchd-rhel7",
    "albo/aws-load-balancer-controller-rhel8",
    "albo/aws-load-balancer-operator-bundle",
    "albo/aws-load-balancer-rhel8-operator",
    "noo/node-observability-agent-rhel8",
    "noo/node-observability-operator-bundle-rhel8",
    "noo/node-observability-rhel8-operator",
    "openshift4/ose-cli",
    "openshift4/ose-kube-rbac-proxy",
    "redhat/redhat-operator-index",
    "rhel8/mysql-80",
    "rhel8/redis-6",
    "rhscl/postgresql-10-rhel7"
  ]
}
```

## Expected Outcome
Error log file should be generated with operator and bundle names of the related image that failed. 

Also the bundle related to the related image that failed should be skipped.