### PR TITLE
CLID-279: removes the tech preview warning from v2

### DIFF
--- a/v2/pkg/cli/cli_wrapper.go
+++ b/v2/pkg/cli/cli_wrapper.go
@@ -16,7 +16,6 @@ func V2Cmd(loglevel string) *cobra.Command {
 	log := clog.New(loglevel)
 
 	fmt.Println()
-	log.Warn("⚠️  --v2 flag identified, flow redirected to the oc-mirror v2 version. This is Tech Preview, it is still under development and it is not production ready.")
 
 	cmd := cli.NewMirrorCmd(log)
 	return cmd


### PR DESCRIPTION
# Description

This PR removes the Tech Preview warning from v2.

Fixes [CLID-279](https://github.com/aguidirh/oc-mirror/pull/new/clid-279)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
In all workflows (m2d, d2m and mirrorToMirror) the Tech Preview warning should not be showed.

## Expected Outcome
Tech Preview warning should not be showed in the workflows.