### PR TITLE
CLID-269: adds dependabot.yml config file for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: all
+    # Disable version updates
+    open-pull-requests-limit: 0
+    groups:
+      golang:
+        applies-to: security-updates
+        patterns: [ "*" ]


### PR DESCRIPTION
# Description

Dependabot is enabled in oc-mirror repo, but it is not opening PRs automatically yet. 

Adding the config file as an attempt to enable the creation of PR automatically.

Fixes # [CLID-269](https://issues.redhat.com/browse/CLID-269)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Currently Dependabot alerts are visible for maintainers.

## Expected Outcome
Dependabot alers are visible