### PR TITLE
CLID-275: Fix Catalog rebuild in Mirror To Mirror workflow

### DIFF
--- a/v2/internal/pkg/operator/common_test.go
+++ b/v2/internal/pkg/operator/common_test.go
@@ -1,0 +1,384 @@
+package operator
+
+import (
+	"os"
+	"testing"
+
+	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/common"
+	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrepareM2MCopyBatch(t *testing.T) {
+
+	log := clog.New("trace")
+
+	tempDir := t.TempDir()
+	defer os.RemoveAll(tempDir)
+	type testCase struct {
+		caseName       string
+		relatedImages  map[string][]v2alpha1.RelatedImage
+		expectedResult []v2alpha1.CopyImageSchema
+		expectedError  bool
+	}
+
+	testCases := []testCase{
+		{
+			caseName: "OperatorImageCollector - Mirror to Mirror: related images by digest should pass",
+			relatedImages: map[string][]v2alpha1.RelatedImage{
+				"operatorA": {
+					{
+						Name:  "testA",
+						Image: "sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+						Type:  v2alpha1.TypeOperatorBundle,
+					},
+					{
+						Name:  "testB",
+						Image: "sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+						Type:  v2alpha1.TypeOperatorRelatedImage,
+					},
+				},
+			},
+			expectedError: false,
+			expectedResult: []v2alpha1.CopyImageSchema{
+				{
+					Source:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Type:        v2alpha1.TypeOperatorBundle,
+				},
+				{
+					Source:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Type:        v2alpha1.TypeOperatorRelatedImage,
+				},
+			},
+		},
+		{
+			caseName: "OperatorImageCollector - Mirror to Mirror: related image by digest and tag should pass",
+			relatedImages: map[string][]v2alpha1.RelatedImage{
+				"operatorB": {
+
+					{
+						Name:  "kube-rbac-proxy",
+						Image: "gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1@sha256:d4883d7c622683b3319b5e6b3a7edfbf2594c18060131a8bf64504805f875522",
+						Type:  v2alpha1.TypeOperatorRelatedImage,
+					},
+				},
+			},
+			expectedError: false,
+			expectedResult: []v2alpha1.CopyImageSchema{
+				{
+					Source:      "docker://gcr.io/kubebuilder/kube-rbac-proxy@sha256:d4883d7c622683b3319b5e6b3a7edfbf2594c18060131a8bf64504805f875522",
+					Destination: "docker://localhost:5000/test/kubebuilder/kube-rbac-proxy:v0.13.1",
+					Origin:      "docker://gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1@sha256:d4883d7c622683b3319b5e6b3a7edfbf2594c18060131a8bf64504805f875522",
+					Type:        v2alpha1.TypeOperatorRelatedImage,
+				},
+			},
+		},
+		{
+			caseName: "OperatorImageCollector - Mirror to Mirror: catalog image nominal should pass",
+			relatedImages: map[string][]v2alpha1.RelatedImage{
+
+				"redhat-operator-index.045638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": {
+					{
+						Image:      "registry.redhat.io/redhat/redhat-operator-index:v4.17",
+						Type:       v2alpha1.TypeOperatorCatalog,
+						RebuiltTag: "fbf7a9e933d930758fcf18e1c6e6deff3",
+					},
+				},
+			},
+			expectedError: false,
+			expectedResult: []v2alpha1.CopyImageSchema{
+
+				{
+					Source:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.17",
+					Destination: "docker://localhost:9999/redhat/redhat-operator-index:v4.17",
+					Origin:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.17",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "fbf7a9e933d930758fcf18e1c6e6deff3",
+				},
+				{
+					Source:      "docker://localhost:9999/redhat/redhat-operator-index:fbf7a9e933d930758fcf18e1c6e6deff3",
+					Destination: "docker://localhost:5000/test/redhat/redhat-operator-index:v4.17",
+					Origin:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.17",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "fbf7a9e933d930758fcf18e1c6e6deff3",
+				},
+			},
+		},
+		{
+			caseName: "OperatorImageCollector - Mirror to Mirror: catalog image - targetTag should pass",
+			relatedImages: map[string][]v2alpha1.RelatedImage{
+
+				"redhat-operator-index.543218f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": {
+					{
+						Image:      "registry.redhat.io/redhat/certified-operators:v4.10",
+						Type:       v2alpha1.TypeOperatorCatalog,
+						TargetTag:  "v4.10.0",
+						RebuiltTag: "543219e933d930758fcf18e1c6e6deff3",
+					},
+				},
+			},
+			expectedError: false,
+			expectedResult: []v2alpha1.CopyImageSchema{
+
+				{
+					Source:      "docker://registry.redhat.io/redhat/certified-operators:v4.10",
+					Destination: "docker://localhost:9999/redhat/certified-operators:v4.10.0",
+					Origin:      "docker://registry.redhat.io/redhat/certified-operators:v4.10",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "543219e933d930758fcf18e1c6e6deff3",
+				},
+				{
+					Source:      "docker://localhost:9999/redhat/certified-operators:543219e933d930758fcf18e1c6e6deff3",
+					Destination: "docker://localhost:5000/test/redhat/certified-operators:v4.10.0",
+					Origin:      "docker://registry.redhat.io/redhat/certified-operators:v4.10",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "543219e933d930758fcf18e1c6e6deff3",
+				},
+			},
+		},
+		{
+			caseName: "OperatorImageCollector - Mirror to Mirror: catalog image - targetCatalog should pass",
+			relatedImages: map[string][]v2alpha1.RelatedImage{
+
+				"redhat-operator-index.123458f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": {
+					{
+						Image:         "registry.redhat.io/redhat/certified-operators:v4.14",
+						Type:          v2alpha1.TypeOperatorCatalog,
+						TargetCatalog: "12345/certified-operators-pinned",
+						RebuiltTag:    "123459e933d930758fcf18e1c6e6deff3",
+					},
+				},
+			},
+			expectedError: false,
+			expectedResult: []v2alpha1.CopyImageSchema{
+
+				{
+					Source:      "docker://registry.redhat.io/redhat/certified-operators:v4.14",
+					Destination: "docker://localhost:9999/12345/certified-operators-pinned:v4.14",
+					Origin:      "docker://registry.redhat.io/redhat/certified-operators:v4.14",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "123459e933d930758fcf18e1c6e6deff3",
+				},
+				{
+					Source:      "docker://localhost:9999/12345/certified-operators-pinned:123459e933d930758fcf18e1c6e6deff3",
+					Destination: "docker://localhost:5000/test/12345/certified-operators-pinned:v4.14",
+					Origin:      "docker://registry.redhat.io/redhat/certified-operators:v4.14",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "123459e933d930758fcf18e1c6e6deff3",
+				},
+			},
+		},
+		{
+			caseName: "OperatorImageCollector - Mirror to Mirror: catalog image - targetTag & targetCatalog should pass",
+			relatedImages: map[string][]v2alpha1.RelatedImage{
+
+				"certified-operators.f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": {
+					{
+						Image:         "registry.redhat.io/redhat/certified-operators:v4.17",
+						Type:          v2alpha1.TypeOperatorCatalog,
+						TargetTag:     "v4.17.0-20241114",
+						TargetCatalog: "redhat/certified-operators-pinned",
+						RebuiltTag:    "dbf7a9e933d930758fcf18e1c6e6deff3",
+					},
+				},
+			},
+			expectedResult: []v2alpha1.CopyImageSchema{
+				{
+					Source:      "docker://registry.redhat.io/redhat/certified-operators:v4.17",
+					Destination: "docker://localhost:9999/redhat/certified-operators-pinned:v4.17.0-20241114",
+					Origin:      "docker://registry.redhat.io/redhat/certified-operators:v4.17",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "dbf7a9e933d930758fcf18e1c6e6deff3",
+				},
+				{
+					Source:      "docker://localhost:9999/redhat/certified-operators-pinned:dbf7a9e933d930758fcf18e1c6e6deff3",
+					Destination: "docker://localhost:5000/test/redhat/certified-operators-pinned:v4.17.0-20241114",
+					Origin:      "docker://registry.redhat.io/redhat/certified-operators:v4.17",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "dbf7a9e933d930758fcf18e1c6e6deff3",
+				},
+			},
+			expectedError: false,
+		},
+		{
+			caseName: "OperatorImageCollector - Mirror to Mirror: oci catalog image - targetTag & targetCatalog should pass",
+			relatedImages: map[string][]v2alpha1.RelatedImage{
+
+				"catalog-on-disk2.f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": {
+					{
+						Name:          "coffee-shop-index",
+						Image:         "oci://../../../tests/catalog-on-disk2",
+						Type:          v2alpha1.TypeOperatorCatalog,
+						TargetTag:     "v1.0",
+						TargetCatalog: "coffee-shop-index",
+						RebuiltTag:    "af7a9e933d930758fcf18e1c6e6deff3",
+					},
+				},
+			},
+			expectedError: false,
+			expectedResult: []v2alpha1.CopyImageSchema{
+
+				{
+					Source:      "oci://../../../tests/catalog-on-disk2",
+					Destination: "docker://localhost:9999/coffee-shop-index:v1.0",
+					Origin:      "oci://../../../tests/catalog-on-disk2",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "af7a9e933d930758fcf18e1c6e6deff3",
+				},
+				{
+					Source:      "docker://localhost:9999/coffee-shop-index:af7a9e933d930758fcf18e1c6e6deff3",
+					Destination: "docker://localhost:5000/test/coffee-shop-index:v1.0",
+					Origin:      "oci://../../../tests/catalog-on-disk2",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "af7a9e933d930758fcf18e1c6e6deff3",
+				},
+			},
+		},
+		{
+			caseName: "OperatorImageCollector - Mirror to Mirror: oci catalog image - targetCatalog should pass",
+			relatedImages: map[string][]v2alpha1.RelatedImage{
+				"catalog-on-disk3.f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": []v2alpha1.RelatedImage{
+					{Name: "tea-shop-index",
+						Image:         "oci://../../../tests/catalog-on-disk3",
+						Type:          v2alpha1.TypeOperatorCatalog,
+						TargetCatalog: "tea-shop-index",
+						RebuiltTag:    "bf7a9e933d930758fcf18e1c6e6deff3",
+					},
+				},
+			},
+			expectedError: false,
+			expectedResult: []v2alpha1.CopyImageSchema{
+
+				{
+					Source:      "oci://" + common.TestFolder + "catalog-on-disk3",
+					Destination: "docker://localhost:9999/tea-shop-index:latest",
+					Origin:      "oci://" + common.TestFolder + "catalog-on-disk3",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "bf7a9e933d930758fcf18e1c6e6deff3",
+				},
+				{
+					Source:      "docker://localhost:9999/tea-shop-index:bf7a9e933d930758fcf18e1c6e6deff3",
+					Destination: "docker://localhost:5000/test/tea-shop-index:latest",
+					Origin:      "oci://" + common.TestFolder + "catalog-on-disk3",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "bf7a9e933d930758fcf18e1c6e6deff3",
+				},
+			},
+		},
+		{
+			caseName: "OperatorImageCollector - Mirror to Mirror: oci catalog image - targetTag should pass",
+			relatedImages: map[string][]v2alpha1.RelatedImage{
+
+				"catalog-on-disk1.f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": []v2alpha1.RelatedImage{
+					{
+						Name:       "catalog-on-disk1",
+						Image:      "oci://../../../tests/catalog-on-disk1",
+						Type:       v2alpha1.TypeOperatorCatalog,
+						TargetTag:  "v1.1",
+						RebuiltTag: "cf7a9e933d930758fcf18e1c6e6deff3",
+					},
+				},
+			},
+			expectedError: false,
+			expectedResult: []v2alpha1.CopyImageSchema{
+
+				{
+					Source:      "oci://../../../tests/catalog-on-disk1",
+					Destination: "docker://localhost:9999/catalog-on-disk1:v1.1",
+					Origin:      "oci://../../../tests/catalog-on-disk1",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "cf7a9e933d930758fcf18e1c6e6deff3",
+				},
+				{
+					Source:      "docker://localhost:9999/catalog-on-disk1:cf7a9e933d930758fcf18e1c6e6deff3",
+					Destination: "docker://localhost:5000/test/catalog-on-disk1:v1.1",
+					Origin:      "oci://../../../tests/catalog-on-disk1",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "cf7a9e933d930758fcf18e1c6e6deff3",
+				},
+			},
+		},
+		{
+			caseName: "OperatorImageCollector - Mirror to Mirror: oci catalog image nominal should pass",
+			relatedImages: map[string][]v2alpha1.RelatedImage{
+
+				"catalog-on-disk1.0987660452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": {
+					{
+						Name:       "catalog-on-disk4",
+						Image:      "oci://../../../tests/catalog-on-disk4",
+						Type:       v2alpha1.TypeOperatorCatalog,
+						RebuiltTag: "09876e933d930758fcf18e1c6e6deff3",
+					},
+				},
+			},
+			expectedError: false,
+			expectedResult: []v2alpha1.CopyImageSchema{
+
+				{
+					Source:      "oci://" + common.TestFolder + "catalog-on-disk4",
+					Destination: "docker://localhost:9999/catalog-on-disk4:latest",
+					Origin:      "oci://" + common.TestFolder + "catalog-on-disk4",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "09876e933d930758fcf18e1c6e6deff3",
+				},
+				{
+					Source:      "docker://localhost:9999/catalog-on-disk4:09876e933d930758fcf18e1c6e6deff3",
+					Destination: "docker://localhost:5000/test/catalog-on-disk4:latest",
+					Origin:      "oci://" + common.TestFolder + "catalog-on-disk4",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "09876e933d930758fcf18e1c6e6deff3",
+				},
+			},
+		},
+		{
+			caseName: "OperatorImageCollector - Mirror to Mirror: Full=true catalog image nominal should pass",
+			relatedImages: map[string][]v2alpha1.RelatedImage{
+
+				"redhat-operator-index.f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": {
+					{
+						Image: "registry.redhat.io/redhat/redhat-operator-index:v4.18",
+						Type:  v2alpha1.TypeOperatorCatalog,
+						// no rebuildTag: simulating full = true
+					},
+				},
+			},
+			expectedError: false,
+			expectedResult: []v2alpha1.CopyImageSchema{
+				{
+					Source:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.18",
+					Destination: "docker://localhost:9999/redhat/redhat-operator-index:v4.18",
+					Origin:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.18",
+					Type:        v2alpha1.TypeOperatorCatalog,
+				},
+				{
+					Source:      "docker://localhost:9999/redhat/redhat-operator-index:v4.18",
+					Destination: "docker://localhost:5000/test/redhat/redhat-operator-index:v4.18",
+					Origin:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.18",
+					Type:        v2alpha1.TypeOperatorCatalog,
+				},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.caseName, func(t *testing.T) {
+			ex := setupFilterCollector_MirrorToDisk(tempDir, log, &MockManifest{})
+			ex.Opts.Mode = mirror.MirrorToMirror
+			ex.Opts.Destination = "docker://localhost:5000/test"
+			res, err := ex.dispatchImagesForM2M(testCase.relatedImages)
+			if testCase.expectedError && err == nil {
+				t.Fatalf("should fail")
+			}
+			if !testCase.expectedError && err != nil {
+				t.Fatal("should not fail")
+			}
+			assert.ElementsMatch(t, testCase.expectedResult, res)
+		})
+	}
+
+}

--- a/v2/internal/pkg/operator/filtered_collector_test.go
+++ b/v2/internal/pkg/operator/filtered_collector_test.go
@@ -17,6 +17,69 @@ import (
 	"github.com/openshift/oc-mirror/v2/internal/pkg/common"
 )
 
+var (
+	nominalConfigM2M = v2alpha1.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+			Mirror: v2alpha1.Mirror{
+				Operators: []v2alpha1.Operator{
+					{
+						Catalog: "registry.redhat.io/redhat/community-operator-index:v4.18",
+						Full:    true,
+					},
+					{
+						Catalog:       "registry.redhat.io/redhat/redhat-operator-index:v4.17",
+						TargetCatalog: "redhat/redhat-filtered-index",
+						IncludeConfig: v2alpha1.IncludeConfig{
+							Packages: []v2alpha1.IncludePackage{
+								{Name: "op1"},
+							},
+						},
+					},
+					{
+						Catalog:       "registry.redhat.io/redhat/certified-operators:v4.17",
+						Full:          true,
+						TargetCatalog: "redhat/certified-operators-pinned",
+						TargetTag:     "v4.17.0-20241114",
+						IncludeConfig: v2alpha1.IncludeConfig{
+							Packages: []v2alpha1.IncludePackage{
+								{Name: "op1"},
+							},
+						},
+					},
+					{
+						Catalog: "oci://" + common.TestFolder + "catalog-on-disk1",
+						IncludeConfig: v2alpha1.IncludeConfig{
+							Packages: []v2alpha1.IncludePackage{
+								{Name: "op1"},
+							},
+						},
+					},
+					{
+						Catalog:       "oci://" + common.TestFolder + "catalog-on-disk2",
+						Full:          true,
+						TargetCatalog: "coffee-shop-index",
+						IncludeConfig: v2alpha1.IncludeConfig{
+							Packages: []v2alpha1.IncludePackage{
+								{Name: "op1"},
+							},
+						},
+					},
+					{
+						Catalog:       "oci://" + common.TestFolder + "catalog-on-disk3",
+						TargetCatalog: "tea-shop-index",
+						TargetTag:     "v3.14",
+						IncludeConfig: v2alpha1.IncludeConfig{
+							Packages: []v2alpha1.IncludePackage{
+								{Name: "op1"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
 func TestFilterCollectorM2D(t *testing.T) {
 	log := clog.New("trace")
 
@@ -67,18 +130,21 @@ func TestFilterCollectorM2D(t *testing.T) {
 					Destination: "docker://localhost:9999/certified-operators:v4.7",
 					Origin:      "docker://certified-operators:v4.7",
 					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "442c7ba64d56a85eea155325aa0c6537",
 				},
 				{
 					Source:      "docker://community-operators:v4.7",
 					Destination: "docker://localhost:9999/community-operators:v4.7",
 					Origin:      "docker://community-operators:v4.7",
 					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "4dab2467f35b4d9c9ba7c2a7823de8bd",
 				},
 				{
 					Source:      "oci://" + common.TestFolder + "simple-test-bundle",
 					Destination: "docker://localhost:9999/simple-test-bundle:latest",
 					Origin:      "oci://" + common.TestFolder + "simple-test-bundle",
 					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
 				},
 			},
 		},
@@ -110,6 +176,7 @@ func TestFilterCollectorM2D(t *testing.T) {
 					Destination: "docker://localhost:9999/simple-test-bundle:v4.14",
 					Origin:      "oci://" + common.TestFolder + "simple-test-bundle",
 					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
 				},
 			},
 		},
@@ -147,6 +214,7 @@ func TestFilterCollectorM2D(t *testing.T) {
 					Destination: "docker://localhost:9999/test-catalog:v4.14",
 					Origin:      "oci://" + common.TestFolder + "simple-test-bundle",
 					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
 				},
 			},
 		},
@@ -178,6 +246,7 @@ func TestFilterCollectorM2D(t *testing.T) {
 					Destination: "docker://localhost:9999/test-namespace/test-catalog:v2.0",
 					Origin:      "docker://certified-operators:v4.7",
 					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "442c7ba64d56a85eea155325aa0c6537",
 				},
 			},
 		},
@@ -252,16 +321,18 @@ func TestFilterCollectorD2M(t *testing.T) {
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
-					Source:      "docker://localhost:9999/simple-test-bundle:latest",
+					Source:      "docker://localhost:9999/simple-test-bundle:9fadc6c70adb4b2571f66f674a876279",
 					Destination: "docker://localhost:5000/test/simple-test-bundle:latest",
 					Origin:      "oci://" + common.TestFolder + "simple-test-bundle",
 					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
 				},
 				{
-					Source:      "docker://localhost:9999/redhat/redhat-operator-index:v4.14",
+					Source:      "docker://localhost:9999/redhat/redhat-operator-index:6566d78129230a2e107cb5aafcb7787b",
 					Destination: "docker://localhost:5000/test/redhat/redhat-operator-index:v4.14",
 					Origin:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.14",
 					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "6566d78129230a2e107cb5aafcb7787b",
 				},
 			},
 		},
@@ -294,10 +365,11 @@ func TestFilterCollectorD2M(t *testing.T) {
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
-					Source:      "docker://localhost:9999/test-catalog:v4.14",
+					Source:      "docker://localhost:9999/test-catalog:9fadc6c70adb4b2571f66f674a876279",
 					Destination: "docker://localhost:5000/test/test-catalog:v4.14",
 					Origin:      "oci://" + common.TestFolder + "simple-test-bundle",
 					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
 				},
 			},
 		},
@@ -337,15 +409,15 @@ func TestFilterCollectorM2M(t *testing.T) {
 	os.RemoveAll(common.TestFolder + "tmp/")
 
 	//copy tests/hold-test-fake to working-dir
-	err := copy.Copy(common.TestFolder+"working-dir-fake/hold-operator/redhat-operator-index/v4.14", filepath.Join(tempDir, "working-dir", operatorImageExtractDir, "redhat-operator-index/f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"))
+	err := copy.Copy(common.TestFolder+"working-dir-fake/hold-operator/redhat-operator-index/v4.14", filepath.Join(tempDir, "working-dir", operatorImageExtractDir, "redhat/redhat-operator-index/f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"))
 	if err != nil {
 		t.Fatalf("should not fail")
 	}
 
 	testCases := []testCase{
 		{
-			caseName:      "OperatorImageCollector - Mirror to disk: should pass",
-			config:        nominalConfigM2D,
+			caseName:      "OperatorImageCollector - Mirror to Mirror: should pass",
+			config:        nominalConfigM2M,
 			expectedError: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
@@ -367,52 +439,87 @@ func TestFilterCollectorM2M(t *testing.T) {
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
-					Source:      "docker://redhat-operators:v4.7",
-					Destination: "docker://localhost:5000/test/redhat-operators:v4.7",
-					Origin:      "docker://redhat-operators:v4.7",
+					Source:      "docker://registry.redhat.io/redhat/community-operator-index:v4.18",
+					Destination: "docker://localhost:9999/redhat/community-operator-index:v4.18",
+					Origin:      "docker://registry.redhat.io/redhat/community-operator-index:v4.18",
 					Type:        v2alpha1.TypeOperatorCatalog,
 				},
 				{
-					Source:      "docker://certified-operators:v4.7",
-					Destination: "docker://localhost:5000/test/certified-operators:v4.7",
-					Origin:      "docker://certified-operators:v4.7",
+					Source:      "docker://localhost:9999/redhat/community-operator-index:v4.18",
+					Destination: "docker://localhost:5000/test/redhat/community-operator-index:v4.18",
+					Origin:      "docker://registry.redhat.io/redhat/community-operator-index:v4.18",
 					Type:        v2alpha1.TypeOperatorCatalog,
 				},
 				{
-					Source:      "docker://community-operators:v4.7",
-					Destination: "docker://localhost:5000/test/community-operators:v4.7",
-					Origin:      "docker://community-operators:v4.7",
+					Source:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.17",
+					Destination: "docker://localhost:9999/redhat/redhat-filtered-index:v4.17",
+					Origin:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.17",
 					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "08a5610c0e6f72fd34b1c76d30788c66",
 				},
 				{
-					Source:      "oci://" + common.TestFolder + "simple-test-bundle",
-					Destination: "docker://localhost:5000/test/simple-test-bundle:latest",
-					Origin:      "oci://" + common.TestFolder + "simple-test-bundle",
+					Source:      "docker://registry.redhat.io/redhat/certified-operators:v4.17",
+					Destination: "docker://localhost:9999/redhat/certified-operators-pinned:v4.17.0-20241114",
+					Origin:      "docker://registry.redhat.io/redhat/certified-operators:v4.17",
 					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "65af60f894902a1758a30ae262c0e39e",
 				},
 				{
-					Source:      "docker://redhat-operators:v4.7",
-					Destination: "docker://localhost:9999/redhat-operators:v4.7",
-					Origin:      "docker://redhat-operators:v4.7",
+					Source:      "oci://" + common.TestFolder + "catalog-on-disk1",
+					Destination: "docker://localhost:9999/catalog-on-disk1:latest",
+					Origin:      "oci://" + common.TestFolder + "catalog-on-disk1",
 					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "fc2e113a1d6f0dbe89bd2bc5c83886e3",
 				},
 				{
-					Source:      "docker://certified-operators:v4.7",
-					Destination: "docker://localhost:9999/certified-operators:v4.7",
-					Origin:      "docker://certified-operators:v4.7",
+					Source:      "oci://" + common.TestFolder + "catalog-on-disk2",
+					Destination: "docker://localhost:9999/coffee-shop-index:latest",
+					Origin:      "oci://" + common.TestFolder + "catalog-on-disk2",
 					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "421035ded2cb0e83f50ee6445b1466a5",
 				},
 				{
-					Source:      "docker://community-operators:v4.7",
-					Destination: "docker://localhost:9999/community-operators:v4.7",
-					Origin:      "docker://community-operators:v4.7",
+					Source:      "oci://" + common.TestFolder + "catalog-on-disk3",
+					Destination: "docker://localhost:9999/tea-shop-index:v3.14",
+					Origin:      "oci://" + common.TestFolder + "catalog-on-disk3",
 					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "d81a7ad49cabfc8aa050edaf56f25a3f",
+				},
+
+				{
+					Source:      "docker://localhost:9999/redhat/redhat-filtered-index:08a5610c0e6f72fd34b1c76d30788c66",
+					Destination: "docker://localhost:5000/test/redhat/redhat-filtered-index:v4.17",
+					Origin:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.17",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "08a5610c0e6f72fd34b1c76d30788c66",
 				},
 				{
-					Source:      "oci://" + common.TestFolder + "simple-test-bundle",
-					Destination: "docker://localhost:9999/simple-test-bundle:latest",
-					Origin:      "oci://" + common.TestFolder + "simple-test-bundle",
+					Source:      "docker://localhost:9999/redhat/certified-operators-pinned:65af60f894902a1758a30ae262c0e39e",
+					Destination: "docker://localhost:5000/test/redhat/certified-operators-pinned:v4.17.0-20241114",
+					Origin:      "docker://registry.redhat.io/redhat/certified-operators:v4.17",
 					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "65af60f894902a1758a30ae262c0e39e",
+				},
+				{
+					Source:      "docker://localhost:9999/catalog-on-disk1:fc2e113a1d6f0dbe89bd2bc5c83886e3",
+					Destination: "docker://localhost:5000/test/catalog-on-disk1:latest",
+					Origin:      "oci://" + common.TestFolder + "catalog-on-disk1",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "fc2e113a1d6f0dbe89bd2bc5c83886e3",
+				},
+				{
+					Source:      "docker://localhost:9999/coffee-shop-index:421035ded2cb0e83f50ee6445b1466a5",
+					Destination: "docker://localhost:5000/test/coffee-shop-index:latest",
+					Origin:      "oci://" + common.TestFolder + "catalog-on-disk2",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "421035ded2cb0e83f50ee6445b1466a5",
+				},
+				{
+					Source:      "docker://localhost:9999/tea-shop-index:d81a7ad49cabfc8aa050edaf56f25a3f",
+					Destination: "docker://localhost:5000/test/tea-shop-index:v3.14",
+					Origin:      "oci://" + common.TestFolder + "catalog-on-disk3",
+					Type:        v2alpha1.TypeOperatorCatalog,
+					RebuiltTag:  "d81a7ad49cabfc8aa050edaf56f25a3f",
 				},
 			},
 		},

--- a/v2/internal/pkg/operator/interface.go
+++ b/v2/internal/pkg/operator/interface.go
@@ -18,3 +18,7 @@ type catalogHandlerInterface interface {
 	filterRelatedImagesFromCatalog(operatorCatalog OperatorCatalog, ctlgInIsc v2alpha1.Operator, copyImageSchemaMap *v2alpha1.CopyImageSchemaMap) (map[string][]v2alpha1.RelatedImage, error)
 	getRelatedImagesFromCatalog(dc *declcfg.DeclarativeConfig, copyImageSchemaMap *v2alpha1.CopyImageSchemaMap) (map[string][]v2alpha1.RelatedImage, error)
 }
+
+type imageDispatcher interface {
+	dispatch(image v2alpha1.RelatedImage) ([]v2alpha1.CopyImageSchema, error)
+}


### PR DESCRIPTION
# Description

This PR get catalog rebuilding to be done only once in mirror to mirror workflow.

Fixes # [CLID-275](https://issues.redhat.com/browse/CLID-275)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

With the following imagesetconfig, Mirror to disk + disk to mirror as well as mirror to mirror are performed.

## Expected Outcome
All catalogs mirrors should be the filtered ones.

```
podman pull docker://sherinefedora:5000/275d/redhat/redhat-operator-index:v4.14
podman pull docker://sherinefedora:5000/275d/other/certified-operator-index:v4.16
podman pull docker://sherinefedora:5000/275d/other/certified-operator-index:v4.15.0
podman pull docker://sherinefedora:5000/275d/redhat/community-operator-index:v4.15.0-c

podman run podman pull docker://sherinefedora:5000/275d/redhat/community-operator-index:v4.15.0-c &
podman ps
podman exec -it $containerID bash
cd /configs
```
The /configs folder witin the container should contain the filtered operators only.
The catalog should run well (no cache integrity errors)