### PR TITLE
OCPBUGS-38037: unable to build graph image in enclave environment

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -24,7 +24,9 @@ require (
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
 	github.com/vbauerster/mpb/v8 v8.4.0
 	golang.org/x/crypto v0.17.0
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/sync v0.3.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/klog/v2 v2.100.1
@@ -165,7 +167,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.21.0 // indirect
 	go.opentelemetry.io/otel/trace v1.21.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/net v0.18.0 // indirect
 	golang.org/x/oauth2 v0.11.0 // indirect
@@ -183,7 +184,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/client-go v0.27.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect

--- a/v2/internal/e2e/templates/isc_templates/release_isc.yaml
+++ b/v2/internal/e2e/templates/isc_templates/release_isc.yaml
@@ -5,4 +5,5 @@ mirror:
   platform:
     channels:
     - name: {{.}} 
+    graph: true
 {{end}}

--- a/v2/internal/pkg/additional/local_stored_collector_test.go
+++ b/v2/internal/pkg/additional/local_stored_collector_test.go
@@ -29,6 +29,8 @@ func TestAdditionalImageCollector(t *testing.T) {
 	_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 	_, retryOpts := mirror.RetryFlags()
 
+	localstorageFQDN := "test.registry.com"
+
 	opts := mirror.CopyOptions{
 		Global:              global,
 		DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
@@ -38,6 +40,7 @@ func TestAdditionalImageCollector(t *testing.T) {
 		Destination:         "oci://test",
 		Dev:                 false,
 		Mode:                mirror.MirrorToDisk,
+		LocalStorageFQDN:    localstorageFQDN,
 	}
 
 	// use the minamal amount of images
@@ -56,8 +59,8 @@ func TestAdditionalImageCollector(t *testing.T) {
 
 	mockmirror := MockMirror{}
 	manifest := MockManifest{Log: log}
-	localstorageFQDN := "test.registry.com"
-	ex := New(log, cfg, opts, mockmirror, manifest, localstorageFQDN)
+
+	ex := New(log, cfg, opts, mockmirror, manifest)
 	ctx := context.Background()
 
 	// this test covers mirrorToDisk
@@ -73,7 +76,7 @@ func TestAdditionalImageCollector(t *testing.T) {
 	// update opts
 	// this test covers diskToMirror
 	opts.Mode = mirror.DiskToMirror
-	ex = New(log, cfg, opts, mockmirror, manifest, localstorageFQDN)
+	ex = New(log, cfg, opts, mockmirror, manifest)
 
 	t.Run("Testing AdditionalImagesCollector : diskToMirror should pass", func(t *testing.T) {
 		res, err := ex.AdditionalImagesCollector(ctx)
@@ -87,7 +90,7 @@ func TestAdditionalImageCollector(t *testing.T) {
 	// should error mirrorToDisk
 	cfg.Mirror.AdditionalImages[1].Name = "sometest.registry.com/testns/test@shaf30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"
 	opts.Mode = mirror.MirrorToDisk
-	ex = New(log, cfg, opts, mockmirror, manifest, localstorageFQDN)
+	ex = New(log, cfg, opts, mockmirror, manifest)
 
 	t.Run("Testing AdditionalImagesCollector : mirrorToDisk should not fail (skipped)", func(t *testing.T) {
 		_, err := ex.AdditionalImagesCollector(ctx)
@@ -99,7 +102,7 @@ func TestAdditionalImageCollector(t *testing.T) {
 	// should error diskToMirror
 	cfg.Mirror.AdditionalImages[1].Name = "sometest.registry.com/testns/test@shaf30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"
 	opts.Mode = mirror.DiskToMirror
-	ex = New(log, cfg, opts, mockmirror, manifest, localstorageFQDN)
+	ex = New(log, cfg, opts, mockmirror, manifest)
 
 	t.Run("Testing AdditionalImagesCollector : diskToMirror should fail", func(t *testing.T) {
 		_, err := ex.AdditionalImagesCollector(ctx)

--- a/v2/internal/pkg/additional/new.go
+++ b/v2/internal/pkg/additional/new.go
@@ -12,7 +12,6 @@ func New(log clog.PluggableLoggerInterface,
 	opts mirror.CopyOptions,
 	mirror mirror.MirrorInterface,
 	manifest manifest.ManifestInterface,
-	localstorageFQDN string,
 ) CollectorInterface {
-	return &LocalStorageCollector{Log: log, Config: config, Opts: opts, Mirror: mirror, Manifest: manifest, LocalStorageFQDN: localstorageFQDN}
+	return &LocalStorageCollector{Log: log, Config: config, Opts: opts, Mirror: mirror, Manifest: manifest, LocalStorageFQDN: opts.LocalStorageFQDN}
 }

--- a/v2/internal/pkg/api/v2alpha1/type_image.go
+++ b/v2/internal/pkg/api/v2alpha1/type_image.go
@@ -44,7 +44,7 @@ var imageStringsType = map[string]ImageType{
 }
 
 func (it ImageType) IsRelease() bool {
-	return it == TypeOCPRelease || it == TypeOCPReleaseContent
+	return it == TypeOCPRelease || it == TypeOCPReleaseContent || it == TypeCincinnatiGraph
 }
 
 func (it ImageType) IsOperator() bool {

--- a/v2/internal/pkg/batch/concurrent_worker.go
+++ b/v2/internal/pkg/batch/concurrent_worker.go
@@ -185,7 +185,7 @@ func (o *ConcurrentBatch) Worker(ctx context.Context, collectorSchema v2alpha1.C
 		}
 		if collectorSchema.TotalAdditionalImages != 0 {
 			if o.CopiedImages.TotalAdditionalImages == collectorSchema.TotalAdditionalImages {
-				o.Log.Info("✅ %d / %dadditional images mirrored successfully", o.CopiedImages.TotalAdditionalImages, collectorSchema.TotalAdditionalImages)
+				o.Log.Info("✅ %d / %d additional images mirrored successfully", o.CopiedImages.TotalAdditionalImages, collectorSchema.TotalAdditionalImages)
 			} else {
 				o.Log.Info("❌ %d / %d addtional images mirrored: Some additional images failed to mirror - please check the logs", o.CopiedImages.TotalAdditionalImages, collectorSchema.TotalAdditionalImages)
 			}

--- a/v2/internal/pkg/batch/concurrent_worker.go
+++ b/v2/internal/pkg/batch/concurrent_worker.go
@@ -141,7 +141,7 @@ func (o *ConcurrentBatch) Worker(ctx context.Context, collectorSchema v2alpha1.C
 				case img.Type.IsAdditionalImage():
 					errArray = append(errArray, mirrorErrorSchema{image: img, err: err})
 					spinner.Abort(false)
-				case img.Type.IsRelease(): //TODO ALEX ASK SHERINE IF CINCINNATI SHOULD BE INCLUDED HERE
+				case img.Type.IsRelease():
 					// error on release image, save the errArray and immediately return `UnsafeError` to caller
 					currentMirrorError := mirrorErrorSchema{image: img, err: err}
 					errArray = append(errArray, currentMirrorError)

--- a/v2/internal/pkg/cli/additional_integration_test.go
+++ b/v2/internal/pkg/cli/additional_integration_test.go
@@ -130,7 +130,7 @@ func (suite *TestEnvironmentAddditional) runMirror2Disk(t *testing.T) {
 	err := os.MkdirAll(resultFolder, 0755)
 	assert.NoError(t, err, "should not fail creating a temp folder for results")
 
-	os.Setenv("OC_MIRROR_CACHE", suite.tempFolder+"/.cacheM2D")
+	t.Setenv("OC_MIRROR_CACHE", suite.tempFolder+"/.cacheM2D")
 	ocmirror.SetArgs([]string{"-c", suite.tempFolder + "/isc.yaml", "--v2", "-p", "55001", "--src-tls-verify=false", "--dest-tls-verify=false", "file://" + resultFolder})
 	err = ocmirror.Execute()
 	assert.NoError(t, err, "should not fail executing oc-mirror")
@@ -142,7 +142,7 @@ func (suite *TestEnvironmentAddditional) runMirror2Disk(t *testing.T) {
 func (suite *TestEnvironmentAddditional) runDisk2Mirror(t *testing.T) {
 	ocmirror := NewMirrorCmd(clog.New("trace"))
 	resultFolder := filepath.Join(suite.tempFolder, "additional", d2mSubFolder)
-	os.Setenv("OC_MIRROR_CACHE", suite.tempFolder+"/.cacheD2M")
+	t.Setenv("OC_MIRROR_CACHE", suite.tempFolder+"/.cacheD2M")
 	ocmirror.SetArgs([]string{"-c", suite.tempFolder + "/isc.yaml", "--v2", "-p", "55002", "--from", "file://" + resultFolder, "--src-tls-verify=false", "--dest-tls-verify=false", "docker://" + suite.destinationRegistryDomain + "/additional"})
 	err := ocmirror.Execute()
 	assert.NoError(t, err, "should not fail executing oc-mirror")
@@ -159,7 +159,7 @@ func (suite *TestEnvironmentAddditional) runDisk2Mirror(t *testing.T) {
 }
 
 func (suite *TestEnvironmentAddditional) runMirror2Mirror(t *testing.T) {
-	os.Setenv("OC_MIRROR_CACHE", suite.tempFolder+"/.cacheM2D")
+	t.Setenv("OC_MIRROR_CACHE", suite.tempFolder+"/.cacheM2D")
 	// create cobra command and run
 	ocmirror := NewMirrorCmd(clog.New("trace"))
 	// b := bytes.NewBufferString("")

--- a/v2/internal/pkg/cli/delete.go
+++ b/v2/internal/pkg/cli/delete.go
@@ -219,7 +219,7 @@ func (o *ExecutorSchema) CompleteDelete(args []string) error {
 	if o.isLocalStoragePortBound() {
 		return fmt.Errorf("%d is already bound and cannot be used", o.Opts.Global.Port)
 	}
-	o.LocalStorageFQDN = "localhost:" + strconv.Itoa(int(o.Opts.Global.Port))
+	o.Opts.LocalStorageFQDN = "localhost:" + strconv.Itoa(int(o.Opts.Global.Port))
 
 	// ensure mirror and batch worker use delete logic
 	o.Opts.Function = string(mirror.DeleteMode)
@@ -252,14 +252,14 @@ func (o *ExecutorSchema) CompleteDelete(args []string) error {
 	client, _ := release.NewOCPClient(uuid.New())
 	signature := release.NewSignatureClient(o.Log, o.Config, *o.Opts)
 	cn := release.NewCincinnati(o.Log, &o.Config, *o.Opts, client, false, signature)
-	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.LocalStorageFQDN, o.ImageBuilder)
+	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.ImageBuilder)
 	o.Batch = batch.New(o.Log, o.LogsDir, o.Mirror)
-	o.Operator = operator.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, o.LocalStorageFQDN)
-	o.AdditionalImages = additional.New(o.Log, o.Config, *o.Opts, o.Mirror, o.Manifest, o.LocalStorageFQDN)
+	o.Operator = operator.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest)
+	o.AdditionalImages = additional.New(o.Log, o.Config, *o.Opts, o.Mirror, o.Manifest)
 
 	// instantiate delete module
 	bg := archive.NewImageBlobGatherer(o.Opts)
-	o.Delete = delete.New(o.Log, *o.Opts, o.Batch, bg, o.Config, o.Manifest, o.LocalStorageDisk, o.LocalStorageFQDN)
+	o.Delete = delete.New(o.Log, *o.Opts, o.Batch, bg, o.Config, o.Manifest, o.LocalStorageDisk)
 
 	return nil
 }

--- a/v2/internal/pkg/cli/delete_test.go
+++ b/v2/internal/pkg/cli/delete_test.go
@@ -133,7 +133,7 @@ func TestExecutorCompleteDelete(t *testing.T) {
 			LogsDir: "/tmp/",
 		}
 
-		os.Setenv(cacheEnvVar, "/tmp/")
+		t.Setenv(cacheEnvVar, "/tmp/")
 
 		defer os.RemoveAll("../../pkg/cli/test")
 		defer os.RemoveAll("../../pkg/cli/tmp")

--- a/v2/internal/pkg/cli/delete_test.go
+++ b/v2/internal/pkg/cli/delete_test.go
@@ -220,6 +220,7 @@ func TestExecutorRunDelete(t *testing.T) {
 		_ = os.MkdirAll(testFolder+"/docker/registry/v2/repositories", 0755)
 		_ = os.MkdirAll(common.TestFolder+"cache-fake-temp", 0755)
 		defer os.RemoveAll(common.TestFolder + "cache-fake-temp")
+		opts.LocalStorageFQDN = regCfg.HTTP.Addr
 
 		ex := &ExecutorSchema{
 			Log:                          log,
@@ -234,7 +235,6 @@ func TestExecutorRunDelete(t *testing.T) {
 			LogsDir:                      "/tmp/",
 			Delete:                       MockDelete{},
 			LocalStorageDisk:             common.TestFolder + "cache-fake-temp/",
-			LocalStorageFQDN:             regCfg.HTTP.Addr,
 		}
 
 		res := &cobra.Command{}

--- a/v2/internal/pkg/cli/dryrun_test.go
+++ b/v2/internal/pkg/cli/dryrun_test.go
@@ -45,17 +45,6 @@ func TestDryRun(t *testing.T) {
 
 		global.WorkingDir = testFolder
 
-		opts := &mirror.CopyOptions{
-			Global:              global,
-			DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
-			SrcImage:            srcOpts,
-			DestImage:           destOpts,
-			RetryOpts:           retryOpts,
-			IsDryRun:            true,
-			Mode:                mirror.MirrorToDisk,
-			Dev:                 false,
-		}
-
 		// storage cache for test
 		regCfg, err := setupRegForTest(testFolder)
 		if err != nil {
@@ -68,6 +57,17 @@ func TestDryRun(t *testing.T) {
 		fakeStorageInterruptChan := make(chan error)
 		go skipSignalsToInterruptStorage(fakeStorageInterruptChan)
 
+		opts := &mirror.CopyOptions{
+			Global:              global,
+			DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
+			SrcImage:            srcOpts,
+			DestImage:           destOpts,
+			RetryOpts:           retryOpts,
+			IsDryRun:            true,
+			Mode:                mirror.MirrorToDisk,
+			Dev:                 false,
+			LocalStorageFQDN:    regCfg.HTTP.Addr,
+		}
 		// read the ImageSetConfiguration
 		res, err := config.ReadConfig(opts.Global.ConfigPath, v2alpha1.ImageSetConfigurationKind)
 		if err != nil {
@@ -93,7 +93,6 @@ func TestDryRun(t *testing.T) {
 			localStorageInterruptChannel: fakeStorageInterruptChan,
 			LogsDir:                      testFolder,
 			MakeDir:                      MakeDir{},
-			LocalStorageFQDN:             regCfg.HTTP.Addr,
 		}
 
 		err = ex.DryRun(context.TODO(), imgs)
@@ -120,16 +119,6 @@ func TestDryRun(t *testing.T) {
 		defer os.RemoveAll(testFolder)
 
 		global.WorkingDir = testFolder
-		opts := &mirror.CopyOptions{
-			Global:              global,
-			DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
-			SrcImage:            srcOpts,
-			DestImage:           destOpts,
-			RetryOpts:           retryOpts,
-			IsDryRun:            true,
-			Mode:                mirror.MirrorToDisk,
-			Dev:                 false,
-		}
 
 		// storage cache for test
 		regCfg, err := setupRegForTest(testFolder)
@@ -143,6 +132,17 @@ func TestDryRun(t *testing.T) {
 		fakeStorageInterruptChan := make(chan error)
 		go skipSignalsToInterruptStorage(fakeStorageInterruptChan)
 
+		opts := &mirror.CopyOptions{
+			Global:              global,
+			DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
+			SrcImage:            srcOpts,
+			DestImage:           destOpts,
+			RetryOpts:           retryOpts,
+			IsDryRun:            true,
+			Mode:                mirror.MirrorToDisk,
+			Dev:                 false,
+			LocalStorageFQDN:    regCfg.HTTP.Addr,
+		}
 		// read the ImageSetConfiguration
 		res, err := config.ReadConfig(opts.Global.ConfigPath, v2alpha1.ImageSetConfigurationKind)
 		if err != nil {
@@ -169,7 +169,6 @@ func TestDryRun(t *testing.T) {
 			localStorageInterruptChannel: fakeStorageInterruptChan,
 			LogsDir:                      "/tmp/",
 			MakeDir:                      MakeDir{},
-			LocalStorageFQDN:             regCfg.HTTP.Addr,
 		}
 
 		err = ex.DryRun(context.TODO(), imgs)

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -115,7 +115,6 @@ type ExecutorSchema struct {
 	Batch                        batch.BatchInterface
 	LocalStorageService          registry.Registry
 	localStorageInterruptChannel chan error
-	LocalStorageFQDN             string
 	LocalStorageDisk             string
 	ClusterResources             clusterresources.GeneratorInterface
 	ImageBuilder                 imagebuilder.ImageBuilderInterface
@@ -405,7 +404,7 @@ func (o *ExecutorSchema) Complete(args []string) error {
 	if o.isLocalStoragePortBound() {
 		return fmt.Errorf("%d is already bound and cannot be used", o.Opts.Global.Port)
 	}
-	o.LocalStorageFQDN = "localhost:" + strconv.Itoa(int(o.Opts.Global.Port))
+	o.Opts.LocalStorageFQDN = "localhost:" + strconv.Itoa(int(o.Opts.Global.Port))
 
 	err = o.setupWorkingDir()
 	if err != nil {
@@ -423,9 +422,9 @@ func (o *ExecutorSchema) Complete(args []string) error {
 
 	signature := release.NewSignatureClient(o.Log, o.Config, *o.Opts)
 	cn := release.NewCincinnati(o.Log, &o.Config, *o.Opts, client, false, signature)
-	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.LocalStorageFQDN, o.ImageBuilder)
-	o.Operator = operator.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, o.LocalStorageFQDN)
-	o.AdditionalImages = additional.New(o.Log, o.Config, *o.Opts, o.Mirror, o.Manifest, o.LocalStorageFQDN)
+	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.ImageBuilder)
+	o.Operator = operator.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest)
+	o.AdditionalImages = additional.New(o.Log, o.Config, *o.Opts, o.Mirror, o.Manifest)
 	o.ClusterResources = clusterresources.New(o.Log, o.Opts.Global.WorkingDir, o.Config)
 	o.Batch = batch.NewConcurrentBatch(o.Log, o.LogsDir, o.Mirror, calculateMaxBatchSize(o.MaxParallelOverallDownloads, o.ParallelBatchImages))
 

--- a/v2/internal/pkg/cli/executor_test.go
+++ b/v2/internal/pkg/cli/executor_test.go
@@ -51,17 +51,6 @@ func TestExecutorMirroring(t *testing.T) {
 	_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 	_, retryOpts := mirror.RetryFlags()
 
-	opts := &mirror.CopyOptions{
-		Global:              global,
-		DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
-		SrcImage:            srcOpts,
-		DestImage:           destOpts,
-		RetryOpts:           retryOpts,
-		Dev:                 false,
-		Mode:                mirror.MirrorToDisk,
-		Destination:         workDir,
-	}
-
 	// storage cache for test
 	regCfg, err := setupRegForTest(testFolder)
 	if err != nil {
@@ -74,6 +63,17 @@ func TestExecutorMirroring(t *testing.T) {
 	fakeStorageInterruptChan := make(chan error)
 	go skipSignalsToInterruptStorage(fakeStorageInterruptChan)
 
+	opts := &mirror.CopyOptions{
+		Global:              global,
+		DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
+		SrcImage:            srcOpts,
+		DestImage:           destOpts,
+		RetryOpts:           retryOpts,
+		Dev:                 false,
+		Mode:                mirror.MirrorToDisk,
+		Destination:         workDir,
+		LocalStorageFQDN:    regCfg.HTTP.Addr,
+	}
 	// read the ImageSetConfiguration
 	res, err := config.ReadConfig(opts.Global.ConfigPath, v2alpha1.ImageSetConfigurationKind)
 	if err != nil {
@@ -108,7 +108,6 @@ func TestExecutorMirroring(t *testing.T) {
 			localStorageInterruptChannel: fakeStorageInterruptChan,
 			MakeDir:                      MakeDir{},
 			LogsDir:                      "/tmp/",
-			LocalStorageFQDN:             regCfg.HTTP.Addr,
 		}
 
 		res := &cobra.Command{}
@@ -143,7 +142,6 @@ func TestExecutorMirroring(t *testing.T) {
 			localStorageInterruptChannel: fakeStorageInterruptChan,
 			MakeDir:                      MakeDir{},
 			LogsDir:                      "/tmp/",
-			LocalStorageFQDN:             regCfg.HTTP.Addr,
 		}
 
 		res := &cobra.Command{}
@@ -181,7 +179,6 @@ func TestExecutorMirroring(t *testing.T) {
 			ClusterResources:             cr,
 			MakeDir:                      MakeDir{},
 			LogsDir:                      "/tmp/",
-			LocalStorageFQDN:             regCfg.HTTP.Addr,
 		}
 
 		res := &cobra.Command{}
@@ -218,7 +215,6 @@ func TestExecutorMirroring(t *testing.T) {
 			ClusterResources:             cr,
 			MakeDir:                      MakeDir{},
 			LogsDir:                      "/tmp/",
-			LocalStorageFQDN:             regCfg.HTTP.Addr,
 		}
 
 		res := &cobra.Command{}
@@ -254,7 +250,6 @@ func TestExecutorMirroring(t *testing.T) {
 			ClusterResources:             cr,
 			MakeDir:                      MakeDir{},
 			LogsDir:                      "/tmp/",
-			LocalStorageFQDN:             regCfg.HTTP.Addr,
 		}
 
 		res := &cobra.Command{}

--- a/v2/internal/pkg/cli/executor_test.go
+++ b/v2/internal/pkg/cli/executor_test.go
@@ -663,7 +663,7 @@ func TestExecutorComplete(t *testing.T) {
 			LogsDir: "/tmp/",
 		}
 
-		os.Setenv(cacheEnvVar, "/tmp/")
+		t.Setenv(cacheEnvVar, "/tmp/")
 
 		// file protocol
 		err := ex.Complete([]string{"file:///tmp/test"})

--- a/v2/internal/pkg/cli/release_integration_test.go
+++ b/v2/internal/pkg/cli/release_integration_test.go
@@ -54,7 +54,6 @@ func setupReleaseTest(t *testing.T) TestEnvironmentRelease {
 
 func (suite *TestEnvironmentRelease) tearDown(t *testing.T) {
 
-	os.Unsetenv("CONTAINERS_REGISTRIES_CONF")
 	os.RemoveAll(suite.tempFolder)
 	suite.sourceServer.Close()
 	suite.destinationServer.Close()
@@ -104,7 +103,7 @@ func TestIntegrationReleaseM2M(t *testing.T) {
 }
 
 func (suite *TestEnvironmentRelease) setupTestData(t *testing.T) {
-	os.Setenv("CONTAINERS_REGISTRIES_CONF", suite.tempFolder+"/registries.conf")
+	t.Setenv("CONTAINERS_REGISTRIES_CONF", suite.tempFolder+"/registries.conf")
 
 	// copy test registries.conf to user home
 	regConfTemplatePath := "../../e2e/templates/regisitries.conf"
@@ -152,8 +151,8 @@ func (suite *TestEnvironmentRelease) setupTestData(t *testing.T) {
 }
 
 func (suite *TestEnvironmentRelease) runMirror2Disk(t *testing.T) {
-	os.Setenv("OC_MIRROR_CACHE", suite.tempFolder+"/.cacheM2D")
-	os.Setenv("UPDATE_URL_OVERRIDE", "http://"+suite.cincinnatiEndpoint)
+	t.Setenv("OC_MIRROR_CACHE", suite.tempFolder+"/.cacheM2D")
+	t.Setenv("UPDATE_URL_OVERRIDE", "http://"+suite.cincinnatiEndpoint)
 
 	// create cobra command and run
 	ocmirror := NewMirrorCmd(clog.New("trace"))
@@ -172,8 +171,8 @@ func (suite *TestEnvironmentRelease) runMirror2Disk(t *testing.T) {
 }
 
 func (suite *TestEnvironmentRelease) runDisk2Mirror(t *testing.T) {
-	os.Setenv("OC_MIRROR_CACHE", suite.tempFolder+"/.cacheD2M")
-	os.Setenv("UPDATE_URL_OVERRIDE", "http://"+suite.cincinnatiEndpoint)
+	t.Setenv("OC_MIRROR_CACHE", suite.tempFolder+"/.cacheD2M")
+	t.Setenv("UPDATE_URL_OVERRIDE", "http://"+suite.cincinnatiEndpoint)
 
 	// create cobra command and run
 	ocmirror := NewMirrorCmd(clog.New("trace"))
@@ -196,8 +195,8 @@ func (suite *TestEnvironmentRelease) runDisk2Mirror(t *testing.T) {
 }
 
 func (suite *TestEnvironmentRelease) runMirror2Mirror(t *testing.T) {
-	os.Setenv("UPDATE_URL_OVERRIDE", "http://"+suite.cincinnatiEndpoint)
-	os.Setenv("OC_MIRROR_CACHE", suite.tempFolder+"/.cacheD2M")
+	t.Setenv("UPDATE_URL_OVERRIDE", "http://"+suite.cincinnatiEndpoint)
+	t.Setenv("OC_MIRROR_CACHE", suite.tempFolder+"/.cacheD2M")
 
 	// create cobra command and run
 	ocmirror := NewMirrorCmd(clog.New("trace"))

--- a/v2/internal/pkg/cli/release_integration_test.go
+++ b/v2/internal/pkg/cli/release_integration_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/otiai10/copy"
+
 	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
 	"github.com/openshift/oc-mirror/v2/internal/testutils"
 	"github.com/stretchr/testify/assert"
@@ -142,6 +144,11 @@ func (suite *TestEnvironmentRelease) setupTestData(t *testing.T) {
 	_, err = io.Copy(workingDirLocation, signatureFile)
 	assert.NoError(t, err)
 
+	graphPrepDir := suite.tempFolder + "/release/m2d/working-dir/graph-preparation"
+
+	err = copy.Copy("../../../tests/graph-staging", graphPrepDir)
+	assert.NoError(t, err)
+
 	// create the image set config
 	templatePath := "../../e2e/templates/isc_templates/release_isc.yaml"
 	suite.imageSetConfig = suite.tempFolder + "/isc.yaml"
@@ -190,6 +197,10 @@ func (suite *TestEnvironmentRelease) runDisk2Mirror(t *testing.T) {
 		assert.True(t, exists)
 	}
 
+	graphExists, err := testutils.ImageExists(suite.destinationRegistryDomain + "/release/openshift/graph-image:latest")
+	assert.NoError(t, err)
+	assert.True(t, graphExists)
+
 	// assert IDMS is generated
 	assert.FileExists(t, filepath.Join(resultFolder, "working-dir/cluster-resources/idms-oc-mirror.yaml"))
 }
@@ -217,6 +228,10 @@ func (suite *TestEnvironmentRelease) runMirror2Mirror(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, exists)
 	}
+
+	graphExists, err := testutils.ImageExists(suite.destinationRegistryDomain + "/release/openshift/graph-image:latest")
+	assert.NoError(t, err)
+	assert.True(t, graphExists)
 
 	// assert IDMS is generated
 	assert.FileExists(t, filepath.Join(resultFolder, "working-dir/cluster-resources/idms-oc-mirror.yaml"))

--- a/v2/internal/pkg/delete/delete_images_test.go
+++ b/v2/internal/pkg/delete/delete_images_test.go
@@ -41,6 +41,7 @@ func TestAllDeleteImages(t *testing.T) {
 		Destination:         "docker://myregistry",
 		Dev:                 false,
 		Mode:                mirror.MirrorToDisk,
+		LocalStorageFQDN:    "localhost:8888",
 	}
 
 	isc := v2alpha1.ImageSetConfiguration{
@@ -63,7 +64,7 @@ func TestAllDeleteImages(t *testing.T) {
 		},
 	}
 
-	di := New(log, opts, &mockBatch{}, &mockBlobs{}, isc, &mockManifest{}, "/tmp", "localhost:8888")
+	di := New(log, opts, &mockBatch{}, &mockBlobs{}, isc, &mockManifest{}, "/tmp")
 
 	t.Run("Testing ReadDeleteData : should pass", func(t *testing.T) {
 		opts.Global.WorkingDir = common.TestFolder
@@ -91,7 +92,7 @@ func TestAllDeleteImages(t *testing.T) {
 		defer os.RemoveAll(testFolder)
 		opts.Global.WorkingDir = common.TestFolder
 		opts.Global.ForceCacheDelete = true
-		deleteDI := New(log, opts, &mockBatch{}, &mockBlobs{}, v2alpha1.ImageSetConfiguration{}, &mockManifest{}, "/tmp", "localhost:8888")
+		deleteDI := New(log, opts, &mockBatch{}, &mockBlobs{}, v2alpha1.ImageSetConfiguration{}, &mockManifest{}, "/tmp")
 		imgs, err := di.ReadDeleteMetaData()
 		if err != nil {
 			t.Fatal("should not fail")
@@ -132,10 +133,11 @@ func TestWriteMetaData(t *testing.T) {
 		Destination:         "oci:test",
 		Dev:                 false,
 		Mode:                mirror.MirrorToDisk,
+		LocalStorageFQDN:    "localhost:8888",
 	}
 
 	cfg := v2alpha1.ImageSetConfiguration{}
-	di := New(log, opts, &mockBatch{}, &mockBlobs{}, cfg, &mockManifest{}, "/tmp", "localhost:8888")
+	di := New(log, opts, &mockBatch{}, &mockBlobs{}, cfg, &mockManifest{}, "/tmp")
 
 	t.Run("Testing ReadDeleteData : should pass", func(t *testing.T) {
 		cpImages := []v2alpha1.CopyImageSchema{

--- a/v2/internal/pkg/delete/new.go
+++ b/v2/internal/pkg/delete/new.go
@@ -16,7 +16,6 @@ func New(log clog.PluggableLoggerInterface,
 	config v2alpha1.ImageSetConfiguration,
 	manifest manifest.ManifestInterface,
 	localStorageDisk string,
-	localStorageFQDN string,
 ) DeleteInterface {
 	return &DeleteImages{
 		Log:              log,
@@ -26,6 +25,6 @@ func New(log clog.PluggableLoggerInterface,
 		Config:           config,
 		Manifest:         manifest,
 		LocalStorageDisk: localStorageDisk,
-		LocalStorageFQDN: localStorageFQDN,
+		LocalStorageFQDN: opts.LocalStorageFQDN,
 	}
 }

--- a/v2/internal/pkg/mirror/mirror.go
+++ b/v2/internal/pkg/mirror/mirror.go
@@ -102,10 +102,17 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 	if err != nil {
 		return err
 	}
+	if strings.Contains(src, opts.LocalStorageFQDN) { // when copying from cache, use HTTP
+		sourceCtx.DockerInsecureSkipTLSVerify = types.OptionalBoolTrue
+	}
 
 	destinationCtx, err := opts.DestImage.NewSystemContext()
 	if err != nil {
 		return err
+	}
+
+	if strings.Contains(dest, opts.LocalStorageFQDN) { // when copying to cache, use HTTP
+		destinationCtx.DockerInsecureSkipTLSVerify = types.OptionalBoolTrue
 	}
 
 	var manifestType string
@@ -264,6 +271,10 @@ func (o *Mirror) delete(ctx context.Context, image string, opts *CopyOptions) er
 	sysCtx, err := opts.DestImage.NewSystemContext()
 	if err != nil {
 		return err
+	}
+
+	if strings.Contains(image, opts.LocalStorageFQDN) { // when copying to cache, use HTTP
+		sysCtx.DockerInsecureSkipTLSVerify = types.OptionalBoolTrue
 	}
 
 	ctx, cancel := opts.Global.CommandTimeoutContext()

--- a/v2/internal/pkg/mirror/mirror.go
+++ b/v2/internal/pkg/mirror/mirror.go
@@ -81,7 +81,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 
 	policyContext, err := opts.Global.GetPolicyContext()
 	if err != nil {
-		return fmt.Errorf("Error loading trust policy: %v", err)
+		return fmt.Errorf("error loading trust policy: %v", err)
 	}
 	defer func() {
 		if err := policyContext.Destroy(); err != nil {
@@ -91,11 +91,11 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 
 	srcRef, err := alltransports.ParseImageName(src)
 	if err != nil {
-		return fmt.Errorf("Invalid source name %s: %v", src, err)
+		return fmt.Errorf("invalid source name %s: %v", src, err)
 	}
 	destRef, err := alltransports.ParseImageName(dest)
 	if err != nil {
-		return fmt.Errorf("Invalid destination name %s: %v", dest, err)
+		return fmt.Errorf("invalid destination name %s: %v", dest, err)
 	}
 
 	sourceCtx, err := opts.SrcImage.NewSystemContext()
@@ -128,7 +128,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 
 	imageListSelection := copy.CopySystemImage
 	if len(opts.MultiArch) > 0 && opts.All {
-		return fmt.Errorf("Cannot use --all and --multi-arch flags together")
+		return fmt.Errorf("cannot use --all and --multi-arch flags together")
 	}
 
 	if len(opts.MultiArch) > 0 {
@@ -150,7 +150,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 	// with independent passphrases, but that would make the CLI probably too confusing.
 	// For now, use the passphrase with either, but only one of them.
 	if opts.SignPassphraseFile != "" && opts.SignByFingerprint != "" && opts.SignBySigstorePrivateKey != "" {
-		return fmt.Errorf("Only one of --sign-by and sign-by-sigstore-private-key can be used with sign-passphrase-file")
+		return fmt.Errorf("only one of --sign-by and sign-by-sigstore-private-key can be used with sign-passphrase-file")
 	}
 	var passphrase string
 	if opts.SignPassphraseFile != "" {
@@ -167,7 +167,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 	if opts.SignIdentity != "" {
 		signIdentity, err = reference.ParseNamed(opts.SignIdentity)
 		if err != nil {
-			return fmt.Errorf("Could not parse --sign-identity: %v", err)
+			return fmt.Errorf("could not parse --sign-identity: %v", err)
 		}
 	}
 
@@ -205,7 +205,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 				return err
 			}
 			if err = os.WriteFile(opts.DigestFile, []byte(manifestDigest.String()), 0644); err != nil {
-				return fmt.Errorf("Failed to write digest to file %q: %w", opts.DigestFile, err)
+				return fmt.Errorf("failed to write digest to file %q: %w", opts.DigestFile, err)
 			}
 		}
 		return nil
@@ -265,7 +265,7 @@ func (o *Mirror) delete(ctx context.Context, image string, opts *CopyOptions) er
 
 	imageRef, err := alltransports.ParseImageName(image)
 	if err != nil {
-		return fmt.Errorf("Invalid source name %s: %v", image, err)
+		return fmt.Errorf("invalid source name %s: %v", image, err)
 	}
 
 	sysCtx, err := opts.DestImage.NewSystemContext()

--- a/v2/internal/pkg/mirror/mirror_test.go
+++ b/v2/internal/pkg/mirror/mirror_test.go
@@ -58,12 +58,12 @@ func TestMirrorCopy(t *testing.T) {
 
 	t.Run("Testing Mirror : copy should fail", func(t *testing.T) {
 		err := m.Run(context.Background(), "broken", "oci:test", "copy", &opts)
-		assert.Equal(t, "Invalid source name broken: Invalid image name \"broken\", expected colon-separated transport:reference", err.Error())
+		assert.Equal(t, "invalid source name broken: Invalid image name \"broken\", expected colon-separated transport:reference", err.Error())
 	})
 
 	t.Run("Testing Mirror : copy should fail", func(t *testing.T) {
 		err := m.Run(context.Background(), "docker://localhost.localdomain:5000/tes", "broken", "copy", &opts)
-		assert.Equal(t, "Invalid destination name broken: Invalid image name \"broken\", expected colon-separated transport:reference", err.Error())
+		assert.Equal(t, "invalid destination name broken: Invalid image name \"broken\", expected colon-separated transport:reference", err.Error())
 	})
 
 	opts.MultiArch = "other"
@@ -75,7 +75,7 @@ func TestMirrorCopy(t *testing.T) {
 	opts.All = true
 	t.Run("Testing Mirror : copy should fail", func(t *testing.T) {
 		err := m.Run(context.Background(), "docker://localhost.localdomain:5000/tes", "oci:test", "copy", &opts)
-		assert.Equal(t, "Cannot use --all and --multi-arch flags together", err.Error())
+		assert.Equal(t, "cannot use --all and --multi-arch flags together", err.Error())
 	})
 
 	opts.All = true
@@ -96,7 +96,7 @@ func TestMirrorCopy(t *testing.T) {
 	opts.SignBySigstorePrivateKey = "test"
 	t.Run("Testing Mirror : copy should fail", func(t *testing.T) {
 		err := m.Run(context.Background(), "docker://localhost.localdomain:5000/tes", "oci:test", "copy", &opts)
-		assert.Equal(t, "Only one of --sign-by and sign-by-sigstore-private-key can be used with sign-passphrase-file", err.Error())
+		assert.Equal(t, "only one of --sign-by and sign-by-sigstore-private-key can be used with sign-passphrase-file", err.Error())
 	})
 }
 
@@ -218,7 +218,7 @@ func TestMirrorDelete(t *testing.T) {
 
 	t.Run("Testing Mirror : delete should fail", func(t *testing.T) {
 		err = New(NewMirrorCopy(), NewMirrorDelete()).Run(context.Background(), src, "broken", "delete", &opts)
-		assert.Equal(t, "Invalid source name broken: Invalid image name \"broken\", expected colon-separated transport:reference", err.Error())
+		assert.Equal(t, "invalid source name broken: Invalid image name \"broken\", expected colon-separated transport:reference", err.Error())
 	})
 
 	t.Run("Testing Mirror : delete should fail", func(t *testing.T) {

--- a/v2/internal/pkg/mirror/options.go
+++ b/v2/internal/pkg/mirror/options.go
@@ -86,6 +86,7 @@ type CopyOptions struct {
 	Stdout                   io.Writer
 	MaxParallelDownloads     uint
 	Function                 string // copy or delete (default is copy)
+	LocalStorageFQDN         string
 }
 
 // deprecatedTLSVerifyOption represents a deprecated --tls-verify option,

--- a/v2/internal/pkg/operator/local_stored_collector_test.go
+++ b/v2/internal/pkg/operator/local_stored_collector_test.go
@@ -401,7 +401,7 @@ func TestOperatorLocalStoredCollectorM2D(t *testing.T) {
 	t.Run("Testing OperatorImageCollector - Mirror to disk: should pass", func(t *testing.T) {
 		ex := setupCollector_MirrorToDisk(tempDir, log, manifest)
 		// ensure coverage in new.go
-		_ = New(log, "working-dir", ex.Config, ex.Opts, ex.Mirror, manifest, "localhost:9999")
+		_ = New(log, "working-dir", ex.Config, ex.Opts, ex.Mirror, manifest)
 	})
 }
 func TestOperatorLocalStoredCollectorD2M(t *testing.T) {
@@ -531,6 +531,7 @@ func setupCollector_DiskToMirror(tempDir string, log clog.PluggableLoggerInterfa
 		Destination:         "docker://localhost:5000/test",
 		Dev:                 false,
 		Mode:                mirror.DiskToMirror,
+		LocalStorageFQDN:    "localhost:9999",
 	}
 
 	ex := &LocalStorageCollector{
@@ -567,6 +568,7 @@ func setupCollector_MirrorToDisk(tempDir string, log clog.PluggableLoggerInterfa
 		Destination:         "file://test",
 		Dev:                 false,
 		Mode:                mirror.MirrorToDisk,
+		LocalStorageFQDN:    "localhost:9999",
 	}
 
 	ex := &LocalStorageCollector{

--- a/v2/internal/pkg/operator/new.go
+++ b/v2/internal/pkg/operator/new.go
@@ -13,7 +13,6 @@ func New(log clog.PluggableLoggerInterface,
 	opts mirror.CopyOptions,
 	mirror mirror.MirrorInterface,
 	manifest manifest.ManifestInterface,
-	localStorageFQDN string,
 ) CollectorInterface {
-	return &LocalStorageCollector{Log: log, LogsDir: logsDir, Config: config, Opts: opts, Mirror: mirror, Manifest: manifest, LocalStorageFQDN: localStorageFQDN}
+	return &LocalStorageCollector{Log: log, LogsDir: logsDir, Config: config, Opts: opts, Mirror: mirror, Manifest: manifest, LocalStorageFQDN: opts.LocalStorageFQDN}
 }

--- a/v2/internal/pkg/release/cincinnati.go
+++ b/v2/internal/pkg/release/cincinnati.go
@@ -229,11 +229,11 @@ func (o *CincinnatiSchema) GetReleaseReferenceImages(ctx context.Context) []v2al
 
 	imgs, err := o.Signature.GenerateReleaseSignatures(ctx, allImages)
 	if err != nil {
-		o.Log.Error("error list %v ", err)
+		o.Log.Error("generate release signatures: error list %v ", err)
 	}
 
 	for _, e := range errs {
-		o.Log.Error("error list %v ", e)
+		o.Log.Error("get release images: error list %v ", e)
 	}
 	return imgs
 }

--- a/v2/internal/pkg/release/client_test.go
+++ b/v2/internal/pkg/release/client_test.go
@@ -44,8 +44,8 @@ func TestOKDClient(t *testing.T) {
 	require.Equal(t, "", client.GetURL().RawQuery)
 }
 
-func TestOCPClientWithOvveride(t *testing.T) {
-	os.Setenv("UPDATE_URL_OVERRIDE", "localhost.localdomain")
+func TestOCPClientWithOveride(t *testing.T) {
+	os.Setenv("UPDATE_URL_OVERRIDE", "http://localhost.localdomain")
 	id := uuid.MustParse("01234567-0123-0123-0123-0123456789ab")
 	//updateAPI, err := url.Parse(UpdateURL)
 	//require.NoError(t, err)
@@ -55,9 +55,10 @@ func TestOCPClientWithOvveride(t *testing.T) {
 	//expURL := *updateAPI
 	actualURL := client.GetURL()
 	require.Equal(t, expID, client.GetID())
-	require.Equal(t, "localhost.localdomain", actualURL.String())
+	require.Equal(t, "http://localhost.localdomain", actualURL.String())
 
 	// Test parameter settings
 	client.SetQueryParams("arch", "channel", "version")
 	require.Equal(t, "arch=arch&channel=channel&id=01234567-0123-0123-0123-0123456789ab&version=version", client.GetURL().RawQuery)
+	os.Unsetenv("UPDATE_URL_OVERRIDE")
 }

--- a/v2/internal/pkg/release/client_test.go
+++ b/v2/internal/pkg/release/client_test.go
@@ -2,7 +2,6 @@ package release
 
 import (
 	"net/url"
-	"os"
 	"testing"
 
 	"github.com/google/uuid"
@@ -45,7 +44,7 @@ func TestOKDClient(t *testing.T) {
 }
 
 func TestOCPClientWithOveride(t *testing.T) {
-	os.Setenv("UPDATE_URL_OVERRIDE", "http://localhost.localdomain")
+	t.Setenv("UPDATE_URL_OVERRIDE", "http://localhost.localdomain")
 	id := uuid.MustParse("01234567-0123-0123-0123-0123456789ab")
 	//updateAPI, err := url.Parse(UpdateURL)
 	//require.NoError(t, err)
@@ -60,5 +59,4 @@ func TestOCPClientWithOveride(t *testing.T) {
 	// Test parameter settings
 	client.SetQueryParams("arch", "channel", "version")
 	require.Equal(t, "arch=arch&channel=channel&id=01234567-0123-0123-0123-0123456789ab&version=version", client.GetURL().RawQuery)
-	os.Unsetenv("UPDATE_URL_OVERRIDE")
 }

--- a/v2/internal/pkg/release/graph_test.go
+++ b/v2/internal/pkg/release/graph_test.go
@@ -40,6 +40,7 @@ func TestCreateGraphImage(t *testing.T) {
 		Destination:         "file://test",
 		Dev:                 false,
 		Mode:                mirror.MirrorToDisk,
+		LocalStorageFQDN:    "localhost:9999",
 	}
 
 	cfgm2d := v2alpha1.ImageSetConfiguration{
@@ -141,7 +142,7 @@ func TestCreateGraphImage(t *testing.T) {
 		}
 
 		// just to ensure we cover new.go
-		_ = New(log, "nada", cfgm2d, m2dOpts, &MockMirror{}, &MockManifest{}, cincinnati, "localhost:9999", &mockImageBuilder{})
+		_ = New(log, "nada", cfgm2d, m2dOpts, &MockMirror{}, &MockManifest{}, cincinnati, &mockImageBuilder{})
 
 		_, err := ex.CreateGraphImage(ctx, graphURL)
 		if err != nil {

--- a/v2/internal/pkg/release/local_stored_collector.go
+++ b/v2/internal/pkg/release/local_stored_collector.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -152,31 +151,13 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v2
 		}
 
 		if o.Config.Mirror.Platform.Graph {
-			o.Log.Debug(collectorPrefix + "creating graph data image")
-			finalGraphURL := graphURL
-			if updateURLOverride := os.Getenv("UPDATE_URL_OVERRIDE"); len(updateURLOverride) != 0 {
-				url, err := graphURLFromUpdateURL(updateURLOverride)
-				if err != nil {
-					o.Log.Error(errMsg, "graph image build: unable to construct graph URL from UPDATE_URL_OVERRIDE: "+err.Error())
-					return []v2alpha1.CopyImageSchema{}, err
-				}
-				finalGraphURL = url
-			}
-			graphImgRef, err := o.CreateGraphImage(ctx, finalGraphURL)
+			graphImage, err := o.handleGraphImage(ctx)
 			if err != nil {
-				o.Log.Error(errMsg, err.Error())
-				return []v2alpha1.CopyImageSchema{}, err
+				o.Log.Warn("error during graph image processing - SKIPPING: %v", err)
+			} else if graphImage.Source != "" {
+				allImages = append(allImages, graphImage)
 			}
-			o.Log.Debug(collectorPrefix + "graph image created and pushed to cache.")
-			// still add the graph image to the `allImages` so that we later can add it in the tar.gz archive
-			// or copied to the destination registry (case of mirror to mirror)
-			graphCopy := v2alpha1.CopyImageSchema{
-				Source:      graphImgRef,
-				Destination: graphImgRef,
-				Origin:      graphImgRef,
-				Type:        v2alpha1.TypeCincinnatiGraph,
-			}
-			allImages = append(allImages, graphCopy)
+
 		}
 
 	} else if o.Opts.IsDiskToMirror() {
@@ -229,24 +210,31 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v2
 				Image: filepath.Join(o.LocalStorageFQDN, graphImageName) + ":latest",
 				Type:  v2alpha1.TypeCincinnatiGraph,
 			}
-			// OCPBUGS-26513: In order to get the destination for the graphDataImage
-			// into `o.GraphDataImage`, we call `prepareD2MCopyBatch` on an array
-			// containing only the graph image. This way we can easily identify the destination
-			// of the graph image.
-			graphImageSlice := []v2alpha1.RelatedImage{graphRelatedImage}
-			graphCopySlice, err := o.prepareD2MCopyBatch(graphImageSlice)
-			if err != nil {
-				o.Log.Error(errMsg, err.Error())
-				return []v2alpha1.CopyImageSchema{}, err
+			// OCPBUGS-38037: Check the graph image is in the cache before adding it
+			graphInCache, err := o.imageExists(ctx, dockerProtocol+graphRelatedImage.Image)
+			if err != nil || !graphInCache {
+				o.Log.Warn("unable to find graph image in local cache: SKIPPING. %v")
+				o.Log.Warn("%v", err)
+			} else {
+				// OCPBUGS-26513: In order to get the destination for the graphDataImage
+				// into `o.GraphDataImage`, we call `prepareD2MCopyBatch` on an array
+				// containing only the graph image. This way we can easily identify the destination
+				// of the graph image.
+				graphImageSlice := []v2alpha1.RelatedImage{graphRelatedImage}
+				graphCopySlice, err := o.prepareD2MCopyBatch(graphImageSlice)
+				if err != nil {
+					o.Log.Error(errMsg, err.Error())
+					return []v2alpha1.CopyImageSchema{}, err
+				}
+				// if there is no error, we are certain that the slice only contains 1 element
+				// but double checking...
+				if len(graphCopySlice) != 1 {
+					o.Log.Error(errMsg, "error while calculating the destination reference for the graph image")
+					return []v2alpha1.CopyImageSchema{}, fmt.Errorf(collectorPrefix + "error while calculating the destination reference for the graph image")
+				}
+				o.GraphDataImage = graphCopySlice[0].Destination
+				allImages = append(allImages, graphCopySlice...)
 			}
-			// if there is no error, we are certain that the slice only contains 1 element
-			// but double checking...
-			if len(graphCopySlice) != 1 {
-				o.Log.Error(errMsg, "error while calculating the destination reference for the graph image")
-				return []v2alpha1.CopyImageSchema{}, fmt.Errorf(collectorPrefix + "error while calculating the destination reference for the graph image")
-			}
-			o.GraphDataImage = graphCopySlice[0].Destination
-			allImages = append(allImages, graphCopySlice...)
 		}
 		releaseCopyImages, err := o.prepareD2MCopyBatch(allRelatedImages)
 		if err != nil {
@@ -450,20 +438,58 @@ func (o LocalStorageCollector) getKubeVirtImage(releaseArtifactsDir string) (v2a
 	return kubeVirtImage, nil
 }
 
-func graphURLFromUpdateURL(updateURL string) (string, error) {
-	finalGraphURL := graphURL
+func (o LocalStorageCollector) handleGraphImage(ctx context.Context) (v2alpha1.CopyImageSchema, error) {
+	o.Log.Debug(collectorPrefix + "processing graph data image")
+	if updateURLOverride := os.Getenv("UPDATE_URL_OVERRIDE"); len(updateURLOverride) != 0 {
+		// OCPBUGS-38037: this indicates that the official cincinnati API is not reacheable
+		// and that graph image cannot be rebuilt on top the complete graph in tar.gz format
 
-	if updateURL != "" {
-		originalURLStruct, err := url.Parse(graphURL)
+		graphImgRef := dockerProtocol + filepath.Join(o.destinationRegistry(), graphImageName) + ":latest"
+
+		// 1. check if graph image is already in cache
+		cachedImageRef := dockerProtocol + filepath.Join(o.LocalStorageFQDN, graphImageName) + ":latest"
+		alreadyInCache, err := o.imageExists(ctx, cachedImageRef)
 		if err != nil {
-			return "", err
+			o.Log.Warn("graph image not found in cache: %v", err)
 		}
-		updateURLStruct, err := url.Parse(updateURL)
+		if alreadyInCache { // use graph image from cache
+			graphCopy := v2alpha1.CopyImageSchema{
+				Source:      cachedImageRef,
+				Destination: graphImgRef,
+				Origin:      cachedImageRef,
+				Type:        v2alpha1.TypeCincinnatiGraph,
+			}
+			return graphCopy, nil
+		}
+		// 2. check if graph image exist in oci format in working-dir
+		workingDirGraphImageRef, err := o.graphImageInWorkingDir(ctx)
+		if err != nil || workingDirGraphImageRef == "" {
+			return v2alpha1.CopyImageSchema{}, fmt.Errorf("no graph image in cache (nor working-dir): %v", err)
+		} else {
+			//    => use OCI image in workingDir
+			graphCopy := v2alpha1.CopyImageSchema{
+				Source:      workingDirGraphImageRef,
+				Destination: graphImgRef,
+				Origin:      workingDirGraphImageRef,
+				Type:        v2alpha1.TypeCincinnatiGraph,
+			}
+			return graphCopy, nil
+		}
+
+	} else {
+		graphImgRef, err := o.CreateGraphImage(ctx, graphURL)
 		if err != nil {
-			return "", err
+			return v2alpha1.CopyImageSchema{}, err
 		}
-		finalGraphURL = strings.Replace(finalGraphURL, originalURLStruct.Host, updateURLStruct.Host, 1)
-		finalGraphURL = strings.Replace(finalGraphURL, originalURLStruct.Scheme, updateURLStruct.Scheme, 1)
+		o.Log.Debug(collectorPrefix + "graph image created and pushed to cache.")
+		// still add the graph image to the `allImages` so that we later can add it in the tar.gz archive
+		// or copied to the destination registry (case of mirror to mirror)
+		graphCopy := v2alpha1.CopyImageSchema{
+			Source:      graphImgRef,
+			Destination: graphImgRef,
+			Origin:      graphImgRef,
+			Type:        v2alpha1.TypeCincinnatiGraph,
+		}
+		return graphCopy, nil
 	}
-	return finalGraphURL, nil
 }

--- a/v2/internal/pkg/release/local_stored_collector.go
+++ b/v2/internal/pkg/release/local_stored_collector.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -152,7 +153,16 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v2
 
 		if o.Config.Mirror.Platform.Graph {
 			o.Log.Debug(collectorPrefix + "creating graph data image")
-			graphImgRef, err := o.CreateGraphImage(ctx, graphURL)
+			finalGraphURL := graphURL
+			if updateURLOverride := os.Getenv("UPDATE_URL_OVERRIDE"); len(updateURLOverride) != 0 {
+				url, err := graphURLFromUpdateURL(updateURLOverride)
+				if err != nil {
+					o.Log.Error(errMsg, "graph image build: unable to construct graph URL from UPDATE_URL_OVERRIDE: "+err.Error())
+					return []v2alpha1.CopyImageSchema{}, err
+				}
+				finalGraphURL = url
+			}
+			graphImgRef, err := o.CreateGraphImage(ctx, finalGraphURL)
 			if err != nil {
 				o.Log.Error(errMsg, err.Error())
 				return []v2alpha1.CopyImageSchema{}, err
@@ -438,4 +448,22 @@ func (o LocalStorageCollector) getKubeVirtImage(releaseArtifactsDir string) (v2a
 		Type:  v2alpha1.TypeOCPRelease,
 	}
 	return kubeVirtImage, nil
+}
+
+func graphURLFromUpdateURL(updateURL string) (string, error) {
+	finalGraphURL := graphURL
+
+	if updateURL != "" {
+		originalURLStruct, err := url.Parse(graphURL)
+		if err != nil {
+			return "", err
+		}
+		updateURLStruct, err := url.Parse(updateURL)
+		if err != nil {
+			return "", err
+		}
+		finalGraphURL = strings.Replace(finalGraphURL, originalURLStruct.Host, updateURLStruct.Host, 1)
+		finalGraphURL = strings.Replace(finalGraphURL, originalURLStruct.Scheme, updateURLStruct.Scheme, 1)
+	}
+	return finalGraphURL, nil
 }

--- a/v2/internal/pkg/release/local_stored_collector_test.go
+++ b/v2/internal/pkg/release/local_stored_collector_test.go
@@ -60,7 +60,7 @@ func TestReleaseLocalStoredCollector(t *testing.T) {
 
 		res, err := ex.ReleaseImageCollector(ctx)
 		if err != nil {
-			t.Fatalf("should not fail")
+			t.Fatalf("should not fail: %v", err)
 		}
 		log.Debug("completed test related images %v ", res)
 	})
@@ -198,6 +198,46 @@ func TestReleaseImage(t *testing.T) {
 	})
 }
 
+func TestGraphURLFromUpdateURL(t *testing.T) {
+	type testCase struct {
+		name          string
+		updateURL     string
+		expectedURL   string
+		expectedError bool
+	}
+	testCases := []testCase{
+		{
+			name:          "nominal case passes",
+			updateURL:     "https://localhost.localdomain:5000/graph",
+			expectedURL:   "https://localhost.localdomain:5000/api/upgrades_info/graph-data",
+			expectedError: false,
+		},
+		{
+			name:          "malformed updateURL fails",
+			updateURL:     "https://localhost.localdomain:wrong/graph",
+			expectedURL:   "",
+			expectedError: true,
+		},
+		{
+			name:          "http scheme updateURL passes",
+			updateURL:     "http://localhost.localdomain:5000/graph",
+			expectedURL:   "http://localhost.localdomain:5000/api/upgrades_info/graph-data",
+			expectedError: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			finalGraphURL, err := graphURLFromUpdateURL(tc.updateURL)
+			if tc.expectedError && err == nil {
+				t.Error("expected error but error was nil")
+			}
+			if !tc.expectedError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			assert.Equal(t, tc.expectedURL, finalGraphURL)
+		})
+	}
+}
 func setupCollector_DiskToMirror(tempDir string, log clog.PluggableLoggerInterface) *LocalStorageCollector {
 	manifest := &MockManifest{Log: log}
 

--- a/v2/internal/pkg/release/local_stored_collector_test.go
+++ b/v2/internal/pkg/release/local_stored_collector_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
 	"github.com/otiai10/copy"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type MockMirror struct {
@@ -198,46 +199,193 @@ func TestReleaseImage(t *testing.T) {
 	})
 }
 
-func TestGraphURLFromUpdateURL(t *testing.T) {
+func TestHandleGraphImage(t *testing.T) {
 	type testCase struct {
-		name          string
-		updateURL     string
-		expectedURL   string
-		expectedError bool
+		name              string
+		mode              string
+		updateURLOverride string
+		imageInCache      bool
+		imageInWorkingDir bool
+		expectedError     bool
+		expectedGraphCopy v2alpha1.CopyImageSchema
 	}
 	testCases := []testCase{
 		{
-			name:          "nominal case passes",
-			updateURL:     "https://localhost.localdomain:5000/graph",
-			expectedURL:   "https://localhost.localdomain:5000/api/upgrades_info/graph-data",
-			expectedError: false,
+			name:              "M2M - no UPDATE_URL_OVERRIDE: should pass",
+			mode:              mirror.MirrorToMirror,
+			updateURLOverride: "",
+			imageInCache:      false,
+			imageInWorkingDir: false,
+			expectedError:     false,
+			expectedGraphCopy: v2alpha1.CopyImageSchema{
+				Source:      "docker://mymirror/openshift/graph-image:latest",
+				Destination: "docker://mymirror/openshift/graph-image:latest",
+				Origin:      "docker://mymirror/openshift/graph-image:latest",
+				Type:        v2alpha1.TypeCincinnatiGraph,
+			},
 		},
 		{
-			name:          "malformed updateURL fails",
-			updateURL:     "https://localhost.localdomain:wrong/graph",
-			expectedURL:   "",
-			expectedError: true,
+			name:              "M2D - no UPDATE_URL_OVERRIDE: should pass",
+			mode:              mirror.MirrorToDisk,
+			updateURLOverride: "",
+			imageInCache:      false,
+			imageInWorkingDir: false,
+			expectedError:     false,
+			expectedGraphCopy: v2alpha1.CopyImageSchema{
+				Source:      "docker://localhost:9999/openshift/graph-image:latest",
+				Destination: "docker://localhost:9999/openshift/graph-image:latest",
+				Origin:      "docker://localhost:9999/openshift/graph-image:latest",
+				Type:        v2alpha1.TypeCincinnatiGraph,
+			},
 		},
 		{
-			name:          "http scheme updateURL passes",
-			updateURL:     "http://localhost.localdomain:5000/graph",
-			expectedURL:   "http://localhost.localdomain:5000/api/upgrades_info/graph-data",
-			expectedError: false,
+			name:              "M2M - UPDATE_URL_OVERRIDE - image in cache: should pass",
+			mode:              mirror.MirrorToMirror,
+			updateURLOverride: "https://localhost.localdomain:3443/graph",
+			imageInCache:      true,
+			imageInWorkingDir: false,
+			expectedError:     false,
+			expectedGraphCopy: v2alpha1.CopyImageSchema{
+				Source:      "docker://localhost:9999/openshift/graph-image:latest",
+				Destination: "docker://mymirror/openshift/graph-image:latest",
+				Origin:      "docker://localhost:9999/openshift/graph-image:latest",
+				Type:        v2alpha1.TypeCincinnatiGraph,
+			},
+		},
+		{
+			name:              "M2M - UPDATE_URL_OVERRIDE - image in working-dir: should pass",
+			mode:              mirror.MirrorToMirror,
+			updateURLOverride: "https://localhost.localdomain:3443/graph",
+			imageInCache:      false,
+			imageInWorkingDir: true,
+			expectedError:     false,
+			expectedGraphCopy: v2alpha1.CopyImageSchema{
+				Source:      "oci://TEMPDIR/" + graphPreparationDir,
+				Destination: "docker://mymirror/openshift/graph-image:latest",
+				Origin:      "oci://TEMPDIR/" + graphPreparationDir,
+				Type:        v2alpha1.TypeCincinnatiGraph,
+			},
+		},
+		{
+			name:              "M2M - UPDATE_URL_OVERRIDE - image nowhere: should pass",
+			mode:              mirror.MirrorToMirror,
+			updateURLOverride: "https://localhost.localdomain:3443/graph",
+			imageInCache:      false,
+			imageInWorkingDir: false,
+			expectedError:     true,
+			expectedGraphCopy: v2alpha1.CopyImageSchema{},
+		},
+		{
+			name:              "M2D - UPDATE_URL_OVERRIDE - image in cache: should pass",
+			mode:              mirror.MirrorToDisk,
+			updateURLOverride: "https://localhost.localdomain:3443/graph",
+			imageInCache:      true,
+			imageInWorkingDir: false,
+			expectedError:     false,
+			expectedGraphCopy: v2alpha1.CopyImageSchema{
+				Source:      "docker://localhost:9999/openshift/graph-image:latest",
+				Destination: "docker://localhost:9999/openshift/graph-image:latest",
+				Origin:      "docker://localhost:9999/openshift/graph-image:latest",
+				Type:        v2alpha1.TypeCincinnatiGraph,
+			},
+		},
+		{
+			name:              "M2D - UPDATE_URL_OVERRIDE - image in working-dir: should pass",
+			mode:              mirror.MirrorToDisk,
+			updateURLOverride: "https://localhost.localdomain:3443/graph",
+			imageInCache:      false,
+			imageInWorkingDir: true,
+			expectedError:     false,
+			expectedGraphCopy: v2alpha1.CopyImageSchema{
+				Source:      "oci://TEMPDIR/" + graphPreparationDir,
+				Destination: "docker://localhost:9999/openshift/graph-image:latest",
+				Origin:      "oci://TEMPDIR/" + graphPreparationDir,
+				Type:        v2alpha1.TypeCincinnatiGraph,
+			},
+		},
+		{
+			name:              "M2D - UPDATE_URL_OVERRIDE - image nowhere: should pass",
+			mode:              mirror.MirrorToDisk,
+			updateURLOverride: "https://localhost.localdomain:3443/graph",
+			imageInCache:      false,
+			imageInWorkingDir: false,
+			expectedError:     true,
+			expectedGraphCopy: v2alpha1.CopyImageSchema{},
 		},
 	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			finalGraphURL, err := graphURLFromUpdateURL(tc.updateURL)
-			if tc.expectedError && err == nil {
-				t.Error("expected error but error was nil")
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			globalOpts := &mirror.GlobalOptions{
+				SecurePolicy: false,
+				WorkingDir:   tempDir,
 			}
-			if !tc.expectedError && err != nil {
-				t.Errorf("unexpected error: %v", err)
+
+			_, sharedOpts := mirror.SharedImageFlags()
+			_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
+			_, retryOpts := mirror.RetryFlags()
+			_, srcOpts := mirror.ImageSrcFlags(globalOpts, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
+			_, destOpts := mirror.ImageDestFlags(globalOpts, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
+
+			copyOpts := mirror.CopyOptions{
+				Global:              globalOpts,
+				DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
+				SrcImage:            srcOpts,
+				DestImage:           destOpts,
+				RetryOpts:           retryOpts,
+				Dev:                 false,
+				Mode:                testCase.mode,
 			}
-			assert.Equal(t, tc.expectedURL, finalGraphURL)
+
+			if testCase.mode == mirror.MirrorToDisk {
+				copyOpts.Destination = "file://" + tempDir
+				copyOpts.Global.WorkingDir = tempDir
+			}
+			if testCase.mode == mirror.MirrorToMirror {
+				copyOpts.Destination = "docker://mymirror"
+				copyOpts.Global.WorkingDir = tempDir
+			}
+
+			log := clog.New("trace")
+			manifestMock := new(ManifestMock)
+			if testCase.imageInCache {
+				manifestMock.On("GetDigest", mock.Anything, mock.Anything, "docker://localhost:9999/openshift/graph-image:latest").Return("123456", nil)
+			} else {
+				manifestMock.On("GetDigest", mock.Anything, mock.Anything, "docker://localhost:9999/openshift/graph-image:latest").Return("", fmt.Errorf("simulating image doesn't exist in cache"))
+			}
+			if testCase.imageInWorkingDir {
+				manifestMock.On("GetDigest", mock.Anything, mock.Anything, "oci://"+copyOpts.Global.WorkingDir+"/"+graphPreparationDir).Return("123456", nil)
+			} else {
+				manifestMock.On("GetDigest", mock.Anything, mock.Anything, "oci://"+copyOpts.Global.WorkingDir+"/"+graphPreparationDir).Return("", fmt.Errorf("simulating image doesn't exist in cache"))
+			}
+			if testCase.updateURLOverride != "" {
+				t.Setenv("UPDATE_URL_OVERRIDE", testCase.updateURLOverride)
+			}
+			ex := &LocalStorageCollector{
+				Log:              log,
+				Mirror:           &MockMirror{Fail: false},
+				Opts:             copyOpts,
+				Manifest:         manifestMock,
+				LocalStorageFQDN: "localhost:9999",
+				ImageBuilder:     &mockImageBuilder{},
+				LogsDir:          "/tmp/",
+			}
+			graphImage, err := ex.handleGraphImage(context.Background())
+			if testCase.expectedError && err == nil {
+				t.Error("expecting test to fail with error, but no error returned")
+			}
+			if !testCase.expectedError && err != nil {
+				t.Errorf("unexpected failure: %v", err)
+			}
+			testCase.expectedGraphCopy.Source = strings.Replace(testCase.expectedGraphCopy.Source, "TEMPDIR", copyOpts.Global.WorkingDir, 1)
+			testCase.expectedGraphCopy.Origin = strings.Replace(testCase.expectedGraphCopy.Origin, "TEMPDIR", copyOpts.Global.WorkingDir, 1)
+			testCase.expectedGraphCopy.Destination = strings.Replace(testCase.expectedGraphCopy.Destination, "TEMPDIR", copyOpts.Global.WorkingDir, 1)
+
+			assert.Equal(t, testCase.expectedGraphCopy, graphImage)
 		})
 	}
 }
+
 func setupCollector_DiskToMirror(tempDir string, log clog.PluggableLoggerInterface) *LocalStorageCollector {
 	manifest := &MockManifest{Log: log}
 
@@ -533,4 +681,37 @@ func (o MockCincinnati) GenerateReleaseSignatures(ctx context.Context, images []
 	fmt.Println("test release signature")
 
 	return images, nil
+}
+
+type ManifestMock struct {
+	mock.Mock
+}
+
+func (o *ManifestMock) GetImageIndex(dir string) (*v2alpha1.OCISchema, error) {
+	return &v2alpha1.OCISchema{}, nil
+}
+func (o *ManifestMock) GetImageManifest(file string) (*v2alpha1.OCISchema, error) {
+	return &v2alpha1.OCISchema{}, nil
+}
+func (o *ManifestMock) GetOperatorConfig(file string) (*v2alpha1.OperatorConfigSchema, error) {
+	return &v2alpha1.OperatorConfigSchema{}, nil
+}
+func (o *ManifestMock) GetCatalog(filePath string) (manifest.OperatorCatalog, error) {
+	return manifest.OperatorCatalog{}, nil
+}
+func (o *ManifestMock) GetRelatedImagesFromCatalog(operatorCatalog manifest.OperatorCatalog, ctlgInIsc v2alpha1.Operator, copyImageSchemaMap *v2alpha1.CopyImageSchemaMap) (map[string][]v2alpha1.RelatedImage, error) {
+	return map[string][]v2alpha1.RelatedImage{}, nil
+}
+func (o *ManifestMock) ExtractLayersOCI(filePath, toPath, label string, oci *v2alpha1.OCISchema) error {
+	return nil
+}
+func (o *ManifestMock) GetReleaseSchema(filePath string) ([]v2alpha1.RelatedImage, error) {
+	return []v2alpha1.RelatedImage{}, nil
+}
+func (o *ManifestMock) ConvertIndexToSingleManifest(dir string, oci *v2alpha1.OCISchema) error {
+	return nil
+}
+func (o *ManifestMock) GetDigest(ctx context.Context, sourceCtx *types.SystemContext, imgRef string) (string, error) {
+	args := o.Called(ctx, sourceCtx, imgRef)
+	return args.String(0), args.Error(1)
 }

--- a/v2/internal/pkg/release/new.go
+++ b/v2/internal/pkg/release/new.go
@@ -15,8 +15,7 @@ func New(log clog.PluggableLoggerInterface,
 	mirror mirror.MirrorInterface,
 	manifest manifest.ManifestInterface,
 	cincinnati CincinnatiInterface,
-	localStorageFQDN string,
 	imageBuilder imagebuilder.ImageBuilderInterface,
 ) CollectorInterface {
-	return &LocalStorageCollector{Log: log, LogsDir: logsDir, Config: config, Opts: opts, Mirror: mirror, Manifest: manifest, Cincinnati: cincinnati, LocalStorageFQDN: localStorageFQDN, ImageBuilder: imageBuilder}
+	return &LocalStorageCollector{Log: log, LogsDir: logsDir, Config: config, Opts: opts, Mirror: mirror, Manifest: manifest, Cincinnati: cincinnati, LocalStorageFQDN: opts.LocalStorageFQDN, ImageBuilder: imageBuilder}
 }

--- a/v2/internal/pkg/release/signature_test.go
+++ b/v2/internal/pkg/release/signature_test.go
@@ -100,7 +100,7 @@ func TestReleaseSignature(t *testing.T) {
 	})
 
 	t.Run("Testing ReleaseSignature with custom PGP key - should pass", func(t *testing.T) {
-		os.Setenv("OCP_SIGNATURE_VERIFICATION_PK", common.TestFolder+"custom-ocp-sig-key.asc")
+		t.Setenv("OCP_SIGNATURE_VERIFICATION_PK", common.TestFolder+"custom-ocp-sig-key.asc")
 
 		ex := NewSignatureClient(log, cfg, opts)
 
@@ -120,7 +120,7 @@ func TestReleaseSignature(t *testing.T) {
 	})
 
 	t.Run("Testing ReleaseSignature with custom but buggy PGP key - should fail", func(t *testing.T) {
-		os.Setenv("OCP_SIGNATURE_VERIFICATION_PK", common.TestFolder+"buggy-ocp-sig-key.asc")
+		t.Setenv("OCP_SIGNATURE_VERIFICATION_PK", common.TestFolder+"buggy-ocp-sig-key.asc")
 
 		ex := NewSignatureClient(log, cfg, opts)
 
@@ -138,7 +138,7 @@ func TestReleaseSignature(t *testing.T) {
 	})
 
 	t.Run("Testing ReleaseSignature with custom but inexisting PGP key - should pass", func(t *testing.T) {
-		os.Setenv("OCP_SIGNATURE_VERIFICATION_PK", common.TestFolder+"inexisting-ocp-sig-key.asc")
+		t.Setenv("OCP_SIGNATURE_VERIFICATION_PK", common.TestFolder+"inexisting-ocp-sig-key.asc")
 
 		ex := NewSignatureClient(log, cfg, opts)
 

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/additional/new.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/additional/new.go
@@ -12,7 +12,6 @@ func New(log clog.PluggableLoggerInterface,
 	opts mirror.CopyOptions,
 	mirror mirror.MirrorInterface,
 	manifest manifest.ManifestInterface,
-	localstorageFQDN string,
 ) CollectorInterface {
-	return &LocalStorageCollector{Log: log, Config: config, Opts: opts, Mirror: mirror, Manifest: manifest, LocalStorageFQDN: localstorageFQDN}
+	return &LocalStorageCollector{Log: log, Config: config, Opts: opts, Mirror: mirror, Manifest: manifest, LocalStorageFQDN: opts.LocalStorageFQDN}
 }

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1/type_image.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1/type_image.go
@@ -44,7 +44,7 @@ var imageStringsType = map[string]ImageType{
 }
 
 func (it ImageType) IsRelease() bool {
-	return it == TypeOCPRelease || it == TypeOCPReleaseContent
+	return it == TypeOCPRelease || it == TypeOCPReleaseContent || it == TypeCincinnatiGraph
 }
 
 func (it ImageType) IsOperator() bool {

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/concurrent_worker.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/batch/concurrent_worker.go
@@ -141,7 +141,7 @@ func (o *ConcurrentBatch) Worker(ctx context.Context, collectorSchema v2alpha1.C
 				case img.Type.IsAdditionalImage():
 					errArray = append(errArray, mirrorErrorSchema{image: img, err: err})
 					spinner.Abort(false)
-				case img.Type.IsRelease(): //TODO ALEX ASK SHERINE IF CINCINNATI SHOULD BE INCLUDED HERE
+				case img.Type.IsRelease():
 					// error on release image, save the errArray and immediately return `UnsafeError` to caller
 					currentMirrorError := mirrorErrorSchema{image: img, err: err}
 					errArray = append(errArray, currentMirrorError)
@@ -185,7 +185,7 @@ func (o *ConcurrentBatch) Worker(ctx context.Context, collectorSchema v2alpha1.C
 		}
 		if collectorSchema.TotalAdditionalImages != 0 {
 			if o.CopiedImages.TotalAdditionalImages == collectorSchema.TotalAdditionalImages {
-				o.Log.Info("✅ %d / %dadditional images mirrored successfully", o.CopiedImages.TotalAdditionalImages, collectorSchema.TotalAdditionalImages)
+				o.Log.Info("✅ %d / %d additional images mirrored successfully", o.CopiedImages.TotalAdditionalImages, collectorSchema.TotalAdditionalImages)
 			} else {
 				o.Log.Info("❌ %d / %d addtional images mirrored: Some additional images failed to mirror - please check the logs", o.CopiedImages.TotalAdditionalImages, collectorSchema.TotalAdditionalImages)
 			}

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/delete.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/delete.go
@@ -219,7 +219,7 @@ func (o *ExecutorSchema) CompleteDelete(args []string) error {
 	if o.isLocalStoragePortBound() {
 		return fmt.Errorf("%d is already bound and cannot be used", o.Opts.Global.Port)
 	}
-	o.LocalStorageFQDN = "localhost:" + strconv.Itoa(int(o.Opts.Global.Port))
+	o.Opts.LocalStorageFQDN = "localhost:" + strconv.Itoa(int(o.Opts.Global.Port))
 
 	// ensure mirror and batch worker use delete logic
 	o.Opts.Function = string(mirror.DeleteMode)
@@ -252,14 +252,14 @@ func (o *ExecutorSchema) CompleteDelete(args []string) error {
 	client, _ := release.NewOCPClient(uuid.New())
 	signature := release.NewSignatureClient(o.Log, o.Config, *o.Opts)
 	cn := release.NewCincinnati(o.Log, &o.Config, *o.Opts, client, false, signature)
-	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.LocalStorageFQDN, o.ImageBuilder)
+	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.ImageBuilder)
 	o.Batch = batch.New(o.Log, o.LogsDir, o.Mirror)
-	o.Operator = operator.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, o.LocalStorageFQDN)
-	o.AdditionalImages = additional.New(o.Log, o.Config, *o.Opts, o.Mirror, o.Manifest, o.LocalStorageFQDN)
+	o.Operator = operator.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest)
+	o.AdditionalImages = additional.New(o.Log, o.Config, *o.Opts, o.Mirror, o.Manifest)
 
 	// instantiate delete module
 	bg := archive.NewImageBlobGatherer(o.Opts)
-	o.Delete = delete.New(o.Log, *o.Opts, o.Batch, bg, o.Config, o.Manifest, o.LocalStorageDisk, o.LocalStorageFQDN)
+	o.Delete = delete.New(o.Log, *o.Opts, o.Batch, bg, o.Config, o.Manifest, o.LocalStorageDisk)
 
 	return nil
 }

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
@@ -115,7 +115,6 @@ type ExecutorSchema struct {
 	Batch                        batch.BatchInterface
 	LocalStorageService          registry.Registry
 	localStorageInterruptChannel chan error
-	LocalStorageFQDN             string
 	LocalStorageDisk             string
 	ClusterResources             clusterresources.GeneratorInterface
 	ImageBuilder                 imagebuilder.ImageBuilderInterface
@@ -405,7 +404,7 @@ func (o *ExecutorSchema) Complete(args []string) error {
 	if o.isLocalStoragePortBound() {
 		return fmt.Errorf("%d is already bound and cannot be used", o.Opts.Global.Port)
 	}
-	o.LocalStorageFQDN = "localhost:" + strconv.Itoa(int(o.Opts.Global.Port))
+	o.Opts.LocalStorageFQDN = "localhost:" + strconv.Itoa(int(o.Opts.Global.Port))
 
 	err = o.setupWorkingDir()
 	if err != nil {
@@ -423,9 +422,9 @@ func (o *ExecutorSchema) Complete(args []string) error {
 
 	signature := release.NewSignatureClient(o.Log, o.Config, *o.Opts)
 	cn := release.NewCincinnati(o.Log, &o.Config, *o.Opts, client, false, signature)
-	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.LocalStorageFQDN, o.ImageBuilder)
-	o.Operator = operator.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, o.LocalStorageFQDN)
-	o.AdditionalImages = additional.New(o.Log, o.Config, *o.Opts, o.Mirror, o.Manifest, o.LocalStorageFQDN)
+	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.ImageBuilder)
+	o.Operator = operator.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest)
+	o.AdditionalImages = additional.New(o.Log, o.Config, *o.Opts, o.Mirror, o.Manifest)
 	o.ClusterResources = clusterresources.New(o.Log, o.Opts.Global.WorkingDir, o.Config)
 	o.Batch = batch.NewConcurrentBatch(o.Log, o.LogsDir, o.Mirror, calculateMaxBatchSize(o.MaxParallelOverallDownloads, o.ParallelBatchImages))
 

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/delete/new.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/delete/new.go
@@ -16,7 +16,6 @@ func New(log clog.PluggableLoggerInterface,
 	config v2alpha1.ImageSetConfiguration,
 	manifest manifest.ManifestInterface,
 	localStorageDisk string,
-	localStorageFQDN string,
 ) DeleteInterface {
 	return &DeleteImages{
 		Log:              log,
@@ -26,6 +25,6 @@ func New(log clog.PluggableLoggerInterface,
 		Config:           config,
 		Manifest:         manifest,
 		LocalStorageDisk: localStorageDisk,
-		LocalStorageFQDN: localStorageFQDN,
+		LocalStorageFQDN: opts.LocalStorageFQDN,
 	}
 }

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/mirror/mirror.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/mirror/mirror.go
@@ -102,10 +102,17 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 	if err != nil {
 		return err
 	}
+	if strings.Contains(src, opts.LocalStorageFQDN) { // when copying from cache, use HTTP
+		sourceCtx.DockerInsecureSkipTLSVerify = types.OptionalBoolTrue
+	}
 
 	destinationCtx, err := opts.DestImage.NewSystemContext()
 	if err != nil {
 		return err
+	}
+
+	if strings.Contains(dest, opts.LocalStorageFQDN) { // when copying to cache, use HTTP
+		destinationCtx.DockerInsecureSkipTLSVerify = types.OptionalBoolTrue
 	}
 
 	var manifestType string
@@ -264,6 +271,10 @@ func (o *Mirror) delete(ctx context.Context, image string, opts *CopyOptions) er
 	sysCtx, err := opts.DestImage.NewSystemContext()
 	if err != nil {
 		return err
+	}
+
+	if strings.Contains(image, opts.LocalStorageFQDN) { // when copying to cache, use HTTP
+		sysCtx.DockerInsecureSkipTLSVerify = types.OptionalBoolTrue
 	}
 
 	ctx, cancel := opts.Global.CommandTimeoutContext()

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/mirror/mirror.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/mirror/mirror.go
@@ -81,7 +81,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 
 	policyContext, err := opts.Global.GetPolicyContext()
 	if err != nil {
-		return fmt.Errorf("Error loading trust policy: %v", err)
+		return fmt.Errorf("error loading trust policy: %v", err)
 	}
 	defer func() {
 		if err := policyContext.Destroy(); err != nil {
@@ -91,11 +91,11 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 
 	srcRef, err := alltransports.ParseImageName(src)
 	if err != nil {
-		return fmt.Errorf("Invalid source name %s: %v", src, err)
+		return fmt.Errorf("invalid source name %s: %v", src, err)
 	}
 	destRef, err := alltransports.ParseImageName(dest)
 	if err != nil {
-		return fmt.Errorf("Invalid destination name %s: %v", dest, err)
+		return fmt.Errorf("invalid destination name %s: %v", dest, err)
 	}
 
 	sourceCtx, err := opts.SrcImage.NewSystemContext()
@@ -128,7 +128,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 
 	imageListSelection := copy.CopySystemImage
 	if len(opts.MultiArch) > 0 && opts.All {
-		return fmt.Errorf("Cannot use --all and --multi-arch flags together")
+		return fmt.Errorf("cannot use --all and --multi-arch flags together")
 	}
 
 	if len(opts.MultiArch) > 0 {
@@ -150,7 +150,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 	// with independent passphrases, but that would make the CLI probably too confusing.
 	// For now, use the passphrase with either, but only one of them.
 	if opts.SignPassphraseFile != "" && opts.SignByFingerprint != "" && opts.SignBySigstorePrivateKey != "" {
-		return fmt.Errorf("Only one of --sign-by and sign-by-sigstore-private-key can be used with sign-passphrase-file")
+		return fmt.Errorf("only one of --sign-by and sign-by-sigstore-private-key can be used with sign-passphrase-file")
 	}
 	var passphrase string
 	if opts.SignPassphraseFile != "" {
@@ -167,7 +167,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 	if opts.SignIdentity != "" {
 		signIdentity, err = reference.ParseNamed(opts.SignIdentity)
 		if err != nil {
-			return fmt.Errorf("Could not parse --sign-identity: %v", err)
+			return fmt.Errorf("could not parse --sign-identity: %v", err)
 		}
 	}
 
@@ -205,7 +205,7 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 				return err
 			}
 			if err = os.WriteFile(opts.DigestFile, []byte(manifestDigest.String()), 0644); err != nil {
-				return fmt.Errorf("Failed to write digest to file %q: %w", opts.DigestFile, err)
+				return fmt.Errorf("failed to write digest to file %q: %w", opts.DigestFile, err)
 			}
 		}
 		return nil
@@ -265,7 +265,7 @@ func (o *Mirror) delete(ctx context.Context, image string, opts *CopyOptions) er
 
 	imageRef, err := alltransports.ParseImageName(image)
 	if err != nil {
-		return fmt.Errorf("Invalid source name %s: %v", image, err)
+		return fmt.Errorf("invalid source name %s: %v", image, err)
 	}
 
 	sysCtx, err := opts.DestImage.NewSystemContext()

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/mirror/options.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/mirror/options.go
@@ -86,6 +86,7 @@ type CopyOptions struct {
 	Stdout                   io.Writer
 	MaxParallelDownloads     uint
 	Function                 string // copy or delete (default is copy)
+	LocalStorageFQDN         string
 }
 
 // deprecatedTLSVerifyOption represents a deprecated --tls-verify option,

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/operator/new.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/operator/new.go
@@ -13,7 +13,6 @@ func New(log clog.PluggableLoggerInterface,
 	opts mirror.CopyOptions,
 	mirror mirror.MirrorInterface,
 	manifest manifest.ManifestInterface,
-	localStorageFQDN string,
 ) CollectorInterface {
-	return &LocalStorageCollector{Log: log, LogsDir: logsDir, Config: config, Opts: opts, Mirror: mirror, Manifest: manifest, LocalStorageFQDN: localStorageFQDN}
+	return &LocalStorageCollector{Log: log, LogsDir: logsDir, Config: config, Opts: opts, Mirror: mirror, Manifest: manifest, LocalStorageFQDN: opts.LocalStorageFQDN}
 }

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/cincinnati.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/cincinnati.go
@@ -229,11 +229,11 @@ func (o *CincinnatiSchema) GetReleaseReferenceImages(ctx context.Context) []v2al
 
 	imgs, err := o.Signature.GenerateReleaseSignatures(ctx, allImages)
 	if err != nil {
-		o.Log.Error("error list %v ", err)
+		o.Log.Error("generate release signatures: error list %v ", err)
 	}
 
 	for _, e := range errs {
-		o.Log.Error("error list %v ", e)
+		o.Log.Error("get release images: error list %v ", e)
 	}
 	return imgs
 }

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/local_stored_collector.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -152,31 +151,13 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v2
 		}
 
 		if o.Config.Mirror.Platform.Graph {
-			o.Log.Debug(collectorPrefix + "creating graph data image")
-			finalGraphURL := graphURL
-			if updateURLOverride := os.Getenv("UPDATE_URL_OVERRIDE"); len(updateURLOverride) != 0 {
-				url, err := graphURLFromUpdateURL(updateURLOverride)
-				if err != nil {
-					o.Log.Error(errMsg, "graph image build: unable to construct graph URL from UPDATE_URL_OVERRIDE: "+err.Error())
-					return []v2alpha1.CopyImageSchema{}, err
-				}
-				finalGraphURL = url
-			}
-			graphImgRef, err := o.CreateGraphImage(ctx, finalGraphURL)
+			graphImage, err := o.handleGraphImage(ctx)
 			if err != nil {
-				o.Log.Error(errMsg, err.Error())
-				return []v2alpha1.CopyImageSchema{}, err
+				o.Log.Warn("error during graph image processing - SKIPPING: %v", err)
+			} else if graphImage.Source != "" {
+				allImages = append(allImages, graphImage)
 			}
-			o.Log.Debug(collectorPrefix + "graph image created and pushed to cache.")
-			// still add the graph image to the `allImages` so that we later can add it in the tar.gz archive
-			// or copied to the destination registry (case of mirror to mirror)
-			graphCopy := v2alpha1.CopyImageSchema{
-				Source:      graphImgRef,
-				Destination: graphImgRef,
-				Origin:      graphImgRef,
-				Type:        v2alpha1.TypeCincinnatiGraph,
-			}
-			allImages = append(allImages, graphCopy)
+
 		}
 
 	} else if o.Opts.IsDiskToMirror() {
@@ -229,24 +210,31 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v2
 				Image: filepath.Join(o.LocalStorageFQDN, graphImageName) + ":latest",
 				Type:  v2alpha1.TypeCincinnatiGraph,
 			}
-			// OCPBUGS-26513: In order to get the destination for the graphDataImage
-			// into `o.GraphDataImage`, we call `prepareD2MCopyBatch` on an array
-			// containing only the graph image. This way we can easily identify the destination
-			// of the graph image.
-			graphImageSlice := []v2alpha1.RelatedImage{graphRelatedImage}
-			graphCopySlice, err := o.prepareD2MCopyBatch(graphImageSlice)
-			if err != nil {
-				o.Log.Error(errMsg, err.Error())
-				return []v2alpha1.CopyImageSchema{}, err
+			// OCPBUGS-38037: Check the graph image is in the cache before adding it
+			graphInCache, err := o.imageExists(ctx, dockerProtocol+graphRelatedImage.Image)
+			if err != nil || !graphInCache {
+				o.Log.Warn("unable to find graph image in local cache: SKIPPING. %v")
+				o.Log.Warn("%v", err)
+			} else {
+				// OCPBUGS-26513: In order to get the destination for the graphDataImage
+				// into `o.GraphDataImage`, we call `prepareD2MCopyBatch` on an array
+				// containing only the graph image. This way we can easily identify the destination
+				// of the graph image.
+				graphImageSlice := []v2alpha1.RelatedImage{graphRelatedImage}
+				graphCopySlice, err := o.prepareD2MCopyBatch(graphImageSlice)
+				if err != nil {
+					o.Log.Error(errMsg, err.Error())
+					return []v2alpha1.CopyImageSchema{}, err
+				}
+				// if there is no error, we are certain that the slice only contains 1 element
+				// but double checking...
+				if len(graphCopySlice) != 1 {
+					o.Log.Error(errMsg, "error while calculating the destination reference for the graph image")
+					return []v2alpha1.CopyImageSchema{}, fmt.Errorf(collectorPrefix + "error while calculating the destination reference for the graph image")
+				}
+				o.GraphDataImage = graphCopySlice[0].Destination
+				allImages = append(allImages, graphCopySlice...)
 			}
-			// if there is no error, we are certain that the slice only contains 1 element
-			// but double checking...
-			if len(graphCopySlice) != 1 {
-				o.Log.Error(errMsg, "error while calculating the destination reference for the graph image")
-				return []v2alpha1.CopyImageSchema{}, fmt.Errorf(collectorPrefix + "error while calculating the destination reference for the graph image")
-			}
-			o.GraphDataImage = graphCopySlice[0].Destination
-			allImages = append(allImages, graphCopySlice...)
 		}
 		releaseCopyImages, err := o.prepareD2MCopyBatch(allRelatedImages)
 		if err != nil {
@@ -450,20 +438,58 @@ func (o LocalStorageCollector) getKubeVirtImage(releaseArtifactsDir string) (v2a
 	return kubeVirtImage, nil
 }
 
-func graphURLFromUpdateURL(updateURL string) (string, error) {
-	finalGraphURL := graphURL
+func (o LocalStorageCollector) handleGraphImage(ctx context.Context) (v2alpha1.CopyImageSchema, error) {
+	o.Log.Debug(collectorPrefix + "processing graph data image")
+	if updateURLOverride := os.Getenv("UPDATE_URL_OVERRIDE"); len(updateURLOverride) != 0 {
+		// OCPBUGS-38037: this indicates that the official cincinnati API is not reacheable
+		// and that graph image cannot be rebuilt on top the complete graph in tar.gz format
 
-	if updateURL != "" {
-		originalURLStruct, err := url.Parse(graphURL)
+		graphImgRef := dockerProtocol + filepath.Join(o.destinationRegistry(), graphImageName) + ":latest"
+
+		// 1. check if graph image is already in cache
+		cachedImageRef := dockerProtocol + filepath.Join(o.LocalStorageFQDN, graphImageName) + ":latest"
+		alreadyInCache, err := o.imageExists(ctx, cachedImageRef)
 		if err != nil {
-			return "", err
+			o.Log.Warn("graph image not found in cache: %v", err)
 		}
-		updateURLStruct, err := url.Parse(updateURL)
+		if alreadyInCache { // use graph image from cache
+			graphCopy := v2alpha1.CopyImageSchema{
+				Source:      cachedImageRef,
+				Destination: graphImgRef,
+				Origin:      cachedImageRef,
+				Type:        v2alpha1.TypeCincinnatiGraph,
+			}
+			return graphCopy, nil
+		}
+		// 2. check if graph image exist in oci format in working-dir
+		workingDirGraphImageRef, err := o.graphImageInWorkingDir(ctx)
+		if err != nil || workingDirGraphImageRef == "" {
+			return v2alpha1.CopyImageSchema{}, fmt.Errorf("no graph image in cache (nor working-dir): %v", err)
+		} else {
+			//    => use OCI image in workingDir
+			graphCopy := v2alpha1.CopyImageSchema{
+				Source:      workingDirGraphImageRef,
+				Destination: graphImgRef,
+				Origin:      workingDirGraphImageRef,
+				Type:        v2alpha1.TypeCincinnatiGraph,
+			}
+			return graphCopy, nil
+		}
+
+	} else {
+		graphImgRef, err := o.CreateGraphImage(ctx, graphURL)
 		if err != nil {
-			return "", err
+			return v2alpha1.CopyImageSchema{}, err
 		}
-		finalGraphURL = strings.Replace(finalGraphURL, originalURLStruct.Host, updateURLStruct.Host, 1)
-		finalGraphURL = strings.Replace(finalGraphURL, originalURLStruct.Scheme, updateURLStruct.Scheme, 1)
+		o.Log.Debug(collectorPrefix + "graph image created and pushed to cache.")
+		// still add the graph image to the `allImages` so that we later can add it in the tar.gz archive
+		// or copied to the destination registry (case of mirror to mirror)
+		graphCopy := v2alpha1.CopyImageSchema{
+			Source:      graphImgRef,
+			Destination: graphImgRef,
+			Origin:      graphImgRef,
+			Type:        v2alpha1.TypeCincinnatiGraph,
+		}
+		return graphCopy, nil
 	}
-	return finalGraphURL, nil
 }

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/local_stored_collector.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/local_stored_collector.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -152,7 +153,16 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v2
 
 		if o.Config.Mirror.Platform.Graph {
 			o.Log.Debug(collectorPrefix + "creating graph data image")
-			graphImgRef, err := o.CreateGraphImage(ctx, graphURL)
+			finalGraphURL := graphURL
+			if updateURLOverride := os.Getenv("UPDATE_URL_OVERRIDE"); len(updateURLOverride) != 0 {
+				url, err := graphURLFromUpdateURL(updateURLOverride)
+				if err != nil {
+					o.Log.Error(errMsg, "graph image build: unable to construct graph URL from UPDATE_URL_OVERRIDE: "+err.Error())
+					return []v2alpha1.CopyImageSchema{}, err
+				}
+				finalGraphURL = url
+			}
+			graphImgRef, err := o.CreateGraphImage(ctx, finalGraphURL)
 			if err != nil {
 				o.Log.Error(errMsg, err.Error())
 				return []v2alpha1.CopyImageSchema{}, err
@@ -438,4 +448,22 @@ func (o LocalStorageCollector) getKubeVirtImage(releaseArtifactsDir string) (v2a
 		Type:  v2alpha1.TypeOCPRelease,
 	}
 	return kubeVirtImage, nil
+}
+
+func graphURLFromUpdateURL(updateURL string) (string, error) {
+	finalGraphURL := graphURL
+
+	if updateURL != "" {
+		originalURLStruct, err := url.Parse(graphURL)
+		if err != nil {
+			return "", err
+		}
+		updateURLStruct, err := url.Parse(updateURL)
+		if err != nil {
+			return "", err
+		}
+		finalGraphURL = strings.Replace(finalGraphURL, originalURLStruct.Host, updateURLStruct.Host, 1)
+		finalGraphURL = strings.Replace(finalGraphURL, originalURLStruct.Scheme, updateURLStruct.Scheme, 1)
+	}
+	return finalGraphURL, nil
 }

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/new.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/new.go
@@ -15,8 +15,7 @@ func New(log clog.PluggableLoggerInterface,
 	mirror mirror.MirrorInterface,
 	manifest manifest.ManifestInterface,
 	cincinnati CincinnatiInterface,
-	localStorageFQDN string,
 	imageBuilder imagebuilder.ImageBuilderInterface,
 ) CollectorInterface {
-	return &LocalStorageCollector{Log: log, LogsDir: logsDir, Config: config, Opts: opts, Mirror: mirror, Manifest: manifest, Cincinnati: cincinnati, LocalStorageFQDN: localStorageFQDN, ImageBuilder: imageBuilder}
+	return &LocalStorageCollector{Log: log, LogsDir: logsDir, Config: config, Opts: opts, Mirror: mirror, Manifest: manifest, Cincinnati: cincinnati, LocalStorageFQDN: opts.LocalStorageFQDN, ImageBuilder: imageBuilder}
 }


### PR DESCRIPTION
# Description

When running oc-mirror v2 techPreview in mirror to disk mode in an air gapped environment, oc-mirror cannot reach api.openshift.com to download graph.tar.gz. This caused the mirroring to fail.
With this fix, and only for the context of air gapped environments (ie UPDATE_URL_OVERRIDE environment variable is defined) oc-mirror attempts to find the graph image in the oc-mirror cache instead, and skips the graph image (without failing) if the graph image isn't found. 

Fixes # [OCPBUGS-38037](https://issues.redhat.com/browse/OCPBUGS-38037)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit test.
Automated E2E test

## Expected Outcome
Unit tests & E2E tests pass.