### PR TITLE
OCPBUGS-42849: Assign a static name to the release signature configmap

### DIFF
--- a/v2/internal/pkg/clusterresources/clusterresources.go
+++ b/v2/internal/pkg/clusterresources/clusterresources.go
@@ -626,6 +626,7 @@ func (o *ClusterResourcesGenerator) GenerateSignatureConfigMap(allRelatedImages 
 		},
 		ObjectMeta: cm.ObjectMeta{
 			Namespace: signatureNamespace,
+			Name:      configMapName,
 			Labels: map[string]string{
 				signatureLabel: "",
 			},
@@ -660,7 +661,7 @@ func (o *ClusterResourcesGenerator) GenerateSignatureConfigMap(allRelatedImages 
 			if file, ok := signatureFiles[imgSpec.Tag]; ok {
 				data, err := os.ReadFile(sigDir + "/" + file)
 				if err != nil {
-					o.Log.Warn("[GenerateSignatureConfigMap] release index image signature with tag %s : SKIPPED", imgSpec.Tag)
+					o.Log.Warn("[GenerateSignatureConfigMap] release index image signature with tag %s : SKIPPED. %v", imgSpec.Tag, err)
 					continue
 				}
 				// check if we have an entry already

--- a/v2/internal/pkg/clusterresources/clusterresources_test.go
+++ b/v2/internal/pkg/clusterresources/clusterresources_test.go
@@ -1159,7 +1159,13 @@ func TestGenerateSignatureConfigMap(t *testing.T) {
 
 		for id, file := range files {
 			key := fmt.Sprintf("sha256-%s-%d", strings.Split(file, "-sha256-")[1], id+1)
+			expectedCMName := configMapName
+			cmjName := cmJson.Name
+			assert.Equal(t, expectedCMName, cmjName)
 			bdJson := len(cmJson.BinaryData[key])
+
+			cmyName := cmYaml.Name
+			assert.Equal(t, expectedCMName, cmyName)
 			assert.Equal(t, bdJson, 1200)
 			bdYaml := len(cmYaml.BinaryData[key])
 			assert.Equal(t, bdYaml, 1200)

--- a/v2/internal/pkg/clusterresources/const.go
+++ b/v2/internal/pkg/clusterresources/const.go
@@ -9,6 +9,7 @@ const (
 	configMapKind                         = "ConfigMap"
 	configMapBinaryDataIndexFormat        = "sha256-%s-%d"
 	signatureNamespace                    = "openshift-config-managed"
+	configMapName                         = "mirrored-release-signatures"
 	signatureLabel                        = "release.openshift.io/verification-signatures"
 	signatureConfigMapMsg                 = "[GenerateSignatureConfigMap] %v"
 	signatureDir                          = "signatures"


### PR DESCRIPTION
# Description

Fixes # OCPBUGS-42849

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Unit test added
M2M produces confimap containing name

## Expected Outcome
unit tests pass