### PR TITLE
CLID-276: changes the delete feature to use the new collector

### DIFF
--- a/v2/internal/pkg/cli/delete.go
+++ b/v2/internal/pkg/cli/delete.go
@@ -257,7 +257,7 @@ func (o *ExecutorSchema) CompleteDelete(args []string) error {
 	cn := release.NewCincinnati(o.Log, &o.Config, *o.Opts, client, false, signature)
 	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.ImageBuilder)
 	o.Batch = batch.NewConcurrentBatch(o.Log, o.LogsDir, o.Mirror, calculateMaxBatchSize(o.MaxParallelOverallDownloads, o.ParallelBatchImages))
-	o.Operator = operator.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest)
+	o.Operator = operator.NewWithFilter(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest)
 	o.AdditionalImages = additional.New(o.Log, o.Config, *o.Opts, o.Mirror, o.Manifest)
 	o.HelmCollector = helm.New(o.Log, o.Config, *o.Opts, nil, nil, &http.Client{Timeout: time.Duration(5) * time.Second})
 


### PR DESCRIPTION
# Description

This PR changes the collector for the delete feature so it uses the same collector as mirrorToDisk, diskToMirror and mirrorToMirror.

Fixes [CLID-276](https://issues.redhat.com/browse/CLID-276)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
With the following ImageSetConfiguration:
```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15 
      packages:
       - name: aws-load-balancer-operator
       - name: 3scale-operator
       - name: node-observability-operator
```

The following commands were run:

m2d
```
./bin/oc-mirror -c /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-isc/isc.yaml file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-276 --v2
```

d2m
```
./bin/oc-mirror -c /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-isc/isc.yaml --from file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-276 docker://localhost:6000 --v2 --dest-tls-verify=false
```

Then with the following DeleteImageSetConfiguration:

```
kind: DeleteImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
delete:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15 
      packages:
       - name: aws-load-balancer-operator
       - name: 3scale-operator
       - name: node-observability-operator
```

The following commands were run:

delete generate
```
./bin/oc-mirror delete -c /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-isc/isc-delete.yaml --generate --workspace file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-276 docker://localhost:6000 --v2
```

delete
```
./bin/oc-mirror delete --delete-yaml-file /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-276/working-dir/delete/delete-images.yaml docker://localhost:6000 --v2 --dest-tls-verify=false
```

=======

Also mirrorToMirror was run followed by delete generate and delete

```
./bin/oc-mirror -c /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-isc/isc.yaml --workspace file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-276 docker://localhost:6000  --v2 --dest-tls-verify=false
```


## Expected Outcome
The destination registry should delete all manifests specified in the DeleteImageSetConfiguration 