### PR TITLE
CLID-265,CLID-259,CLID-262: generates folders based on the filtered catalog digest

### DIFF
--- a/v2/internal/pkg/api/v2alpha1/type_image.go
+++ b/v2/internal/pkg/api/v2alpha1/type_image.go
@@ -54,6 +54,10 @@ func (it ImageType) IsOperator() bool {
 	return it == TypeOperatorBundle || it == TypeOperatorCatalog || it == TypeOperatorRelatedImage
 }
 
+func (it ImageType) IsOperatorCatalog() bool {
+	return it == TypeOperatorCatalog
+}
+
 func (it ImageType) IsAdditionalImage() bool {
 	return it == TypeGeneric
 }

--- a/v2/internal/pkg/api/v2alpha1/type_internal.go
+++ b/v2/internal/pkg/api/v2alpha1/type_internal.go
@@ -191,7 +191,8 @@ type RelatedImage struct {
 	TargetTag string `json:"targetTag"`
 	// Used to keep specific naming info for the related image
 	// if set should be used when mirroring
-	TargetCatalog string `json:"targetCatalog"`
+	TargetCatalog    string `json:"targetCatalog"`
+	IsCatalogRebuilt bool   `json:"isCatalogRebuilt"`
 }
 
 type CollectorSchema struct {
@@ -219,7 +220,8 @@ type CopyImageSchema struct {
 	Origin string
 	// Type: metadata to explain why this image is being copied
 	// it doesn´t need to be persisted to json
-	Type ImageType `json:"-"`
+	Type             ImageType `json:"-"`
+	IsCatalogRebuilt bool      `json:"isCatalogRebuilt"`
 }
 
 // SignatureContentSchema

--- a/v2/internal/pkg/api/v2alpha1/type_internal.go
+++ b/v2/internal/pkg/api/v2alpha1/type_internal.go
@@ -191,8 +191,8 @@ type RelatedImage struct {
 	TargetTag string `json:"targetTag"`
 	// Used to keep specific naming info for the related image
 	// if set should be used when mirroring
-	TargetCatalog    string `json:"targetCatalog"`
-	IsCatalogRebuilt bool   `json:"isCatalogRebuilt"`
+	TargetCatalog string `json:"targetCatalog"`
+	RebuiltTag    string `json:"rebuiltTag"`
 }
 
 type CollectorSchema struct {
@@ -220,8 +220,8 @@ type CopyImageSchema struct {
 	Origin string
 	// Type: metadata to explain why this image is being copied
 	// it doesn´t need to be persisted to json
-	Type             ImageType `json:"-"`
-	IsCatalogRebuilt bool      `json:"isCatalogRebuilt"`
+	Type       ImageType `json:"-"`
+	RebuiltTag string    `json:"rebuiltTag"`
 }
 
 // SignatureContentSchema

--- a/v2/internal/pkg/cli/const.go
+++ b/v2/internal/pkg/cli/const.go
@@ -16,6 +16,7 @@ const (
 	releaseImageExtractDir        string = "hold-release"
 	cincinnatiGraphDataDir        string = "cincinnati-graph-data"
 	operatorImageExtractDir       string = "hold-operator"
+	operatorCatalogsDir           string = "operator-catalogs"
 	signaturesDir                 string = "signatures"
 	registryLogFilename           string = "registry.log"
 	startMessage                  string = "starting local storage on localhost:%v"

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -1040,9 +1040,9 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 
 	// CLID-230 rebuild-catalogs
 	oImgs := operatorImgs.AllImages
-	if o.alphaCtlgFilter && (o.Opts.IsMirrorToDisk() || o.Opts.IsMirrorToMirror()) { //TODO ALEX ADD A CHECK TO SEE IF THE CATALOG WAS ALREADY REBUILT BEFORE, IF YES, SKIP, IT WILL AVOID REBUILDING CATALOGS ALREADY REBUILT PREVIOUSLY
+	if o.alphaCtlgFilter && (o.Opts.IsMirrorToDisk() || o.Opts.IsMirrorToMirror()) {
 		for _, copyImage := range oImgs {
-			if copyImage.Type == v2alpha1.TypeOperatorCatalog {
+			if copyImage.Type == v2alpha1.TypeOperatorCatalog && copyImage.RebuiltTag == "" {
 				ref, err := image.ParseRef(copyImage.Origin)
 				if err != nil {
 					o.closeAll()

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -123,6 +123,7 @@ type ExecutorSchema struct {
 	LocalStorageDisk             string
 	ClusterResources             clusterresources.GeneratorInterface
 	ImageBuilder                 imagebuilder.ImageBuilderInterface
+	CatalogBuilder               imagebuilder.CatalogBuilderInterface
 	MirrorArchiver               archive.Archiver
 	MirrorUnArchiver             archive.UnArchiver
 	MakeDir                      MakeDirInterface
@@ -432,7 +433,7 @@ func (o *ExecutorSchema) Complete(args []string) error {
 	client, _ := release.NewOCPClient(uuid.New(), o.Log)
 
 	o.ImageBuilder = imagebuilder.NewBuilder(o.Log, *o.Opts)
-
+	o.CatalogBuilder = imagebuilder.NewCatalogBuilder(o.Log, *o.Opts)
 	signature := release.NewSignatureClient(o.Log, o.Config, *o.Opts)
 	cn := release.NewCincinnati(o.Log, &o.Config, *o.Opts, client, false, signature)
 	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.ImageBuilder)
@@ -1017,36 +1018,46 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 	o.Log.Info("🕵️  going to discover the necessary images...")
 	o.Log.Info("🔍 collecting release images...")
 	// collect releases
-	rImgs, err := o.Release.ReleaseImageCollector(ctx)
+	releaseImgs, err := o.Release.ReleaseImageCollector(ctx)
 	if err != nil {
 		o.closeAll()
 		return v2alpha1.CollectorSchema{}, err
 	}
 	// exclude blocked images
-	rImgs = excludeImages(rImgs, o.Config.Mirror.BlockedImages)
+	releaseImgs = excludeImages(releaseImgs, o.Config.Mirror.BlockedImages)
 
-	collectorSchema.TotalReleaseImages = len(rImgs)
+	collectorSchema.TotalReleaseImages = len(releaseImgs)
 	o.Log.Debug(collecAllPrefix+"total release images to %s %d ", o.Opts.Function, collectorSchema.TotalReleaseImages)
-	allRelatedImages = append(allRelatedImages, rImgs...)
+	allRelatedImages = append(allRelatedImages, releaseImgs...)
 
 	o.Log.Info("🔍 collecting operator images...")
 	// collect operators
-	oCollector, err := o.Operator.OperatorImageCollector(ctx)
+	operatorImgs, err := o.Operator.OperatorImageCollector(ctx)
 	if err != nil {
 		o.closeAll()
 		return v2alpha1.CollectorSchema{}, err
 	}
 
 	// CLID-230 rebuild-catalogs
-	oImgs := oCollector.AllImages
+	oImgs := operatorImgs.AllImages
 	if o.alphaCtlgFilter && (o.Opts.IsMirrorToDisk() || o.Opts.IsMirrorToMirror()) { //TODO ALEX ADD A CHECK TO SEE IF THE CATALOG WAS ALREADY REBUILT BEFORE, IF YES, SKIP, IT WILL AVOID REBUILDING CATALOGS ALREADY REBUILT PREVIOUSLY
-		results, err := o.ImageBuilder.RebuildCatalogs(ctx, oCollector)
-		if err != nil {
-			o.closeAll()
-			return v2alpha1.CollectorSchema{}, err
-		}
-		if o.Opts.IsMirrorToMirror() {
-			oImgs = append(oImgs, results...)
+		for _, copyImage := range oImgs {
+			if copyImage.Type == v2alpha1.TypeOperatorCatalog {
+				ref, err := image.ParseRef(copyImage.Origin)
+				if err != nil {
+					o.closeAll()
+					return v2alpha1.CollectorSchema{}, fmt.Errorf("unable to rebuild catalog %s: %v", copyImage.Origin, err)
+				}
+				filteredCopyImage, err := o.CatalogBuilder.RebuildCatalog(ctx, copyImage, operatorImgs.CatalogToFBCMap[ref.Reference].FilteredConfigPath)
+				if err != nil {
+					o.closeAll()
+					return v2alpha1.CollectorSchema{}, fmt.Errorf("unable to rebuild catalog %s: %v", copyImage.Origin, err)
+				}
+
+				if o.Opts.IsMirrorToMirror() {
+					oImgs = append(oImgs, filteredCopyImage)
+				}
+			}
 		}
 	}
 
@@ -1055,7 +1066,7 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 	collectorSchema.TotalOperatorImages = len(oImgs)
 	o.Log.Debug(collecAllPrefix+"total operator images to %s %d ", o.Opts.Function, collectorSchema.TotalOperatorImages)
 	allRelatedImages = append(allRelatedImages, oImgs...)
-	collectorSchema.CopyImageSchemaMap = oCollector.CopyImageSchemaMap
+	collectorSchema.CopyImageSchemaMap = operatorImgs.CopyImageSchemaMap
 
 	o.Log.Info("🔍 collecting additional images...")
 	// collect additionalImages

--- a/v2/internal/pkg/image/image.go
+++ b/v2/internal/pkg/image/image.go
@@ -159,3 +159,11 @@ func (i ImageSpec) ComponentName() string {
 		return i.PathComponent
 	}
 }
+
+func (i ImageSpec) SetTag(tag string) ImageSpec {
+	oldTag := i.Tag
+	i.Tag = tag
+	i.Reference = strings.Replace(i.Reference, oldTag, tag, 1)
+	i.ReferenceWithTransport = strings.Replace(i.ReferenceWithTransport, oldTag, tag, 1)
+	return i
+}

--- a/v2/internal/pkg/imagebuilder/interface.go
+++ b/v2/internal/pkg/imagebuilder/interface.go
@@ -12,5 +12,8 @@ type ImageBuilderInterface interface {
 	BuildAndPush(ctx context.Context, targetRef string, layoutPath layout.Path, cmd []string, layers ...v1.Layer) error
 	SaveImageLayoutToDir(ctx context.Context, imgRef string, layoutDir string) (layout.Path, error)
 	ProcessImageIndex(ctx context.Context, idx v1.ImageIndex, v2format *bool, cmd []string, targetRef string, layers ...v1.Layer) (v1.ImageIndex, error)
-	RebuildCatalogs(ctx context.Context, collectorSchema v2alpha1.CollectorSchema) ([]v2alpha1.CopyImageSchema, error)
+}
+
+type CatalogBuilderInterface interface {
+	RebuildCatalog(ctx context.Context, catalogCopyRefs v2alpha1.CopyImageSchema, configPath string) (v2alpha1.CopyImageSchema, error)
 }

--- a/v2/internal/pkg/imagebuilder/interface.go
+++ b/v2/internal/pkg/imagebuilder/interface.go
@@ -12,5 +12,5 @@ type ImageBuilderInterface interface {
 	BuildAndPush(ctx context.Context, targetRef string, layoutPath layout.Path, cmd []string, layers ...v1.Layer) error
 	SaveImageLayoutToDir(ctx context.Context, imgRef string, layoutDir string) (layout.Path, error)
 	ProcessImageIndex(ctx context.Context, idx v1.ImageIndex, v2format *bool, cmd []string, targetRef string, layers ...v1.Layer) (v1.ImageIndex, error)
-	RebuildCatalogs(ctx context.Context, collectorSchema v2alpha1.CollectorSchema) ([]v2alpha1.CopyImageSchema, []v2alpha1.Image, error)
+	RebuildCatalogs(ctx context.Context, collectorSchema v2alpha1.CollectorSchema) ([]v2alpha1.CopyImageSchema, error)
 }

--- a/v2/internal/pkg/imagebuilder/rebuild_catalog.go
+++ b/v2/internal/pkg/imagebuilder/rebuild_catalog.go
@@ -21,7 +21,8 @@ import (
 	"github.com/containers/storage"
 
 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
-	"github.com/openshift/oc-mirror/v2/internal/pkg/image"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/log"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
 	filecopy "github.com/otiai10/copy"
 )
 
@@ -30,14 +31,25 @@ const (
 	MirrorToMirror = "mirrorToMirror"
 )
 
+type CatalogBuilder struct {
+	CatalogBuilderInterface
+	Logger   log.PluggableLoggerInterface
+	CopyOpts mirror.CopyOptions
+}
+
+func NewCatalogBuilder(logger log.PluggableLoggerInterface, opts mirror.CopyOptions) CatalogBuilderInterface {
+
+	return &CatalogBuilder{
+		Logger:   logger,
+		CopyOpts: opts,
+	}
+}
+
 // RebuildCatalogs - uses buildah library that reads a containerfile and builds mult-arch manifestlist
 // NB - due to the unshare (reexec) for buildah no unit tests have been implemented
 // The final goal is to implement integration tests for this functionality
-func (o *ImageBuilder) RebuildCatalogs(ctx context.Context, catalogSchema v2alpha1.CollectorSchema) ([]v2alpha1.CopyImageSchema, error) {
+func (o CatalogBuilder) RebuildCatalog(ctx context.Context, catalogCopyRefs v2alpha1.CopyImageSchema, configPath string) (v2alpha1.CopyImageSchema, error) {
 
-	// set variables
-	catalogs := catalogSchema.CatalogToFBCMap
-	result := []v2alpha1.CopyImageSchema{}
 	containerTemplate := `
 FROM {{ .Catalog }} AS builder
 USER 0
@@ -55,175 +67,151 @@ USER 1001
 RUN rm -fr /tmp/cache/*
 COPY --from=builder /tmp/cache /tmp/cache
 `
+	filteredDir := filepath.Dir(configPath)
 
-	for _, v := range catalogs {
-		filteredDir := filepath.Dir(v.FilteredConfigPath)
+	o.Logger.Info("🔂 rebuilding catalog (pulling catalog image) %s", catalogCopyRefs.Origin)
+	contents := bytes.NewBufferString("")
+	tmpl, err := template.New("Containerfile").Parse(containerTemplate)
+	if err != nil {
+		return catalogCopyRefs, err
+	}
+	err = tmpl.Execute(contents, map[string]interface{}{
+		"Catalog": catalogCopyRefs.Origin,
+	})
+	if err != nil {
+		return catalogCopyRefs, err
+	}
 
-		o.Logger.Info("🔂 rebuilding catalog (pulling catalog image) %s", v.OperatorFilter.Catalog)
-		contents := bytes.NewBufferString("")
-		tmpl, err := template.New("Containerfile").Parse(containerTemplate)
-		if err != nil {
-			return result, err
-		}
-		err = tmpl.Execute(contents, map[string]interface{}{
-			"Catalog": v.OperatorFilter.Catalog,
-		})
-		if err != nil {
-			return result, err
-		}
+	// write the Containerfile content to a file
+	containerfilePath := filepath.Join(filteredDir, "Containerfile")
 
-		// write the Containerfile content to a file
-		containerfilePath := filepath.Join(filteredDir, "Containerfile")
+	err = os.WriteFile(containerfilePath, contents.Bytes(), 0755)
+	if err != nil {
+		return catalogCopyRefs, err
+	}
 
-		err = os.WriteFile(containerfilePath, contents.Bytes(), 0755)
-		if err != nil {
-			return result, err
-		}
+	var srcCache string
 
-		imgSpec, err := image.ParseRef(v.OperatorFilter.Catalog)
-		if err != nil {
-			return result, err
-		}
+	switch o.CopyOpts.Mode {
+	case mirror.MirrorToDisk:
+		srcCache = catalogCopyRefs.Destination
+	case mirror.MirrorToMirror:
+		srcCache = strings.Replace(catalogCopyRefs.Destination, o.CopyOpts.Destination, dockerProtocol+o.CopyOpts.LocalStorageFQDN, 1)
+		o.CopyOpts.DestImage.TlsVerify = false
+	case mirror.DiskToMirror:
+		srcCache = catalogCopyRefs.Source
+	}
 
-		srcCache := dockerProtocol + strings.Join([]string{o.LocalFQDN, imgSpec.PathComponent}, "/") + ":" + filepath.Base(filteredDir)
+	updatedDest := strings.TrimPrefix(srcCache, dockerProtocol)
 
-		// this is safe as we know that there is a docker:// prefix
-		updatedDest := strings.Split(srcCache, dockerProtocol)[1]
+	srcSysCtx, err := o.CopyOpts.SrcImage.NewSystemContext()
+	if err != nil {
+		return catalogCopyRefs, err
+	}
+	buildOptions, err := getStandardBuildOptions(updatedDest, srcSysCtx)
+	if err != nil {
+		return catalogCopyRefs, err
+	}
 
-		buildOptions, err := getStandardBuildOptions(updatedDest, o.SrcTlsVerify)
-		if err != nil {
-			return result, err
-		}
+	buildOptions.DefaultMountsFilePath = ""
 
-		buildOptions.DefaultMountsFilePath = ""
+	o.Logger.Trace("containerfile %s", string(contents.Bytes()))
 
-		o.Logger.Trace("containerfile %s", string(contents.Bytes()))
+	buildStoreOptions, err := storage.DefaultStoreOptions()
+	if err != nil {
+		return catalogCopyRefs, err
+	}
 
-		buildStoreOptions, err := storage.DefaultStoreOptions()
-		if err != nil {
-			return result, err
-		}
+	buildStore, err := storage.GetStore(buildStoreOptions)
+	if err != nil {
+		return catalogCopyRefs, err
+	}
+	defer buildStore.Shutdown(false)
 
-		buildStore, err := storage.GetStore(buildStoreOptions)
-		if err != nil {
-			return result, err
-		}
-		defer buildStore.Shutdown(false)
+	os.MkdirAll("configs", 0644)
+	filecopy.Copy(configPath, "./configs")
+	defer os.RemoveAll("configs")
 
-		os.MkdirAll("configs", 0644)
-		filecopy.Copy(v.FilteredConfigPath, "./configs")
-		defer os.RemoveAll("configs")
+	id, ref, err := imagebuildah.BuildDockerfiles(ctx, buildStore, buildOptions, []string{containerfilePath}...)
+	if err == nil && buildOptions.Manifest != "" {
+		o.Logger.Info("✅ successfully created catalog")
+		o.Logger.Debug("  manifest list id : %s", id)
+		o.Logger.Debug("  image reference  : %s", ref.String())
+	}
+	if err != nil {
+		return catalogCopyRefs, err
+	}
 
-		id, ref, err := imagebuildah.BuildDockerfiles(ctx, buildStore, buildOptions, []string{containerfilePath}...)
-		if err == nil && buildOptions.Manifest != "" {
-			o.Logger.Info("✅ successfully created catalog")
-			o.Logger.Debug("  manifest list id : %s", id)
-			o.Logger.Debug("  image reference  : %s", ref.String())
-		}
-		if err != nil {
-			return result, err
-		}
+	var retries *uint
+	retries = new(uint)
+	*retries = 3
 
-		var retries *uint
-		retries = new(uint)
-		*retries = 3
+	destSysContext, err := o.CopyOpts.DestImage.NewSystemContext()
+	if err != nil {
+		return catalogCopyRefs, err
+	}
+	manifestPushOptions := manifests.PushOptions{
+		Store:                  buildStore,
+		SystemContext:          destSysContext,
+		ImageListSelection:     cp.CopyAllImages,
+		Instances:              nil,
+		RemoveSignatures:       true,
+		SignBy:                 "",
+		ManifestType:           "application/vnd.oci.image.manifest.v1+json",
+		AddCompression:         []string{},
+		ForceCompressionFormat: false,
+		MaxRetries:             retries,
+	}
 
-		manifestPushOptions := manifests.PushOptions{
-			Store:                  buildStore,
-			SystemContext:          newSystemContext(o.DestTlsVerify),
-			ImageListSelection:     cp.CopyAllImages,
-			Instances:              nil,
-			RemoveSignatures:       true,
-			SignBy:                 "",
-			ManifestType:           "application/vnd.oci.image.manifest.v1+json",
-			AddCompression:         []string{},
-			ForceCompressionFormat: false,
-			MaxRetries:             retries,
-		}
+	destImageRef, err := alltransports.ParseImageName(srcCache)
+	if err != nil {
+		return catalogCopyRefs, err
+	}
 
-		destImageRef, err := alltransports.ParseImageName(srcCache)
-		if err != nil {
-			return result, err
-		}
+	_, list, err := manifests.LoadFromImage(buildStore, id)
+	if err != nil {
+		return catalogCopyRefs, err
+	}
 
-		_, list, err := manifests.LoadFromImage(buildStore, id)
-		if err != nil {
-			return result, err
-		}
+	o.Logger.Debug("local cache destination (rebuilt-catalog) %s", srcCache)
+	o.Logger.Debug("destination image reference %v", destImageRef)
+	o.Logger.Debug("pushing manifest list to remote registry")
+	// push the manifest list to local cache
+	_, digest, err := list.Push(ctx, destImageRef, manifestPushOptions)
+	if err != nil {
+		return catalogCopyRefs, err
+	}
 
-		o.Logger.Debug("local cache destination (rebuilt-catalog) %s", srcCache)
-		o.Logger.Debug("destination image reference %v", destImageRef)
-		o.Logger.Debug("pushing manifest list to remote registry")
-		// push the manifest list to local cache
-		_, digest, err := list.Push(ctx, destImageRef, manifestPushOptions)
-		if err != nil {
-			return result, err
-		}
+	digestOnly := digest.Encoded()
 
-		digestOnly := digest.String()
-		if strings.Contains(digestOnly, ":") {
-			digestOnly = strings.Split(digest.String(), ":")[1]
-		}
+	err = os.WriteFile(filepath.Join(filteredDir, "digest"), []byte(digestOnly), 0755)
+	if err != nil {
+		return catalogCopyRefs, err
+	}
 
-		err = os.WriteFile(filepath.Join(filteredDir, "digest"), []byte(digestOnly), 0755)
-		if err != nil {
-			return result, err
-		}
+	_, err = buildStore.DeleteImage(id, true)
+	if err != nil {
+		return catalogCopyRefs, err
+	}
 
-		_, err = buildStore.DeleteImage(id, true)
-		if err != nil {
-			return result, err
-		}
+	o.Logger.Info("✅ successfully pushed catalog manifest list")
+	o.Logger.Debug("  digest           : %s", digest)
 
-		o.Logger.Info("✅ successfully pushed catalog manifest list")
-		o.Logger.Debug("  digest           : %s", digest)
-
-		if o.Mode == MirrorToMirror {
-
-			var dest string
-			for _, img := range catalogSchema.AllImages {
-				if img.Type.IsOperatorCatalog() && strings.Split(img.Origin, dockerProtocol)[1] == v.OperatorFilter.Catalog && !strings.Contains(img.Destination, o.LocalFQDN) {
-					if v.OperatorFilter.TargetTag != "" {
-						dest = img.Destination
-					} else {
-						//TODO ALEX so far we are not considering digests only, it is needed to cover the digest only as well
-						parts := strings.Split(img.Destination, ":")
-						parts[len(parts)-1] = filepath.Base(filteredDir)
-
-						dest = strings.Join(parts, ":")
-					}
-
-				}
-			}
-
-			copyImage := v2alpha1.CopyImageSchema{
-				Origin:           v.OperatorFilter.Catalog,
-				Source:           srcCache,
-				Destination:      dest,
-				Type:             v2alpha1.TypeOperatorCatalog,
-				IsCatalogRebuilt: true,
-			}
-			result = append(result, copyImage) //TODO ALEX currently in mirrorToMirror both original and filtered are being mirrored, find a way to keep the original only in the cache for mirrorToMirror
+	if o.CopyOpts.Mode == MirrorToMirror {
+		catalogCopyRefs = v2alpha1.CopyImageSchema{
+			Origin:           catalogCopyRefs.Origin,
+			Source:           srcCache,
+			Destination:      catalogCopyRefs.Destination,
+			Type:             v2alpha1.TypeOperatorCatalog,
+			IsCatalogRebuilt: true,
 		}
 	}
-	o.Logger.Info("✅ completed rebuild catalog/s")
-	o.Logger.Debug("result %v", result)
-	return result, nil
+
+	o.Logger.Info("✅ completed rebuild catalog %s", catalogCopyRefs.Origin)
+	return catalogCopyRefs, nil
 }
 
-func newSystemContext(tlsVerify bool) *types.SystemContext {
-	ctx := &types.SystemContext{
-		RegistriesDirPath:           "",
-		ArchitectureChoice:          "",
-		OSChoice:                    "",
-		VariantChoice:               "",
-		BigFilesTemporaryDir:        "",
-		DockerInsecureSkipTLSVerify: types.NewOptionalBool(!tlsVerify),
-	}
-	return ctx
-}
-
-func getStandardBuildOptions(destination string, tlsVerify bool) (define.BuildOptions, error) {
+func getStandardBuildOptions(destination string, sysCtx *types.SystemContext) (define.BuildOptions, error) {
 	// define platforms
 	platforms := []struct{ OS, Arch, Variant string }{
 		{"linux", "amd64", ""},
@@ -310,7 +298,7 @@ func getStandardBuildOptions(destination string, tlsVerify bool) (define.BuildOp
 		SignaturePolicyPath:     "",
 		SkipUnusedStages:        types.NewOptionalBool(false),
 		Squash:                  false,
-		SystemContext:           newSystemContext(tlsVerify),
+		SystemContext:           sysCtx,
 		Target:                  "",
 		Timestamp:               nil,
 		TransientMounts:         nil,

--- a/v2/internal/pkg/operator/common.go
+++ b/v2/internal/pkg/operator/common.go
@@ -148,7 +148,7 @@ func (o OperatorCollector) prepareD2MCopyBatch(images map[string][]v2alpha1.Rela
 				o.Log.Debug("delete mode, catalog index %s : SKIPPED", img.Image)
 			} else {
 				if _, found := alreadyIncluded[img.Image]; !found {
-					result = append(result, v2alpha1.CopyImageSchema{Origin: imgSpec.ReferenceWithTransport, Source: src, Destination: dest, Type: img.Type})
+					result = append(result, v2alpha1.CopyImageSchema{Origin: imgSpec.ReferenceWithTransport, Source: src, Destination: dest, Type: img.Type, IsCatalogRebuilt: img.IsCatalogRebuilt})
 					alreadyIncluded[img.Image] = struct{}{}
 				}
 			}
@@ -202,12 +202,12 @@ func (o OperatorCollector) prepareM2DCopyBatch(images map[string][]v2alpha1.Rela
 			o.Log.Debug("destination %s", dest)
 
 			if _, found := alreadyIncluded[img.Image]; !found {
-				result = append(result, v2alpha1.CopyImageSchema{Source: src, Destination: dest, Origin: imgSpec.ReferenceWithTransport, Type: img.Type})
+				result = append(result, v2alpha1.CopyImageSchema{Source: src, Destination: dest, Origin: imgSpec.ReferenceWithTransport, Type: img.Type, IsCatalogRebuilt: img.IsCatalogRebuilt})
 				// OCPBUGS-37948 + CLID-196
 				// Keep a copy of the catalog image in local cache for delete workflow
 				if img.Type == v2alpha1.TypeOperatorCatalog && o.Opts.Mode == mirror.MirrorToMirror {
 					cacheDest := strings.Replace(dest, o.destinationRegistry(), o.LocalStorageFQDN, 1)
-					result = append(result, v2alpha1.CopyImageSchema{Source: src, Destination: cacheDest, Origin: imgSpec.ReferenceWithTransport, Type: img.Type})
+					result = append(result, v2alpha1.CopyImageSchema{Source: src, Destination: cacheDest, Origin: imgSpec.ReferenceWithTransport, Type: img.Type, IsCatalogRebuilt: img.IsCatalogRebuilt})
 
 				}
 				alreadyIncluded[img.Image] = struct{}{}

--- a/v2/internal/pkg/operator/const.go
+++ b/v2/internal/pkg/operator/const.go
@@ -1,16 +1,20 @@
 package operator
 
 const (
-	operatorImageExtractDir        = "hold-operator"
-	dockerProtocol                 = "docker://"
-	ociProtocol                    = "oci://"
-	ociProtocolTrimmed             = "oci:"
-	operatorImageDir               = "operator-images"
-	blobsDir                       = "blobs/sha256"
-	collectorPrefix                = "[OperatorImageCollector] "
-	errMsg                         = collectorPrefix + "%s"
-	logsFile                       = "operator.log"
-	errorSemver             string = " semver %v "
-	filteredCatalogDir             = "filtered-operator"
-	digestIncorrectMessage  string = "the digests seem to be incorrect for %s: %s "
+	operatorImageExtractDir           = "hold-operator" //TODO ALEX REMOVE ME when filtered_collector.go is the default
+	dockerProtocol                    = "docker://"
+	ociProtocol                       = "oci://"
+	ociProtocolTrimmed                = "oci:"
+	operatorImageDir                  = "operator-images" //TODO ALEX REMOVE ME when filtered_collector.go is the default
+	operatorCatalogsDir        string = "operator-catalogs"
+	operatorCatalogConfigDir   string = "catalog-config"
+	operatorCatalogImageDir    string = "catalog-image"
+	operatorCatalogFilteredDir string = "filtered-catalogs"
+	blobsDir                          = "blobs/sha256"
+	collectorPrefix                   = "[OperatorImageCollector] "
+	errMsg                            = collectorPrefix + "%s"
+	logsFile                          = "operator.log"
+	errorSemver                string = " semver %v "
+	filteredCatalogDir                = "filtered-operator"
+	digestIncorrectMessage     string = "the digests seem to be incorrect for %s: %s "
 )

--- a/v2/internal/pkg/release/graph_test.go
+++ b/v2/internal/pkg/release/graph_test.go
@@ -211,6 +211,6 @@ func (o mockImageBuilder) ProcessImageIndex(ctx context.Context, idx v1.ImageInd
 	return nil, nil
 }
 
-func (o mockImageBuilder) RebuildCatalogs(ctx context.Context, collectorSchema v2alpha1.CollectorSchema) ([]v2alpha1.CopyImageSchema, []v2alpha1.Image, error) {
-	return []v2alpha1.CopyImageSchema{}, []v2alpha1.Image{}, nil
+func (o mockImageBuilder) RebuildCatalogs(ctx context.Context, collectorSchema v2alpha1.CollectorSchema) ([]v2alpha1.CopyImageSchema, error) {
+	return []v2alpha1.CopyImageSchema{}, nil
 }


### PR DESCRIPTION
# Description

This PR generates the folders based on the digest of the operator catalog filtered. Using the digest of the filtered catalog allows oc-mirror to identify if the operator catalog was already rebuilt previously, avoiding in this way rebuilding again unnecessarily.

With this approach will be also possible to filter a catalog based on the original catalog saved on the local cache.

The operator collector currently is a little complex and the refactorings to make it easier to understand and maintain will be handled in a separated PR.

Fixes [CLID-265](https://issues.redhat.com/browse/CLID-265)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

With the following ImageSetConfiguration:

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15 
      packages:
       - name: aws-load-balancer-operator
       - name: 3scale-operator
       - name: node-observability-operator
```

I ran mirrorToDisk:

```
./bin/oc-mirror -c /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-isc/isc.yaml file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-265 --alpha-ctlg-filter=true --v2
```

And diskToMirror

```
./bin/oc-mirror -c /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-isc/isc.yaml --from file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-265 docker://localhost:6000 --alpha-ctlg-filter=true --v2 --dest-tls-verify=false
```

And MirrorToMirror

```
./bin/oc-mirror -c /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-isc/isc.yaml --workspace file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-265 docker://localhost:6000 --alpha-ctlg-filter=true --v2 --dest-tls-verify=false
```
## Expected Outcome
All the flows above should pass successfully. 

NOTE: Delete, targetTag and targetCatalog were not tested yet.