### PR TITLE
OCPBUGS-42862: oc-mirror fails to find the image-references

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -288,6 +288,19 @@ func HideFlags(cmd *cobra.Command) {
 
 // Validate - cobra validation
 func (o ExecutorSchema) Validate(dest []string) error {
+	keyWords := []string{
+		"cluster-resources",
+		"dry-run",
+		"graph-preparation",
+		"helm",
+		"hold-operator",
+		"hold-release",
+		"delete",
+		"logs",
+		"operator-catalogs",
+		"release-images",
+		"signatures",
+	}
 
 	if len(o.Opts.Global.ConfigPath) == 0 {
 		return fmt.Errorf("use the --config flag it is mandatory")
@@ -295,11 +308,24 @@ func (o ExecutorSchema) Validate(dest []string) error {
 	if strings.Contains(dest[0], fileProtocol) && o.Opts.Global.From != "" {
 		return fmt.Errorf("when destination is file://, mirrorToDisk workflow is assumed, and the --from argument is not needed")
 	}
+	// OCPBUGS-42862
+	if strings.Contains(dest[0], fileProtocol) && o.Opts.Global.From == "" {
+		if keyWord := checkKeyWord(keyWords, dest[0]); len(keyWord) > 0 {
+			return fmt.Errorf("the destination contains an internal oc-mirror keyword '%s'", keyWord)
+		}
+	}
 	if len(o.Opts.Global.From) > 0 && !strings.Contains(o.Opts.Global.From, fileProtocol) {
 		return fmt.Errorf("when --from is used, it must have file:// prefix")
 	}
 	if len(o.Opts.Global.From) > 0 && o.Opts.Global.SinceString != "" {
 		o.Log.Warn("since flag is only taken into account during mirrorToDisk workflow")
+	}
+	// OCPBUGS-42862
+	// this should be covered in the m2d scenario, but just incase ...
+	if len(o.Opts.Global.From) > 0 {
+		if keyWord := checkKeyWord(keyWords, o.Opts.Global.From); len(keyWord) > 0 {
+			return fmt.Errorf("the path set in --from flag contains an internal oc-mirror keyword '%s'", keyWord)
+		}
 	}
 	if o.Opts.Global.SinceString != "" {
 		if _, err := time.Parse(time.DateOnly, o.Opts.Global.SinceString); err != nil {
@@ -1196,4 +1222,13 @@ func calculateMaxBatchSize(maxParallelDownloads uint, parallelBatchImages uint) 
 		maxBatchSize = 20
 	}
 	return maxBatchSize
+}
+
+func checkKeyWord(key_words []string, check string) string {
+	for _, i := range key_words {
+		if strings.Contains(check, i) {
+			return i
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
# Description

This fix addresses the issue when an mirroring using "_internal oc-mirror reserved or key words_" as an example **release-images** in the destination or --from paths

Fixes # OCPBUGS-42862

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Use the following cli 

```
bin/oc-mirror --config ocpbugs-42862.yaml file://ocpbugs-42862/release-images --v2
```
If somehow the client does a m2d and then copies the tar to a directory in the enclave and calls it with a keyword (as an example below - it should also fail)

```
bin/oc-mirror --config ocpbugs-42862.yaml --from file:///home/lzuccarelli/some-new-directory/release-images docker://localhost:5000/ocpbugs-42862 --dry-run --v2

```



## Expected Outcome

Should fail (in both cases indicated above)

```
2024/11/28 16:10:34  [INFO]   : 👋 Hello, welcome to oc-mirror
2024/11/28 16:10:34  [INFO]   : ⚙️  setting up the environment for you...
2024/11/28 16:10:34  [ERROR]  : the destination contains an internal oc-mirror keyword 'release-images' 
```

And in the second case

```
2024/11/28 16:15:38  [INFO]   : 👋 Hello, welcome to oc-mirror
2024/11/28 16:15:38  [INFO]   : ⚙️  setting up the environment for you...
2024/11/28 16:15:38  [ERROR]  : the path set in --from flag contains an internal oc-mirror keyword 'release-images'
```