### PR TITLE
OCPBUGS-41503: [release-4.17] oc-mirror throws error when performing delete operation with --generate

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -428,7 +428,7 @@ func (o *ExecutorSchema) Complete(args []string) error {
 	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.ImageBuilder)
 	o.Operator = operator.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest)
 	o.AdditionalImages = additional.New(o.Log, o.Config, *o.Opts, o.Mirror, o.Manifest)
-	o.ClusterResources = clusterresources.New(o.Log, o.Opts.Global.WorkingDir, o.Config)
+	o.ClusterResources = clusterresources.New(o.Log, o.Opts.Global.WorkingDir, o.Config, o.Opts.LocalStorageFQDN)
 	o.Batch = batch.NewConcurrentBatch(o.Log, o.LogsDir, o.Mirror, calculateMaxBatchSize(o.MaxParallelOverallDownloads, o.ParallelBatchImages))
 
 	if o.Opts.IsMirrorToDisk() {

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -760,6 +760,12 @@ func (o *ExecutorSchema) RunMirrorToDisk(cmd *cobra.Command, args []string) erro
 func (o *ExecutorSchema) RunMirrorToMirror(cmd *cobra.Command, args []string) error {
 	startTime := time.Now()
 	var batchError error
+
+	// OCPBUGS-37948 + CLID-196: local cache should be started during mirror to mirror as well:
+	// All operator catalogs will be cached.
+	o.Log.Debug(startMessage, o.Opts.Global.Port)
+	go startLocalRegistry(&o.LocalStorageService, o.localStorageInterruptChannel)
+
 	collectorSchema, err := o.CollectAll(cmd.Context())
 	if err != nil {
 		return err

--- a/v2/internal/pkg/cli/executor_test.go
+++ b/v2/internal/pkg/cli/executor_test.go
@@ -287,6 +287,18 @@ func TestRunMirrorToMirror(t *testing.T) {
 	_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 	_, retryOpts := mirror.RetryFlags()
 
+	// storage cache for test
+	regCfg, err := setupRegForTest(testFolder)
+	if err != nil {
+		t.Errorf("storage cache error: %v ", err)
+	}
+	reg, err := registry.NewRegistry(context.Background(), regCfg)
+	if err != nil {
+		t.Errorf("storage cache error: %v ", err)
+	}
+	fakeStorageInterruptChan := make(chan error)
+	go skipSignalsToInterruptStorage(fakeStorageInterruptChan)
+
 	opts := &mirror.CopyOptions{
 		Global:              global,
 		DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
@@ -296,6 +308,7 @@ func TestRunMirrorToMirror(t *testing.T) {
 		Dev:                 false,
 		Mode:                mirror.MirrorToMirror,
 		Destination:         "docker://test",
+		LocalStorageFQDN:    regCfg.HTTP.Addr,
 	}
 
 	// read the ImageSetConfiguration
@@ -322,17 +335,18 @@ func TestRunMirrorToMirror(t *testing.T) {
 		cr := MockClusterResources{}
 
 		ex := &ExecutorSchema{
-			Log:              log,
-			Config:           cfg,
-			Opts:             opts,
-			Operator:         collector,
-			Release:          collector,
-			AdditionalImages: collector,
-			Mirror:           Mirror{},
-			Batch:            batch,
-			MakeDir:          MakeDir{},
-			LogsDir:          "/tmp/",
-			ClusterResources: cr,
+			Log:                 log,
+			Config:              cfg,
+			Opts:                opts,
+			Operator:            collector,
+			Release:             collector,
+			AdditionalImages:    collector,
+			Mirror:              Mirror{},
+			Batch:               batch,
+			MakeDir:             MakeDir{},
+			LogsDir:             "/tmp/",
+			ClusterResources:    cr,
+			LocalStorageService: *reg,
 		}
 
 		res := &cobra.Command{}
@@ -352,16 +366,17 @@ func TestRunMirrorToMirror(t *testing.T) {
 		cr := MockClusterResources{}
 
 		ex := &ExecutorSchema{
-			Log:              log,
-			Config:           cfg,
-			Opts:             opts,
-			Operator:         collector,
-			Release:          collector,
-			AdditionalImages: collector,
-			Batch:            batch,
-			MakeDir:          MakeDir{},
-			LogsDir:          "/tmp/",
-			ClusterResources: cr,
+			Log:                 log,
+			Config:              cfg,
+			Opts:                opts,
+			Operator:            collector,
+			Release:             collector,
+			AdditionalImages:    collector,
+			Batch:               batch,
+			MakeDir:             MakeDir{},
+			LogsDir:             "/tmp/",
+			ClusterResources:    cr,
+			LocalStorageService: *reg,
 		}
 
 		res := &cobra.Command{}
@@ -382,16 +397,17 @@ func TestRunMirrorToMirror(t *testing.T) {
 		cr := MockClusterResources{}
 
 		ex := &ExecutorSchema{
-			Log:              log,
-			Config:           cfg,
-			Opts:             opts,
-			Operator:         collector,
-			Release:          collector,
-			AdditionalImages: collector,
-			Batch:            batch,
-			MakeDir:          MakeDir{},
-			LogsDir:          "/tmp/",
-			ClusterResources: cr,
+			Log:                 log,
+			Config:              cfg,
+			Opts:                opts,
+			Operator:            collector,
+			Release:             collector,
+			AdditionalImages:    collector,
+			Batch:               batch,
+			MakeDir:             MakeDir{},
+			LogsDir:             "/tmp/",
+			ClusterResources:    cr,
+			LocalStorageService: *reg,
 		}
 
 		res := &cobra.Command{}

--- a/v2/internal/pkg/clusterresources/clusterresources_test.go
+++ b/v2/internal/pkg/clusterresources/clusterresources_test.go
@@ -185,8 +185,9 @@ func TestIDMS_ITMSGenerator(t *testing.T) {
 
 			defer os.RemoveAll(tmpDir)
 			cr := &ClusterResourcesGenerator{
-				Log:        log,
-				WorkingDir: workingDir,
+				Log:              log,
+				WorkingDir:       workingDir,
+				LocalStorageFQDN: "localhost:55000",
 			}
 			err := cr.IDMS_ITMSGenerator(testCase.imgList, false)
 			if err != nil {
@@ -308,8 +309,9 @@ func TestGenerateIDMS(t *testing.T) {
 
 			defer os.RemoveAll(tmpDir)
 			cr := &ClusterResourcesGenerator{
-				Log:        log,
-				WorkingDir: workingDir,
+				Log:              log,
+				WorkingDir:       workingDir,
+				LocalStorageFQDN: "localhost:55000",
 			}
 			idmsList, err := cr.generateImageMirrors(testCase.imgList, DigestsOnlyMode, false)
 			if err != nil {
@@ -394,8 +396,9 @@ func TestGenerateITMS(t *testing.T) {
 
 			defer os.RemoveAll(tmpDir)
 			cr := &ClusterResourcesGenerator{
-				Log:        log,
-				WorkingDir: workingDir,
+				Log:              log,
+				WorkingDir:       workingDir,
+				LocalStorageFQDN: "localhost:55000",
 			}
 			itmsList, err := cr.generateImageMirrors(testCase.imgList, TagsOnlyMode, false)
 			if err != nil {
@@ -443,6 +446,12 @@ func TestCatalogSourceGenerator(t *testing.T) {
 			Origin:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.15",
 			Type:        v2alpha1.TypeOperatorCatalog,
 		},
+		{ // OCPBUGS-41608 - this should be skipped because it mirrors to the cache
+			Source:      "docker://localhost:5000/redhat/redhat-operator-index:v4.15",
+			Destination: "docker://localhost:55000/redhat/redhat-operator-index:v4.15",
+			Origin:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.15",
+			Type:        v2alpha1.TypeOperatorCatalog,
+		},
 		{
 			Source:      "docker://localhost:5000/kubebuilder/kube-rbac-proxy:v0.5.0",
 			Destination: "docker://myregistry/mynamespace/kubebuilder/kube-rbac-proxy:v0.5.0",
@@ -460,8 +469,9 @@ func TestCatalogSourceGenerator(t *testing.T) {
 	t.Run("Testing GenerateCatalogSource : should pass", func(t *testing.T) {
 
 		cr := &ClusterResourcesGenerator{
-			Log:        log,
-			WorkingDir: workingDir,
+			Log:              log,
+			WorkingDir:       workingDir,
+			LocalStorageFQDN: "localhost:55000",
 			Config: v2alpha1.ImageSetConfiguration{
 				ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
 					Mirror: v2alpha1.Mirror{
@@ -533,8 +543,9 @@ func TestCatalogSourceGenerator(t *testing.T) {
 	t.Run("Testing GenerateCatalogSource with template: should pass", func(t *testing.T) {
 
 		cr := &ClusterResourcesGenerator{
-			Log:        log,
-			WorkingDir: workingDir,
+			Log:              log,
+			WorkingDir:       workingDir,
+			LocalStorageFQDN: "localhost:55000",
 			Config: v2alpha1.ImageSetConfiguration{
 				ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
 					Mirror: v2alpha1.Mirror{
@@ -613,8 +624,9 @@ func TestCatalogSourceGenerator(t *testing.T) {
 
 	templateFailCases := []ClusterResourcesGenerator{
 		{
-			Log:        log,
-			WorkingDir: workingDir,
+			Log:              log,
+			WorkingDir:       workingDir,
+			LocalStorageFQDN: "localhost:55000",
 			Config: v2alpha1.ImageSetConfiguration{
 				ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
 					Mirror: v2alpha1.Mirror{
@@ -629,8 +641,9 @@ func TestCatalogSourceGenerator(t *testing.T) {
 			},
 		},
 		{
-			Log:        log,
-			WorkingDir: workingDir,
+			Log:              log,
+			WorkingDir:       workingDir,
+			LocalStorageFQDN: "localhost:55000",
 			Config: v2alpha1.ImageSetConfiguration{
 				ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
 					Mirror: v2alpha1.Mirror{
@@ -732,8 +745,9 @@ func TestCatalogSourceGenerator(t *testing.T) {
 			},
 		}
 		cr := &ClusterResourcesGenerator{
-			Log:        log,
-			WorkingDir: workingDir,
+			Log:              log,
+			WorkingDir:       workingDir,
+			LocalStorageFQDN: "localhost:55000",
 			Config: v2alpha1.ImageSetConfiguration{
 				ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
 					Mirror: v2alpha1.Mirror{
@@ -912,8 +926,9 @@ func TestGenerateImageMirrors(t *testing.T) {
 	}
 
 	cr := &ClusterResourcesGenerator{
-		Log:        clog.New("trace"),
-		WorkingDir: "",
+		Log:              clog.New("trace"),
+		WorkingDir:       "",
+		LocalStorageFQDN: "localhost:55000",
 	}
 	for _, test := range testCases {
 		t.Run(test.caseName, func(t *testing.T) {
@@ -954,8 +969,9 @@ func TestUpdateServiceGenerator(t *testing.T) {
 
 	t.Run("Testing IDMSGenerator - Disk to Mirror : should pass", func(t *testing.T) {
 		cr := &ClusterResourcesGenerator{
-			Log:        log,
-			WorkingDir: workingDir,
+			Log:              log,
+			WorkingDir:       workingDir,
+			LocalStorageFQDN: "localhost:55000",
 		}
 		err := cr.UpdateServiceGenerator(graphImage, releaseImage)
 		if err != nil {

--- a/v2/internal/pkg/operator/local_stored_collector_test.go
+++ b/v2/internal/pkg/operator/local_stored_collector_test.go
@@ -507,6 +507,117 @@ func TestOperatorLocalStoredCollectorD2M(t *testing.T) {
 
 }
 
+func TestOperatorLocalStoredCollectorM2M(t *testing.T) {
+	log := clog.New("trace")
+
+	tempDir := t.TempDir()
+	defer os.RemoveAll(tempDir)
+	type testCase struct {
+		caseName       string
+		config         v2alpha1.ImageSetConfiguration
+		expectedResult []v2alpha1.CopyImageSchema
+		expectedError  bool
+	}
+
+	ctx := context.Background()
+	os.RemoveAll(common.TestFolder + "hold-operator/")
+	os.RemoveAll(common.TestFolder + "operator-images")
+	os.RemoveAll(common.TestFolder + "tmp/")
+
+	//copy tests/hold-test-fake to working-dir
+	err := copy.Copy(common.TestFolder+"working-dir-fake/hold-operator/redhat-operator-index/v4.14", filepath.Join(tempDir, "working-dir", operatorImageExtractDir, "redhat-operator-index/f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"))
+	if err != nil {
+		t.Fatalf("should not fail")
+	}
+
+	testCases := []testCase{
+		{
+			caseName:      "OperatorImageCollector - Mirror to disk: should pass",
+			config:        nominalConfigM2D,
+			expectedError: false,
+			expectedResult: []v2alpha1.CopyImageSchema{
+				{
+					Source:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Type:        v2alpha1.TypeInvalid,
+				},
+				{
+					Source:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Type:        v2alpha1.TypeInvalid,
+				},
+				{
+					Source:      "docker://redhat-operators:v4.7",
+					Destination: "docker://localhost:5000/test/redhat-operators:v4.7",
+					Origin:      "docker://redhat-operators:v4.7",
+					Type:        v2alpha1.TypeOperatorCatalog,
+				},
+				{
+					Source:      "docker://certified-operators:v4.7",
+					Destination: "docker://localhost:5000/test/certified-operators:v4.7",
+					Origin:      "docker://certified-operators:v4.7",
+					Type:        v2alpha1.TypeOperatorCatalog,
+				},
+				{
+					Source:      "docker://community-operators:v4.7",
+					Destination: "docker://localhost:5000/test/community-operators:v4.7",
+					Origin:      "docker://community-operators:v4.7",
+					Type:        v2alpha1.TypeOperatorCatalog,
+				},
+				{
+					Source:      "oci://" + common.TestFolder + "simple-test-bundle",
+					Destination: "docker://localhost:5000/test/simple-test-bundle:latest",
+					Origin:      "oci://" + common.TestFolder + "simple-test-bundle",
+					Type:        v2alpha1.TypeOperatorCatalog,
+				},
+				{
+					Source:      "docker://redhat-operators:v4.7",
+					Destination: "docker://localhost:9999/redhat-operators:v4.7",
+					Origin:      "docker://redhat-operators:v4.7",
+					Type:        v2alpha1.TypeOperatorCatalog,
+				},
+				{
+					Source:      "docker://certified-operators:v4.7",
+					Destination: "docker://localhost:9999/certified-operators:v4.7",
+					Origin:      "docker://certified-operators:v4.7",
+					Type:        v2alpha1.TypeOperatorCatalog,
+				},
+				{
+					Source:      "docker://community-operators:v4.7",
+					Destination: "docker://localhost:9999/community-operators:v4.7",
+					Origin:      "docker://community-operators:v4.7",
+					Type:        v2alpha1.TypeOperatorCatalog,
+				},
+				{
+					Source:      "oci://" + common.TestFolder + "simple-test-bundle",
+					Destination: "docker://localhost:9999/simple-test-bundle:latest",
+					Origin:      "oci://" + common.TestFolder + "simple-test-bundle",
+					Type:        v2alpha1.TypeOperatorCatalog,
+				},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.caseName, func(t *testing.T) {
+			ex := setupCollector_MirrorToDisk(tempDir, log, &MockManifest{})
+			ex.Opts.Mode = mirror.MirrorToMirror
+			ex.Opts.Destination = "docker://localhost:5000/test"
+			ex = ex.withConfig(testCase.config)
+			res, err := ex.OperatorImageCollector(ctx)
+			if testCase.expectedError && err == nil {
+				t.Fatalf("should fail")
+			}
+			if !testCase.expectedError && err != nil {
+				t.Fatal("should not fail")
+			}
+			assert.ElementsMatch(t, testCase.expectedResult, res.AllImages)
+		})
+	}
+
+}
+
 func setupCollector_DiskToMirror(tempDir string, log clog.PluggableLoggerInterface) *LocalStorageCollector {
 	manifest := &MockManifest{Log: log}
 

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
@@ -428,7 +428,7 @@ func (o *ExecutorSchema) Complete(args []string) error {
 	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.ImageBuilder)
 	o.Operator = operator.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest)
 	o.AdditionalImages = additional.New(o.Log, o.Config, *o.Opts, o.Mirror, o.Manifest)
-	o.ClusterResources = clusterresources.New(o.Log, o.Opts.Global.WorkingDir, o.Config)
+	o.ClusterResources = clusterresources.New(o.Log, o.Opts.Global.WorkingDir, o.Config, o.Opts.LocalStorageFQDN)
 	o.Batch = batch.NewConcurrentBatch(o.Log, o.LogsDir, o.Mirror, calculateMaxBatchSize(o.MaxParallelOverallDownloads, o.ParallelBatchImages))
 
 	if o.Opts.IsMirrorToDisk() {

--- a/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
+++ b/vendor/github.com/openshift/oc-mirror/v2/internal/pkg/cli/executor.go
@@ -760,6 +760,12 @@ func (o *ExecutorSchema) RunMirrorToDisk(cmd *cobra.Command, args []string) erro
 func (o *ExecutorSchema) RunMirrorToMirror(cmd *cobra.Command, args []string) error {
 	startTime := time.Now()
 	var batchError error
+
+	// OCPBUGS-37948 + CLID-196: local cache should be started during mirror to mirror as well:
+	// All operator catalogs will be cached.
+	o.Log.Debug(startMessage, o.Opts.Global.Port)
+	go startLocalRegistry(&o.LocalStorageService, o.localStorageInterruptChannel)
+
 	collectorSchema, err := o.CollectAll(cmd.Context())
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description
This is a manual cherry-pick of #920 (OCPBUGS-37948) and #923(OCPBUGS-41608) for release 4.17

## Bug analysis
Delete feature simulates a DiskToMirror mode for operator collector.

Since the catalogs are saved in the working-dir under a folder whose name corresponds to the catalog digest, the collector first tries to translate the catalog tag into a digest.
For doing so, it assumes that the catalog is in the local cache. It also assumes the local cache is TLS enabled ([OCPBUGS-37948](https://issues.redhat.com/browse/OCPBUGS-37948)).

For catalogs mirrored in MirrorToMirror, catalog images will not exist in the local cache: Failing to determine the catalog digest from the catalog tag leads to failure in collecting images from catalog. The detele-images.yaml file is therefore empty.

## Fix
 
The fix consists in 3 actions:
* Startup the cache registry during mirror to mirror workflow
* During operator collection, when trying to get `catalogDigest` by getting the manifest of the catalog image by tag from the local cache, use TLSVerification=false
* During the operator collection, in case of mirror to mirror workflow, copy the catalog image twice: once to the final destination, and once to the local cache. This way it stays available for use by the delete workflow.
Fixes # OCPBUGS-41503, OCPBUGS-37948

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

With the following imagesetConfig, perform a mirror to mirror:
```bash
cat isc_196.yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
  - catalog: quay.io/skhoury/demo/redhat/redhat-operator-index:diet
    packages:
    - name: aws-load-balancer-operator
$ ./bin/oc-mirror --v2 -c configs_logs/isc_196.yaml docker://sherinefedora:5000/clid196 --workspace file:///home/skhoury/clid-196
```

Next, perform a delete generate:
```bash
$ cat disc_196.yaml
kind: DeleteImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
delete:
  operators:
  - catalog: quay.io/skhoury/demo/redhat/redhat-operator-index:diet
    packages:
    - name: aws-load-balancer-operator
$ ./bin/oc-mirror delete --v2 -c configs_logs/disc_196.yaml docker://sherinefedora:5000/clid1962 --workspace file:///ho
me/skhoury/clid-196 --generate --delete-id clid196
```

## Expected Outcome

Only 1 catalogsource file should be generated during mirror to mirror.
Delete generation should be successful. The following file is expected:
```
$ more /home/skhoury/clid-196/working-dir/delete/delete-images-clid196.yaml 
apiVersion: mirror.openshift.io/v2alpha1
items:
- imageName: docker://registry.redhat.io/albo/aws-load-balancer-controller-rhel8@sha256:2e0b9332a44d8d9c23e19c7accab0813a651f3921
0257820db508cac28876595
  imageReference: docker://sherinefedora:5000/clid1962/albo/aws-load-balancer-controller-rhel8:2e0b9332a44d8d9c23e19c7accab0813a6
51f39210257820db508cac28876595
- imageName: docker://registry.redhat.io/albo/aws-load-balancer-operator-bundle@sha256:01f2ca529d2486f113bcefc9fedce6a6fd07bcb48a
af534394b5b04c353f8853
  imageReference: docker://sherinefedora:5000/clid1962/albo/aws-load-balancer-operator-bundle:01f2ca529d2486f113bcefc9fedce6a6fd0
7bcb48aaf534394b5b04c353f8853
kind: DeleteImageList
$ ./bin/oc-mirror delete --v2 --delete-yaml-file /home/skhoury/clid-196/working-dir/delete/delete-images-clid196.yaml docker://sherinefedora:5000/clid1962
2024/09/05 14:43:12  [WARN]   : ⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.
2024/09/05 14:43:12  [INFO]   : 👋 Hello, welcome to oc-mirror
2024/09/05 14:43:12  [INFO]   : ⚙️  setting up the environment for you...
2024/09/05 14:43:12  [INFO]   : 🔀 workflow mode: diskToMirror / delete
2024/09/05 14:43:13  [INFO]   : 👀 Reading delete file...
2024/09/05 14:43:13  [INFO]   : 🚀 Start deleting the images...
2024/09/05 14:43:13  [INFO]   : === Overall Progress -  image 1 / 2 ===
2024/09/05 14:43:13  [INFO]   :  image: docker://registry.redhat.io/albo/aws-load-balancer-controller-rhel8@sha256:2e0b9332a44d8d9c23e19c7accab0813a651f39210257820db508cac28876595
2024/09/05 14:43:13  [INFO]   : =======================================
2024/09/05 14:43:13  [INFO]   : === Overall Progress -  image 2 / 2 ===
2024/09/05 14:43:13  [INFO]   :  image: docker://registry.redhat.io/albo/aws-load-balancer-operator-bundle@sha256:01f2ca529d2486f113bcefc9fedce6a6fd07bcb48aaf534394b5b04c353f8853
2024/09/05 14:43:13  [INFO]   : =======================================
2024/09/05 14:43:13  [INFO]   : === Results ===
2024/09/05 14:43:13  [INFO]   : All images deleted successfully 2 / 2 ✅
2024/09/05 14:43:13  [INFO]   : delete time     : 22.266773ms
2024/09/05 14:43:13  [INFO]   : 📝 Remember to execute a garbage collect (or similar) on your remote repository
2024/09/05 14:43:13  [INFO]   : 👋 Goodbye, thank you for using oc-mirror
```
