### PR TITLE
OCPBUGS-42416: Only generate release config map when releases are sp…

### DIFF
--- a/v2/internal/pkg/clusterresources/clusterresources.go
+++ b/v2/internal/pkg/clusterresources/clusterresources.go
@@ -609,7 +609,6 @@ func toRFC1035(r rune) rune {
 }
 
 func (o *ClusterResourcesGenerator) GenerateSignatureConfigMap(allRelatedImages []v2alpha1.CopyImageSchema) error {
-	o.Log.Info("📄 Generating Signature Configmap...")
 	// create and store config map
 	cm := &cm.ConfigMap{
 		TypeMeta: cm.TypeMeta{
@@ -631,11 +630,6 @@ func (o *ClusterResourcesGenerator) GenerateSignatureConfigMap(allRelatedImages 
 	if err != nil {
 		return fmt.Errorf(signatureConfigMapMsg, err)
 	}
-
-	if len(signatures) == 0 {
-		return fmt.Errorf(signatureConfigMapMsg, "signature files not found, could not generate signature configmap")
-	}
-
 	signatureFiles := make(map[string]string)
 	for _, f := range signatures {
 		if strings.Contains(f.Name(), "-sha256-") {
@@ -670,8 +664,9 @@ func (o *ClusterResourcesGenerator) GenerateSignatureConfigMap(allRelatedImages 
 	}
 
 	// pointless creating configmap if there were no BinaryData found
-	crPath := filepath.Join(o.WorkingDir, clusterResourcesDir)
 	if len(cm.BinaryData) > 0 {
+		crPath := filepath.Join(o.WorkingDir, clusterResourcesDir)
+		o.Log.Info("📄 Generating Signature Configmap...")
 		jsonData, err := json.Marshal(cm)
 		if err != nil {
 			return fmt.Errorf(signatureConfigMapMsg, err)
@@ -690,11 +685,9 @@ func (o *ClusterResourcesGenerator) GenerateSignatureConfigMap(allRelatedImages 
 		if ferr != nil {
 			return fmt.Errorf(signatureConfigMapMsg, ferr)
 		}
-	} else {
-		o.Log.Warn(signatureConfigMapMsg, "no binary data assigned, configmap file/s not created")
+		o.Log.Info("%s file created", crPath+"/signature-configmap.json")
+		o.Log.Info("%s file created", crPath+"/signature-configmap.yaml")
 	}
-	o.Log.Info("%s file created", crPath+"/signature-configmap.json")
-	o.Log.Info("%s file created", crPath+"/signature-configmap.yaml")
 
 	return nil
 }


### PR DESCRIPTION
…ecified

# Description

This bug fix addresses the issue when there is no platform (releases) specifed in the ImageSetConfig it should not attempt to generate the signature config map files.

Fixes # OCPBUGS-42416

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally

Use this ImageSetConfig to verify

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.16
    packages:
    - name: multiarch-tuning-operator
      minVersion: 0.9.0
      maxVersion: 0.9.0

```

Perform a mirror to disk workflow

Once completed perform a disk to mirror workflow


## Expected Outcome

No mention of  signature config map generation

```
2024/09/25 10:49:37  [WARN]   : ⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.
2024/09/25 10:49:37  [INFO]   : 👋 Hello, welcome to oc-mirror
2024/09/25 10:49:37  [INFO]   : ⚙️  setting up the environment for you...
2024/09/25 10:49:37  [INFO]   : 🔀 workflow mode: diskToMirror 
2024/09/25 10:49:43  [INFO]   : 🕵️  going to discover the necessary images...
2024/09/25 10:49:43  [INFO]   : 🔍 collecting release images...
2024/09/25 10:49:43  [INFO]   : 🔍 collecting operator images...
2024/09/25 10:49:52  [INFO]   : 🔍 collecting additional images...
2024/09/25 10:49:52  [INFO]   : 🚀 Start copying the images...
2024/09/25 10:49:52  [INFO]   : images to copy 4 
 ✓   1/4 : (0s) docker://gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1@sha256:d4883d7c622683b3319b5e6b3a7edfbf2594c18060131a8bf64504805f875522 
 ✓   2/4 : (0s) docker://registry.redhat.io/multiarch-tuning/multiarch-tuning-rhel9-operator@sha256:118500bb10296469335b260ba28fb67785d05b1f9d0aab7dbf1d1b243620ed8f 
 ✓   3/4 : (0s) docker://registry.redhat.io/multiarch-tuning/multiarch-tuning-operator-bundle@sha256:b7c0e2ac16ea027d5af85e3ee10556e2f4cb5cbda956e432b63030ba688262cb 
 ✓   4/4 : (1s) docker://registry.redhat.io/redhat/redhat-operator-index:v4.16 
2024/09/25 10:49:53  [INFO]   : === Results ===
2024/09/25 10:49:53  [INFO]   : ✅ 4 / 4 operator images mirrored successfully
2024/09/25 10:49:53  [INFO]   : 📄 Generating IDMS file...
2024/09/25 10:49:53  [INFO]   : ying/working-dir/cluster-resources/idms-oc-mirror.yaml file created
2024/09/25 10:49:53  [INFO]   : 📄 Generating ITMS file...
2024/09/25 10:49:53  [INFO]   : ying/working-dir/cluster-resources/itms-oc-mirror.yaml file created
2024/09/25 10:49:53  [INFO]   : 📄 Generating CatalogSource file...
2024/09/25 10:49:53  [INFO]   : ying/working-dir/cluster-resources/cs-redhat-operator-index-v4-16.yaml file created
2024/09/25 10:49:53  [INFO]   : mirror time     : 16.316465947s
2024/09/25 10:49:53  [INFO]   : 👋 Goodbye, thank you for using oc-mirror

```