### PR TITLE
OCPBUGS-43731,OCPBUGS-44836:Ability to generate delete-images.yaml with v1 tags

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1902,8 +1902,10 @@ github.com/sherine-k/catalog-filter v0.0.0-20241002153845-3a46851dde84/go.mod h1
 github.com/sherine-k/catalog-filter v0.0.0-20241008074337-d320370f5c38/go.mod h1:brrCOvEmD3aCujZVM6AVzPbHrJuBeFK9VMFnZED5ZcU=
 github.com/sherine-k/catalog-filter v0.0.1 h1:4XATs+3jzB+p/OQkikdxJePVigjlyRqbLh9c7kdouxQ=
 github.com/sherine-k/catalog-filter v0.0.1/go.mod h1:brrCOvEmD3aCujZVM6AVzPbHrJuBeFK9VMFnZED5ZcU=
-github.com/sherine-k/catalog-filter v0.0.2-0.20241126124527-d48d6997e9f2 h1:tdWQ4C1RwH68gyIbc1iWnqKml6Fh5M6YfYCM3vGe94k=
 github.com/sherine-k/catalog-filter v0.0.2-0.20241126124527-d48d6997e9f2/go.mod h1:brrCOvEmD3aCujZVM6AVzPbHrJuBeFK9VMFnZED5ZcU=
+github.com/sherine-k/catalog-filter v0.0.2/go.mod h1:brrCOvEmD3aCujZVM6AVzPbHrJuBeFK9VMFnZED5ZcU=
+github.com/sherine-k/catalog-filter v0.0.3 h1:YBcoOfIXeYaAi22Sd9ZFgzOcCHwuj4oBDC1w9gQDbEg=
+github.com/sherine-k/catalog-filter v0.0.3/go.mod h1:brrCOvEmD3aCujZVM6AVzPbHrJuBeFK9VMFnZED5ZcU=
 github.com/shibumi/go-pathspec v1.3.0/go.mod h1:Xutfslp817l2I1cZvgcfeMQJG5QnU2lh5tVaaMCl3jE=
 github.com/shirou/gopsutil/v3 v3.21.10/go.mod h1:t75NhzCZ/dYyPQjyQmrAYP6c8+LCdFANeBMdLPCNnew=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=

--- a/go.work.sum
+++ b/go.work.sum
@@ -891,19 +891,13 @@ github.com/chromedp/chromedp v0.9.2/go.mod h1:LkSXJKONWTCHAfQasKFUZI+mxqS4tZqhmt
 github.com/chromedp/sysutil v1.0.0/go.mod h1:kgWmDdq8fTzXYcKIBqIYvRRTnYb9aNS9moAV0xufSww=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.2.0/go.mod h1:9+9sk7u7pGNWYMkh0hdiL++6OeibzJccyQU4p4MedaY=
-github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
-github.com/chzyer/readline v1.5.1 h1:upd/6fQk4src78LMRzh5vItIt361/o4uq553V8B5sGI=
-github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
-github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3/go.mod h1:MA5e5Lr8slmEg9bt0VpxxWqJlO4iwu3FBdHUzV7wQVg=
 github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775/go.mod h1:7cR51M8ViRLIdUjrmSXlK9pkrsDlLHbO8jiB8X8JnOc=
 github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.9.1/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
-github.com/cilium/ebpf v0.11.0 h1:V8gS/bTCCjX9uUnkUFUpPsksM8n1lXBAvHcpiFk1X2Y=
-github.com/cilium/ebpf v0.11.0/go.mod h1:WE7CZAnqOL2RouJ4f1uyNhqr2P4CCvXFIqdRDUgWsVs=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
@@ -1045,15 +1039,11 @@ github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ
 github.com/containernetworking/cni v1.0.1/go.mod h1:AKuhXbN5EzmD4yTNtfSsX3tPcmtrBI6QcRV0NiNt15Y=
 github.com/containernetworking/cni v1.1.1/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
 github.com/containernetworking/cni v1.1.2/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
-github.com/containernetworking/cni v1.2.3 h1:hhOcjNVUQTnzdRJ6alC5XF+wd9mfGIUaj8FuJbEslXM=
-github.com/containernetworking/cni v1.2.3/go.mod h1:DuLgF+aPd3DzcTQTtp/Nvl1Kim23oFKdm2okJzBQA5M=
 github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHVlzhJpcY6TQxn/fUyDDM=
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
 github.com/containernetworking/plugins v1.0.1/go.mod h1:QHCfGpaTwYTbbH+nZXKVTxNBDZcxSOplJT5ico8/FLE=
 github.com/containernetworking/plugins v1.1.1/go.mod h1:Sr5TH/eBsGLXK/h71HeLfX19sZPp3ry5uHSkI4LPxV8=
 github.com/containernetworking/plugins v1.2.0/go.mod h1:/VjX4uHecW5vVimFa1wkG4s+r/s9qIfPdqlLF4TW8c4=
-github.com/containernetworking/plugins v1.5.1 h1:T5ji+LPYjjgW0QM+KyrigZbLsZ8jaX+E5J/EcKOE4gQ=
-github.com/containernetworking/plugins v1.5.1/go.mod h1:MIQfgMayGuHYs0XdNudf31cLLAC+i242hNm6KuDGqCM=
 github.com/containers/image/v5 v5.26.0/go.mod h1:QSW67adLL/B4eYsFPG6TjH5Ye4LiLazPAGWk5oQnUdQ=
 github.com/containers/ocicrypt v1.0.1/go.mod h1:MeJDzk1RJHv89LjsH0Sp5KTY3ZYkjXO/C+bKAeWFIrc=
 github.com/containers/ocicrypt v1.1.0/go.mod h1:b8AOe0YR67uU8OqfVNcznfFpAzu3rdgUV4GP9qXPfu4=
@@ -1073,7 +1063,6 @@ github.com/coreos/go-oidc/v3 v3.10.0/go.mod h1:5j11xcw0D3+SGxn6Z/WFADsgcWVMyNAlS
 github.com/coreos/go-systemd v0.0.0-20161114122254-48702e0da86b/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=
 github.com/coreos/go-systemd v0.0.0-20190620071333-e64a0ec8b42a/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
-github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f h1:JOrtw2xFKzlg+cbHpyrpLDmnN1HqhBfnX7WDiW7eG2c=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -1105,8 +1094,6 @@ github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13/go.mod h1:SqUrOPUn
 github.com/dhui/dktest v0.3.16/go.mod h1:gYaA3LRmM8Z4vJl2MA0THIigJoZrwOansEOsp+kqxp0=
 github.com/dhui/dktest v0.4.1/go.mod h1:DdOqcUpL7vgyP4GlF3X3w7HbSlz8cEQzwewPveYEQbA=
 github.com/digitalocean/godo v1.108.0/go.mod h1:R6EmmWI8CT1+fCtjWY9UCB+L5uufuZH13wk3YhxycCs=
-github.com/disiqueira/gotree/v3 v3.0.2 h1:ik5iuLQQoufZBNPY518dXhiO5056hyNBIK9lWhkNRq8=
-github.com/disiqueira/gotree/v3 v3.0.2/go.mod h1:ZuyjE4+mUQZlbpkI24AmruZKhg3VHEgPLDY8Qk+uUu8=
 github.com/distribution/distribution/v3 v3.0.0-20220526142353-ffbd94cbe269/go.mod h1:28YO/VJk9/64+sTGNuYaBjWxrXTPrj0C0XmgTIOjxX4=
 github.com/distribution/distribution/v3 v3.0.0-20221208165359-362910506bc2/go.mod h1:WHNsWjnIn2V1LYOrME7e8KxSeKunYHsxEm4am0BUtcI=
 github.com/distribution/distribution/v3 v3.0.0-20230511163743-f7717b7855ca/go.mod h1:t1IxPNGdTGez+YGKyJyQrtSSqisfMIm1hnFhvMPlxtE=
@@ -1177,7 +1164,6 @@ github.com/foxcpp/go-mockdns v0.0.0-20210729171921-fb145fc6f897/go.mod h1:lgRN6+
 github.com/frankban/quicktest v1.14.5/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
-github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsouza/fake-gcs-server v1.17.0/go.mod h1:D1rTE4YCyHFNa99oyJJ5HyclvN/0uQR+pM/VdlL83bw=
 github.com/fsouza/go-dockerclient v1.7.1/go.mod h1:PHUSk8IVIp+nkIVGrQa2GK69jPOeW/43OUKQgQcOH+M=
 github.com/fsouza/go-dockerclient v1.10.0/go.mod h1:+iNzAW78AzClIBTZ6WFjkaMvOgz68GyCJ236b1opLTs=
@@ -1281,8 +1267,6 @@ github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 h1:ZpnhV/YsD2/4cESfV5+Hoeu/iUR3ruzNvZ+yQfO03a0=
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
-github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
@@ -1556,8 +1540,6 @@ github.com/jhump/protoreflect v1.6.1/go.mod h1:RZQ/lnuN+zqeRVpQigTwO6o0AJUkxbnSn
 github.com/jhump/protoreflect v1.15.3/go.mod h1:4ORHmSBmlCW8fh3xHmJMGyul1zNqZK4Elxc8qKP+p1k=
 github.com/jingyugao/rowserrcheck v1.1.1/go.mod h1:4yvlZSDb3IyDTUZJUmpZfm2Hwok+Dtp+nu2qOq+er9c=
 github.com/jinzhu/copier v0.3.5/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
-github.com/jinzhu/copier v0.4.0 h1:w3ciUoD19shMCRargcpm0cm91ytaBhDvuRpz1ODO/U8=
-github.com/jinzhu/copier v0.4.0/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af/go.mod h1:HEWGJkRDzjJY2sqdDwxccsGicWEf9BQOZsq2tV+xzM0=
@@ -1636,8 +1618,6 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2
 github.com/magefile/mage v1.14.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
-github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/maratori/testpackage v1.0.1/go.mod h1:ddKdw+XG0Phzhx8BFDTKgpWP4i7MpApTE5fXSKAqwDU=
 github.com/markbates/pkger v0.15.1/go.mod h1:0JoVlrol20BSywW79rN3kdFFsE5xYM+rSCQDXbLhiuI=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
@@ -1666,8 +1646,6 @@ github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.6/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
-github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
-github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
@@ -1701,8 +1679,6 @@ github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQ
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mndrix/tap-go v0.0.0-20171203230836-629fa407e90b/go.mod h1:pzzDgJWZ34fGzaAZGFW22KVZDfyrYW+QABMrWnJBnSs=
 github.com/moby/buildkit v0.0.0-20181107081847-c3a857e3fca0/go.mod h1:nnELdKPRkUAQR6pAB3mRU3+IlbqL3SSaAWqQL8k/K+4=
-github.com/moby/buildkit v0.12.5 h1:RNHH1l3HDhYyZafr5EgstEu8aGNCwyfvMtrQDtjH9T0=
-github.com/moby/buildkit v0.12.5/go.mod h1:YGwjA2loqyiYfZeEo8FtI7z4x5XponAaIWsWcSjWwso=
 github.com/moby/sys/mount v0.2.0 h1:WhCW5B355jtxndN5ovugJlMFJawbUODuW8fSnEH6SSM=
 github.com/moby/sys/mount v0.2.0/go.mod h1:aAivFE2LB3W4bACsUXChRHQ0qKWsetY4Y9V7sxOougM=
 github.com/moby/sys/mount v0.3.3/go.mod h1:PBaEorSNTLG5t/+4EgukEQVlAvVEc6ZjTySwKdqp5K0=
@@ -1798,8 +1774,6 @@ github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/opencontainers/runtime-tools v0.9.1-0.20221014010322-58c91d646d86/go.mod h1:BRHJJd0E+cx42OybVYSgUvZmU0B8P9gZuRXlZUP7TKI=
 github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626/go.mod h1:BRHJJd0E+cx42OybVYSgUvZmU0B8P9gZuRXlZUP7TKI=
-github.com/opencontainers/runtime-tools v0.9.1-0.20230914150019-408c51e934dc h1:d2hUh5O6MRBvStV55MQ8we08t42zSTqBbscoQccWmMc=
-github.com/opencontainers/runtime-tools v0.9.1-0.20230914150019-408c51e934dc/go.mod h1:8tx1helyqhUC65McMm3x7HmOex8lO2/v9zPuxmKHurs=
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
@@ -1916,7 +1890,6 @@ github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24
 github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
-github.com/seccomp/libseccomp-golang v0.10.0/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/secure-systems-lab/go-securesystemslib v0.6.0/go.mod h1:8Mtpo9JKks/qhPG4HGZ2LGMvrPbzuxwfz/f/zLfEWkk=
 github.com/secure-systems-lab/go-securesystemslib v0.7.0/go.mod h1:/2gYnlnHVQ6xeGtfIqFy7Do03K4cdCY0A/GlJLDKLHI=
 github.com/securego/gosec/v2 v2.9.1/go.mod h1:oDcDLcatOJxkCGaCaq8lua1jTnYf6Sou4wdiJ1n4iHc=
@@ -1927,7 +1900,10 @@ github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c/go.mod h1:/PevMnwAx
 github.com/sherine-k/catalog-filter v0.0.0-20240923132931-be549836be50/go.mod h1:brrCOvEmD3aCujZVM6AVzPbHrJuBeFK9VMFnZED5ZcU=
 github.com/sherine-k/catalog-filter v0.0.0-20241002153845-3a46851dde84/go.mod h1:brrCOvEmD3aCujZVM6AVzPbHrJuBeFK9VMFnZED5ZcU=
 github.com/sherine-k/catalog-filter v0.0.0-20241008074337-d320370f5c38/go.mod h1:brrCOvEmD3aCujZVM6AVzPbHrJuBeFK9VMFnZED5ZcU=
+github.com/sherine-k/catalog-filter v0.0.1 h1:4XATs+3jzB+p/OQkikdxJePVigjlyRqbLh9c7kdouxQ=
 github.com/sherine-k/catalog-filter v0.0.1/go.mod h1:brrCOvEmD3aCujZVM6AVzPbHrJuBeFK9VMFnZED5ZcU=
+github.com/sherine-k/catalog-filter v0.0.2-0.20241126124527-d48d6997e9f2 h1:tdWQ4C1RwH68gyIbc1iWnqKml6Fh5M6YfYCM3vGe94k=
+github.com/sherine-k/catalog-filter v0.0.2-0.20241126124527-d48d6997e9f2/go.mod h1:brrCOvEmD3aCujZVM6AVzPbHrJuBeFK9VMFnZED5ZcU=
 github.com/shibumi/go-pathspec v1.3.0/go.mod h1:Xutfslp817l2I1cZvgcfeMQJG5QnU2lh5tVaaMCl3jE=
 github.com/shirou/gopsutil/v3 v3.21.10/go.mod h1:t75NhzCZ/dYyPQjyQmrAYP6c8+LCdFANeBMdLPCNnew=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
@@ -2054,12 +2030,8 @@ github.com/vincent-petithory/dataurl v1.0.0/go.mod h1:FHafX5vmDzyP+1CQATJn7WFKc9
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
-github.com/vishvananda/netlink v1.2.1-beta.2 h1:Llsql0lnQEbHj0I1OuKyp8otXp0r3q0mPkuhwHfStVs=
-github.com/vishvananda/netlink v1.2.1-beta.2/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
-github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
-github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/vultr/govultr/v2 v2.17.2/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
 github.com/weppos/publicsuffix-go v0.12.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/weppos/publicsuffix-go v0.13.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
@@ -2618,9 +2590,9 @@ k8s.io/utils v0.0.0-20230406110748-d93618cff8a2/go.mod h1:OLgZIPagt7ERELqWJFomSt
 k8s.io/utils v0.0.0-20230505201702-9f6742963106/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 k8s.io/utils v0.0.0-20230711102312-30195339c3c7/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 k8s.io/utils v0.0.0-20240310230437-4693a0247e57 h1:gbqbevonBh57eILzModw6mrkbwM0gQBEuevE/AaBsHY=
-knative.dev/pkg v0.0.0-20230404101938-ee73c9355c9d/go.mod h1:EQk8+qkZ8fMtrDYOOb9e9xMQG29N+L54iXBCfNXRm90=
 kernel.org/pub/linux/libs/security/libcap/cap v1.2.67/go.mod h1:GkntoBuwffz19qtdFVB+k2NtWNN+yCKnC/Ykv/hMiTU=
 kernel.org/pub/linux/libs/security/libcap/psx v1.2.67/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=
+knative.dev/pkg v0.0.0-20230404101938-ee73c9355c9d/go.mod h1:EQk8+qkZ8fMtrDYOOb9e9xMQG29N+L54iXBCfNXRm90=
 knative.dev/pkg v0.0.0-20230612155445-74c4be5e935e/go.mod h1:dqC6IrvyBE7E+oZocs5PkVhq1G59pDTA7r8U17EAKMk=
 lukechampine.com/uint128 v1.3.0/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 modernc.org/b v1.0.0/go.mod h1:uZWcZfRj1BpYzfN9JTerzlNUnnPsV9O2ZA8JsRcubNg=
@@ -2667,6 +2639,4 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/structured-merge-diff/v4 v4.0.3/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
 tags.cncf.io/container-device-interface v0.7.2/go.mod h1:Xb1PvXv2BhfNb3tla4r9JL129ck1Lxv9KuU6eVOfKto=
-tags.cncf.io/container-device-interface v0.8.0 h1:8bCFo/g9WODjWx3m6EYl3GfUG31eKJbaggyBDxEldRc=
-tags.cncf.io/container-device-interface v0.8.0/go.mod h1:Apb7N4VdILW0EVdEMRYXIDVRZfNJZ+kmEUss2kRRQ6Y=
 tags.cncf.io/container-device-interface/specs-go v0.7.0/go.mod h1:hMAwAbMZyBLdmYqWgYcKH0F/yctNpV3P35f+/088A80=

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/openshift/api v0.0.0-20240529192326-16d44e6d3e7d
 	github.com/operator-framework/operator-registry v1.47.0
 	github.com/otiai10/copy v1.14.0
-	github.com/sherine-k/catalog-filter v0.0.2-0.20241126124527-d48d6997e9f2
+	github.com/sherine-k/catalog-filter v0.0.3
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/openshift/api v0.0.0-20240529192326-16d44e6d3e7d
 	github.com/operator-framework/operator-registry v1.47.0
 	github.com/otiai10/copy v1.14.0
-	github.com/sherine-k/catalog-filter v0.0.1
+	github.com/sherine-k/catalog-filter v0.0.2-0.20241126124527-d48d6997e9f2
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -476,8 +476,7 @@ github.com/secure-systems-lab/go-securesystemslib v0.8.0 h1:mr5An6X45Kb2nddcFlbm
 github.com/secure-systems-lab/go-securesystemslib v0.8.0/go.mod h1:UH2VZVuJfCYR8WgMlCU1uFsOUU+KeyrTWcSS73NBOzU=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
-github.com/sherine-k/catalog-filter v0.0.1 h1:4XATs+3jzB+p/OQkikdxJePVigjlyRqbLh9c7kdouxQ=
-github.com/sherine-k/catalog-filter v0.0.1/go.mod h1:brrCOvEmD3aCujZVM6AVzPbHrJuBeFK9VMFnZED5ZcU=
+github.com/sherine-k/catalog-filter v0.0.2-0.20241126124527-d48d6997e9f2 h1:tdWQ4C1RwH68gyIbc1iWnqKml6Fh5M6YfYCM3vGe94k=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -476,7 +476,7 @@ github.com/secure-systems-lab/go-securesystemslib v0.8.0 h1:mr5An6X45Kb2nddcFlbm
 github.com/secure-systems-lab/go-securesystemslib v0.8.0/go.mod h1:UH2VZVuJfCYR8WgMlCU1uFsOUU+KeyrTWcSS73NBOzU=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
-github.com/sherine-k/catalog-filter v0.0.2-0.20241126124527-d48d6997e9f2 h1:tdWQ4C1RwH68gyIbc1iWnqKml6Fh5M6YfYCM3vGe94k=
+github.com/sherine-k/catalog-filter v0.0.3 h1:YBcoOfIXeYaAi22Sd9ZFgzOcCHwuj4oBDC1w9gQDbEg=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/v2/internal/pkg/additional/local_stored_collector_test.go
+++ b/v2/internal/pkg/additional/local_stored_collector_test.go
@@ -141,6 +141,45 @@ func TestAdditionalImageCollector(t *testing.T) {
 		assert.ElementsMatch(t, expected, res)
 	})
 
+	t.Run("Testing AdditionalImagesCollector : diskToMirror with generateV1Tags should use latest for images by digest", func(t *testing.T) {
+		// should error diskToMirror
+		opts.Mode = mirror.DiskToMirror
+		ex = New(log, cfg, opts, mockmirror, manifest)
+		ex = WithV1Tags(ex)
+		expected := []v2alpha1.CopyImageSchema{
+			{
+				Destination: "docker://mirror.acme.com/ubi8/ubi:latest",
+				Origin:      "registry.redhat.io/ubi8/ubi:latest",
+				Source:      "docker://test.registry.com/ubi8/ubi:latest",
+				Type:        v2alpha1.TypeGeneric,
+			},
+			{
+				Destination: "docker://mirror.acme.com/ubi8/ubi:latest",
+				Origin:      "registry.redhat.io/ubi8/ubi:latest@sha256:44d75007b39e0e1bbf1bcfd0721245add54c54c3f83903f8926fb4bef6827aa2",
+				Source:      "docker://test.registry.com/ubi8/ubi:latest",
+				Type:        v2alpha1.TypeGeneric,
+			},
+			{
+				Destination: "docker://mirror.acme.com/testns/test:latest",
+				Origin:      "sometest.registry.com/testns/test@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+				Source:      "docker://test.registry.com/testns/test:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+				Type:        v2alpha1.TypeGeneric,
+			},
+			{
+				Destination: "docker://mirror.acme.com/folder-a/folder-b/testns/test:latest",
+				Origin:      "oci:///folder-a/folder-b/testns/test",
+				Source:      "docker://test.registry.com/folder-a/folder-b/testns/test:latest",
+				Type:        v2alpha1.TypeGeneric,
+			},
+		}
+		res, err := ex.AdditionalImagesCollector(ctx)
+		if err != nil {
+			log.Error(" %v ", err)
+			t.Fatalf("should not fail")
+		}
+		assert.ElementsMatch(t, expected, res)
+	})
+
 	// should error mirrorToDisk
 	cfg.Mirror.AdditionalImages[1].Name = "sometest.registry.com/testns/test@shaf30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"
 	opts.Mode = mirror.MirrorToDisk

--- a/v2/internal/pkg/cli/delete_test.go
+++ b/v2/internal/pkg/cli/delete_test.go
@@ -42,10 +42,11 @@ func TestExecutorValidateDelete(t *testing.T) {
 		}
 		opts.Global.ConfigPath = common.TestFolder + "isc.yaml"
 
-		ex := &ExecutorSchema{
-			Log:     log,
-			Opts:    opts,
-			LogsDir: "/tmp/",
+		ex := &DeleteSchema{
+			ExecutorSchema: ExecutorSchema{Log: log,
+				Opts:    opts,
+				LogsDir: "/tmp/",
+			},
 		}
 
 		defer os.RemoveAll("../../pkg/cli/test")
@@ -126,11 +127,13 @@ func TestExecutorCompleteDelete(t *testing.T) {
 		opts.Global.DeleteGenerate = true
 		opts.Global.DeleteID = "test"
 
-		ex := &ExecutorSchema{
-			Log:     log,
-			Opts:    &opts,
-			MakeDir: MakeDir{},
-			LogsDir: "/tmp/",
+		ex := &DeleteSchema{
+			ExecutorSchema: ExecutorSchema{
+				Log:     log,
+				Opts:    &opts,
+				MakeDir: MakeDir{},
+				LogsDir: "/tmp/",
+			},
 		}
 
 		t.Setenv(cacheEnvVar, "/tmp/")
@@ -222,20 +225,22 @@ func TestExecutorRunDelete(t *testing.T) {
 		defer os.RemoveAll(common.TestFolder + "cache-fake-temp")
 		opts.LocalStorageFQDN = regCfg.HTTP.Addr
 
-		ex := &ExecutorSchema{
-			Log:                          log,
-			Opts:                         &opts,
-			Operator:                     collector,
-			Release:                      collector,
-			AdditionalImages:             collector,
-			HelmCollector:                collector,
-			Mirror:                       mockMirror,
-			Batch:                        &mockBatch,
-			LocalStorageService:          *reg,
-			localStorageInterruptChannel: fakeStorageInterruptChan,
-			LogsDir:                      "/tmp/",
-			Delete:                       MockDelete{},
-			LocalStorageDisk:             common.TestFolder + "cache-fake-temp/",
+		ex := &DeleteSchema{
+			ExecutorSchema: ExecutorSchema{
+				Log:                          log,
+				Opts:                         &opts,
+				Operator:                     collector,
+				Release:                      collector,
+				AdditionalImages:             collector,
+				HelmCollector:                collector,
+				Mirror:                       mockMirror,
+				Batch:                        &mockBatch,
+				LocalStorageService:          *reg,
+				localStorageInterruptChannel: fakeStorageInterruptChan,
+				LogsDir:                      "/tmp/",
+				Delete:                       MockDelete{},
+				LocalStorageDisk:             common.TestFolder + "cache-fake-temp/",
+			},
 		}
 
 		res := &cobra.Command{}

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -1076,6 +1076,15 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 	o.Log.Debug(collecAllPrefix+"total helm images to %s %d ", o.Opts.Function, collectorSchema.TotalHelmImages)
 	allRelatedImages = append(allRelatedImages, hImgs...)
 
+	// OCPBUGS-43731 - remove duplicates
+	allRelatedImages = slices.CompactFunc(allRelatedImages, func(a, b v2alpha1.CopyImageSchema) bool {
+		if o.Opts.Function == string(mirror.DeleteMode) {
+			return a.Destination == b.Destination
+		} else {
+			return a.Source == b.Source && a.Destination == b.Destination && a.Origin == b.Origin
+		}
+	})
+
 	collectorSchema.AllImages = allRelatedImages
 
 	endTime := time.Now()

--- a/v2/internal/pkg/helm/local_stored_collector_test.go
+++ b/v2/internal/pkg/helm/local_stored_collector_test.go
@@ -44,13 +44,14 @@ type MockChartDownloader struct{}
 type MockHttpClient struct{}
 
 type testCase struct {
-	caseName       string
-	mirrorMode     string
-	helmConfig     v2alpha1.Helm
-	localStorage   string
-	dest           string
-	expectedResult []v2alpha1.CopyImageSchema
-	expectedError  error
+	caseName           string
+	mirrorMode         string
+	helmConfig         v2alpha1.Helm
+	localStorage       string
+	dest               string
+	generateV1DestTags bool
+	expectedResult     []v2alpha1.CopyImageSchema
+	expectedError      error
 }
 
 func TestHelmImageCollector(t *testing.T) {
@@ -66,6 +67,7 @@ func TestHelmImageCollector(t *testing.T) {
 					{Name: "podinfo-local", Path: filepath.Join(testChartsDataPath, "podinfo-5.0.0.tgz")},
 				},
 			},
+			generateV1DestTags: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://ghcr.io/stefanprodan/podinfo:5.0.0",
@@ -85,6 +87,7 @@ func TestHelmImageCollector(t *testing.T) {
 					{Name: "podinfo", URL: "https://stefanprodan.github.io/podinfo", Charts: []v2alpha1.Chart{{Name: "podinfo", Version: "5.0.0"}}},
 				},
 			},
+			generateV1DestTags: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://ghcr.io/stefanprodan/podinfo:5.0.0",
@@ -104,6 +107,7 @@ func TestHelmImageCollector(t *testing.T) {
 					{Name: "sbo", URL: "https://redhat-developer.github.io/service-binding-operator-helm-chart/"},
 				},
 			},
+			generateV1DestTags: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://quay.io/redhat-developer/servicebinding-operator@sha256:16286ac84ddd521897d92472dae857a4c18479f255b725dfb683bc72df6e0865",
@@ -177,6 +181,7 @@ func TestHelmImageCollector(t *testing.T) {
 					{Name: "podinfo-local", Path: filepath.Join(testChartsDataPath, "podinfo-5.0.0.tgz")},
 				},
 			},
+			generateV1DestTags: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://ghcr.io/stefanprodan/podinfo:5.0.0",
@@ -196,6 +201,7 @@ func TestHelmImageCollector(t *testing.T) {
 					{Name: "podinfo", URL: "https://stefanprodan.github.io/podinfo", Charts: []v2alpha1.Chart{{Name: "podinfo", Version: "5.0.0"}}},
 				},
 			},
+			generateV1DestTags: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://ghcr.io/stefanprodan/podinfo:5.0.0",
@@ -215,6 +221,7 @@ func TestHelmImageCollector(t *testing.T) {
 					{Name: "sbo", URL: "https://redhat-developer.github.io/service-binding-operator-helm-chart/"},
 				},
 			},
+			generateV1DestTags: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://quay.io/redhat-developer/servicebinding-operator@sha256:16286ac84ddd521897d92472dae857a4c18479f255b725dfb683bc72df6e0865",
@@ -289,6 +296,7 @@ func TestHelmImageCollector(t *testing.T) {
 					{Name: "podinfo-local", Path: filepath.Join(testChartsDataPath, "podinfo-5.0.0.tgz")},
 				},
 			},
+			generateV1DestTags: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://" + testLocalStorageFQDN + "/stefanprodan/podinfo:5.0.0",
@@ -309,6 +317,7 @@ func TestHelmImageCollector(t *testing.T) {
 					{Name: "podinfo", URL: "https://stefanprodan.github.io/podinfo", Charts: []v2alpha1.Chart{{Name: "podinfo", Version: "5.0.0"}}},
 				},
 			},
+			generateV1DestTags: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://" + testLocalStorageFQDN + "/stefanprodan/podinfo:5.0.0",
@@ -329,6 +338,7 @@ func TestHelmImageCollector(t *testing.T) {
 					{Name: "sbo", URL: "https://redhat-developer.github.io/service-binding-operator-helm-chart/"},
 				},
 			},
+			generateV1DestTags: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://" + testLocalStorageFQDN + "/redhat-developer/servicebinding-operator:sha256-16286ac84ddd521897d92472dae857a4c18479f255b725dfb683bc72df6e0865",
@@ -393,6 +403,81 @@ func TestHelmImageCollector(t *testing.T) {
 			},
 			expectedError: nil,
 		},
+		{
+			caseName:     "repositories helm chart - charts not included - diskToMirror with generateV1Tags: should pass",
+			mirrorMode:   mirror.DiskToMirror,
+			localStorage: testLocalStorageFQDN,
+			dest:         testDest,
+			helmConfig: v2alpha1.Helm{
+				Repositories: []v2alpha1.Repository{
+					{Name: "sbo", URL: "https://redhat-developer.github.io/service-binding-operator-helm-chart/"},
+				},
+			},
+			generateV1DestTags: true,
+			expectedResult: []v2alpha1.CopyImageSchema{
+				{
+					Source:      "docker://" + testLocalStorageFQDN + "/redhat-developer/servicebinding-operator:sha256-16286ac84ddd521897d92472dae857a4c18479f255b725dfb683bc72df6e0865",
+					Destination: testDest + "/redhat-developer/servicebinding-operator:latest",
+					Origin:      "quay.io/redhat-developer/servicebinding-operator@sha256:16286ac84ddd521897d92472dae857a4c18479f255b725dfb683bc72df6e0865",
+					Type:        v2alpha1.TypeHelmImage,
+				},
+				{
+					Source:      "docker://" + testLocalStorageFQDN + "/redhat-developer/servicebinding-operator:sha256-ac47f496fb7ecdcbc371f8c809fad2687ec0c35bbc8c522a7ab63b3e5ffd90ea",
+					Destination: testDest + "/redhat-developer/servicebinding-operator:latest",
+					Origin:      "quay.io/redhat-developer/servicebinding-operator@sha256:ac47f496fb7ecdcbc371f8c809fad2687ec0c35bbc8c522a7ab63b3e5ffd90ea",
+					Type:        v2alpha1.TypeHelmImage,
+				},
+				{
+					Source:      "docker://" + testLocalStorageFQDN + "/redhat-developer/servicebinding-operator:sha256-e4259939a496f292a31b5e57760196d63a8182b999164d93a446da48c4ea24eb",
+					Destination: testDest + "/redhat-developer/servicebinding-operator:latest",
+					Origin:      "quay.io/redhat-developer/servicebinding-operator@sha256:e4259939a496f292a31b5e57760196d63a8182b999164d93a446da48c4ea24eb",
+					Type:        v2alpha1.TypeHelmImage,
+				},
+				{
+					Source:      "docker://" + testLocalStorageFQDN + "/redhat-developer/servicebinding-operator:sha256-30bf7f0f21024bb2e1e4db901b1f5e89ab56e0f3197a919d2bbb670f3fe5223a",
+					Destination: testDest + "/redhat-developer/servicebinding-operator:latest",
+					Origin:      "quay.io/redhat-developer/servicebinding-operator@sha256:30bf7f0f21024bb2e1e4db901b1f5e89ab56e0f3197a919d2bbb670f3fe5223a",
+					Type:        v2alpha1.TypeHelmImage,
+				},
+				{
+					Source:      "docker://" + testLocalStorageFQDN + "/redhat-developer/servicebinding-operator:sha256-67c2a2502f59fac1e7ded9ed19b59bbd4e50f5559a13978a87ecd2283b81e067",
+					Destination: testDest + "/redhat-developer/servicebinding-operator:latest",
+					Origin:      "quay.io/redhat-developer/servicebinding-operator@sha256:67c2a2502f59fac1e7ded9ed19b59bbd4e50f5559a13978a87ecd2283b81e067",
+					Type:        v2alpha1.TypeHelmImage,
+				},
+				{
+					Source:      "docker://" + testLocalStorageFQDN + "/redhat-developer/servicebinding-operator:sha256-e01016cacae84dfb6eaf7a1022130e7d95e2a8489c38d4d46e4f734848e93849",
+					Destination: testDest + "/redhat-developer/servicebinding-operator:latest",
+					Origin:      "quay.io/redhat-developer/servicebinding-operator@sha256:e01016cacae84dfb6eaf7a1022130e7d95e2a8489c38d4d46e4f734848e93849",
+					Type:        v2alpha1.TypeHelmImage,
+				},
+				{
+					Source:      "docker://" + testLocalStorageFQDN + "/redhat-developer/servicebinding-operator:sha256-f79f6999a15534dbe56e658caf94fc4b7afb5ceeb7b49f32a60ead06fbd7c3fc",
+					Destination: testDest + "/redhat-developer/servicebinding-operator:latest",
+					Origin:      "quay.io/redhat-developer/servicebinding-operator@sha256:f79f6999a15534dbe56e658caf94fc4b7afb5ceeb7b49f32a60ead06fbd7c3fc",
+					Type:        v2alpha1.TypeHelmImage,
+				},
+				{
+					Source:      "docker://" + testLocalStorageFQDN + "/redhat-developer/servicebinding-operator:sha256-69a95c6216ead931e01e4144ae8f4fb7ab35d1f68a14c18f6860a085ccb950f5",
+					Destination: testDest + "/redhat-developer/servicebinding-operator:latest",
+					Origin:      "quay.io/redhat-developer/servicebinding-operator@sha256:69a95c6216ead931e01e4144ae8f4fb7ab35d1f68a14c18f6860a085ccb950f5",
+					Type:        v2alpha1.TypeHelmImage,
+				},
+				{
+					Source:      "docker://" + testLocalStorageFQDN + "/redhat-developer/servicebinding-operator:sha256-cc5aab01ddd3744510c480eb4f58b834936a833d36bec5c9c13fb40bbb06c663",
+					Destination: testDest + "/redhat-developer/servicebinding-operator:latest",
+					Origin:      "quay.io/redhat-developer/servicebinding-operator@sha256:cc5aab01ddd3744510c480eb4f58b834936a833d36bec5c9c13fb40bbb06c663",
+					Type:        v2alpha1.TypeHelmImage,
+				},
+				{
+					Source:      "docker://" + testLocalStorageFQDN + "/redhat-developer/servicebinding-operator:sha256-de1881753e82c51b31e958fcf383cb35b0f70f6ec99d402d42243e595d00c6dd",
+					Destination: testDest + "/redhat-developer/servicebinding-operator:latest",
+					Origin:      "quay.io/redhat-developer/servicebinding-operator@sha256:de1881753e82c51b31e958fcf383cb35b0f70f6ec99d402d42243e595d00c6dd",
+					Type:        v2alpha1.TypeHelmImage,
+				},
+			},
+			expectedError: nil,
+		},
 	}
 
 	tempDir := t.TempDir()
@@ -420,7 +505,9 @@ func TestHelmImageCollector(t *testing.T) {
 			mockHttpClient := MockHttpClient{}
 
 			helmCollector := New(log, cfg, opts, mockIndexDownloader, mockChartDownloader, mockHttpClient)
-
+			if testCase.generateV1DestTags {
+				helmCollector = WithV1Tags(helmCollector)
+			}
 			if testCase.mirrorMode == mirror.DiskToMirror {
 				prepareDiskToMirror(testCase)
 			}

--- a/v2/internal/pkg/operator/catalog_handler_test.go
+++ b/v2/internal/pkg/operator/catalog_handler_test.go
@@ -28,7 +28,7 @@ func TestGetRelatedImagesFromCatalog(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			caseName: "only catalog (no filtering) - only the head of the default channel - should pass",
+			caseName: "only catalog (no filtering) - heads for all channels - should pass",
 			cfg: v2alpha1.Operator{
 				IncludeConfig: v2alpha1.IncludeConfig{},
 			},
@@ -658,13 +658,15 @@ func TestFilterCatalog(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			caseName: "only catalog (no filtering) - only the head of the default channel - should pass",
+			caseName: "only catalog (no filtering) - only heads of all channels - should pass",
 			cfg: v2alpha1.Operator{
 				IncludeConfig: v2alpha1.IncludeConfig{},
 			},
 			expectedBundles: []string{
 				"3scale-operator.v0.11.0-mas",
 				"devworkspace-operator.v0.19.1-0.1682321189.p",
+				"3scale-operator.v0.9.1-0.1664967752.p",
+				"3scale-operator.v0.8.4-0.1655690146.p",
 				"jaeger-operator.v1.51.0-1",
 			},
 		},
@@ -716,7 +718,7 @@ func TestFilterCatalog(t *testing.T) {
 			},
 		},
 		{
-			caseName: "packages with no Min Max version (no channels) - 1 bundle, corresponding to the head version of the default channel for each package - should pass",
+			caseName: "packages with no Min Max version (no channels) - 1 bundle, corresponding to the head version of any channel for selected packages - should pass",
 			cfg: v2alpha1.Operator{
 				IncludeConfig: v2alpha1.IncludeConfig{
 					Packages: []v2alpha1.IncludePackage{
@@ -734,6 +736,8 @@ func TestFilterCatalog(t *testing.T) {
 			},
 			expectedBundles: []string{
 				"3scale-operator.v0.11.0-mas",
+				"3scale-operator.v0.9.1-0.1664967752.p",
+				"3scale-operator.v0.8.4-0.1655690146.p",
 				"devworkspace-operator.v0.19.1-0.1682321189.p",
 				"jaeger-operator.v1.51.0-1",
 			},
@@ -817,6 +821,8 @@ func TestFilterCatalog(t *testing.T) {
 			},
 			expectedBundles: []string{
 				"3scale-operator.v0.11.0-mas",
+				"3scale-operator.v0.9.1-0.1664967752.p",
+				"3scale-operator.v0.8.4-0.1655690146.p",
 				"devworkspace-operator.v0.18.1",
 				"devworkspace-operator.v0.18.1-0.1675929565.p",
 				"devworkspace-operator.v0.19.1",
@@ -845,6 +851,8 @@ func TestFilterCatalog(t *testing.T) {
 			},
 			expectedBundles: []string{
 				"3scale-operator.v0.11.0-mas",
+				"3scale-operator.v0.9.1-0.1664967752.p",
+				"3scale-operator.v0.8.4-0.1655690146.p",
 				"devworkspace-operator.v0.9.0",
 				"devworkspace-operator.v0.10.0",
 				"devworkspace-operator.v0.11.0",
@@ -884,6 +892,8 @@ func TestFilterCatalog(t *testing.T) {
 			},
 			expectedBundles: []string{
 				"3scale-operator.v0.11.0-mas",
+				"3scale-operator.v0.9.1-0.1664967752.p",
+				"3scale-operator.v0.8.4-0.1655690146.p",
 				"devworkspace-operator.v0.16.0",
 				"devworkspace-operator.v0.16.0-0.1666668361.p",
 				"devworkspace-operator.v0.17.0",

--- a/v2/internal/pkg/operator/filtered_collector.go
+++ b/v2/internal/pkg/operator/filtered_collector.go
@@ -433,12 +433,13 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 			o.Log.Error(errMsg, err.Error())
 			return v2alpha1.CollectorSchema{}, err
 		}
-	case o.Opts.IsDiskToMirror():
+	case o.Opts.IsDiskToMirror() || o.Opts.Mode == string(mirror.DeleteMode):
 		allImages, err = o.prepareD2MCopyBatch(relatedImages)
 		if err != nil {
 			o.Log.Error(errMsg, err.Error())
 			return v2alpha1.CollectorSchema{}, err
 		}
+
 	}
 
 	sort.Sort(ByTypePriority(allImages))


### PR DESCRIPTION
# Description

This PR attempts to provide a way forward for customers who are looking to use oc-mirror v2 delete functionality for cleaning up artifacts previously mirrored with oc-mirror v1.

For images referenced by digest, and not by tag, v1 and v2 both attribute a tag to prevent the mirrored image from being deleted because it's not referenced. But they do so in a different way:
* for **operator images** 
 * v1 uses oc underneath, which [applies a hash](https://github.com/openshift/oc/blob/bdce85daf64eda40dd1b604270b85c67a296bc93/pkg/cli/admin/catalog/mirrorer.go#L176-L185) on the complete image reference
  * v2 uses the digest as the hash
* for **release images**: both v1 and v2 use the tagging convension for release components
* for **helm charts**
  * v1 uses `latest`
  * v2 uses a combination of digest algorithm and digest (`sha256-23242534546`)
* for **additional images**
  * v1 uses `latest`
  * v2 uses the image digest

In order to force oc-mirror v2 to generate v1-like tags, the user can now use the flag `--delete-v1-images` . This tag is only allowed for the delete workflow, and MUST be combined with the `--generate` flag.

See below for the steps to delete v1 mirrored operators.

Fixes #[OCPBUGS-43731](https://issues.redhat.com/browse/OCPBUGS-43731)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

## **Step1** use v1 to do a mirror to mirror
```bash
$ ./bin/oc-mirror -c config_logs/bugs.yaml docker://localhost:5000/43731 --dest-skip-tls --dest-use-http
```
with the following ISC
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15
      packages:
        - name: sandboxed-containers-operator
  platform:
    channels:
      - name: stable-4.17
  helm:
    repositories:
      - name: sbo
        url: https://redhat-developer.github.io/service-binding-operator-helm-chart/
  additionalImages: # List of additional images to be included in imageset
    - name: registry.redhat.io/ubi8/ubi@sha256:d497966ce214138de5271eef321680639e18daf105ae94a6bff54247d8a191a3
```
:warning: Keep the mapping.txt for later use for verification purposes.

## **Step2** use v2 for a mirror to disk starting from the mirrored catalog
```bash
./bin/oc-mirror --v2 -c config_logs/bugs.yaml docker://sherinefedora:5000/43731 --workspace file:///home/skhoury/clid261d 
```
with the following ISC
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
    - catalog: sherinefedora:5000/43731/redhat/redhat-operator-index:v4.15
      packages:
        - name: sandboxed-containers-operator 
  platform:
    channels:
      - name: stable-4.17
  helm:
    repositories:
      - name: sbo
        url: https://redhat-developer.github.io/service-binding-operator-helm-chart/
  additionalImages: # List of additional images to be included in imageset
    - name: registry.redhat.io/ubi8/ubi@sha256:d497966ce214138de5271eef321680639e18daf105ae94a6bff54247d8a191a3
```
:eyes: Notice that the catalog used is coming from the mirror registry: in fact, redhat catalog tags are updated almost every day, and the v4.15 mirrored last month will probably contain different image digests than the v4.15 of today.

## **Step3** use v2 to generate the delete-images.yaml file
```bash
./bin/oc-mirror delete --generate --v2 -c config_logs/bugs.yaml docker://sherinefedora:5000/43731 --workspace file:///home/skhoury/clid261d --delete-v1-images
```
with the following DISC
```yaml
kind: DeleteImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
delete:
  operators:
    - catalog: sherinefedora:5000/43731/redhat/redhat-operator-index:v4.15
      packages:
        - name: sandboxed-containers-operator  
  platform:
    channels:
      - name: stable-4.17
  helm:
    repositories:
      - name: sbo
        url: https://redhat-developer.github.io/service-binding-operator-helm-chart/
  additionalImages: # List of additional images to be included in imageset
    - name: registry.redhat.io/ubi8/ubi@sha256:d497966ce214138de5271eef321680639e18daf105ae94a6bff54247d8a191a3
```

## Expected Outcome
The images found in the v1 mapping.txt file should all also be found in delete-images.yaml (except the catalog image)
```bash
 for i in `cat /home/skhoury/clid261d/working-dir/delete/delete-images.yaml | yq .items.[].imageReference| cut -d: -f4`; do grep $i oc-mirror-workspace/results-1732188843/mapping.txt ; done
```