### PR TITLE
CLID-253: adds helm images to delete feature

### DIFF
--- a/v2/internal/pkg/api/v2alpha1/type_internal.go
+++ b/v2/internal/pkg/api/v2alpha1/type_internal.go
@@ -246,8 +246,9 @@ type DeleteImageList struct {
 }
 
 type DeleteItem struct {
-	ImageName      string `json:"imageName"`
-	ImageReference string `json:"imageReference"`
+	ImageName      string    `json:"imageName"`
+	ImageReference string    `json:"imageReference"`
+	Type           ImageType `json:"type"`
 }
 
 type CatalogFilterResult struct {

--- a/v2/internal/pkg/cli/delete.go
+++ b/v2/internal/pkg/cli/delete.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -20,6 +21,7 @@ import (
 	"github.com/openshift/oc-mirror/v2/internal/pkg/batch"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/config"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/delete"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/helm"
 	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/manifest"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
@@ -32,9 +34,6 @@ const (
 	deleteErrMsg = "[delete] %v"
 	deleteYaml   = "/delete/delete-images.yaml"
 	deleteDir    = "/delete/"
-
-	deletePrefix = "[RunDelete] "
-	errMsg       = deletePrefix + "%s"
 )
 
 // NewDeleteCommand - setup all the relevant support structs
@@ -145,11 +144,11 @@ func (o ExecutorSchema) ValidateDelete(args []string) error {
 		return fmt.Errorf("the destination registry argument must have a docker:// protocol prefix")
 	}
 
-	delete_file := o.Opts.Global.DeleteYaml
+	deleteFile := o.Opts.Global.DeleteYaml
 
-	_, err := os.Stat(delete_file)
+	_, err := os.Stat(deleteFile)
 	if len(o.Opts.Global.DeleteYaml) > 0 && !o.Opts.Global.DeleteGenerate && os.IsNotExist(err) {
-		return fmt.Errorf("file not found %s", delete_file)
+		return fmt.Errorf("file not found %s", deleteFile)
 	}
 	return nil
 }
@@ -184,6 +183,7 @@ func (o *ExecutorSchema) CompleteDelete(args []string) error {
 					Platform:         converted.Delete.Platform,
 					Operators:        converted.Delete.Operators,
 					AdditionalImages: converted.Delete.AdditionalImages,
+					Helm:             converted.Delete.Helm,
 				},
 			},
 		}
@@ -253,9 +253,10 @@ func (o *ExecutorSchema) CompleteDelete(args []string) error {
 	signature := release.NewSignatureClient(o.Log, o.Config, *o.Opts)
 	cn := release.NewCincinnati(o.Log, &o.Config, *o.Opts, client, false, signature)
 	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.ImageBuilder)
-	o.Batch = batch.New(o.Log, o.LogsDir, o.Mirror)
+	o.Batch = batch.NewConcurrentBatch(o.Log, o.LogsDir, o.Mirror, calculateMaxBatchSize(o.MaxParallelOverallDownloads, o.ParallelBatchImages))
 	o.Operator = operator.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest)
 	o.AdditionalImages = additional.New(o.Log, o.Config, *o.Opts, o.Mirror, o.Manifest)
+	o.HelmCollector = helm.New(o.Log, o.Config, *o.Opts, nil, nil, &http.Client{Timeout: time.Duration(5) * time.Second})
 
 	// instantiate delete module
 	bg := archive.NewImageBlobGatherer(o.Opts)
@@ -274,35 +275,12 @@ func (o *ExecutorSchema) RunDelete(cmd *cobra.Command) error {
 
 	if o.Opts.Global.DeleteGenerate {
 
-		o.Log.Info("🕵️  going to discover the necessary images...")
-		o.Log.Info("🔍 collecting release images...")
-		// convert release images
-		var allImages []v2alpha1.CopyImageSchema
-
-		if ri, err := o.Release.ReleaseImageCollector(cmd.Context()); err != nil {
-			o.Log.Error(" %s", err.Error())
-		} else {
-			allImages = append(allImages, ri...)
-		}
-
-		o.Log.Info("🔍 collecting operator images...")
-		// collect operator images
-		oCollector, err := o.Operator.OperatorImageCollector(cmd.Context())
+		collectorSchema, err := o.CollectAll(cmd.Context())
 		if err != nil {
-			o.Log.Error(" %v", err)
+			return err
 		}
-		oImgs := oCollector.AllImages
-		allImages = append(allImages, oImgs...)
 
-		o.Log.Info("🔍 collecting additional images...")
-		// collect additional images
-		ai, err := o.AdditionalImages.AdditionalImagesCollector(cmd.Context())
-		if err != nil {
-			o.Log.Error(errMsg, err.Error())
-		}
-		allImages = append(allImages, ai...)
-
-		err = o.Delete.WriteDeleteMetaData(allImages)
+		err = o.Delete.WriteDeleteMetaData(collectorSchema.AllImages)
 		if err != nil {
 			return err
 		}

--- a/v2/internal/pkg/cli/delete_test.go
+++ b/v2/internal/pkg/cli/delete_test.go
@@ -228,6 +228,7 @@ func TestExecutorRunDelete(t *testing.T) {
 			Operator:                     collector,
 			Release:                      collector,
 			AdditionalImages:             collector,
+			HelmCollector:                collector,
 			Mirror:                       mockMirror,
 			Batch:                        &mockBatch,
 			LocalStorageService:          *reg,

--- a/v2/internal/pkg/helm/new.go
+++ b/v2/internal/pkg/helm/new.go
@@ -18,19 +18,21 @@ func New(log clog.PluggableLoggerInterface,
 	lsc = &LocalStorageCollector{Log: log, Config: config, Opts: opts, Helm: NewHelmOptions(opts.SrcImage.TlsVerify)}
 	lsc.Log.Debug("helm.New opts.SrcImage.TlsVerify %t", opts.SrcImage.TlsVerify)
 
-	wClient = httpClient
+	if !opts.IsDiskToMirror() {
+		wClient = httpClient
 
-	cleanup, file, _ := createTempFile(filepath.Join(lsc.Opts.Global.WorkingDir, helmDir))
-	lsc.Helm.settings.RepositoryConfig = file
-	lsc.cleanup = cleanup
+		cleanup, file, _ := createTempFile(filepath.Join(lsc.Opts.Global.WorkingDir, helmDir))
+		lsc.Helm.settings.RepositoryConfig = file
+		lsc.cleanup = cleanup
 
-	lsc.Downloaders.indexDownloader = indexDownloader
+		lsc.Downloaders.indexDownloader = indexDownloader
 
-	if chartDownloader == nil {
-		lsc.Downloaders.chartDownloader = GetDefaultChartDownloader()
+		if chartDownloader == nil {
+			lsc.Downloaders.chartDownloader = GetDefaultChartDownloader()
 
-	} else {
-		lsc.Downloaders.chartDownloader = chartDownloader
+		} else {
+			lsc.Downloaders.chartDownloader = chartDownloader
+		}
 	}
 
 	return lsc


### PR DESCRIPTION
# Description

This PR implements the code necessary to take into account the helm images in the delete feature.

This PR also change the batch worker to the same being used in the mirroring (concurrent_worker.go)

Fixes # [CLID-253](https://issues.redhat.com/browse/CLID-253)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

With the following ImageSetConfiguration:

```
apiVersion: mirror.openshift.io/v2alpha1
kind: ImageSetConfiguration
mirror:
  helm:
    repositories:
      - name: podinfo
        url: https://stefanprodan.github.io/podinfo
        charts:
          - name: podinfo
            version: 5.0.0
      - name: sbo
        url: https://redhat-developer.github.io/service-binding-operator-helm-chart/
```

Step 1 - Run `MirrorToDisk`

```
./bin/oc-mirror -c ./alex-tests/alex-isc/clid-28-v2.yaml file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-253 --v2
```

Step 2 - Run `DiskToMirror`

```
./bin/oc-mirror -c ./alex-tests/alex-isc/clid-28-v2.yaml --from file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-253 docker://localhost:6000 --dest-tls-verify=false --v2
```

Step 3 - Check in the target registry if the manifests were included (all the curl below should return the manifest's json)

```
curl http://localhost:6000/v2/stefanprodan/podinfo/manifests/5.0.0
curl http://localhost:6000/v2/redhat-developer/servicebinding-operator/manifests/sha256-67c2a2502f59fac1e7ded9ed19b59bbd4e50f5559a13978a87ecd2283b81e067
curl http://localhost:6000/v2/redhat-developer/servicebinding-operator/manifests/sha256-f79f6999a15534dbe56e658caf94fc4b7afb5ceeb7b49f32a60ead06fbd7c3fc
curl http://localhost:6000/v2/redhat-developer/servicebinding-operator/manifests/sha256-e4259939a496f292a31b5e57760196d63a8182b999164d93a446da48c4ea24eb
curl http://localhost:6000/v2/redhat-developer/servicebinding-operator/manifests/sha256-30bf7f0f21024bb2e1e4db901b1f5e89ab56e0f3197a919d2bbb670f3fe5223a
curl http://localhost:6000/v2/redhat-developer/servicebinding-operator/manifests/sha256-ac47f496fb7ecdcbc371f8c809fad2687ec0c35bbc8c522a7ab63b3e5ffd90ea
curl http://localhost:6000/v2/redhat-developer/servicebinding-operator/manifests/sha256-e01016cacae84dfb6eaf7a1022130e7d95e2a8489c38d4d46e4f734848e93849
curl http://localhost:6000/v2/redhat-developer/servicebinding-operator/manifests/sha256-69a95c6216ead931e01e4144ae8f4fb7ab35d1f68a14c18f6860a085ccb950f5
curl http://localhost:6000/v2/redhat-developer/servicebinding-operator/manifests/sha256-16286ac84ddd521897d92472dae857a4c18479f255b725dfb683bc72df6e0865
curl http://localhost:6000/v2/redhat-developer/servicebinding-operator/manifests/sha256-de1881753e82c51b31e958fcf383cb35b0f70f6ec99d402d42243e595d00c6dd
curl http://localhost:6000/v2/redhat-developer/servicebinding-operator/manifests/sha256-cc5aab01ddd3744510c480eb4f58b834936a833d36bec5c9c13fb40bbb06c663
```

Step 4 - Run the `delete generate` (after running the command below, two files should be generated under working-dir/delete

```
./bin/oc-mirror delete -c ./alex-tests/alex-isc/helm-delete.yaml --generate --workspace file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-253 --delete-id helm-test docker://localhost:6000 --v2 --dest-tls-verify=false
```

Step 5 - Run the `delete` (with or without `--force-cache-delete true`)

```
./bin/oc-mirror delete --delete-yaml-file /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-253/working-dir/delete/delete-images-helm-test.yaml docker://localhost:6000 --v2 --dest-tls-verify=false
```

## Expected Outcome

After running the 5 steps above, run the curl commands again, no manifest json should be returned since they were deleted.

This is one response example:

```
curl http://localhost:6000/v2/redhat-developer/servicebinding-operator/manifests/sha256-de1881753e82c51b31e958fcf383cb35b0f70f6ec99d402d42243e595d00c6dd
{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown","detail":{"Tag":"sha256-de1881753e82c51b31e958fcf383cb35b0f70f6ec99d402d42243e595d00c6dd"}}]}
```