### PR TITLE
OCPBUGS-43356: changes the PreserveDigests default to true

### DIFF
--- a/v2/internal/pkg/batch/concurrent_worker.go
+++ b/v2/internal/pkg/batch/concurrent_worker.go
@@ -62,6 +62,8 @@ func (o *ConcurrentBatch) Worker(ctx context.Context, collectorSchema v2alpha1.C
 		mirrorMsg = "deleting"
 	}
 
+	opts.PreserveDigests = true
+
 	startTime := time.Now()
 
 	batches := splitImagesToBatches(collectorSchema, int(o.BatchSize))


### PR DESCRIPTION
# Description

This PR changes the default of PreserveDigests to true. This is required because oc-mirror relies on the original digest to handle several things during the workflow and also because of the signatures.

Fixes # [OCPBUGS-43356](https://issues.redhat.com/browse/OCPBUGS-43356)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

With the following ImageSetConfiguration
```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index@sha256:562445602e026dea6c695e7c551ceb2b1b9f7539c0bde95371b64259d060833b
      packages:
       - name: aws-load-balancer-operator
       - name: 3scale-operator
       - name: node-observability-operator
```

Run `mirrorToDisk` and `diskToMirror`

## Expected Outcome
Both workflows should pass without errors