### PR TITLE
OCPBUGS-44033: Failed to mirror ocp payload using digest

### DIFF
--- a/v2/internal/pkg/release/local_stored_collector.go
+++ b/v2/internal/pkg/release/local_stored_collector.go
@@ -185,10 +185,14 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v2
 			if err != nil {
 				return []v2alpha1.CopyImageSchema{}, fmt.Errorf(errMsg, err.Error())
 			}
-			if releaseRef.Tag == "" {
-				return []v2alpha1.CopyImageSchema{}, fmt.Errorf(errMsg, "release image "+releaseImg.Image+" doesn't have a tag")
+			if releaseRef.Tag == "" && len(releaseRef.Digest) == 0 {
+				return []v2alpha1.CopyImageSchema{}, fmt.Errorf(errMsg, "release image "+releaseImg.Image+" doesn't have a tag or digest")
 			}
-			monoReleaseSlice, err := o.prepareD2MCopyBatch([]v2alpha1.RelatedImage{releaseImg}, releaseRef.Tag)
+			tag := releaseRef.Tag
+			if releaseRef.Tag == "" && len(releaseRef.Digest) > 0 {
+				tag = releaseRef.Digest
+			}
+			monoReleaseSlice, err := o.prepareD2MCopyBatch([]v2alpha1.RelatedImage{releaseImg}, tag)
 			if err != nil {
 				return []v2alpha1.CopyImageSchema{}, fmt.Errorf(errMsg, err.Error())
 			}


### PR DESCRIPTION
# Description

This bugfix addresses the issue when mirroring a release that use a digest rather than a tag

Fixes # OCPBUGS-44033

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Use the following isc

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  platform:
       release: registry.ci.openshift.org/ocp/release@sha256:a29a109f286c77aecb71906696830c2f48c9b6ba0df77b88a7fb5c4399f3334a
```
1. Execute a simple m2m command

```
bin/oc-mirror --config ocpbugs-44033.yaml --workspace file://ocpbugs-44033 docker://localhost:5000/ocpbugs-44033 --v2 --dest-tls-verify=false
```

2. Execute a disk to mirror 

```
bin/oc-mirror --config ocpbugs-44033.yaml --from file://ocpbugs-44033 docker://localhost:5000/ocpbugs-44033 --v2 --dest-tls-verify=false
```

3. Repeat for mirror to disk and then disk to mirror

## Expected Outcome

Mirroring should pass for all scenarios
