### PR TITLE
OCPBUGS-37740: Should not panic when invalid log-level flag is used

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -213,7 +213,7 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 	cmd.AddCommand(version.NewVersionCommand(log))
 	cmd.AddCommand(NewDeleteCommand(log))
 	cmd.PersistentFlags().StringVarP(&opts.Global.ConfigPath, "config", "c", "", "Path to imageset configuration file")
-	cmd.Flags().StringVar(&opts.Global.LogLevel, "loglevel", "info", "Log level one of (info, debug, trace, error)")
+	cmd.Flags().StringVar(&opts.Global.LogLevel, "log-level", "info", "Log level one of (info, debug, trace, error)")
 	cmd.Flags().StringVar(&opts.Global.WorkingDir, "workspace", "", "oc-mirror workspace where resources and internal artifacts are generated")
 	cmd.Flags().StringVar(&opts.Global.From, "from", "", "Local storage directory for disk to mirror workflow")
 	cmd.Flags().Uint16VarP(&opts.Global.Port, "port", "p", 55000, "HTTP port used by oc-mirror's local storage instance")
@@ -313,6 +313,9 @@ func (o ExecutorSchema) Validate(dest []string) error {
 	}
 	if o.Opts.MaxParallelDownloads > 64 {
 		o.Log.Warn("⚠️ --max-parallel-downloads set to %d: %d > %d. Flag ignored. Setting max-parallel-downloads = %d", o.Opts.MaxParallelDownloads, o.Opts.MaxParallelDownloads, limitOverallParallelDownloads, limitOverallParallelDownloads)
+	}
+	if !slices.Contains([]string{"info", "debug", "trace"}, o.Opts.Global.LogLevel) {
+		return fmt.Errorf("log-level has an invalid value %s , it should be one of (info,debug,trace)", o.Opts.Global.LogLevel)
 	}
 	if strings.Contains(dest[0], fileProtocol) || strings.Contains(dest[0], dockerProtocol) {
 		return nil

--- a/v2/internal/pkg/cli/executor_test.go
+++ b/v2/internal/pkg/cli/executor_test.go
@@ -446,6 +446,7 @@ func TestExecutorValidate(t *testing.T) {
 		warnArgs := []interface{}{uint(2), uint(2), uint(10), uint(10)}
 		log.On("Warn", "⚠️ --max-parallel-downloads set to %d: %d < %d. Flag ignored. Setting max-parallel-downloads = %d", warnArgs).Return(nil)
 
+		opts.Global.LogLevel = "info"
 		opts.Global.ConfigPath = "test"
 		opts.Global.From = "" //reset
 		opts.MaxParallelDownloads = 2
@@ -454,6 +455,7 @@ func TestExecutorValidate(t *testing.T) {
 		log.AssertExpectations(t)
 
 	})
+
 	t.Run("Testing Executor : maxParallelDownloads =20, validate should pass", func(t *testing.T) {
 		log := new(LogMock)
 
@@ -482,6 +484,7 @@ func TestExecutorValidate(t *testing.T) {
 			Opts:    opts,
 			LogsDir: "/tmp/",
 		}
+		opts.Global.LogLevel = "info"
 		opts.Global.ConfigPath = "test"
 		opts.Global.From = "" //reset
 		opts.MaxParallelDownloads = 20
@@ -520,6 +523,7 @@ func TestExecutorValidate(t *testing.T) {
 		warnArgs := []interface{}{uint(300), uint(300), uint(200), uint(200)}
 		log.On("Warn", "⚠️ --max-parallel-downloads set to %d: %d > %d. Flag ignored. Setting max-parallel-downloads = %d", warnArgs).Return(nil)
 
+		opts.Global.LogLevel = "info"
 		opts.Global.ConfigPath = "test"
 		opts.Global.From = "" //reset
 		opts.MaxParallelDownloads = 300
@@ -551,6 +555,7 @@ func TestExecutorValidate(t *testing.T) {
 			Dev:                 false,
 		}
 		opts.Global.ConfigPath = "test"
+		opts.Global.LogLevel = "info"
 
 		ex := &ExecutorSchema{
 			Log:     log,


### PR DESCRIPTION
# Description

This fix avoid oc-mirror v2 going into panic, when an invalid log-level flag is used.
**NB** The loglevel flag has been changed to log-level to comply with other tools such a Podman etc

Fixes # OCPBUGS-37740

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally , executing binary

## Expected Outcome

```
bin/oc-mirror --config simple.yaml file://test-lmz --v2 --log-level -v

2024/09/04 12:36:30  [WARN]   : ⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.
2024/09/04 12:36:30  [INFO]   : 👋 Hello, welcome to oc-mirror
2024/09/04 12:36:30  [INFO]   : ⚙️  setting up the environment for you...
2024/09/04 12:36:30  [ERROR]  : log-level has an invalid value -v , it should be one of (info,debug,trace)
```