### PR TITLE
CLID-261,CLID-274: rebuild independently of collect

### DIFF
--- a/v2/go.sum
+++ b/v2/go.sum
@@ -217,6 +217,7 @@ github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
+github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/v2/internal/pkg/imagebuilder/interface.go
+++ b/v2/internal/pkg/imagebuilder/interface.go
@@ -15,5 +15,5 @@ type ImageBuilderInterface interface {
 }
 
 type CatalogBuilderInterface interface {
-	RebuildCatalog(ctx context.Context, catalogCopyRefs v2alpha1.CopyImageSchema, configPath string) (v2alpha1.CopyImageSchema, error)
+	RebuildCatalog(ctx context.Context, catalogCopyRefs v2alpha1.CopyImageSchema, configPath string) error
 }

--- a/v2/internal/pkg/operator/filtered_collector.go
+++ b/v2/internal/pkg/operator/filtered_collector.go
@@ -19,8 +19,11 @@ import (
 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/image"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/spinners"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/otiai10/copy"
+	"github.com/vbauerster/mpb/v8"
+	"github.com/vbauerster/mpb/v8/decor"
 )
 
 type FilterCollector struct {
@@ -51,15 +54,34 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 		// download the operator index image
 		o.Log.Debug(collectorPrefix+"copying operator image %s", op.Catalog)
 
+		// prepare spinner
+		p := mpb.New()
+		spinner := p.AddSpinner(
+			1, mpb.BarFillerMiddleware(spinners.PositionSpinnerLeft),
+			mpb.BarWidth(3),
+			mpb.PrependDecorators(
+				decor.OnComplete(spinners.EmptyDecorator(), "\x1b[1;92m ✓ \x1b[0m"),
+				decor.OnAbort(spinners.EmptyDecorator(), "\x1b[1;91m ✗ \x1b[0m"),
+			),
+			mpb.AppendDecorators(
+				decor.Name("("),
+				decor.Elapsed(decor.ET_STYLE_GO),
+				decor.Name(") Collecting catalog "+op.Catalog+" "),
+			),
+			mpb.BarFillerClearOnComplete(),
+			spinners.BarFillerClearOnAbort(),
+		)
 		// CLID-47 double check that targetCatalog is valid
 		if op.TargetCatalog != "" && !v2alpha1.IsValidPathComponent(op.TargetCatalog) {
 			o.Log.Error(collectorPrefix+"invalid targetCatalog %s", op.TargetCatalog)
+			spinner.Abort(false)
 			return v2alpha1.CollectorSchema{}, fmt.Errorf(collectorPrefix+"invalid targetCatalog %s", op.TargetCatalog)
 		}
 		// CLID-27 ensure we pick up oci:// (on disk) catalogs
 		imgSpec, err := image.ParseRef(op.Catalog)
 		if err != nil {
 			o.Log.Error(errMsg, err.Error())
+			spinner.Abort(false)
 			return v2alpha1.CollectorSchema{}, err
 		}
 		//OCPBUGS-36214: For diskToMirror (and delete), access to the source registry is not guaranteed
@@ -68,12 +90,14 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 			d, err := o.catalogDigest(ctx, op)
 			if err != nil {
 				o.Log.Error(errMsg, err.Error())
+				spinner.Abort(false)
 				return v2alpha1.CollectorSchema{}, err
 			}
 			catalogDigest = d
 		} else {
 			sourceCtx, err := o.Opts.SrcImage.NewSystemContext()
 			if err != nil {
+				spinner.Abort(false)
 				return v2alpha1.CollectorSchema{}, err
 			}
 			d, err := o.Manifest.GetDigest(ctx, sourceCtx, imgSpec.ReferenceWithTransport)
@@ -94,6 +118,7 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 		err = createFolders([]string{configsDir, catalogImageDir, filteredCatalogsDir})
 		if err != nil {
 			o.Log.Error(errMsg, err.Error())
+			spinner.Abort(false)
 			return v2alpha1.CollectorSchema{}, err
 		}
 
@@ -102,6 +127,7 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 
 		filterDigest, err := digestOfFilter(op)
 		if err != nil {
+			spinner.Abort(false)
 			return v2alpha1.CollectorSchema{}, err
 		}
 		rebuiltTag = filterDigest
@@ -112,6 +138,7 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 			srcFilteredCatalog, err = o.cachedCatalog(op, filterDigest)
 			if err != nil {
 				o.Log.Error(errMsg, err.Error())
+				spinner.Abort(false)
 				return v2alpha1.CollectorSchema{}, err
 			}
 			isAlreadyFiltered = o.isAlreadyFiltered(ctx, srcFilteredCatalog, string(filteredImageDigest))
@@ -122,6 +149,7 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 			filteredDC, err = o.ctlgHandler.getDeclarativeConfig(filterConfigDir)
 			if err != nil {
 				o.Log.Error(errMsg, err.Error())
+				spinner.Abort(false)
 				return v2alpha1.CollectorSchema{}, err
 			}
 			if len(op.TargetCatalog) > 0 {
@@ -146,6 +174,7 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 					err := copy.Copy(imgSpec.PathComponent, catalogImageDir)
 					if err != nil {
 						o.Log.Error(errMsg, err.Error())
+						spinner.Abort(false)
 						return v2alpha1.CollectorSchema{}, err
 					}
 				}
@@ -173,6 +202,7 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 			oci, err := o.Manifest.GetImageIndex(catalogImageDir)
 			if err != nil {
 				o.Log.Error(errMsg, err.Error())
+				spinner.Abort(false)
 				return v2alpha1.CollectorSchema{}, err
 			}
 
@@ -180,12 +210,14 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 				err = o.Manifest.ConvertIndexToSingleManifest(catalogImageDir, oci)
 				if err != nil {
 					o.Log.Error(errMsg, err.Error())
+					spinner.Abort(false)
 					return v2alpha1.CollectorSchema{}, err
 				}
 
 				oci, err = o.Manifest.GetImageIndex(catalogImageDir)
 				if err != nil {
 					o.Log.Error(errMsg, err.Error())
+					spinner.Abort(false)
 					return v2alpha1.CollectorSchema{}, err
 				}
 
@@ -196,12 +228,14 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 
 			if len(oci.Manifests) == 0 {
 				o.Log.Error(collectorPrefix+"no manifests found for %s ", op.Catalog)
+				spinner.Abort(false)
 				return v2alpha1.CollectorSchema{}, fmt.Errorf(collectorPrefix+"no manifests found for %s ", op.Catalog)
 			}
 
 			validDigest, err := digest.Parse(oci.Manifests[0].Digest)
 			if err != nil {
 				o.Log.Error(collectorPrefix+digestIncorrectMessage, op.Catalog, err.Error())
+				spinner.Abort(false)
 				return v2alpha1.CollectorSchema{}, fmt.Errorf(collectorPrefix+"the digests seem to be incorrect for %s: %s ", op.Catalog, err.Error())
 			}
 
@@ -212,6 +246,7 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 			oci, err = o.Manifest.GetImageManifest(manifestDir)
 			if err != nil {
 				o.Log.Error(errMsg, err.Error())
+				spinner.Abort(false)
 				return v2alpha1.CollectorSchema{}, err
 			}
 
@@ -223,12 +258,14 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 				subDigest, err := digest.Parse(oci.Manifests[0].Digest)
 				if err != nil {
 					o.Log.Error(collectorPrefix+digestIncorrectMessage, op.Catalog, err.Error())
+					spinner.Abort(false)
 					return v2alpha1.CollectorSchema{}, fmt.Errorf(collectorPrefix+"the digests seem to be incorrect for %s: %s ", op.Catalog, err.Error())
 				}
 				manifestDir := filepath.Join(catalogImageDir, blobsDir, subDigest.Encoded())
 				oci, err = o.Manifest.GetImageManifest(manifestDir)
 				if err != nil {
 					o.Log.Error(collectorPrefix+"manifest %s: %s ", op.Catalog, err.Error())
+					spinner.Abort(false)
 					return v2alpha1.CollectorSchema{}, fmt.Errorf(collectorPrefix+"manifest %s: %s ", op.Catalog, err.Error())
 				}
 			}
@@ -238,12 +275,14 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 			configDigest, err := digest.Parse(oci.Config.Digest)
 			if err != nil {
 				o.Log.Error(collectorPrefix+digestIncorrectMessage, op.Catalog, err.Error())
+				spinner.Abort(false)
 				return v2alpha1.CollectorSchema{}, fmt.Errorf(collectorPrefix+"the digests seem to be incorrect for %s: %s ", op.Catalog, err.Error())
 			}
 			catalogDir := filepath.Join(catalogImageDir, blobsDir, configDigest.Encoded())
 			ocs, err := o.Manifest.GetOperatorConfig(catalogDir)
 			if err != nil {
 				o.Log.Error(errMsg, err.Error())
+				spinner.Abort(false)
 				return v2alpha1.CollectorSchema{}, err
 			}
 
@@ -255,11 +294,13 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 			fromDir := strings.Join([]string{catalogImageDir, blobsDir}, "/")
 			err = o.Manifest.ExtractLayersOCI(fromDir, configsDir, label, oci)
 			if err != nil {
+				spinner.Abort(false)
 				return v2alpha1.CollectorSchema{}, err
 			}
 
 			originalDC, err := o.ctlgHandler.getDeclarativeConfig(filepath.Join(configsDir, label))
 			if err != nil {
+				spinner.Abort(false)
 				return v2alpha1.CollectorSchema{}, err
 			}
 
@@ -270,12 +311,14 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 
 				filteredDC, err = filterCatalog(ctx, *originalDC, op)
 				if err != nil {
+					spinner.Abort(false)
 					return v2alpha1.CollectorSchema{}, err
 				}
 
 				filterDigest, err = digestOfFilter(op)
 				if err != nil {
 					o.Log.Error(errMsg, err.Error())
+					spinner.Abort(false)
 					return v2alpha1.CollectorSchema{}, err
 				}
 
@@ -285,12 +328,14 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 					err = createFolders([]string{filteredDigestPath})
 					if err != nil {
 						o.Log.Error(errMsg, err.Error())
+						spinner.Abort(false)
 						return v2alpha1.CollectorSchema{}, err
 					}
 				}
 
 				err = saveDeclarativeConfig(*filteredDC, filteredDigestPath)
 				if err != nil {
+					spinner.Abort(false)
 					return v2alpha1.CollectorSchema{}, err
 				}
 
@@ -311,6 +356,7 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 
 		ri, err := o.ctlgHandler.getRelatedImagesFromCatalog(filteredDC, copyImageSchemaMap)
 		if err != nil {
+			spinner.Abort(false)
 			return v2alpha1.CollectorSchema{}, err
 		}
 
@@ -346,6 +392,8 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 				RebuiltTag:    rebuiltTag,
 			},
 		}
+		spinner.Increment()
+		p.Wait()
 	}
 
 	o.Log.Debug(collectorPrefix+"related images length %d ", len(relatedImages))

--- a/v2/internal/pkg/spinners/spinners.go
+++ b/v2/internal/pkg/spinners/spinners.go
@@ -1,0 +1,30 @@
+package spinners
+
+import (
+	"io"
+
+	"github.com/vbauerster/mpb/v8"
+	"github.com/vbauerster/mpb/v8/decor"
+)
+
+func PositionSpinnerLeft(original mpb.BarFiller) mpb.BarFiller {
+	return mpb.SpinnerStyle("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", " ").PositionLeft().Build()
+}
+
+func EmptyDecorator() decor.Decorator {
+	return decor.Any(func(s decor.Statistics) string {
+		return ""
+	})
+}
+
+func BarFillerClearOnAbort() mpb.BarOption {
+	return mpb.BarFillerMiddleware(func(base mpb.BarFiller) mpb.BarFiller {
+		return mpb.BarFillerFunc(func(w io.Writer, st decor.Statistics) error {
+			if st.Aborted {
+				_, err := io.WriteString(w, "")
+				return err
+			}
+			return base.Fill(w, st)
+		})
+	})
+}


### PR DESCRIPTION
# Description

* In order to inform the user why Operator Collector is taking long, # [CLID-274](https://issues.redhat.com/browse/CLID-274) adds spinners ( :warning: without adding concurrency) to both:
  * the for loop around operator catalog collection
  * the for loop around operator catalog rebuild
* In order for catalog rebuild not to be done when `--dry-run`, [CLID-261](https://issues.redhat.com/browse/CLID-261) moves the logic of catalog rebuild away from the `CollectAll` method and into its own separate method within the executor

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Mirror to Disk with the following ImageSetConfig passes:
```
apiVersion: mirror.openshift.io/v2alpha1
kind: ImageSetConfiguration
mirror:
  operators:
    # - catalog: oci:///tmp/oci-catalog
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.14
      packages:
      - name: aws-load-balancer-operator
    - catalog: registry.redhat.io/redhat/certified-operator-index:v4.16
      targetCatalog: other/certified-operator-index
      packages:
      - name: gitlab-operator-kubernetes
    - catalog: registry.redhat.io/redhat/certified-operator-index:v4.15
      targetCatalog: other/certified-operator-index
      targetTag: v4.15.0
      packages:
      - name: gitlab-operator-kubernetes
    - catalog: registry.redhat.io/redhat/community-operator-index:v4.15
      targetTag: v4.15.0-c
      packages:
      - name: cert-utils-operator
```

## Expected Outcome
Please describe the outcome expected from the tests