### PR TITLE
CLID-272: adds a deprecated message for oc-mirror v1

### DIFF
--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -98,6 +98,9 @@ func isV2() bool {
 }
 
 func buildV1Cmd() *cobra.Command {
+
+	klog.Warning("\n\n⚠️  oc-mirror v1 is deprecated (starting in 4.18 release) and will be removed in a future release - please migrate to oc-mirror --v2\n\n")
+
 	o := MirrorOptions{
 		operatorCatalogToFullArtifactPath: map[string]string{},
 	}


### PR DESCRIPTION
# Description

This PR adds a warning for the deprecation of oc-mirror v1 (starting in 4.18)

Fixes # [CLID-272](https://issues.redhat.com/browse/CLID-272)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

With the following command:

```
./bin/oc-mirror -c /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-isc/clid-28.yaml file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-28
```

## Expected Outcome
The following message should appear right in the beginning of the logs:

```
⚠️  oc-mirror v1 is deprecated (starting in 4.18 release) and will be removed in a future release - please migrate to oc-mirror --v2
```