### PR TITLE
OCPBUGS-37950: Bug fix when kubevirt image not found

### DIFF
--- a/v2/internal/pkg/release/local_stored_collector.go
+++ b/v2/internal/pkg/release/local_stored_collector.go
@@ -428,6 +428,9 @@ func (o LocalStorageCollector) getKubeVirtImage(releaseArtifactsDir string) (v2a
 	}
 
 	image := ibi.Architectures.X86_64.Images.Kubevirt.DigestRef
+	if image == "" {
+		return v2alpha1.RelatedImage{}, fmt.Errorf("could not find kubevirt image in this release")
+	}
 	o.Log.Info(fmt.Sprintf("kubeVirtContainer set to true [ including : %v ]", image))
 	kubeVirtImage := v2alpha1.RelatedImage{
 		Image: image,

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/local_stored_collector.go
@@ -428,6 +428,9 @@ func (o LocalStorageCollector) getKubeVirtImage(releaseArtifactsDir string) (v2a
 	}
 
 	image := ibi.Architectures.X86_64.Images.Kubevirt.DigestRef
+	if image == "" {
+		return v2alpha1.RelatedImage{}, fmt.Errorf("could not find kubevirt image in this release")
+	}
 	o.Log.Info(fmt.Sprintf("kubeVirtContainer set to true [ including : %v ]", image))
 	kubeVirtImage := v2alpha1.RelatedImage{
 		Image: image,


### PR DESCRIPTION
# Description

This fix addresses the issue when a kubeVirtContainer flag is set to true in the imagesetconfig but no image is found in the release metatdata yaml files.

Fixes # OCPBUGS-37950

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally using the following imagesetconfig

```
apiVersion: mirror.openshift.io/v2alpha1
kind: ImageSetConfiguration
mirror:
   platform:
    channels:
    - name: stable-4.12
      minVersion: 4.12.61
      maxVersion: 4.12.61
    kubeVirtContainer: true
```

Execute the following command line

```
bin/oc-mirror --config simple.yaml file://ocpbugs-37950 --v2
```


## Expected Outcome

The execution should show a warning in the console log and continue (not stop execution)

```
bin/oc-mirror --config simple.yaml file://ocpbugs-37950 --v2

2024/08/05 11:56:34  [WARN]   : ⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.
2024/08/05 11:56:34  [INFO]   : 👋 Hello, welcome to oc-mirror
2024/08/05 11:56:34  [INFO]   : ⚙️  setting up the environment for you...
2024/08/05 11:56:34  [INFO]   : 🔀 workflow mode: mirrorToDisk 
2024/08/05 11:56:34  [INFO]   : 🕵️  going to discover the necessary images...
2024/08/05 11:56:34  [INFO]   : 🔍 collecting release images...
2024/08/05 11:56:53  [WARN]   : could not find kubevirt image in release payload
2024/08/05 11:56:53  [INFO]   : 🔍 collecting operator images...
2024/08/05 11:56:53  [INFO]   : 🔍 collecting additional images...
2024/08/05 11:56:53  [INFO]   : 🚀 Start copying the images...
2024/08/05 11:56:53  [INFO]   : images to copy 184 
 ⠏   1/184 : (4s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:329a1e02733cd23e5d7c0e184d5ccf21bb9e94629ee91516711973b00fc097d1 
 ⠏   2/184 : (4s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ae564f2f0a2020300daf21c1310a458d2dbebfe3c2e17a34856416e07ee43110 
 ⠏   3/184 : (4s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:5d39b19c99ee6d5c8241a200114e0ef910e574a3fdad0dbaf42cef4632b0b996 
 ⠏   4/184 : (4s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d28344c9ec7b0b66913de7d68f763de4aa8baa0429a5de5ad5b4ce905a317a8f 
 ⠏   5/184 : (4s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:96f54fb68540897f1a8ce57a7f12844f09de1eabfe5557513084ef910ff2245a 
 ⠏   6/184 : (4s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:17de02ea235dd9a4916d1b63402df8dae2c0e9d0fc23542b4c6f90f6c8d5656e 
 ⠏   7/184 : (4s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f00106f4fd3a456d7abace85df160d61a470b06a342068d8b94fea0145879bc6 
 ⠏   8/184 : (4s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d63fe51732c79ba87d47c77dddf6e6f2f071efee2eb9f92c17b2f98ecce640d2
```
