### PR TITLE
OCPBUGS-41331: Add an indicator in the log that catalog is mirrored t…

### DIFF
--- a/v2/internal/pkg/batch/concurrent_worker.go
+++ b/v2/internal/pkg/batch/concurrent_worker.go
@@ -81,6 +81,10 @@ func (o *ConcurrentBatch) Worker(ctx context.Context, collectorSchema v2alpha1.C
 		for _, img := range batch.Images.AllImages {
 			imgOverallIndex++
 			counterText := fmt.Sprintf("%d/%d : (", imgOverallIndex, total)
+			imageText := ") " + img.Origin + " "
+			if strings.Contains(img.Destination, opts.LocalStorageFQDN) {
+				imageText += "► cache "
+			}
 			spinner := p.AddSpinner(
 				1, mpb.BarFillerMiddleware(positionSpinnerLeft),
 				mpb.BarWidth(3),
@@ -91,7 +95,7 @@ func (o *ConcurrentBatch) Worker(ctx context.Context, collectorSchema v2alpha1.C
 				mpb.AppendDecorators(
 					decor.Name(counterText),
 					decor.Elapsed(decor.ET_STYLE_GO),
-					decor.Name(") "+img.Origin+" "),
+					decor.Name(imageText),
 				),
 				mpb.BarFillerClearOnComplete(),
 				barFillerClearOnAbort(),


### PR DESCRIPTION
…o cache

# Description
This PR adds a simple indicator so that the end user doesn' t think that a catalog image is being mirrored twice during mirror to mirror

Fixes # [OCPBUGS-41331](https://issues.redhat.com/browse/OCPBUGS-41331)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Verified by mirror to mirror

## Expected Outcome
```
2024/11/19 12:30:19  [INFO]   : images to copy 6 
 ✓ 1/6 : (3s) docker://registry.redhat.io/albo/aws-load-balancer-controller-rhel8@sha256:2e0b9332a44d8d9c23e19c7accab0813a651f39210257820db508cac288…
 ✓ 2/6 : (3s) docker://registry.redhat.io/albo/aws-load-balancer-rhel8-operator@sha256:16e9ffed36107527a37713ac5bd34a7bc20f042269a81077429fb5884914c…
 ✓   3/6 : (7s) docker://registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:f11f71448986aa17abec9caadb568a6cc34ef1a7898e6dc20bc6a512830ba476 
 ✓ 4/6 : (3s) docker://registry.redhat.io/albo/aws-load-balancer-operator-bundle@sha256:01f2ca529d2486f113bcefc9fedce6a6fd07bcb48aaf534394b5b04c353f…
 ✓   5/6 : (5s) docker://registry.redhat.io/redhat/redhat-operator-index:v4.15 ► cache 
 ✓   6/6 : (6s) docker://registry.redhat.io/redhat/redhat-operator-index:v4.15 
```