### PR TITLE
OCPBUGS-35824: Log warning UPDATE_URL_OVERRIDE correctly

### DIFF
--- a/v2/internal/pkg/cli/delete.go
+++ b/v2/internal/pkg/cli/delete.go
@@ -249,7 +249,7 @@ func (o *ExecutorSchema) CompleteDelete(args []string) error {
 		return err
 	}
 
-	client, _ := release.NewOCPClient(uuid.New())
+	client, _ := release.NewOCPClient(uuid.New(), o.Log)
 	signature := release.NewSignatureClient(o.Log, o.Config, *o.Opts)
 	cn := release.NewCincinnati(o.Log, &o.Config, *o.Opts, client, false, signature)
 	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.ImageBuilder)

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -416,7 +416,7 @@ func (o *ExecutorSchema) Complete(args []string) error {
 		return err
 	}
 
-	client, _ := release.NewOCPClient(uuid.New())
+	client, _ := release.NewOCPClient(uuid.New(), o.Log)
 
 	o.ImageBuilder = imagebuilder.NewBuilder(o.Log, *o.Opts)
 

--- a/v2/internal/pkg/release/cincinnati.go
+++ b/v2/internal/pkg/release/cincinnati.go
@@ -96,7 +96,7 @@ func NewCincinnati(log clog.PluggableLoggerInterface, config *v2alpha1.ImageSetC
 }
 
 func (o *CincinnatiSchema) NewOCPClient() error {
-	client, err := NewOCPClient(uuid.New())
+	client, err := NewOCPClient(uuid.New(), o.Log)
 	o.Client = client
 	return err
 }

--- a/v2/internal/pkg/release/cincinnati_test.go
+++ b/v2/internal/pkg/release/cincinnati_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
 	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
-	_ "k8s.io/klog/v2" // integration tests set glog flags.
 )
 
 type mockSignature struct {

--- a/v2/internal/pkg/release/client.go
+++ b/v2/internal/pkg/release/client.go
@@ -8,7 +8,8 @@ import (
 	"os"
 
 	"github.com/google/uuid"
-	"k8s.io/klog/v2"
+
+	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
 )
 
 var (
@@ -38,10 +39,10 @@ type okdClient struct {
 }
 
 // NewOCPClient creates a new OCP Cincinnati client with the given client identifier.
-func NewOCPClient(id uuid.UUID) (Client, error) {
+func NewOCPClient(id uuid.UUID, log clog.PluggableLoggerInterface) (Client, error) {
 	var updateGraphURL string
 	if updateURLOverride := os.Getenv("UPDATE_URL_OVERRIDE"); len(updateURLOverride) != 0 {
-		klog.Info("Usage of the UPDATE_URL_OVERRIDE environment variable is unsupported")
+		log.Info("Using the UPDATE_URL_OVERRIDE environment variable")
 		updateGraphURL = updateURLOverride
 	} else {
 		updateGraphURL = UpdateURL

--- a/v2/internal/pkg/release/client_test.go
+++ b/v2/internal/pkg/release/client_test.go
@@ -6,13 +6,15 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+
+	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
 )
 
 func TestOCPClient(t *testing.T) {
 	id := uuid.MustParse("01234567-0123-0123-0123-0123456789ab")
 	updateAPI, err := url.Parse(UpdateURL)
 	require.NoError(t, err)
-	client, err := NewOCPClient(id)
+	client, err := NewOCPClient(id, clog.New("trace"))
 	require.NoError(t, err)
 	expID := id
 	expURL := *updateAPI
@@ -48,7 +50,7 @@ func TestOCPClientWithOveride(t *testing.T) {
 	id := uuid.MustParse("01234567-0123-0123-0123-0123456789ab")
 	//updateAPI, err := url.Parse(UpdateURL)
 	//require.NoError(t, err)
-	client, err := NewOCPClient(id)
+	client, err := NewOCPClient(id, clog.New("trace"))
 	require.NoError(t, err)
 	expID := id
 	//expURL := *updateAPI

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/delete.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/delete.go
@@ -249,7 +249,7 @@ func (o *ExecutorSchema) CompleteDelete(args []string) error {
 		return err
 	}
 
-	client, _ := release.NewOCPClient(uuid.New())
+	client, _ := release.NewOCPClient(uuid.New(), o.Log)
 	signature := release.NewSignatureClient(o.Log, o.Config, *o.Opts)
 	cn := release.NewCincinnati(o.Log, &o.Config, *o.Opts, client, false, signature)
 	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.ImageBuilder)

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
@@ -416,7 +416,7 @@ func (o *ExecutorSchema) Complete(args []string) error {
 		return err
 	}
 
-	client, _ := release.NewOCPClient(uuid.New())
+	client, _ := release.NewOCPClient(uuid.New(), o.Log)
 
 	o.ImageBuilder = imagebuilder.NewBuilder(o.Log, *o.Opts)
 

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/cincinnati.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/cincinnati.go
@@ -96,7 +96,7 @@ func NewCincinnati(log clog.PluggableLoggerInterface, config *v2alpha1.ImageSetC
 }
 
 func (o *CincinnatiSchema) NewOCPClient() error {
-	client, err := NewOCPClient(uuid.New())
+	client, err := NewOCPClient(uuid.New(), o.Log)
 	o.Client = client
 	return err
 }

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/client.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/client.go
@@ -8,7 +8,8 @@ import (
 	"os"
 
 	"github.com/google/uuid"
-	"k8s.io/klog/v2"
+
+	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
 )
 
 var (
@@ -38,10 +39,10 @@ type okdClient struct {
 }
 
 // NewOCPClient creates a new OCP Cincinnati client with the given client identifier.
-func NewOCPClient(id uuid.UUID) (Client, error) {
+func NewOCPClient(id uuid.UUID, log clog.PluggableLoggerInterface) (Client, error) {
 	var updateGraphURL string
 	if updateURLOverride := os.Getenv("UPDATE_URL_OVERRIDE"); len(updateURLOverride) != 0 {
-		klog.Info("Usage of the UPDATE_URL_OVERRIDE environment variable is unsupported")
+		log.Info("Using the UPDATE_URL_OVERRIDE environment variable")
 		updateGraphURL = updateURLOverride
 	} else {
 		updateGraphURL = UpdateURL


### PR DESCRIPTION
# Description

This uses the v2 logger instead of klog for logging things during cincinnati processing of release collection

Fixes # [OCPBUGS-35824](https://issues.redhat.com/browse/OCPBUGS-35824)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
```
export UPDATE_URL_OVERRIDE=https://localhost.localdomain:3443/graph
go run test/e2e/graph/main.go & 
./bin/oc-mirror --v2 -c ec2-demo/isc_resources.yaml file:///home/skhoury/demo
```
with an imagesetconfig requesting  mirroring of 4.15.17 release

## Expected Outcome
Successful mirroring with logs:
```

2024/08/08 11:58:08  [WARN]   : ⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.
2024/08/08 11:58:08  [INFO]   : 👋 Hello, welcome to oc-mirror
2024/08/08 11:58:08  [INFO]   : ⚙️  setting up the environment for you...
2024/08/08 11:58:08  [INFO]   : 🔀 workflow mode: mirrorToDisk 
2024/08/08 11:58:08  [INFO]   : Usage of the UPDATE_URL_OVERRIDE environment variable is unsupported
2024/08/08 11:58:08  [INFO]   : 🕵️  going to discover the necessary images...
2024/08/08 11:58:08  [INFO]   : 🔍 collecting release images...
2024/08/08 11:58:08  [INFO]   : Usage of the UPDATE_URL_OVERRIDE environment variable is unsupported
2024/08/08 11:58:15  [INFO]   : 🔍 collecting operator images...
```