### PR TITLE
[v2] OCPBUGS-38396: use platform.release when set

### DIFF
--- a/v2/internal/pkg/release/cincinnati.go
+++ b/v2/internal/pkg/release/cincinnati.go
@@ -110,12 +110,24 @@ func (o *CincinnatiSchema) NewOKDClient() error {
 func (o *CincinnatiSchema) GetReleaseReferenceImages(ctx context.Context) []v2alpha1.CopyImageSchema {
 	cincinnatiParams := CincinnatiParams{GraphDataDir: filepath.Join(o.Opts.Global.WorkingDir, releaseImageExtractDir, cincinnatiGraphDataDir)}
 
-	filterCopy := o.Config.Mirror.Platform.DeepCopy()
 	var (
 		allImages  []v2alpha1.CopyImageSchema
 		errs       = []error{}
 		flagReport = false
 	)
+
+	// before making a deep copy
+	// check that the "platform.release" field is not empty
+	if len(o.Config.Mirror.Platform.Release) > 0 {
+		copyImage := v2alpha1.CopyImageSchema{
+			Source:      o.Config.Mirror.Platform.Release,
+			Destination: "",
+		}
+		allImages = append(allImages, copyImage)
+		return allImages
+	}
+
+	filterCopy := o.Config.Mirror.Platform.DeepCopy()
 
 	for _, arch := range filterCopy.Architectures {
 		cincinnatiParams.Arch = arch

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/cincinnati.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/release/cincinnati.go
@@ -110,12 +110,24 @@ func (o *CincinnatiSchema) NewOKDClient() error {
 func (o *CincinnatiSchema) GetReleaseReferenceImages(ctx context.Context) []v2alpha1.CopyImageSchema {
 	cincinnatiParams := CincinnatiParams{GraphDataDir: filepath.Join(o.Opts.Global.WorkingDir, releaseImageExtractDir, cincinnatiGraphDataDir)}
 
-	filterCopy := o.Config.Mirror.Platform.DeepCopy()
 	var (
 		allImages  []v2alpha1.CopyImageSchema
 		errs       = []error{}
 		flagReport = false
 	)
+
+	// before making a deep copy
+	// check that the "platform.release" field is not empty
+	if len(o.Config.Mirror.Platform.Release) > 0 {
+		copyImage := v2alpha1.CopyImageSchema{
+			Source:      o.Config.Mirror.Platform.Release,
+			Destination: "",
+		}
+		allImages = append(allImages, copyImage)
+		return allImages
+	}
+
+	filterCopy := o.Config.Mirror.Platform.DeepCopy()
 
 	for _, arch := range filterCopy.Architectures {
 		cincinnatiParams.Arch = arch


### PR DESCRIPTION
# Description

When using oc-mirror v2 with the kubeVirtContainer field (set to true), it calls the cincinnati api and uses the channels (name) with min/max version to downlaod the correct platform release, however in a CI/CD pipeline (pre prod) e2e testing of oc-mirror with channels, the version under test has not been productized and pushed, meaning it will never be picked up via the cincinnati api.

Fixes # OCPBUGS-38396

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally with the following imagesetconfig

```
apiVersion: mirror.openshift.io/v2alpha1
kind: ImageSetConfiguration
mirror:
  platform:
    graph: true
    release: quay.io/openshift-release-dev/ocp-release:4.17.0-ec.3-x86_64 
    kubeVirtContainer: true

```

Use the following command line

```
bin/oc-mirror --config kube-virt.yaml file://test-kubevirt  --v2

```

## Expected Outcome

The console (truncated) should pick up the kubevirt container in the release

```2024/08/13 08:30:12  [WARN]   : ⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.
2024/08/13 08:30:12  [INFO]   : 👋 Hello, welcome to oc-mirror
2024/08/13 08:30:12  [INFO]   : ⚙️  setting up the environment for you...
2024/08/13 08:30:12  [INFO]   : 🔀 workflow mode: mirrorToDisk 
2024/08/13 08:30:12  [INFO]   : 🕵️  going to discover the necessary images...
2024/08/13 08:30:12  [INFO]   : 🔍 collecting release images...
2024/08/13 08:30:12  [INFO]   : kubeVirtContainer set to true [ including : quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:95c3e3bf743804862a8f77f7060b3fb1389bcb9e18770d434a1db70a3e93d662 ]
2024/08/13 08:30:19  [INFO]   : 🔍 collecting operator images...
2024/08/13 08:30:19  [INFO]   : 🔍 collecting additional images...
2024/08/13 08:30:19  [INFO]   : 🚀 Start copying the images...
2024/08/13 08:30:19  [INFO]   : images to copy 190 
 ⠼   1/190 : (4s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8783e433620dc3613965e8f6237b6f85311a77a20fffbc2ad5ac23795a6d8e9a 
 ⠼   2/190 : (4s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e0482e40a461966c6e1c3d60533e3d444ca11c37f070df928a247f55bdfd690b 
 ⠼   3/190 : (4s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:caf56ff6fae7ef0044b4532547172db2dc17d7c9de05cbece5d1a92c235f4ed8 
 ⠼   4/190 : (4s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9bbf3cbd282cb95b5d75dc3b978740209f2e6bb5be4aa2975e985d50d4038545 
 ⠼   5/190 : (4s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:348225d8c9561ef1474259a92c041b80f27d98fac448e2ff1eada9564f86a3f4 
 ⠼   6/190 : (4s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4437db2b8e708c547eb23f996e303433cd93db205149674d19e0f7190b769d7c 
 ⠼   7/190 : (4s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2d1ea8dc4685364f5f692499bac8fd615eb87b290c14dc4de97a52daf6378b59 
 ⠼   8/190 : (4s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:64b2b932982514cee04579c99a761e5bf69c21f49b6240d989031fad699b892f

```
