### PR TITLE
OCPBUGS-41168: [release-4.17] Should not panic when specifying wrong …

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -314,6 +314,9 @@ func (o ExecutorSchema) Validate(dest []string) error {
 	if o.Opts.MaxParallelDownloads > 64 {
 		o.Log.Warn("⚠️ --max-parallel-downloads set to %d: %d > %d. Flag ignored. Setting max-parallel-downloads = %d", o.Opts.MaxParallelDownloads, o.Opts.MaxParallelDownloads, limitOverallParallelDownloads, limitOverallParallelDownloads)
 	}
+	if !slices.Contains([]string{"info", "debug", "trace"}, o.Opts.Global.LogLevel) {
+		return fmt.Errorf("loglevel has an invalid value %s , it should be one of (info,debug,trace)", o.Opts.Global.LogLevel)
+	}
 	if strings.Contains(dest[0], fileProtocol) || strings.Contains(dest[0], dockerProtocol) {
 		return nil
 	} else {

--- a/v2/internal/pkg/cli/executor_test.go
+++ b/v2/internal/pkg/cli/executor_test.go
@@ -446,6 +446,7 @@ func TestExecutorValidate(t *testing.T) {
 		warnArgs := []interface{}{uint(2), uint(2), uint(10), uint(10)}
 		log.On("Warn", "⚠️ --max-parallel-downloads set to %d: %d < %d. Flag ignored. Setting max-parallel-downloads = %d", warnArgs).Return(nil)
 
+		opts.Global.LogLevel = "info"
 		opts.Global.ConfigPath = "test"
 		opts.Global.From = "" //reset
 		opts.MaxParallelDownloads = 2
@@ -482,6 +483,8 @@ func TestExecutorValidate(t *testing.T) {
 			Opts:    opts,
 			LogsDir: "/tmp/",
 		}
+
+		opts.Global.LogLevel = "info"
 		opts.Global.ConfigPath = "test"
 		opts.Global.From = "" //reset
 		opts.MaxParallelDownloads = 20
@@ -520,6 +523,7 @@ func TestExecutorValidate(t *testing.T) {
 		warnArgs := []interface{}{uint(300), uint(300), uint(200), uint(200)}
 		log.On("Warn", "⚠️ --max-parallel-downloads set to %d: %d > %d. Flag ignored. Setting max-parallel-downloads = %d", warnArgs).Return(nil)
 
+		opts.Global.LogLevel = "info"
 		opts.Global.ConfigPath = "test"
 		opts.Global.From = "" //reset
 		opts.MaxParallelDownloads = 300
@@ -551,6 +555,7 @@ func TestExecutorValidate(t *testing.T) {
 			Dev:                 false,
 		}
 		opts.Global.ConfigPath = "test"
+		opts.Global.LogLevel = "info"
 
 		ex := &ExecutorSchema{
 			Log:     log,

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
@@ -314,6 +314,9 @@ func (o ExecutorSchema) Validate(dest []string) error {
 	if o.Opts.MaxParallelDownloads > 64 {
 		o.Log.Warn("⚠️ --max-parallel-downloads set to %d: %d > %d. Flag ignored. Setting max-parallel-downloads = %d", o.Opts.MaxParallelDownloads, o.Opts.MaxParallelDownloads, limitOverallParallelDownloads, limitOverallParallelDownloads)
 	}
+	if !slices.Contains([]string{"info", "debug", "trace"}, o.Opts.Global.LogLevel) {
+		return fmt.Errorf("loglevel has an invalid value %s , it should be one of (info,debug,trace)", o.Opts.Global.LogLevel)
+	}
 	if strings.Contains(dest[0], fileProtocol) || strings.Contains(dest[0], dockerProtocol) {
 		return nil
 	} else {


### PR DESCRIPTION
…loglevel for oc-mirror

# Description

This fix avoids oc-mirror v2 going into panic, when an invalid log-level flag is used.


Fixes # OCPBUGS-41168

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally , executing binary

## Expected Outcome

```
bin/oc-mirror --config simple.yaml file://test-lmz --v2 --log-level -v

2024/09/04 12:36:30  [WARN]   : ⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.
2024/09/04 12:36:30  [INFO]   : 👋 Hello, welcome to oc-mirror
2024/09/04 12:36:30  [INFO]   : ⚙️  setting up the environment for you...
2024/09/04 12:36:30  [ERROR]  : loglevel has an invalid value -v , it should be one of (info,debug,trace)
```