### PR TITLE
CLID-273: Override default container rootless storage path

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -237,6 +237,7 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 	cmd.Flags().UintVar(&ex.ParallelLayers, "parallel-layers", 0, "Indicates the maximum layers downloading in parallel for an image. Defaults to 10")
 	cmd.Flags().UintVar(&ex.ParallelBatchImages, "parallel-batch-images", 0, "Indicates the maximum images downloading in parallel for a batch. Defaults to 8")
 	cmd.Flags().BoolVar(&ex.alphaCtlgFilter, "alpha-ctlg-filter", false, "Enables rebuilding of catalogs when set to true")
+	cmd.Flags().StringVar(&opts.RootlessStoragePath, "rootless-storage-path", "", "Override the default container rootless storage path (usually in etc/containers/storage.conf)")
 	// nolint: errcheck
 	cmd.Flags().AddFlagSet(&flagSharedOpts)
 	cmd.Flags().AddFlagSet(&flagRetryOpts)

--- a/v2/internal/pkg/imagebuilder/rebuild_catalog.go
+++ b/v2/internal/pkg/imagebuilder/rebuild_catalog.go
@@ -124,6 +124,10 @@ RUN rm -fr /tmp/cache/* && /bin/opm serve /configs --cache-only --cache-dir=/tmp
 		return catalogCopyRefs, err
 	}
 
+	if len(o.CopyOpts.RootlessStoragePath) > 0 {
+		buildStoreOptions.RootlessStoragePath = o.CopyOpts.RootlessStoragePath
+	}
+
 	buildStore, err := storage.GetStore(buildStoreOptions)
 	if err != nil {
 		return catalogCopyRefs, err
@@ -237,7 +241,7 @@ func getStandardBuildOptions(destination string, sysCtx *types.SystemContext) (d
 		MaxPullPushRetries: 2,
 		NoCache:            true,
 		Out:                io.Discard,
-		OutputFormat:       buildah.OCIv1ImageManifest, //TODO currently red hat catalog is docker v2 format, converting it to oci is not going to cause problems?
+		OutputFormat:       buildah.OCIv1ImageManifest,
 		Platforms:          platforms,
 		PullPolicy:         define.PullAlways,
 		Quiet:              true,

--- a/v2/internal/pkg/mirror/options.go
+++ b/v2/internal/pkg/mirror/options.go
@@ -87,6 +87,7 @@ type CopyOptions struct {
 	MaxParallelDownloads     uint
 	Function                 string // copy or delete (default is copy)
 	LocalStorageFQDN         string
+	RootlessStoragePath      string // used to override the container rootlesss storage path (usually set in /etc/containers/storage.conf)
 }
 
 // deprecatedTLSVerifyOption represents a deprecated --tls-verify option,


### PR DESCRIPTION
# Description

This update adds an optional flag to override the rootless container storage path (usually set in /etc/containers/storage.conf)

Fixes # (issue)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Create a directory i.e 

```
mkdir -p /home/lzuccarelli/buildah/share/containers/storage
```

Locally using the following  imagesetconfig and cli

imagesetconfig 

```
apiVersion: mirror.openshift.io/v2alpha1
kind: ImageSetConfiguration
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.14
      packages:
      - name: aws-load-balancer-operator
    - catalog: registry.redhat.io/redhat/certified-operator-index:v4.16
      targetCatalog: other/certified-operator-index
      packages:
      - name: gitlab-operator-kubernetes
    - catalog: registry.redhat.io/redhat/certified-operator-index:v4.15
      targetCatalog: other/certified-operator-index
      targetTag: v4.15.0
      packages:
      - name: gitlab-operator-kubernetes
    - catalog: registry.redhat.io/redhat/community-operator-index:v4.16
      targetTag: v4.16.0
      packages:
      - name: cert-utils-operator
```

cli

```
bin/oc-mirror --config isc.yaml file://clid-273 --v2 --alpha-ctlg-filter --rootless-storage-path /home/lzuccarelli/buildah/share/containers/storage
```

## Expected Outcome

Examine contents of path directory 

```
ls -la /home/lzuccarelli/buildah/share/containers/storage

drwxr-xr-x. 1 lzuccarelli lzuccarelli 54 Nov 12 12:38 .
drwxr-xr-x. 1 lzuccarelli lzuccarelli 14 Nov 12 12:20 ..
drwx------. 1 lzuccarelli lzuccarelli 22 Nov 12 12:38 home
-rw-r--r--. 1 lzuccarelli lzuccarelli  0 Nov 12 12:38 storage.lock
-rw-r--r--. 1 lzuccarelli lzuccarelli  0 Nov 12 12:38 userns.lock
```

When using the alpha-ctlg-filter flag (rebuild catalogs in v2)  m2d & d2m and finally m2m should pass
