### PR TITLE
OCPBUGS-44789: Fix mirroring OCI catalogs multiple times

### DIFF
--- a/v2/internal/pkg/operator/filtered_collector.go
+++ b/v2/internal/pkg/operator/filtered_collector.go
@@ -158,13 +158,13 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 				catalogName = path.Base(imgSpec.Reference)
 			}
 			if imgSpec.Transport == ociProtocol {
-				catalogImageDir, err := filepath.Abs(catalogImageDir)
+				// ensure correct oci format and directory lookup
+				sourceOCIDir, err := filepath.Abs(imgSpec.Reference)
 				if err != nil {
 					o.Log.Error(errMsg, err.Error())
 					return v2alpha1.CollectorSchema{}, err
 				}
-				// ensure correct oci format and directory lookup
-				catalogImage = ociProtocol + catalogImageDir
+				catalogImage = ociProtocol + sourceOCIDir
 			} else {
 				catalogImage = op.Catalog
 			}
@@ -235,7 +235,12 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 					return v2alpha1.CollectorSchema{}, err
 				}
 
-				catalogImage = ociProtocol + catalogImageDir
+				sourceOCIDir, err := filepath.Abs(imgSpec.Reference)
+				if err != nil {
+					o.Log.Error(errMsg, err.Error())
+					return v2alpha1.CollectorSchema{}, err
+				}
+				catalogImage = ociProtocol + sourceOCIDir
 			} else {
 				catalogImage = op.Catalog
 			}


### PR DESCRIPTION
# Description

The catalog reference used for oci catalogs should remain the original one for multiple reasons:
* firstly, this reference is the one found in the ISC , and that executor.RebuildCatalogs will use to find the filtered catalog from map CatalogToFBCMap
* secondly, because the OCI image copied into the working-dir is transformed into a single arch one! so when batch is going to mirror from that location, we will start mirroring mono-arch instead of multi-arch

Fixes # OCPBUGS-44789

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

m2d + d2m as well as m2m multiple times for the imagesetconfig shared in OCPBUGS-44789

## Expected Outcome
no errors