### PR TITLE
OCPBUGS-42428: Fix duplication of binary data in signature config map

### DIFF
--- a/v2/internal/pkg/clusterresources/clusterresources.go
+++ b/v2/internal/pkg/clusterresources/clusterresources.go
@@ -654,11 +654,28 @@ func (o *ClusterResourcesGenerator) GenerateSignatureConfigMap(allRelatedImages 
 					o.Log.Warn("[GenerateSignatureConfigMap] release index image signature with tag %s : SKIPPED", imgSpec.Tag)
 					continue
 				}
-				// base64 encode data
-				b64 := base64.StdEncoding.EncodeToString(data)
-				index := fmt.Sprintf(configMapBinaryDataIndexFormat, strings.Split(file, "-sha256-")[1], id)
-				cm.BinaryData[index] = b64
-				id++
+				// check if we have an entry already
+				found := false
+				for k, _ := range cm.BinaryData {
+					search := strings.Split(k, "-")
+					if len(search) != 3 {
+						o.Log.Warn("[GenerateSignatureConfigMap] configmap key seems to be malformed %s : ", k)
+						continue
+					}
+					// duplicate check
+					if strings.Contains(file, search[1]) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					// base64 encode data
+					b64 := base64.StdEncoding.EncodeToString(data)
+					index := fmt.Sprintf(configMapBinaryDataIndexFormat, strings.Split(file, "-sha256-")[1], id)
+					// this is to ensure we dont have duplcate sha256 indexes
+					cm.BinaryData[index] = b64
+					id++
+				}
 			}
 		}
 	}


### PR DESCRIPTION
# Description

This fix ensures that the siagnature configmap yaml and json files created in clusterresource does not have duplicates

Fixes # OCPBUGS-42428

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally

Use the following imagesetconfig

```
apiVersion: mirror.openshift.io/v2alpha1
kind: ImageSetConfiguration
mirror:
  platform:
    channels:
      - name: stable-4.16
        minVersion: 4.16.0
        maxVersion: 4.16.0
      - name: stable-4.15
        minVersion: 4.15.0
        maxVersion: 4.15.0

```

Execute mirror-to-disk 

Then execute disk-to-mirror

There should be no duplicate entries in the yaml or json config maps created in working-dir/cluster-resources

## Expected Outcome

yaml configmap output (in this case only 3 entries ) with no duplicates 

i.e sha256-xxxx-id where "xxxx" is not duplicated 
 
```
apiVersion: v1
binaryData:
  sha256-0da6316466d60a3a4535d5fed3589feb0391989982fba59d47d4c729912d6363-2: owGbwMvMwMEoOU9/4l9n2UDGtYzJSWLxRQW5xZnpukWphboVxQEWxbl6SZl5qXe29lQrJRdllmQmJ+YoWSlUK2XmJqanglkp+cnZqUW6uYl5mWmpxSW6KZnpQAoopVSckWhkamZlkJJoZmxoZmJmlmJmkGicaGJqbJpimpaaYmxqYZmWmmRgbGloaWFpaWGUlpRoapliYp5ikmxuZGlpaJRiZmxmrFSro6BUUlkAsk4psSQ/NzNZITk/ryQR6LAiBaBr8xJLSotSlYCqMlNS80oySyqRHVaUmpZalJqXDNZeWJpYqZeZr59fkJpXnJGZVgKUzklNLE7VTUkt089PLoDxrUz0DE31DHQrLMzizUyUakFuyC8oyczPgwZAclEq0C1FIEODUlMUPBJLFPyBhgaDDFUIBjoqMy9dwbG0JCMfGGyVCgZ6BnqGQGM6mWRYGBg5GNhYmUChysDFKQCLgT4zAYZeps1bfryz7j15qafOW3Dqwv8q1gUhm2eahBm6BEgZRp1fNN1LJEQi0PW1qVrTmQnusy7Pq/t2qcrj83LOh7b7uhMlL7AF3j6QM/HdoTTFaZsulu3qm/FU7SCTwhUH+WsaJw2/l2/bpKDEmvI29TPTCs0pJrFt1UGds0OXeuZf/Pvo9Y8WWw/7sA0lrA0daz6Ef9RdPsGdU+SDpjCrRuai8oIbavb9Fz22FvYv/eMk/dv26L6MPqaU1R56Sz8LVJQ1XQrk3Dzl+THGVZ97BOS0znjwn/RLvsNvc/8V8w39xV/XuhvskLMXfjPp5pErMtbKPMte5krmeEefy5uWvyi9dUPesedH/ey8l894t/RM1odKsaZwtx2X8tecb/eZGsd64P/c77cOnYiX62POMY+L2Xom4bVk5DnDncrKsictr/4yDjnO5Heg0uHN6k1rkv88Ez5yy+HU009+V1l3eFUfVVhfahQS/5trr3JrtIvKFln+s9L17+9brQp10wtkeTqt5OOZrftY7Nqk1mcLejxanF7uyHvSIj+vUPDZhk4GU+MAZ4a3zCfSdeb2l4REqdRwVhoXf7u9/6qnYf79L2IOHE4RzOVbghwsXgWa3T715rLQwT7e/SuYBYqWf87c+CFw0/QTPg3vmI/G/qhaKvLf3sy7U+N2TVDe9OUqj0/wvBI/yOV0y0Mpet1ZRt+zH9tllRMkH60PSd23EAA=
  sha256-66b135c7313b6394cc584369ccc96f57258b057875cc8a2f53d073e4da436120-3: owGbwMvMwMEoOU9/4l9n2UDGtYwpSWLxRQW5xZnpukWphbpOucnmVW56SZl5aY/1GaqVkosySzKTE3OUrBSqlTJzE9NTwayU/OTs1CLd3MS8zLTU4hLdlMx0IAWUUirOSDQyNbMyM0syNDZNNjc2NE4yM7Y0SU42tTAxNrNMTk62NEszNTcytUgyMDW3MDdNTrZINEozNU4xMDdONUlJBKoyNDJQqtVRUCqpLABZp5RYkp+bmayQnJ9XkpiZl1qkAHRtXmJJaVGqElBVZkpqXklmSSWyw4pS01KLUvOSwdoLSxMr9TLz9fMLUvOKMzLTSoDSOamJxam6Kall+vnJBTC+lYmeoamesZFuhYVZvJmJUi3IEfkFJZn5edAQSC5KBTqmCGRqUGqKgkdiiYI/0NRgkKkKwUBXZealKziWlmTkA8OtUsFAz0DPEGhMJ5MMCwMjBwMbKxMoWBm4OAVgURAnx/9Px2rSY4tn92d/tkvuWF39e6nB9Y0C6vvsky/Mkv/+rllm+5MDnbcTEr6kVcxdeHfNk0kXvKXef1izMXB35AcTjYmNUqzvDqeoP76aY2scpJUgNNlnxZ3JM3rsm++cPC5zTJLv4+7fDTP0s1IUxMT1tTu2ppmdEtfOfLYkpjV2ruuPr02y+4IfOda57er+tzzmb/H7WX4H103+XZgfmXap2G5t3G//2xF8NsJxNRvWpT459k+ivVfGnVV0FsdFqdWhGlF50ywXFjoGi37aKu+4z+/vYvOJq9+JFdXNvfixzNVQq11JZdXZXfWeb5KYg+ZYHC/baC+zTviWiN2sKyvfp1urK82SED1UsOSsk9rMgqo1hy+uTV3tPP/r798pEqktUu0zhaSeKohyZUfuPjGj8v9ziQm1t9/JO32WroydXfY0edfi7QExjyPtn2WkFR3+V732dV3rjOBZ2n/nyk1kWtRVceuTarQDl90d9Zbezw4tvzVKVymVG1y0Wn+qPVy+oP/za5b253v1jTfdunnjENevuk6+baYXN3BLTWrt2GQoflX1fTPPlm3pbCfVHq3yS2D/rfQ9Lr5YWuLAvr6uOzOTw5jvNPN2Sa1mFn7j9H7ig3nfCo10XeqWL3p+JFhvnt61ayzRh1acXzfT7uD0EK3UudVbMnZ9lxE4eEr5fYXLmqVCW3JuaD1btDG5N3KqwKvSJsHMN/8TJTK6AQ==
  sha256-3717338045df06e31effea46761b2c7e90f543cc4f00547af8158dd6aea868c3-1: owGbwMvMwMEoOU9/4l9n2UDGtYzJSWLxRQW5xZnpukWphbqJSUGVJf56SZl5adU9WtVKyUWZJZnJiTlKVgrVSpm5iempYFZKfnJ2apFubmJeZlpqcYluSmY6kAJKKRVnJBqZmlkZmxuaGxtbGJiYpqQZmKUaG6ampaUmmpiZmxkmGSWbp1oapJmaGCcnm6QZGJiamCemWRiaWqSkmCWmJlqYWSQbK9XqKCiVVBaArFNKLMnPzUxWSM7PK0nMzEstUgC6Ni+xpLQoVQmoKjMlNa8ks6QS2WFFqWmpRal5yWDthaWJlXqZ+fr5Bal5xRmZaSVA6ZzUxOJU3ZTUMv385AIY38pEz9BMz0C3wsIs3sxEqRbkhvyCksz8PGgAJBelAt1SBDI0KDVFwSOxRMEfaGgwyFCFYKCjMvPSFRxLSzLygcFWqWCgZ6BnCDSmk0mGhYGRg4GNlQkUqgxcnAKwGNiSIcDQLFrmt8ZarfU0234jphipJx9PrVWR6Ne1P/lzlbnN1blfXt+UWnXz4NW1Ne/eHNI+vNpyxpe0VZozL1YKlMg+VCo+uul5S4t3L+8byXsmb98vdVy61TLumM+0Ta1WuikS3NfVlvPNLJ6y4+6qX74pz9pqnXbr32lxenH6btxcpW+C21ICAxd9tOkST7Vemn7kedPrOXyPCkQ5blZK1BdaPYndXcMZK3AsI7a4SqMsrvH2pNgVRU+X3z1t/umAHWv4FbZowW8zDnZtt1ov5215R/dtsXOw4fwEi5WtClM55h0908FyYOor+7/HI0qPZ3DsP8DPIZy4YOl38fb5PPOCTP8fm8t++erKN9mbAh7+Yo90eO8urXuho6OitC3hcIjpf9HiSBMl13fOt6MEF7zsn7Zj5oI7x5Y2Hr6ys/RNxnPZgjlh/pkdr7OccxM2zLFvXTN7b7n0r3dq277/LvuYl+l+e16u18bpMbmZu2VtkmYY31h94+uCaN3I43tbJLmXTtly97Yyc23LrtxtK7PM5K4oSd0oMJ7zaN3Ssr0bEo8GFIT7m9eY/3leG/76McPKO5uDHji8zpWUnfNyv2L315RVXc+usYuwf/v81PvHlz3Vt/49PTFNILy04pjQv788culLEi1edk2amaH5zTfBvN407aP4i6NzPwi98O5nac/cHbZLzDEw4iXjpHWsuWZPzJhyNF3myQb3SlQ7AQA=
kind: ConfigMap
metadata:
  labels:
    release.openshift.io/verification-signatures: ""
  namespace: openshift-config-managed
```
