### PR TITLE
CLID-247: changes the tlsVerify default to true and adds helm tls support

### DIFF
--- a/v2/internal/pkg/archive/image-blob-gatherer.go
+++ b/v2/internal/pkg/archive/image-blob-gatherer.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/transports/alltransports"
+	"github.com/containers/image/v5/types"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
 )
 
@@ -40,7 +41,8 @@ func (o *ImageBlobGatherer) GatherBlobs(ctx context.Context, imgRef string) (blo
 		return nil, fmt.Errorf("invalid source name %s: %v", imgRef, err)
 	}
 	// we are always gathering blobs from the local cache registry - skipping tls verification
-	sourceCtx, err := o.opts.SrcImage.NewSystemContextWithTLSVerificationOverride(false)
+	sourceCtx, err := o.opts.SrcImage.NewSystemContext()
+	sourceCtx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(true)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/internal/pkg/cli/delete.go
+++ b/v2/internal/pkg/cli/delete.go
@@ -190,7 +190,7 @@ func (o *ExecutorSchema) CompleteDelete(args []string) error {
 		o.Config = isc
 		o.Opts.RemoveSignatures = true
 		// nolint: errcheck
-		o.srcFlagSet.Set("src-tls-verify", "false")
+		o.Opts.SrcImage.TlsVerify = false
 	}
 
 	o.Opts.Mode = mirror.DiskToMirror

--- a/v2/internal/pkg/helm/local_stored_collector.go
+++ b/v2/internal/pkg/helm/local_stored_collector.go
@@ -54,10 +54,10 @@ type LocalStorageCollector struct {
 	cleanup     func()
 }
 
-func NewHelmOptions() *HelmOptions {
+func NewHelmOptions(tlsVerify bool) *HelmOptions {
 	return &HelmOptions{
 		settings: helmcli.New(),
-		insecure: true,
+		insecure: !tlsVerify,
 	}
 }
 
@@ -190,6 +190,7 @@ func (cdw *ChartDownloaderWrapper) DownloadTo(ref, version, dest string) (string
 }
 
 func GetDefaultChartDownloader() chartDownloader {
+	lsc.Log.Debug("GetDefaultChartDownloader - lsc.Helm.insecure %t", lsc.Helm.insecure)
 	return &ChartDownloaderWrapper{
 		inner: &downloader.ChartDownloader{
 			Out:     lsc.Opts.Stdout,

--- a/v2/internal/pkg/helm/local_stored_collector_test.go
+++ b/v2/internal/pkg/helm/local_stored_collector_test.go
@@ -402,11 +402,13 @@ func TestHelmImageCollector(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.caseName, func(t *testing.T) {
+			_, srcOpts := mirror.ImageSrcFlags(nil, nil, nil, "src-", "screds")
 			opts := mirror.CopyOptions{
 				Mode:             testCase.mirrorMode,
 				Global:           &mirror.GlobalOptions{WorkingDir: workingDir},
 				LocalStorageFQDN: testCase.localStorage,
 				Destination:      testCase.dest,
+				SrcImage:         srcOpts,
 			}
 
 			cfg.Mirror.Helm = testCase.helmConfig
@@ -431,7 +433,7 @@ func TestHelmImageCollector(t *testing.T) {
 
 			if len(testCase.expectedResult) > 0 {
 				assert.NotEmpty(t, imgs)
-				fmt.Println(assert.ElementsMatch(t, testCase.expectedResult, imgs))
+				assert.ElementsMatch(t, testCase.expectedResult, imgs)
 			}
 
 		})

--- a/v2/internal/pkg/helm/new.go
+++ b/v2/internal/pkg/helm/new.go
@@ -15,7 +15,8 @@ func New(log clog.PluggableLoggerInterface,
 	chartDownloader chartDownloader,
 	httpClient webClient,
 ) CollectorInterface {
-	lsc = &LocalStorageCollector{Log: log, Config: config, Opts: opts, Helm: NewHelmOptions()}
+	lsc = &LocalStorageCollector{Log: log, Config: config, Opts: opts, Helm: NewHelmOptions(opts.SrcImage.TlsVerify)}
+	lsc.Log.Debug("helm.New opts.SrcImage.TlsVerify %t", opts.SrcImage.TlsVerify)
 
 	wClient = httpClient
 

--- a/v2/internal/pkg/mirror/options_test.go
+++ b/v2/internal/pkg/mirror/options_test.go
@@ -31,8 +31,7 @@ func TestOptionsNewContext(t *testing.T) {
 	}
 
 	fs := pflag.FlagSet{}
-	f := flag.OptionalBoolFlag(&fs, &dockerImageOpts.tlsVerify, "tls-verify", "whatever")
-	_ = f.Value.Set("true")
+	fs.BoolVar(&dockerImageOpts.TlsVerify, "tls-verify", false, "whatever")
 	dep := flag.OptionalBoolFlag(&fs, &dockerImageOpts.deprecatedTLSVerify.tlsVerify, "deprecatated", "whatever")
 	_ = dep.Value.Set("true")
 	dockerImageOpts.authFilePath = flag.OptionalString{}


### PR DESCRIPTION
# Description

This PR changes the tlsVerify default to true and adds helm tls support.

Fixes # ([CLID-247](https://issues.redhat.com/browse/CLID-247))

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Run all the workflows (mirrorToDisk, diskToMirror and mirrorToMirror) for releases, operators, additional images and helm charts.

When doing the mirrorToMirror or diskToMirror `--dest-tls-verify=false` should be included in case the target registry does not have the TLS enabled

## Expected Outcome
All the flows (mirrorToDisk, diskToMirror and mirrorToMirror) should continue working for releases, operators, additional images, helm charts.

Also the delete should continue working (except for helm which is not implemented yet)