### PR TITLE
CLID-262:WIP: Create a separate interface for rebuild catalogs

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -123,6 +123,7 @@ type ExecutorSchema struct {
 	LocalStorageDisk             string
 	ClusterResources             clusterresources.GeneratorInterface
 	ImageBuilder                 imagebuilder.ImageBuilderInterface
+	CatalogBuilder               imagebuilder.CatalogBuilderInterface
 	MirrorArchiver               archive.Archiver
 	MirrorUnArchiver             archive.UnArchiver
 	MakeDir                      MakeDirInterface
@@ -432,7 +433,7 @@ func (o *ExecutorSchema) Complete(args []string) error {
 	client, _ := release.NewOCPClient(uuid.New(), o.Log)
 
 	o.ImageBuilder = imagebuilder.NewBuilder(o.Log, *o.Opts)
-
+	o.CatalogBuilder = imagebuilder.NewCatalogBuilder(o.Log, *o.Opts)
 	signature := release.NewSignatureClient(o.Log, o.Config, *o.Opts)
 	cn := release.NewCincinnati(o.Log, &o.Config, *o.Opts, client, false, signature)
 	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.ImageBuilder)
@@ -1009,37 +1010,46 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 	o.Log.Info("🕵️  going to discover the necessary images...")
 	o.Log.Info("🔍 collecting release images...")
 	// collect releases
-	rImgs, err := o.Release.ReleaseImageCollector(ctx)
+	releaseImgs, err := o.Release.ReleaseImageCollector(ctx)
 	if err != nil {
 		o.closeAll()
 		return v2alpha1.CollectorSchema{}, err
 	}
 	// exclude blocked images
-	rImgs = excludeImages(rImgs, o.Config.Mirror.BlockedImages)
+	releaseImgs = excludeImages(releaseImgs, o.Config.Mirror.BlockedImages)
 
-	collectorSchema.TotalReleaseImages = len(rImgs)
+	collectorSchema.TotalReleaseImages = len(releaseImgs)
 	o.Log.Debug(collecAllPrefix+"total release images to %s %d ", o.Opts.Function, collectorSchema.TotalReleaseImages)
-	allRelatedImages = append(allRelatedImages, rImgs...)
+	allRelatedImages = append(allRelatedImages, releaseImgs...)
 
 	o.Log.Info("🔍 collecting operator images...")
 	// collect operators
-	oCollector, err := o.Operator.OperatorImageCollector(ctx)
+	operatorImgs, err := o.Operator.OperatorImageCollector(ctx)
 	if err != nil {
 		o.closeAll()
 		return v2alpha1.CollectorSchema{}, err
 	}
 
 	// CLID-230 rebuild-catalogs
-	oImgs := oCollector.AllImages
+	oImgs := operatorImgs.AllImages
 	if o.alphaCtlgFilter && (o.Opts.IsMirrorToDisk() || o.Opts.IsMirrorToMirror()) {
-		results, delImgs, err := o.ImageBuilder.RebuildCatalogs(ctx, oCollector)
-		if err != nil {
-			o.closeAll()
-			return v2alpha1.CollectorSchema{}, err
-		}
-		oImgs = excludeImages(oImgs, delImgs)
-		if o.Opts.IsMirrorToMirror() {
-			oImgs = append(oImgs, results...)
+		for _, copyImage := range oImgs {
+			if copyImage.Type == v2alpha1.TypeOperatorCatalog {
+				ref, err := image.ParseRef(copyImage.Origin)
+				if err != nil {
+					o.closeAll()
+					return v2alpha1.CollectorSchema{}, fmt.Errorf("unable to rebuild catalog %s: %v", copyImage.Origin, err)
+				}
+				filteredCopyImage, err := o.CatalogBuilder.RebuildCatalog(ctx, copyImage, operatorImgs.CatalogToFBCMap[ref.Reference].FilteredConfigPath)
+				if err != nil {
+					o.closeAll()
+					return v2alpha1.CollectorSchema{}, fmt.Errorf("unable to rebuild catalog %s: %v", copyImage.Origin, err)
+				}
+
+				if o.Opts.IsMirrorToMirror() {
+					oImgs = append(oImgs, filteredCopyImage)
+				}
+			}
 		}
 	}
 
@@ -1048,7 +1058,7 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 	collectorSchema.TotalOperatorImages = len(oImgs)
 	o.Log.Debug(collecAllPrefix+"total operator images to %s %d ", o.Opts.Function, collectorSchema.TotalOperatorImages)
 	allRelatedImages = append(allRelatedImages, oImgs...)
-	collectorSchema.CopyImageSchemaMap = oCollector.CopyImageSchemaMap
+	collectorSchema.CopyImageSchemaMap = operatorImgs.CopyImageSchemaMap
 
 	o.Log.Info("🔍 collecting additional images...")
 	// collect additionalImages

--- a/v2/internal/pkg/imagebuilder/interface.go
+++ b/v2/internal/pkg/imagebuilder/interface.go
@@ -12,5 +12,8 @@ type ImageBuilderInterface interface {
 	BuildAndPush(ctx context.Context, targetRef string, layoutPath layout.Path, cmd []string, layers ...v1.Layer) error
 	SaveImageLayoutToDir(ctx context.Context, imgRef string, layoutDir string) (layout.Path, error)
 	ProcessImageIndex(ctx context.Context, idx v1.ImageIndex, v2format *bool, cmd []string, targetRef string, layers ...v1.Layer) (v1.ImageIndex, error)
-	RebuildCatalogs(ctx context.Context, collectorSchema v2alpha1.CollectorSchema) ([]v2alpha1.CopyImageSchema, []v2alpha1.Image, error)
+}
+
+type CatalogBuilderInterface interface {
+	RebuildCatalog(ctx context.Context, catalogCopyRefs v2alpha1.CopyImageSchema, configPath string) (v2alpha1.CopyImageSchema, error)
 }


### PR DESCRIPTION
# Description

This should be merged after #945

PS: independently from the PR content, the test showed that the collector sends 2 catalogs for each catalog in the imagesetconfig. hence, it looks like the catalog is being rebuilt twice, and copied 4 times? This is something to get sorted after the merge with #945 (see test results below)

Fixes [CLID-262](https://issues.redhat.com/browse/CLID-262)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

$ ./bin/oc-mirror --v2 --alpha-ctlg-filter -c config_logs/clid-230.yaml docker://sherinefedora:5000/clid262 --workspace file:///home/skhoury/demo

2024/11/05 16:50:28  [WARN]   : ⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.
2024/11/05 16:50:28  [INFO]   : 👋 Hello, welcome to oc-mirror
2024/11/05 16:50:28  [INFO]   : ⚙️  setting up the environment for you...
2024/11/05 16:50:28  [INFO]   : 🔀 workflow mode: mirrorToMirror 
2024/11/05 16:50:28  [INFO]   : 🕵️  going to discover the necessary images...
2024/11/05 16:50:28  [INFO]   : 🔍 collecting release images...
2024/11/05 16:50:28  [INFO]   : 🔍 collecting operator images...
2024/11/05 16:50:30  [INFO]   : 🔂 rebuilding catalog (pulling catalog image) docker://registry.redhat.io/redhat/redhat-operator-index:v4.17
2024/11/05 16:50:54  [INFO]   : ✅ successfully created catalog
2024/11/05 16:51:05  [INFO]   : ✅ successfully pushed catalog manifest list
2024/11/05 16:51:05  [INFO]   : ✅ completed rebuild catalog docker://registry.redhat.io/redhat/redhat-operator-index:v4.17
2024/11/05 16:51:05  [INFO]   : 🔂 rebuilding catalog (pulling catalog image) docker://registry.redhat.io/redhat/redhat-operator-index:v4.17
2024/11/05 16:51:18  [INFO]   : ✅ successfully created catalog
2024/11/05 16:51:18  [INFO]   : ✅ successfully pushed catalog manifest list
2024/11/05 16:51:18  [INFO]   : ✅ completed rebuild catalog docker://registry.redhat.io/redhat/redhat-operator-index:v4.17
2024/11/05 16:51:18  [INFO]   : 🔍 collecting additional images...
2024/11/05 16:51:18  [INFO]   : 🔍 collecting helm images...
2024/11/05 16:51:18  [INFO]   : 🚀 Start copying the images...
2024/11/05 16:51:18  [INFO]   : images to copy 8 
 ✓ 1/8 : (2s) docker://registry.redhat.io/albo/aws-load-balancer-controller-rhel8@sha256:2e0b9332a44d8d9c23e19c7accab0813a651…
 ✓ 2/8 : (2s) docker://registry.redhat.io/albo/aws-load-balancer-rhel8-operator@sha256:16e9ffed36107527a37713ac5bd34a7bc20f04…
 ✓ 3/8 : (10s) docker://registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:f11f71448986aa17abec9caadb568a6cc34ef1a7898e…
 ✓ 4/8 : (1s) docker://registry.redhat.io/albo/aws-load-balancer-operator-bundle@sha256:01f2ca529d2486f113bcefc9fedce6a6fd07b…
 ✓   5/8 : (11s) docker://registry.redhat.io/redhat/redhat-operator-index:v4.17 
 ✓   6/8 : (9s) docker://registry.redhat.io/redhat/redhat-operator-index:v4.17 
 ✓   7/8 : (2s) docker://registry.redhat.io/redhat/redhat-operator-index:v4.17 
 ✓   8/8 : (0s) docker://registry.redhat.io/redhat/redhat-operator-index:v4.17 
2024/11/05 16:51:30  [INFO]   : === Results ===
2024/11/05 16:51:30  [INFO]   : ✅ 8 / 8 operator images mirrored successfully
2024/11/05 16:51:30  [INFO]   : 📄 Generating IDMS file...
2024/11/05 16:51:30  [INFO]   : /home/skhoury/demo/working-dir/cluster-resources/idms-oc-mirror.yaml file created
2024/11/05 16:51:30  [INFO]   : 📄 No images by tag were mirrored. Skipping ITMS generation.
2024/11/05 16:51:30  [INFO]   : 📄 Generating CatalogSource file...
2024/11/05 16:51:30  [INFO]   : /home/skhoury/demo/working-dir/cluster-resources/cs-redhat-operator-index-v4-17.yaml file created
2024/11/05 16:51:30  [INFO]   : /home/skhoury/demo/working-dir/cluster-resources/cs-redhat-operator-index-v4-17.yaml file created
2024/11/05 16:51:30  [INFO]   : mirror time     : 1m1.680298594s
2024/11/05 16:51:30  [INFO]   : 👋 Goodbye, thank you for using oc-mirror

## Expected Outcome
podman run of the generated catalog doesn' t fail
podman inspect of the generated catalog shows that cmd is serve /configs --cache-dir=/tmp/cache