### PR TITLE
CLID-278: Fix M2M of operator already built

### DIFF
--- a/v2/internal/pkg/operator/filtered_collector.go
+++ b/v2/internal/pkg/operator/filtered_collector.go
@@ -141,6 +141,14 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 				catalogImage = op.Catalog
 			}
 			catalogDigest = string(filteredImageDigest)
+			if collectorSchema.CatalogToFBCMap == nil {
+				collectorSchema.CatalogToFBCMap = make(map[string]v2alpha1.CatalogFilterResult)
+			}
+			result := v2alpha1.CatalogFilterResult{
+				OperatorFilter:     op,
+				FilteredConfigPath: filterConfigDir,
+			}
+			collectorSchema.CatalogToFBCMap[imgSpec.ReferenceWithTransport] = result
 
 		} else {
 			if imgSpec.Transport == ociProtocol {


### PR DESCRIPTION
# Description

Fixes # [CLID-278](https://issues.redhat.com/browse/CLID-278)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Mirror to mirror twice with same catalog 

## Expected Outcome
pass