### PR TITLE
OCPBUGS-44448: Skip deletion of images with same source and different…

### DIFF
--- a/v2/internal/pkg/batch/concurrent_worker.go
+++ b/v2/internal/pkg/batch/concurrent_worker.go
@@ -64,6 +64,11 @@ func (o *ConcurrentBatch) Worker(ctx context.Context, collectorSchema v2alpha1.C
 
 	opts.PreserveDigests = true
 
+	// OCPBUGS-44448: ONLY for delete: need to track images that have same digest but different destination tags,
+	// so that we don't attempt to delete them multiple times.
+	// For copy, these images, having same image digest but different destination tags need to be mirrored
+	// so that the tag gets created on the destination registry.
+	alreadyDeleted := map[string]string{}
 	startTime := time.Now()
 
 	batches := splitImagesToBatches(collectorSchema, int(o.BatchSize))
@@ -124,11 +129,55 @@ func (o *ConcurrentBatch) Worker(ctx context.Context, collectorSchema v2alpha1.C
 					return nil
 				}
 
-				err := o.Mirror.Run(ctx, img.Source, img.Destination, mirror.Mode(opts.Function), &opts)
-				mu.Lock()
-				switch {
-				case err == nil:
-					o.CopiedImages.AllImages = append(o.CopiedImages.AllImages, img)
+				//OCPBUGS-44448: for delete only, find out if the image has already been deleted
+				isAlreadyHandled := false
+				if opts.Function == string(mirror.DeleteMode) {
+					mu.Lock()
+					if _, ok := alreadyDeleted[img.Origin]; ok {
+						isAlreadyHandled = true
+					}
+					mu.Unlock()
+				}
+
+				if !isAlreadyHandled {
+					err := o.Mirror.Run(ctx, img.Source, img.Destination, mirror.Mode(opts.Function), &opts)
+					mu.Lock()
+					switch {
+					case err == nil:
+						o.CopiedImages.AllImages = append(o.CopiedImages.AllImages, img)
+						if opts.Function == string(mirror.DeleteMode) {
+							alreadyDeleted[img.Origin] = ""
+						}
+						spinner.Increment()
+
+						switch img.Type {
+						case v2alpha1.TypeCincinnatiGraph, v2alpha1.TypeOCPRelease, v2alpha1.TypeOCPReleaseContent:
+							o.CopiedImages.TotalReleaseImages++
+						case v2alpha1.TypeGeneric:
+							o.CopiedImages.TotalAdditionalImages++
+						case v2alpha1.TypeOperatorBundle, v2alpha1.TypeOperatorCatalog, v2alpha1.TypeOperatorRelatedImage:
+							o.CopiedImages.TotalOperatorImages++
+						case v2alpha1.TypeHelmImage:
+							o.CopiedImages.TotalHelmImages++
+						}
+					case img.Type.IsOperator():
+						operators := collectorSchema.CopyImageSchemaMap.OperatorsByImage[img.Origin]
+						bundles := collectorSchema.CopyImageSchemaMap.BundlesByImage[img.Origin]
+						errArray = append(errArray, mirrorErrorSchema{image: img, err: err, operators: operators, bundles: bundles})
+						spinner.Abort(false)
+					case img.Type.IsRelease():
+						// error on release image, save the errArray and immediately return `UnsafeError` to caller
+						currentMirrorError := mirrorErrorSchema{image: img, err: err}
+						errArray = append(errArray, currentMirrorError)
+						spinner.Abort(false)
+						mu.Unlock()
+						return NewUnsafeError(currentMirrorError)
+					case img.Type.IsAdditionalImage() || img.Type.IsHelmImage():
+						errArray = append(errArray, mirrorErrorSchema{image: img, err: err})
+						spinner.Abort(false)
+					}
+					mu.Unlock()
+				} else {
 					spinner.Increment()
 
 					switch img.Type {
@@ -141,23 +190,7 @@ func (o *ConcurrentBatch) Worker(ctx context.Context, collectorSchema v2alpha1.C
 					case v2alpha1.TypeHelmImage:
 						o.CopiedImages.TotalHelmImages++
 					}
-				case img.Type.IsOperator():
-					operators := collectorSchema.CopyImageSchemaMap.OperatorsByImage[img.Origin]
-					bundles := collectorSchema.CopyImageSchemaMap.BundlesByImage[img.Origin]
-					errArray = append(errArray, mirrorErrorSchema{image: img, err: err, operators: operators, bundles: bundles})
-					spinner.Abort(false)
-				case img.Type.IsRelease():
-					// error on release image, save the errArray and immediately return `UnsafeError` to caller
-					currentMirrorError := mirrorErrorSchema{image: img, err: err}
-					errArray = append(errArray, currentMirrorError)
-					spinner.Abort(false)
-					mu.Unlock()
-					return NewUnsafeError(currentMirrorError)
-				case img.Type.IsAdditionalImage() || img.Type.IsHelmImage():
-					errArray = append(errArray, mirrorErrorSchema{image: img, err: err})
-					spinner.Abort(false)
 				}
-				mu.Unlock()
 				return nil
 			})
 


### PR DESCRIPTION
# Description

The root cause of this issue lies in the fact that the same image (referenced by digest) is used multiple times in the release but as different components.
Example in release 4.15.38 that I tested, `quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:bf7fa8cad688bd513c6672260ed5fb2154ae8c7daa00872c16001d2905e9bede` can be found 44 times in the image-references file.
The delete-images.yaml file generated will contain things like:
```yaml
- imageName: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:bf7fa8cad688bd513c6672260ed5fb2154ae8c7daa00872c16001d2905e9bede
  imageReference: docker://sherinefedora:5000/44448/openshift/release:4.15.38-s390x-aws-cloud-controller-manager
  type: ocpReleaseContent
- imageName: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:bf7fa8cad688bd513c6672260ed5fb2154ae8c7daa00872c16001d2905e9bede
  imageReference: docker://sherinefedora:5000/44448/openshift/release:4.15.38-s390x-aws-cluster-api-controllers
  type: ocpReleaseContent
- imageName: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:bf7fa8cad688bd513c6672260ed5fb2154ae8c7daa00872c16001d2905e9bede
  imageReference: docker://sherinefedora:5000/44448/openshift/release:4.15.38-s390x-aws-ebs-csi-driver
  type: ocpReleaseContent
```

Therefore, the first delete will succeed, but the second one on-wards will fail.

The fix consists in adding a map in the concurrentBatch worker, that keeps track of images deleted by their origin reference (the digest), so that we only delete such an image once, regardless of whether it is recognized by multiple tags at the destination.

Fixes # [OCPBUGS-44448](https://issues.redhat.com/browse/OCPBUGS-44448)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  platform:
    architectures:
      - "s390x"
    channels:
    - name: stable-4.15
      type: ocp
```
At the time of the test, the latest OCP release in stable 4.15 was 4.15.38.

I performed M2D+D2M+DeleteGenerate+Delete

## Expected Outcome
No errors in any steps