### PR TITLE
OCPBUGS-37667: Rebuild catalogs -- without cache generation

### DIFF
--- a/pkg/cli/mirror/catalog_images.go
+++ b/pkg/cli/mirror/catalog_images.go
@@ -9,8 +9,10 @@ import (
 	"io/fs"
 	"math/rand"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -326,6 +328,14 @@ func (o *MirrorOptions) processCatalogRefs(ctx context.Context, catalogsByImage 
 
 		layersToAdd := []v1.Layer{}
 		layersToDelete := []v1.Layer{}
+		withCacheRegeneration := o.RebuildCatalogs && o.BuildCatalogCache
+		_, err := os.Stat(filepath.Join(artifactDir, config.OPMCacheLocationPlaceholder))
+		if errors.Is(err, os.ErrNotExist) {
+			withCacheRegeneration = false
+		} else if err != nil {
+			return fmt.Errorf("unable to determine location of cache for image %s. Cache generation failed: %v", ctlgRef, err)
+		}
+
 		configLayerToAdd, err := builder.LayerFromPathWithUidGid("/configs", filepath.Join(artifactDir, config.IndexDir), 0, 0)
 		if err != nil {
 			return fmt.Errorf("error creating add layer: %v", err)
@@ -339,6 +349,40 @@ func (o *MirrorOptions) processCatalogRefs(ctx context.Context, catalogsByImage 
 			return fmt.Errorf("error creating deleted layer: %v", err)
 		}
 		layersToDelete = append(layersToDelete, deletedConfigLayer)
+
+		if withCacheRegeneration {
+
+			opmCmdPath := ""
+			if opmBinary := os.Getenv("OPM_BINARY"); opmBinary != "" {
+				opmCmdPath = opmBinary
+			} else {
+				opmCmdPath = filepath.Join(artifactDir, config.OpmBinDir, "opm")
+			}
+			_, err = os.Stat(opmCmdPath)
+			if err != nil {
+				return fmt.Errorf("cannot find opm in the extracted catalog %v for %s on %s: %v", ctlgRef, runtime.GOOS, runtime.GOARCH, err)
+			}
+
+			absConfigPath, err := filepath.Abs(filepath.Join(artifactDir, config.IndexDir))
+			if err != nil {
+				return fmt.Errorf("error getting absolute path for catalog's index %v: %v", filepath.Join(artifactDir, config.IndexDir), err)
+			}
+			absCachePath, err := filepath.Abs(filepath.Join(artifactDir, config.TmpDir))
+			if err != nil {
+				return fmt.Errorf("error getting absolute path for catalog's cache %v: %v", filepath.Join(artifactDir, config.TmpDir), err)
+			}
+			cmd := exec.Command(opmCmdPath, "serve", absConfigPath, "--cache-dir", absCachePath, "--cache-only")
+			if err := cmd.Run(); err != nil {
+				return fmt.Errorf("error regenerating the cache for %v: %v", ctlgRef, err)
+			}
+			// Fix OCPBUGS-17546:
+			// Add the cache under /cache in a new layer (instead of white-out /tmp/cache, which resulted in crashLoopBackoff only on some clusters)
+			cacheLayerToAdd, err := builder.LayerFromPathWithUidGid("/cache", filepath.Join(artifactDir, config.TmpDir), cacheFolderUID, cacheFolderGID)
+			if err != nil {
+				return fmt.Errorf("error creating add layer: %v", err)
+			}
+			layersToAdd = append(layersToAdd, cacheLayerToAdd)
+		}
 
 		// Deleted layers must be added first in the slice
 		// so that the /configs and /tmp directories are deleted
@@ -360,12 +404,87 @@ func (o *MirrorOptions) processCatalogRefs(ctx context.Context, catalogsByImage 
 			cfg.Config.Labels = labels
 			// Although it was prefered to keep the entrypoint and command as it was
 			// we couldnt reuse /tmp/cache as the cache directory (OCPBUGS-17546)
-			cfg.Config.Cmd = []string{"serve", "/configs"}
+			if withCacheRegeneration {
+				cfg.Config.Cmd = []string{"serve", "/configs", "--cache-dir=/cache"}
+			} else { // this means that --build-catalog-cache flag was not used
+				// if the flag was used this means that no cache nor opm binary was found in the original catalog (old catalog with opm < 1.25)
+				cfg.Config.Cmd = []string{"serve", "/configs"}
+			}
 		}
 		if err := imgBuilder.Run(ctx, refExact, layoutPath, update, layers...); err != nil {
 			return fmt.Errorf("error building catalog layers: %v", err)
 		}
 	}
+	return nil
+}
+
+// extractOPMAndCache is usually called after rendering catalog's declarative config.
+// it uses crane modules to pull the catalog image, select the manifest that corresponds to the
+// current platform architecture. It then extracts from that image any files that are suffixed `*opm` for later
+// use upon rebuilding the catalog: This is because the opm binary can be called `opm` but also
+// `darwin-amd64-opm` etc.
+func extractOPMAndCache(ctx context.Context, srcRef image.TypedImageReference, ctlgSrcDir string, insecure bool) error {
+	var img v1.Image
+	var err error
+	refExact := srcRef.Ref.Exact()
+	if srcRef.OCIFBCPath == "" {
+		remoteOpts := getCraneOpts(ctx, insecure)
+		img, err = crane.Pull(refExact, remoteOpts...)
+		if err != nil {
+			return fmt.Errorf("unable to pull image from %s: %v", refExact, err)
+		}
+	} else {
+		img, err = getPlatformImageFromOCIIndex(v1alpha2.TrimProtocol(srcRef.OCIFBCPath), runtime.GOARCH, runtime.GOOS)
+		if err != nil {
+			return err
+		}
+	}
+	// if we get here and no image was found bail out
+	if img == nil {
+		return fmt.Errorf("unable to obtain image for %v", srcRef)
+	}
+	cachePath, err := getCachePath(img)
+	if err != nil {
+		if errors.Is(err, NoCacheArgsError) {
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	cacheLocationFileName := filepath.Join(ctlgSrcDir, config.OPMCacheLocationPlaceholder)
+
+	baseDir := filepath.Dir(cacheLocationFileName)
+	err = os.MkdirAll(baseDir, 0755)
+	if err != nil {
+		return err
+	}
+
+	cfl, err := os.Create(cacheLocationFileName)
+	if err != nil {
+		return err
+	}
+	defer cfl.Close()
+
+	_, err = cfl.Write([]byte(cachePath))
+	if err != nil {
+		return err
+	}
+	// cachePath exists, opm binary will be needed to regenerate it
+	opmBinaryFileName, err := copyOPMBinary(img, ctlgSrcDir)
+	if err != nil {
+		return err
+	}
+	// check for the extracted opm file (it should exist if we found something)
+	_, err = os.Stat(opmBinaryFileName)
+	if errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("opm binary not found after extracting opm from catalog image %v", srcRef)
+	}
+	err = os.Chmod(opmBinaryFileName, 0744)
+	if err != nil {
+		return fmt.Errorf("error changing permissions to the extracted opm binary while preparing to run opm to regenerate cache: %v", err)
+	}
+
 	return nil
 }
 

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -286,12 +286,6 @@ func (o *MirrorOptions) Validate() error {
 			return fmt.Errorf("unable to read the configuration file provided with --config: %v", err)
 		}
 
-		for _, op := range cfg.Mirror.Operators {
-			if op.IsFBCOCI() {
-				break
-			}
-		}
-
 		// check for defaultChannel
 		for _, op := range cfg.Mirror.Operators {
 			for _, pkg := range op.Packages {

--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -188,20 +188,6 @@ func (o *OperatorOptions) run(
 			return nil, o.checkValidationErr(err)
 		}
 
-		ctlgSrcDir := filepath.Join(o.Dir, config.SourceDir, config.CatalogsDir, targetCtlg.Ref.Registry, targetCtlg.Ref.Namespace, targetCtlg.Ref.Name)
-		if targetCtlg.Ref.ID != "" {
-			ctlgSrcDir = filepath.Join(ctlgSrcDir, targetCtlg.Ref.ID)
-		} else if targetCtlg.Ref.Tag != "" {
-			ctlgSrcDir = filepath.Join(ctlgSrcDir, targetCtlg.Ref.Tag)
-		}
-		if o.RebuildCatalogs {
-			err = extractOPMAndCache(ctx, ctlgRef, ctlgSrcDir, o.SourceSkipTLS)
-			if err != nil {
-				reg.Destroy()
-				return nil, fmt.Errorf("unable to extract OPM binary from catalog %s: %v", targetName, err)
-			}
-		}
-
 		mappings, err := o.plan(ctx, dc, ic, ctlgRef, targetCtlg)
 		if err != nil {
 			reg.Destroy()

--- a/pkg/cli/mirror/operator.go
+++ b/pkg/cli/mirror/operator.go
@@ -188,6 +188,20 @@ func (o *OperatorOptions) run(
 			return nil, o.checkValidationErr(err)
 		}
 
+		if o.RebuildCatalogs && o.BuildCatalogCache {
+			ctlgSrcDir := filepath.Join(o.Dir, config.SourceDir, config.CatalogsDir, targetCtlg.Ref.Registry, targetCtlg.Ref.Namespace, targetCtlg.Ref.Name)
+			if targetCtlg.Ref.ID != "" {
+				ctlgSrcDir = filepath.Join(ctlgSrcDir, targetCtlg.Ref.ID)
+			} else if targetCtlg.Ref.Tag != "" {
+				ctlgSrcDir = filepath.Join(ctlgSrcDir, targetCtlg.Ref.Tag)
+			}
+			err = extractOPMAndCache(ctx, ctlgRef, ctlgSrcDir, o.SourceSkipTLS)
+			if err != nil {
+				reg.Destroy()
+				return nil, fmt.Errorf("unable to extract OPM binary from catalog %s: %v", targetName, err)
+			}
+		}
+
 		mappings, err := o.plan(ctx, dc, ic, ctlgRef, targetCtlg)
 		if err != nil {
 			reg.Destroy()

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -79,8 +79,9 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.EnableOperatorSignatureVerification, "enable-operator-secure-policy", o.EnableOperatorSignatureVerification, "If set, verifies operator catalog signatures prior to mirroring")
 	fs.BoolVar(&o.SkipPruning, "skip-pruning", o.SkipPruning, "If set, will disable pruning globally")
 	fs.IntVar(&o.MaxNestedPaths, "max-nested-paths", 0, "Number of nested paths, for destination registries that limit nested paths")
-	fs.BoolVar(&o.RebuildCatalogs, "rebuild-catalogs", o.RebuildCatalogs, "If set (defaults to false), rebuilds catalogs based on filtered declarative config, and regenerates the cache of that catalog")
+	fs.BoolVar(&o.RebuildCatalogs, "rebuild-catalogs", true, "If set (defaults to true), rebuilds catalogs based on filtered declarative config, and regenerates the cache of that catalog")
 	fs.MarkDeprecated("oci-insecure-signature-policy", "and will be removed in a future release. Use enable-operator-secure-policy instead.")
+	fs.MarkDeprecated("rebuild-catalogs", "rebuild-catalogs is deprecated and will be removed in a future release: the default behavior of oc-mirror v1 is to rebuild catalogs.")
 }
 
 func (o *MirrorOptions) init() {

--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -41,6 +41,7 @@ type MirrorOptions struct {
 	EnableOperatorSignatureVerification bool   // If set, verifies operator catalog signatures prior to mirroring
 	MaxNestedPaths                      int
 	RebuildCatalogs                     bool // If set, rebuilds catalogs based on filtered declarative config, and regenerates the cache of that catalog
+	BuildCatalogCache                   bool // If set (defaults to false), attempt to build catalog cache while building catalogs, using OPM_BINARY if provided, otherwise opm binary from catalog.
 	// cancelCh is a channel listening for command cancellations
 	cancelCh                          <-chan struct{}
 	once                              sync.Once
@@ -80,8 +81,9 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.SkipPruning, "skip-pruning", o.SkipPruning, "If set, will disable pruning globally")
 	fs.IntVar(&o.MaxNestedPaths, "max-nested-paths", 0, "Number of nested paths, for destination registries that limit nested paths")
 	fs.BoolVar(&o.RebuildCatalogs, "rebuild-catalogs", true, "If set (defaults to true), rebuilds catalogs based on filtered declarative config, and regenerates the cache of that catalog")
+	fs.BoolVar(&o.BuildCatalogCache, "build-catalog-cache", false, "If set (defaults to false), attempt to build catalog cache while building catalogs, using OPM_BINARY if provided, otherwise opm binary from catalog.")
 	fs.MarkDeprecated("oci-insecure-signature-policy", "and will be removed in a future release. Use enable-operator-secure-policy instead.")
-	fs.MarkDeprecated("rebuild-catalogs", "rebuild-catalogs is deprecated and will be removed in a future release: the default behavior of oc-mirror v1 is to rebuild catalogs.")
+	fs.MarkHidden("build-catalog-cache")
 }
 
 func (o *MirrorOptions) init() {

--- a/test/e2e/lib/check.sh
+++ b/test/e2e/lib/check.sh
@@ -26,9 +26,9 @@ function check_bundles() {
   mv index.json $index_dir
 
   # extract the cache from the tar file
-  # local cache_dir="${extraction_dir}/cache"
-  # tar xvf $extraction_dir/temp.tar /cache
-  # mv cache "${extraction_dir}"
+  local cache_dir="${extraction_dir}/cache"
+  tar xvf $extraction_dir/temp.tar /cache
+  mv cache "${extraction_dir}"
 
   # extract the opm binary from the tar file
   local opm_path="${extraction_dir}/opm"
@@ -40,8 +40,8 @@ function check_bundles() {
   $opm_path validate $index_dir
 
   # validate cache integrity
-  # $opm_path serve $index_dir --cache-dir=$cache_dir --cache-only --cache-enforce-integrity
-  # rm -fr "$extraction_dir"
+  $opm_path serve $index_dir --cache-dir=$cache_dir --cache-only --cache-enforce-integrity
+  rm -fr "$extraction_dir"
 
   declare -A exp_bundles_set
   for bundle in $exp_bundles_list; do

--- a/test/e2e/lib/check.sh
+++ b/test/e2e/lib/check.sh
@@ -26,9 +26,9 @@ function check_bundles() {
   mv index.json $index_dir
 
   # extract the cache from the tar file
-  local cache_dir="${extraction_dir}/cache"
-  tar xvf $extraction_dir/temp.tar /cache
-  mv cache "${extraction_dir}"
+  # local cache_dir="${extraction_dir}/cache"
+  # tar xvf $extraction_dir/temp.tar /cache
+  # mv cache "${extraction_dir}"
 
   # extract the opm binary from the tar file
   local opm_path="${extraction_dir}/opm"
@@ -40,8 +40,8 @@ function check_bundles() {
   $opm_path validate $index_dir
 
   # validate cache integrity
-  $opm_path serve $index_dir --cache-dir=$cache_dir --cache-only --cache-enforce-integrity
-  rm -fr "$extraction_dir"
+  # $opm_path serve $index_dir --cache-dir=$cache_dir --cache-only --cache-enforce-integrity
+  # rm -fr "$extraction_dir"
 
   declare -A exp_bundles_set
   for bundle in $exp_bundles_list; do

--- a/test/e2e/testcases.sh
+++ b/test/e2e/testcases.sh
@@ -30,7 +30,7 @@ TESTCASES[23]="m2d2m_oci_catalog"
 
 # Test full catalog mode.
 function full_catalog() {
-    workflow_full imageset-config-full.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_full imageset-config-full.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.0.0 baz.v1.0.1 baz.v1.1.0 foo.v0.1.0 foo.v0.2.0 foo.v0.3.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -38,7 +38,7 @@ function full_catalog() {
 
 # Test full catalog mode with digest.
 function full_catalog_with_digest() {
-    workflow_full imageset-config-full-digest.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_full imageset-config-full-digest.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     TMPTAG=$(echo $CATALOGDIGEST | cut -d: -f 2)
     ## We default to 6 for the partial digest length to get unique tags per repo
     TMPTAG=${TMPTAG:0:6}
@@ -49,12 +49,12 @@ function full_catalog_with_digest() {
 
 # Test heads-only mode
 function headsonly_diff () {
-    workflow_full imageset-config-headsonly.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_full imageset-config-headsonly.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
 
-    workflow_diff imageset-config-headsonly.yaml "test-catalog-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_diff imageset-config-headsonly.yaml "test-catalog-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -62,13 +62,13 @@ function headsonly_diff () {
 
 # Test heads-only mode with target
 function headsonly_diff_with_target () {
-    workflow_full imageset-config-headsonly-newtarget.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_full imageset-config-headsonly-newtarget.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     # shellcheck disable=SC2086
     check_bundles localhost.localdomain:"${REGISTRY_DISCONN_PORT}"/"${CATALOGORG}"/${TARGET_CATALOG_NAME}:${TARGET_CATALOG_TAG} \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
 
-    workflow_diff imageset-config-headsonly-newtarget.yaml "test-catalog-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_diff imageset-config-headsonly-newtarget.yaml "test-catalog-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:"${REGISTRY_DISCONN_PORT}"/"${CATALOGORG}"/"${TARGET_CATALOG_NAME}":"${TARGET_CATALOG_TAG}" \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:"${REGISTRY_DISCONN_PORT}"
@@ -76,13 +76,13 @@ function headsonly_diff_with_target () {
 
 # Test heads-only mode with catalogs that prune bundles
 function pruned_catalogs() {
-    workflow_full imageset-config-headsonly.yaml "test-catalog-prune" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_full imageset-config-headsonly.yaml "test-catalog-prune" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.1.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
     check_image_exists "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:${CATALOG_ID}"
 
-    workflow_diff imageset-config-headsonly.yaml "test-catalog-prune-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_diff imageset-config-headsonly.yaml "test-catalog-prune-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.2.0" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -92,13 +92,13 @@ function pruned_catalogs() {
 # Test heads-only mode with catalogs that prune with a custom target
 # name set
 function pruned_catalogs_with_target() {
-    workflow_full imageset-config-headsonly-newtarget.yaml "test-catalog-prune" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_full imageset-config-headsonly-newtarget.yaml "test-catalog-prune" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGORG}/${TARGET_CATALOG_NAME}:${TARGET_CATALOG_TAG} \
     "bar.v0.1.0 foo.v0.1.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
     check_image_exists "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:${CATALOG_ID}"
 
-    workflow_diff imageset-config-headsonly-newtarget.yaml "test-catalog-prune-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_diff imageset-config-headsonly-newtarget.yaml "test-catalog-prune-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGORG}/${TARGET_CATALOG_NAME}:${TARGET_CATALOG_TAG} \
     "bar.v0.1.0 foo.v0.2.0" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -107,13 +107,13 @@ function pruned_catalogs_with_target() {
 
 # Test heads-only mode with catalogs that prune bundles
 function pruned_catalogs_with_include() {
-    workflow_full imageset-config-filter-multi-prune.yaml "test-catalog-prune" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_full imageset-config-filter-multi-prune.yaml "test-catalog-prune" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.1.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
     check_image_exists "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:${CATALOG_ID}"
 
-    workflow_diff imageset-config-filter-multi-prune.yaml "test-catalog-prune-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_diff imageset-config-filter-multi-prune.yaml "test-catalog-prune-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.2.0" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -122,13 +122,13 @@ function pruned_catalogs_with_include() {
 
 # Test heads-only mode with catalogs that prune bundles
 function pruned_catalogs_mirror_to_mirror() {
-    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-prune" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-prune" -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.1.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
     check_image_exists "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:${CATALOG_ID}"
 
-    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-prune-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-prune-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 foo.v0.2.0" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -137,12 +137,12 @@ function pruned_catalogs_mirror_to_mirror() {
 
 # Test registry backend
 function registry_backend () {
-    workflow_full imageset-config-headsonly-backend-registry.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_full imageset-config-headsonly-backend-registry.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
 
-    workflow_diff imageset-config-headsonly-backend-registry.yaml "test-catalog-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_diff imageset-config-headsonly-backend-registry.yaml "test-catalog-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -150,7 +150,7 @@ function registry_backend () {
 
 # Test mirror to mirror with local backend
 function mirror_to_mirror() {
-    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-latest" -c="--source-use-http --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_mirror2mirror imageset-config-headsonly.yaml "test-catalog-latest" -c="--source-use-http --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -158,7 +158,7 @@ function mirror_to_mirror() {
 
 # Test mirror to mirror no backend
 function mirror_to_mirror_nostorage() {
-    workflow_mirror2mirror imageset-config-full.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_mirror2mirror imageset-config-full.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.0.0 baz.v1.0.1 baz.v1.1.0 foo.v0.1.0 foo.v0.2.0 foo.v0.3.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -166,12 +166,12 @@ function mirror_to_mirror_nostorage() {
 
 # Test registry backend with custom namespace
 function custom_namespace {
-    workflow_full imageset-config-headsonly-backend-registry.yaml "test-catalog-latest" --diff -n="custom" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_full imageset-config-headsonly-backend-registry.yaml "test-catalog-latest" --diff -n="custom" -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles "localhost.localdomain:${REGISTRY_DISCONN_PORT}/custom/${CATALOGNAMESPACE}:test-catalog-latest" \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT} "custom"
 
-    workflow_diff imageset-config-headsonly-backend-registry.yaml "test-catalog-diff" -n="custom" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_diff imageset-config-headsonly-backend-registry.yaml "test-catalog-diff" -n="custom" -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles "localhost.localdomain:${REGISTRY_DISCONN_PORT}/custom/${CATALOGNAMESPACE}:test-catalog-latest" \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT} "custom"
@@ -180,12 +180,12 @@ function custom_namespace {
 
 # Test package filtering
 function package_filtering {
-    workflow_full imageset-config-filter.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_full imageset-config-filter.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest" \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 foo.v0.1.0 foo.v0.2.0 foo.v0.3.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
 
-    workflow_diff imageset-config-filter-multi.yaml "test-catalog-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_diff imageset-config-filter-multi.yaml "test-catalog-diff" -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest" \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.0.1 baz.v1.1.0 foo.v0.1.0 foo.v0.2.0 foo.v0.3.0 foo.v0.3.1 foo.v0.3.2" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -193,7 +193,7 @@ function package_filtering {
 
 # Test catalog with one version in a package specified
 function single_version () {
-    workflow_full imageset-config-filter-single.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_full imageset-config-filter-single.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "baz.v1.0.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -201,7 +201,7 @@ function single_version () {
 
 # Test catalog with a version range in a package specified
 function version_range () {
-    workflow_full imageset-config-filter-range.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_full imageset-config-filter-range.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "foo.v0.2.0 foo.v0.3.0" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -209,7 +209,7 @@ function version_range () {
 
 # Test catalog with a max version in a package specified
 function max_version () {
-    workflow_full imageset-config-filter-max.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_full imageset-config-filter-max.yaml "test-catalog-latest" -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "foo.v0.1.0 foo.v0.2.0 foo.v0.3.0" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -218,7 +218,7 @@ function max_version () {
 
 # Test skip deps
 function skip_deps {
-    workflow_full imageset-config-skip-deps.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_full imageset-config-skip-deps.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles "localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest" \
     "bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -240,7 +240,7 @@ function helm_repository {
 
 # Test no updates
 function no_updates_exist {
-    workflow_no_updates imageset-config-headsonly.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_no_updates imageset-config-headsonly.yaml "test-catalog-latest" --diff -c="--source-use-http  --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${CATALOGNAMESPACE}:test-catalog-latest \
     "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -255,7 +255,7 @@ function no_updates_exist {
 # Test OCI local catalog
 function m2m_oci_catalog {
     rm -fr olm_artifacts
-    workflow_m2m_oci_catalog imageset-config-oci-mirror.yaml "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}" -c="--dest-skip-tls --oci-insecure-signature-policy --rebuild-catalogs"
+    workflow_m2m_oci_catalog imageset-config-oci-mirror.yaml "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}" -c="--dest-skip-tls --oci-insecure-signature-policy --rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${OCI_REGISTRY_NAMESPACE}/oc-mirror-dev:test-catalog-latest \
     "baz.v1.0.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}
@@ -276,7 +276,7 @@ function m2m_release_with_oci_catalog {
     test/e2e/graph/main & PID_GO=$!
     echo -e "go cincinnatti web service PID: ${PID_GO}"
     # copy relevant files and start the mirror process
-    workflow_oci_mirror_all imageset-config-oci-mirror-all.yaml "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}/test-catalog-latest" -c="--dest-skip-tls --oci-insecure-signature-policy --rebuild-catalogs"
+    workflow_oci_mirror_all imageset-config-oci-mirror-all.yaml "docker://localhost.localdomain:${REGISTRY_DISCONN_PORT}/test-catalog-latest" -c="--dest-skip-tls --oci-insecure-signature-policy --rebuild-catalogs --build-catalog-cache"
 
     # use crane digest to verify
     crane digest --insecure localhost.localdomain:${REGISTRY_DISCONN_PORT}/test-catalog-latest/${OCI_REGISTRY_NAMESPACE}/oc-mirror-dev:bar-v0.1.0
@@ -293,7 +293,7 @@ function m2m_release_with_oci_catalog {
 # Test full catalog mode.
 function m2d2m_oci_catalog() {
     rm -fr olm_artifacts
-    workflow_m2d2m_oci_catalog imageset-config-oci-mirror.yaml "localhost.localdomain:${REGISTRY_DISCONN_PORT}" -c="--source-use-http   --source-skip-tls --rebuild-catalogs" -p="--rebuild-catalogs"
+    workflow_m2d2m_oci_catalog imageset-config-oci-mirror.yaml "localhost.localdomain:${REGISTRY_DISCONN_PORT}" -c="--source-use-http   --source-skip-tls --rebuild-catalogs --build-catalog-cache" -p="--rebuild-catalogs --build-catalog-cache"
     check_bundles localhost.localdomain:${REGISTRY_DISCONN_PORT}/${OCI_REGISTRY_NAMESPACE}/oc-mirror-dev:test-catalog-latest \
     "baz.v1.0.1" \
     localhost.localdomain:${REGISTRY_DISCONN_PORT}


### PR DESCRIPTION
# Description

## What are we trying to fix?

According to OCPBUGS-35386, when the user mirrors operators and specifies a maxVersion < channel's jead, without catalog rebuild, the full catalog is sent to cluster. On cluster, when installing the operator without specifically selecting maxVersion , the OLM will attempt to install bundle at channel head and fail because that head version was never mirrored.

## What is the fix?

- `--rebuild-catalogs` is still here for backwards compatibility (so --rebuild-catalogs=false means we don't rebuild and still send the catalog as is, just in case anybody wants this?)
- it is marked deprecated, so that in the next release we can remove the flag if no one is using "full" catalogs
- the default value is true: so if omitted, catalog will be rebuilt, with following behavior
  - But we don't regenerate the internal cache
  - And we modify the CMD of the image from `opm serve /configs --cache-dir=/tmp/cache` to `opm serve /configs`
  - We choose not to whiteout `/tmp/cache` from the rebuilt image, because when `/tmp/cache` doesn't exist, `operator-registry` will attempt to [create a temp folder](https://github.com/operator-framework/operator-registry/blob/036918e6ea1c025bd6422883ce059e362be3e017/cmd/opm/serve/serve.go#L120-L126) under `/tmp/opm-serve-cache-1234568` and fails for lack of permission

## Impacts

:warning: This has an impact on the cluster, because this CMD change means that the cache will be calculated when the catalogsource is deployed to the cluster
  - The time needed to calculate this at startup depends on the catalog content, and CPU/memory allocated to the pod.
  - Starting 4.12 there's a startupProbe set to 100s . So if the cache calculation exceeds 100s, the catalog might not be able to start!
  - So it's probably important to test this on clusters , with catalogs having a lot of operators



Fixes OCPBUGS-35386 + OCPBUGS-37667

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
with the following 2 imagesetconfigs, here are the scenarios tested:
```mermaid
flowchart TD
A[OCPBUGS-35386] --> R{--rebuild-catalogs};
R -- True --> R1C{--build-catalog-cache};
R1C -- True --> R1C1{$OPM_BINARY?};
R1C -- False --> R1C2{catalog origin?};

R1C2 -- Registry based --> R1C2R[RegistryCatalog];
R1C2 -- OCI based --> R1C2O[OCICatalog];

R1C2R -->R1C2RN[No targetCatalog - No targetTag];
R1C2R --> R1C2RTT[TargetTag only];
R1C2R --> R1C2RTC[TargetCatalog only];
R1C2R --> R1C2RTTC[TargetCatalog + TargetTag];

R1C2O -->R1C2ON[No targetCatalog - No targetTag];
R1C2O -->R1C2OTT[TargetTag only];
R1C2O --> R1C2OTTC[TargetCatalog + TargetTag];

R1C1 -- True --> R1C1Y[$OPM_BINARY defined];
R1C1 -- False --> R1C1N[no $OPM_BINARY];

R1C1N --> R1C1NT{catalog origin?};
R1C1NT -- Registry based -->R1C1NTR[RegistryCatalog];
R1C1NT -- OCI based -->R1C1NTO[OCICatalog];

R1C1NTR --> R1C1NTRN[No targetCatalog - No targetTag]
R1C1NTR --> R1C1NTRTT[TargetTag only]
R1C1NTR --> R1C1NTRTC[TargetCatalog only]
R1C1NTR --> R1C1NTRTTC[TargetCatalog + TargetTag]

R1C1NTO --> R1C1NTON[No targetCatalog - No targetTag]
R1C1NTO -->R1C1NTOTT[TargetTag only]
R1C1NTO --> R1C1NTOTTC[TargetCatalog + TargetTag]

R1C1Y --> R1C1YT{catalog origin?};
R1C1YT -- Registry based -->R1C1YTR[RegistryCatalog];
R1C1YT -- OCI based -->R1C1YTO[OCICatalog];

R1C1YTR --> R1C1YTRN[No targetCatalog - No targetTag]
R1C1YTR --> R1C1YTRTT[TargetTag only]
R1C1YTR --> R1C1YTRTC[TargetCatalog only]
R1C1YTR --> R1C1YTRTTC[TargetCatalog + TargetTag]

R1C1YTO --> R1C1YTON[No targetCatalog - No targetTag]
R1C1YTO -->R1C1YTOTT[TargetTag only]
R1C1YTO --> R1C1YTOTTC[TargetCatalog + TargetTag]

R -- False --> R2T{catalog origin?};
R2T -- Registry based -->R2R[RegistryCatalog];
R2T -- OCI based -->R2O[OCICatalog];

R2R --> R2RN[No targetCatalog - No targetTag]
R2R --> R2RTT[TargetTag only]
R2R --> R2RTC[TargetCatalog only]
R2R --> R2RTTC[TargetCatalog + TargetTag]

R2O --> R2ON[No targetCatalog - No targetTag]
R2O -->R2OTT[TargetTag only]
R2O --> R2OTTC[TargetCatalog + TargetTag]
```

PS: from the diagram above, only 1 scenario with --build-catalog-cache + $OPM_BINARY was tested, but not the others.

### ImageSetConfig for registry based catalogs:

```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2

mirror:
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.14
    packages:
    - name: aws-load-balancer-operator
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15
    targetCatalog: abc/redhat-operator-index
    packages:
    - name: external-dns-operator
  - catalog: registry.redhat.io/redhat/community-operator-index:v4.14
    targetTag: v0.0
    packages:
    - name: community-trivy-operator
  - catalog: registry.redhat.io/redhat/community-operator-index:v4.15
    targetCatalog: def/community-operator-index
    targetTag: v4.15-tt
    packages:
    - name: opentelemetry-operator
```

### ImageSetConfig for OCI based catalogs:

```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2

mirror:
  operators:
  - catalog: oci:///home/skhoury/OCPBUGS-35386/rhopi
    packages:
    - name: aws-load-balancer-operator
  - catalog: oci:///home/skhoury/OCPBUGS-35386/rhopi416
    targetCatalog: ghi/redhat-operator-index
    targetTag: v4.16
    packages:
    - name: external-dns-operator
  - catalog: oci:///home/skhoury/OCPBUGS-35386/coi414
    targetTag: v0.0
    packages:
    - name: community-trivy-operator
```

### Containerfile used to generate a catalog with a fake opm binary
```bash
FROM registry.redhat.io/redhat/redhat-operator-index:v4.12
USER root
RUN rm -fr /tmp/cache/*
RUN rm -f /usr/bin/opm /bin/registry/opm /usr/bin/registry/opm 
COPY toto.sh /bin/opm
RUN chmod +x /bin/opm
```
Using this Containerfile, do:
```bash
cat << 'EOF' > toto.sh
#!/bin/bash
echo toto
EOF
podman build -f Containerfile_noopm . -t localhost:5000/noopm/catalog:v4.12
 podman push localhost:5000/noopm/catalog:v4.12 --tls-verify=false
```
Then use imageSetConfig:
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
  - catalog: localhost:5000/noopm/catalog:v4.12
    packages:
    - name: aws-load-balancer-operator
```
## Expected Outcome

# Mirroring should be successful
1. For catalogs with `--rebuild-catalogs=false`,
  * the rendered catalogs should have all the operator packages. This can be controlled using `opm render $mirrored_catalog_ref > /tmp/file.json` . If the mirror registry is HTTP only, use `--use-http`
  * the rendered catalogs should be runnable. This can be tested by:
    * applying the catalog source to cluster, pods should run
    * `podman pull $mirrored_catalog_ref; time podman run --rm $mirrored_catalog_ref` : the catalog should take some time to start. Time should be <100s. Log line `time="2024-07-31T13:14:35Z" level=info msg="serving registry" configs=/configs port=50051` should appear
2. For catalogs with `--build-catalog-cache`,
  * the rendered catalogs should have only selected packages. This can be controlled using `opm render $mirrored_catalog_ref > /tmp/file.json` . If the mirror registry is HTTP only, use `--use-http`
  * the rendered catalogs should be runnable. This can be tested by:
    * applying the catalog source to cluster, pods should run
    * `podman pull $mirrored_catalog_ref; time podman run --rm $mirrored_catalog_ref` : the catalog should run instantly.  Log line `time="2024-07-31T13:14:35Z" level=info msg="serving registry" configs=/configs port=50051` should appear