### PR TITLE
OCPBUGS-37948,CLID-196: Fix deletion of operators mirrored in M2M

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -760,6 +760,12 @@ func (o *ExecutorSchema) RunMirrorToDisk(cmd *cobra.Command, args []string) erro
 func (o *ExecutorSchema) RunMirrorToMirror(cmd *cobra.Command, args []string) error {
 	startTime := time.Now()
 	var batchError error
+
+	// OCPBUGS-37948 + CLID-196: local cache should be started during mirror to mirror as well:
+	// All operator catalogs will be cached.
+	o.Log.Debug(startMessage, o.Opts.Global.Port)
+	go startLocalRegistry(&o.LocalStorageService, o.localStorageInterruptChannel)
+
 	collectorSchema, err := o.CollectAll(cmd.Context())
 	if err != nil {
 		return err

--- a/v2/internal/pkg/cli/executor_test.go
+++ b/v2/internal/pkg/cli/executor_test.go
@@ -287,6 +287,18 @@ func TestRunMirrorToMirror(t *testing.T) {
 	_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 	_, retryOpts := mirror.RetryFlags()
 
+	// storage cache for test
+	regCfg, err := setupRegForTest(testFolder)
+	if err != nil {
+		t.Errorf("storage cache error: %v ", err)
+	}
+	reg, err := registry.NewRegistry(context.Background(), regCfg)
+	if err != nil {
+		t.Errorf("storage cache error: %v ", err)
+	}
+	fakeStorageInterruptChan := make(chan error)
+	go skipSignalsToInterruptStorage(fakeStorageInterruptChan)
+
 	opts := &mirror.CopyOptions{
 		Global:              global,
 		DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
@@ -296,6 +308,7 @@ func TestRunMirrorToMirror(t *testing.T) {
 		Dev:                 false,
 		Mode:                mirror.MirrorToMirror,
 		Destination:         "docker://test",
+		LocalStorageFQDN:    regCfg.HTTP.Addr,
 	}
 
 	// read the ImageSetConfiguration
@@ -322,17 +335,18 @@ func TestRunMirrorToMirror(t *testing.T) {
 		cr := MockClusterResources{}
 
 		ex := &ExecutorSchema{
-			Log:              log,
-			Config:           cfg,
-			Opts:             opts,
-			Operator:         collector,
-			Release:          collector,
-			AdditionalImages: collector,
-			Mirror:           Mirror{},
-			Batch:            batch,
-			MakeDir:          MakeDir{},
-			LogsDir:          "/tmp/",
-			ClusterResources: cr,
+			Log:                 log,
+			Config:              cfg,
+			Opts:                opts,
+			Operator:            collector,
+			Release:             collector,
+			AdditionalImages:    collector,
+			Mirror:              Mirror{},
+			Batch:               batch,
+			MakeDir:             MakeDir{},
+			LogsDir:             "/tmp/",
+			ClusterResources:    cr,
+			LocalStorageService: *reg,
 		}
 
 		res := &cobra.Command{}
@@ -352,16 +366,17 @@ func TestRunMirrorToMirror(t *testing.T) {
 		cr := MockClusterResources{}
 
 		ex := &ExecutorSchema{
-			Log:              log,
-			Config:           cfg,
-			Opts:             opts,
-			Operator:         collector,
-			Release:          collector,
-			AdditionalImages: collector,
-			Batch:            batch,
-			MakeDir:          MakeDir{},
-			LogsDir:          "/tmp/",
-			ClusterResources: cr,
+			Log:                 log,
+			Config:              cfg,
+			Opts:                opts,
+			Operator:            collector,
+			Release:             collector,
+			AdditionalImages:    collector,
+			Batch:               batch,
+			MakeDir:             MakeDir{},
+			LogsDir:             "/tmp/",
+			ClusterResources:    cr,
+			LocalStorageService: *reg,
 		}
 
 		res := &cobra.Command{}
@@ -382,16 +397,17 @@ func TestRunMirrorToMirror(t *testing.T) {
 		cr := MockClusterResources{}
 
 		ex := &ExecutorSchema{
-			Log:              log,
-			Config:           cfg,
-			Opts:             opts,
-			Operator:         collector,
-			Release:          collector,
-			AdditionalImages: collector,
-			Batch:            batch,
-			MakeDir:          MakeDir{},
-			LogsDir:          "/tmp/",
-			ClusterResources: cr,
+			Log:                 log,
+			Config:              cfg,
+			Opts:                opts,
+			Operator:            collector,
+			Release:             collector,
+			AdditionalImages:    collector,
+			Batch:               batch,
+			MakeDir:             MakeDir{},
+			LogsDir:             "/tmp/",
+			ClusterResources:    cr,
+			LocalStorageService: *reg,
 		}
 
 		res := &cobra.Command{}

--- a/v2/internal/pkg/operator/local_stored_collector.go
+++ b/v2/internal/pkg/operator/local_stored_collector.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/image"
@@ -352,6 +353,10 @@ func (o LocalStorageCollector) catalogDigest(ctx context.Context, catalog v2alph
 	if err != nil {
 		return "", err
 	}
+	// OCPBUGS-37948 : No TLS verification when getting manifests from the cache registry
+	if strings.Contains(src, o.Opts.LocalStorageFQDN) { // when copying from cache, use HTTP
+		sourceCtx.DockerInsecureSkipTLSVerify = types.OptionalBoolTrue
+	}
 
 	catalogDigest, err := o.Manifest.GetDigest(ctx, sourceCtx, imgSpec.ReferenceWithTransport)
 	if err != nil {
@@ -471,6 +476,13 @@ func (o LocalStorageCollector) prepareM2DCopyBatch(images map[string][]v2alpha1.
 
 			if _, found := alreadyIncluded[img.Image]; !found {
 				result = append(result, v2alpha1.CopyImageSchema{Source: src, Destination: dest, Origin: imgSpec.ReferenceWithTransport, Type: img.Type})
+				// OCPBUGS-37948 + CLID-196
+				// Keep a copy of the catalog image in local cache for delete workflow
+				if img.Type == v2alpha1.TypeOperatorCatalog && o.Opts.Mode == mirror.MirrorToMirror {
+					cacheDest := strings.Replace(dest, o.destinationRegistry(), o.LocalStorageFQDN, 1)
+					result = append(result, v2alpha1.CopyImageSchema{Source: src, Destination: cacheDest, Origin: imgSpec.ReferenceWithTransport, Type: img.Type})
+
+				}
 				alreadyIncluded[img.Image] = struct{}{}
 			}
 


### PR DESCRIPTION
# Description
## Bug analysis
Delete feature simulates a DiskToMirror mode for operator collector.

Since the catalogs are saved in the working-dir under a folder whose name corresponds to the catalog digest, the collector first tries to translate the catalog tag into a digest.
For doing so, it assumes that the catalog is in the local cache. It also assumes the local cache is TLS enabled ([OCPBUGS-37948](https://issues.redhat.com/browse/OCPBUGS-37948)).

For catalogs mirrored in MirrorToMirror, catalog images will not exist in the local cache: Failing to determine the catalog digest from the catalog tag leads to failure in collecting images from catalog. The detele-images.yaml file is therefore empty.

## Fix
 
The fix consists in 3 actions:
* Startup the cache registry during mirror to mirror workflow
* During operator collection, when trying to get `catalogDigest` by getting the manifest of the catalog image by tag from the local cache, use TLSVerification=false
* During the operator collection, in case of mirror to mirror workflow, copy the catalog image twice: once to the final destination, and once to the local cache. This way it stays available for use by the delete workflow.
* 
Fixes [OCPBUGS-37948](https://issues.redhat.com/browse/OCPBUGS-37948) and [CLID-196](https://issues.redhat.com/browse/CLID-196)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

With the following imagesetConfig, perform a mirror to mirror:
```bash
cat isc_196.yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
  - catalog: quay.io/skhoury/demo/redhat/redhat-operator-index:diet
    packages:
    - name: aws-load-balancer-operator
$ ./bin/oc-mirror --v2 -c configs_logs/isc_196.yaml docker://sherinefedora:5000/clid196 --workspace file:///home/skhoury/clid-196
```

Next, perform a delete generate:
```bash
$ cat disc_196.yaml
kind: DeleteImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
delete:
  operators:
  - catalog: quay.io/skhoury/demo/redhat/redhat-operator-index:diet
    packages:
    - name: aws-load-balancer-operator
$ ./bin/oc-mirror delete --v2 -c configs_logs/disc_196.yaml docker://sherinefedora:5000/clid1962 --workspace file:///ho
me/skhoury/clid-196 --generate --delete-id clid196
```

## Expected Outcome
Delete generation should be successful. The following file is expected:
```
$ more /home/skhoury/clid-196/working-dir/delete/delete-images-clid196.yaml 
apiVersion: mirror.openshift.io/v2alpha1
items:
- imageName: docker://registry.redhat.io/albo/aws-load-balancer-controller-rhel8@sha256:2e0b9332a44d8d9c23e19c7accab0813a651f3921
0257820db508cac28876595
  imageReference: docker://sherinefedora:5000/clid1962/albo/aws-load-balancer-controller-rhel8:2e0b9332a44d8d9c23e19c7accab0813a6
51f39210257820db508cac28876595
- imageName: docker://registry.redhat.io/albo/aws-load-balancer-operator-bundle@sha256:01f2ca529d2486f113bcefc9fedce6a6fd07bcb48a
af534394b5b04c353f8853
  imageReference: docker://sherinefedora:5000/clid1962/albo/aws-load-balancer-operator-bundle:01f2ca529d2486f113bcefc9fedce6a6fd0
7bcb48aaf534394b5b04c353f8853
kind: DeleteImageList
$ ./bin/oc-mirror delete --v2 --delete-yaml-file /home/skhoury/clid-196/working-dir/delete/delete-images-clid196.yaml docker://sherinefedora:5000/clid1962
2024/09/05 14:43:12  [WARN]   : ⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.
2024/09/05 14:43:12  [INFO]   : 👋 Hello, welcome to oc-mirror
2024/09/05 14:43:12  [INFO]   : ⚙️  setting up the environment for you...
2024/09/05 14:43:12  [INFO]   : 🔀 workflow mode: diskToMirror / delete
2024/09/05 14:43:13  [INFO]   : 👀 Reading delete file...
2024/09/05 14:43:13  [INFO]   : 🚀 Start deleting the images...
2024/09/05 14:43:13  [INFO]   : === Overall Progress -  image 1 / 2 ===
2024/09/05 14:43:13  [INFO]   :  image: docker://registry.redhat.io/albo/aws-load-balancer-controller-rhel8@sha256:2e0b9332a44d8d9c23e19c7accab0813a651f39210257820db508cac28876595
2024/09/05 14:43:13  [INFO]   : =======================================
2024/09/05 14:43:13  [INFO]   : === Overall Progress -  image 2 / 2 ===
2024/09/05 14:43:13  [INFO]   :  image: docker://registry.redhat.io/albo/aws-load-balancer-operator-bundle@sha256:01f2ca529d2486f113bcefc9fedce6a6fd07bcb48aaf534394b5b04c353f8853
2024/09/05 14:43:13  [INFO]   : =======================================
2024/09/05 14:43:13  [INFO]   : === Results ===
2024/09/05 14:43:13  [INFO]   : All images deleted successfully 2 / 2 ✅
2024/09/05 14:43:13  [INFO]   : delete time     : 22.266773ms
2024/09/05 14:43:13  [INFO]   : 📝 Remember to execute a garbage collect (or similar) on your remote repository
2024/09/05 14:43:13  [INFO]   : 👋 Goodbye, thank you for using oc-mirror
```

