### PR TITLE
OCPBUGS-44033: Failed to mirror ocp payload using digest

### DIFF
--- a/v2/internal/pkg/release/local_stored_collector.go
+++ b/v2/internal/pkg/release/local_stored_collector.go
@@ -530,7 +530,13 @@ func prepareTag(imgSpec image.ImageSpec, imgType v2alpha1.ImageType, releaseTag,
 
 	switch {
 	case imgType == v2alpha1.TypeOCPRelease || imgType == v2alpha1.TypeCincinnatiGraph:
-		tag = imgSpec.Tag
+		// OCPBUGS-44033 mirroring release with no release tag
+		// i.e by digest registry.ci.openshift.org/ocp/release@sha256:0fb444ec9bb1b01f06dd387519f0fe5b4168e2d09a015697a26534fc1565c5e7
+		if len(imgSpec.Tag) == 0 {
+			tag = releaseTag
+		} else {
+			tag = imgSpec.Tag
+		}
 	case imgType == v2alpha1.TypeOCPReleaseContent && imgName != "":
 		tag = releaseTag + "-" + imgName
 	case imgSpec.IsImageByDigestOnly():


### PR DESCRIPTION
# Description

This bugfix addresses the issue when mirroring a release that use a digest rather than a tag

Fixes # OCPBUGS-44033

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Use the following isc

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  platform:
       release: registry.ci.openshift.org/ocp/release@sha256:0fb444ec9bb1b01f06dd387519f0fe5b4168e2d09a015697a26534fc1565c5e7
```
Execute a simple m2m command

```
bin/oc-mirror --config ocpbugs-44033.yaml --workspace file://ocpbugs-44033 docker://localhost:5000/ocpbugs-44033 --v2 --dest-tls-verify=false
```

## Expected Outcome

Mirroring should not fail

```
...
2024/11/26 16:27:07  [INFO]   : Mirroring is ongoing. No errors.
 ✓   177/190 : (2s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cf24f7665d164b2e3072ddb22a3410ba802bf19d5c67638a84bc5faf4452f1fa 
 ✓   178/190 : (4s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8e9c384093ed57093afd85831b0b932e8f7d54b6db3fe76ded349034d6e1c739 
 ✓   179/190 : (3s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e0c6795c4a1c47da7a1308840a924044cdfb8df3c56f760e8c099ad5d750d33a 
 ✓   180/190 : (3s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b038d74748371a5f828725fd1811f7c1069583c52c68832fd149b1dadfaa984b 
 ✓   181/190 : (3s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e6a12ce366320476be0f57d369871b9411043513c4fcd8e539df22329e8a1875 
 ✓   182/190 : (2s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6303cf83d18dbc6ab715c6706d12c8423119f036b71bcfe5558ca9a5a9fa82ad 
 ✓   183/190 : (3s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2915ddea2c7c0dd6c9a3fce0c7d9e4bcc8eaf94aa6638a2f439995d447165614 
 ✓   184/190 : (9s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e20c4652cec4d6dbc099888cc64470759bf75ffd7146e5142b2fad18a71b637a 
2024/11/26 16:27:16  [INFO]   : Mirroring is ongoing. No errors.
 ✓   185/190 : (13s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d07a34786003bec5a112bce8b17c4c3fc6a11af7dfa28330257bbd3921b4291a 
 ✓   186/190 : (9s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7d3bd3b48ba2c71c736a756a017893e18cb2e4844d7eacbf516e2a16b654e106 
 ✓   187/190 : (5s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d130ddc2af17753a89bc57a03cf8ce09098ecea619916e2805b389a7eeff24f4 
 ✓   188/190 : (4s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ca9469f7b970be7a7e7a0d89070b5aac982b7313d1d2461c9dd045b4844ac71c 
 ✓   189/190 : (6s) quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:bf5afce4ddfc76dc8e85ff5b416f56136f8582892d4453a130d7f5a411b4b916 
 ✓   190/190 : (2s) registry.ci.openshift.org/ocp/release@sha256:0fb444ec9bb1b01f06dd387519f0fe5b4168e2d09a015697a26534fc1565c5e7 
2024/11/26 16:27:29  [INFO]   : === Results ===
2024/11/26 16:27:29  [INFO]   : ✅ 190 / 190 release images mirrored successfully
2024/11/26 16:27:29  [INFO]   : 📄 Generating IDMS file...
2024/11/26 16:27:29  [INFO]   : ocpbugs-44033/working-dir/cluster-resources/idms-oc-mirror.yaml file created
2024/11/26 16:27:29  [INFO]   : 📄 No images by tag were mirrored. Skipping ITMS generation.
2024/11/26 16:27:29  [INFO]   : 📄 No catalogs mirrored. Skipping CatalogSource file generation.
2024/11/26 16:27:29  [INFO]   : mirror time     : 2m15.603468848s
2024/11/26 16:27:29  [INFO]   : 👋 Goodbye, thank you for using oc-mirror
```

