### PR TITLE
OCPBUGS-44901: Align tag format for additionalImages and operators

### DIFF
--- a/v2/internal/pkg/additional/local_stored_collector.go
+++ b/v2/internal/pkg/additional/local_stored_collector.go
@@ -65,7 +65,7 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 			origin = img.Name
 			if imgSpec.Transport == dockerProtocol {
 				if imgSpec.IsImageByDigestOnly() {
-					tmpDest = strings.Join([]string{o.destinationRegistry(), imgSpec.PathComponent}, "/") + ":" + imgSpec.Digest
+					tmpDest = strings.Join([]string{o.destinationRegistry(), imgSpec.PathComponent}, "/") + ":" + imgSpec.Algorithm + "-" + imgSpec.Digest
 				} else if imgSpec.IsImageByTagAndDigest() { // OCPBUGS-33196 + OCPBUGS-37867- check source image for tag and digest
 					// use tag only for both src and dest
 					o.Log.Warn(collectorPrefix+"%s has both tag and digest : using digest to pull, but tag only for mirroring", imgSpec.Reference)
@@ -91,12 +91,12 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 			if imgSpec.Transport == dockerProtocol {
 
 				if imgSpec.IsImageByDigestOnly() {
-					tmpSrc = strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
+					tmpSrc = strings.Join([]string{o.LocalStorageFQDN, imgSpec.PathComponent + ":" + imgSpec.Algorithm + "-" + imgSpec.Digest}, "/")
 					if o.generateV1DestTags {
 						tmpDest = strings.Join([]string{o.Opts.Destination, imgSpec.PathComponent + ":latest"}, "/")
 
 					} else {
-						tmpDest = strings.Join([]string{o.Opts.Destination, imgSpec.PathComponent + ":" + imgSpec.Digest}, "/")
+						tmpDest = strings.Join([]string{o.Opts.Destination, imgSpec.PathComponent + ":" + imgSpec.Algorithm + "-" + imgSpec.Digest}, "/")
 					}
 				} else if imgSpec.IsImageByTagAndDigest() { // OCPBUGS-33196 + OCPBUGS-37867- check source image for tag and digest
 					// use tag only for both src and dest

--- a/v2/internal/pkg/additional/local_stored_collector_test.go
+++ b/v2/internal/pkg/additional/local_stored_collector_test.go
@@ -82,7 +82,7 @@ func TestAdditionalImageCollector(t *testing.T) {
 			{
 				Source:      "docker://sometest.registry.com/testns/test@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 				Origin:      "sometest.registry.com/testns/test@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-				Destination: "docker://test.registry.com/testns/test:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+				Destination: "docker://test.registry.com/testns/test:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 				Type:        v2alpha1.TypeGeneric,
 			},
 			{
@@ -121,9 +121,9 @@ func TestAdditionalImageCollector(t *testing.T) {
 				Type:        v2alpha1.TypeGeneric,
 			},
 			{
-				Destination: "docker://mirror.acme.com/testns/test:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+				Destination: "docker://mirror.acme.com/testns/test:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 				Origin:      "sometest.registry.com/testns/test@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-				Source:      "docker://test.registry.com/testns/test:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+				Source:      "docker://test.registry.com/testns/test:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 				Type:        v2alpha1.TypeGeneric,
 			},
 			{
@@ -162,7 +162,7 @@ func TestAdditionalImageCollector(t *testing.T) {
 			{
 				Destination: "docker://mirror.acme.com/testns/test:latest",
 				Origin:      "sometest.registry.com/testns/test@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-				Source:      "docker://test.registry.com/testns/test:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+				Source:      "docker://test.registry.com/testns/test:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 				Type:        v2alpha1.TypeGeneric,
 			},
 			{
@@ -196,7 +196,7 @@ func TestAdditionalImageCollector(t *testing.T) {
 			{
 				Source:      "docker://sometest.registry.com/testns/test@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 				Origin:      "sometest.registry.com/testns/test@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-				Destination: "docker://test.registry.com/testns/test:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+				Destination: "docker://test.registry.com/testns/test:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 				Type:        v2alpha1.TypeGeneric,
 			},
 			{
@@ -227,9 +227,9 @@ func TestAdditionalImageCollector(t *testing.T) {
 				Type:        v2alpha1.TypeGeneric,
 			},
 			{
-				Destination: "docker://mirror.acme.com/testns/test:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+				Destination: "docker://mirror.acme.com/testns/test:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 				Origin:      "sometest.registry.com/testns/test@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-				Source:      "docker://test.registry.com/testns/test:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+				Source:      "docker://test.registry.com/testns/test:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 				Type:        v2alpha1.TypeGeneric,
 			},
 			{

--- a/v2/internal/pkg/operator/common.go
+++ b/v2/internal/pkg/operator/common.go
@@ -103,7 +103,7 @@ func (o OperatorCollector) catalogDigest(ctx context.Context, catalog v2alpha1.O
 	case len(catalog.TargetTag) > 0: // applies only to catalogs
 		src = src + ":" + catalog.TargetTag
 	case srcImgSpec.Tag == "" && srcImgSpec.Digest != "":
-		src = src + ":" + srcImgSpec.Digest
+		src = src + ":" + srcImgSpec.Algorithm + "-" + srcImgSpec.Digest
 	case srcImgSpec.Tag == "" && srcImgSpec.Digest == "" && srcImgSpec.Transport == ociProtocol:
 		src = src + ":latest"
 	default:
@@ -168,7 +168,6 @@ func (o OperatorCollector) prepareD2MCopyBatch(images map[string][]v2alpha1.Rela
 			// add the tag for src and dest
 			switch {
 			// applies only to catalogs
-
 			case img.Type == v2alpha1.TypeOperatorCatalog && len(img.TargetTag) > 0:
 				if img.RebuiltTag != "" {
 					src = src + ":" + img.RebuiltTag
@@ -180,7 +179,7 @@ func (o OperatorCollector) prepareD2MCopyBatch(images map[string][]v2alpha1.Rela
 				if img.RebuiltTag != "" {
 					src = src + ":" + img.RebuiltTag
 				} else {
-					src = src + ":" + imgSpec.Digest
+					src = src + ":" + imgSpec.Algorithm + "-" + imgSpec.Digest
 				}
 				if o.generateV1DestTags {
 					hasher := fnv.New32a()
@@ -191,9 +190,8 @@ func (o OperatorCollector) prepareD2MCopyBatch(images map[string][]v2alpha1.Rela
 					}
 					dest = dest + ":" + fmt.Sprintf("%x", hasher.Sum32())
 				} else {
-					dest = dest + ":" + imgSpec.Digest
+					dest = dest + ":" + imgSpec.Algorithm + "-" + imgSpec.Digest
 				}
-
 			default:
 				if img.RebuiltTag != "" {
 					src = src + ":" + img.RebuiltTag
@@ -252,13 +250,12 @@ func (o OperatorCollector) prepareM2DCopyBatch(images map[string][]v2alpha1.Rela
 			// add the tag for src and dest
 			switch {
 			// applies only to catalogs
-
 			case img.Type == v2alpha1.TypeOperatorCatalog && len(img.TargetTag) > 0:
 				dest = dest + ":" + img.TargetTag
 			case imgSpec.Tag == "" && imgSpec.Transport == ociProtocol:
 				dest = dest + "::latest"
 			case imgSpec.IsImageByDigestOnly():
-				dest = dest + ":" + imgSpec.Digest
+				dest = dest + ":" + imgSpec.Algorithm + "-" + imgSpec.Digest
 			case imgSpec.IsImageByTagAndDigest(): // OCPBUGS-33196 + OCPBUGS-37867- check source image for tag and digest
 				// use tag only for dest, but pull by digest
 				o.Log.Warn(collectorPrefix+"%s has both tag and digest : using digest to pull, but tag only for mirroring", imgSpec.Reference)
@@ -356,7 +353,7 @@ func (d OtherImageDispatcher) dispatch(img v2alpha1.RelatedImage) ([]v2alpha1.Co
 	case imgSpec.Tag == "" && imgSpec.Transport == ociProtocol:
 		dest = dest + ":latest"
 	case imgSpec.IsImageByDigestOnly():
-		dest = dest + ":" + imgSpec.Digest
+		dest = dest + ":" + imgSpec.Algorithm + "-" + imgSpec.Digest
 	case imgSpec.IsImageByTagAndDigest(): // OCPBUGS-33196 + OCPBUGS-37867- check source image for tag and digest
 		// use tag only for dest, but pull by digest
 		d.log.Warn(collectorPrefix+"%s has both tag and digest : using digest to pull, but tag only for mirroring", imgSpec.Reference)
@@ -422,7 +419,7 @@ func saveCtlgToCacheRef(spec image.ImageSpec, img v2alpha1.RelatedImage, cacheRe
 	case spec.Tag == "" && spec.Transport == ociProtocol:
 		saveCtlgDest = saveCtlgDest + ":latest"
 	case spec.IsImageByDigestOnly():
-		saveCtlgDest = saveCtlgDest + ":" + spec.Digest
+		saveCtlgDest = saveCtlgDest + ":" + spec.Algorithm + "-" + spec.Digest
 	case spec.IsImageByTagAndDigest():
 		saveCtlgDest = saveCtlgDest + ":" + spec.Tag
 	default:
@@ -455,7 +452,7 @@ func rebuiltCtlgRef(spec image.ImageSpec, img v2alpha1.RelatedImage, cacheRegist
 	case spec.Tag == "" && spec.Transport == ociProtocol:
 		rebuiltCtlgSrc = rebuiltCtlgSrc + ":latest"
 	case spec.IsImageByDigestOnly():
-		rebuiltCtlgSrc = rebuiltCtlgSrc + ":" + spec.Digest
+		rebuiltCtlgSrc = rebuiltCtlgSrc + ":" + spec.Algorithm + "-" + spec.Digest
 	case spec.IsImageByTagAndDigest(): // OCPBUGS-33196 + OCPBUGS-37867- check source image for tag and digest
 		// use tag only for dest, but pull by digest
 		rebuiltCtlgSrc = rebuiltCtlgSrc + ":" + spec.Tag
@@ -487,7 +484,7 @@ func destCtlgRef(spec image.ImageSpec, img v2alpha1.RelatedImage, destinationReg
 	case spec.Tag == "" && spec.Transport == ociProtocol:
 		dest = dest + ":latest"
 	case spec.IsImageByDigestOnly():
-		dest = dest + ":" + spec.Digest
+		dest = dest + ":" + spec.Algorithm + "-" + spec.Digest
 	case spec.IsImageByTagAndDigest(): // OCPBUGS-33196 + OCPBUGS-37867- check source image for tag and digest
 		// use tag only for dest, but pull by digest
 		dest = dest + ":" + spec.Tag

--- a/v2/internal/pkg/operator/common_test.go
+++ b/v2/internal/pkg/operator/common_test.go
@@ -45,13 +45,13 @@ func TestPrepareDeleteForV1(t *testing.T) {
 			expectedError: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
-					Source:      "docker://localhost:9999/openshift4/ose-kube-rbac-proxy:7efeeb8b29872a6f0271f651d7ae02c91daea16d853c50e374c310f044d8c76c",
+					Source:      "docker://localhost:9999/openshift4/ose-kube-rbac-proxy:sha256-7efeeb8b29872a6f0271f651d7ae02c91daea16d853c50e374c310f044d8c76c",
 					Destination: "docker://localhost:5000/test/openshift4/ose-kube-rbac-proxy:5574585a",
 					Origin:      "docker://registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:7efeeb8b29872a6f0271f651d7ae02c91daea16d853c50e374c310f044d8c76c",
 					Type:        v2alpha1.TypeOperatorBundle,
 				},
 				{
-					Source:      "docker://localhost:9999/openshift-sandboxed-containers/osc-operator-bundle:8da62ba1c19c905bc1b87a6233ead475b047a766dc2acb7569149ac5cfe7f0f1",
+					Source:      "docker://localhost:9999/openshift-sandboxed-containers/osc-operator-bundle:sha256-8da62ba1c19c905bc1b87a6233ead475b047a766dc2acb7569149ac5cfe7f0f1",
 					Destination: "docker://localhost:5000/test/openshift-sandboxed-containers/osc-operator-bundle:1adce9f",
 					Origin:      "docker://registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:8da62ba1c19c905bc1b87a6233ead475b047a766dc2acb7569149ac5cfe7f0f1",
 					Type:        v2alpha1.TypeOperatorRelatedImage,
@@ -110,13 +110,13 @@ func TestPrepareM2MCopyBatch(t *testing.T) {
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:5000/test/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-a:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeOperatorBundle,
 				},
 				{
 					Source:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:5000/test/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-b:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeOperatorRelatedImage,
 				},

--- a/v2/internal/pkg/operator/filtered_collector_test.go
+++ b/v2/internal/pkg/operator/filtered_collector_test.go
@@ -103,13 +103,13 @@ func TestFilterCollectorM2D(t *testing.T) {
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:9999/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-a:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
 					Source:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:9999/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-b:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
@@ -155,13 +155,13 @@ func TestFilterCollectorM2D(t *testing.T) {
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:9999/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-a:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
 					Source:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:9999/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-b:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
@@ -193,13 +193,13 @@ func TestFilterCollectorM2D(t *testing.T) {
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:9999/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-a:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
 					Source:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:9999/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-b:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
@@ -225,13 +225,13 @@ func TestFilterCollectorM2D(t *testing.T) {
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:9999/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-a:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
 					Source:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:9999/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-b:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
@@ -303,14 +303,14 @@ func TestFilterCollectorD2M(t *testing.T) {
 			expectedError: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
-					Source:      "docker://localhost:9999/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:5000/test/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Source:      "docker://localhost:9999/sometestimage-a:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-a:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
-					Source:      "docker://localhost:9999/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:5000/test/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Source:      "docker://localhost:9999/sometestimage-b:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-b:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
@@ -347,14 +347,14 @@ func TestFilterCollectorD2M(t *testing.T) {
 			expectedError: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
-					Source:      "docker://localhost:9999/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:5000/test/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Source:      "docker://localhost:9999/sometestimage-a:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-a:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
-					Source:      "docker://localhost:9999/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:5000/test/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Source:      "docker://localhost:9999/sometestimage-b:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-b:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
@@ -442,13 +442,13 @@ func TestFilterCollectorM2M(t *testing.T) {
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:5000/test/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-a:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
 					Source:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:5000/test/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-b:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},

--- a/v2/internal/pkg/operator/local_stored_collector_test.go
+++ b/v2/internal/pkg/operator/local_stored_collector_test.go
@@ -269,13 +269,13 @@ func TestOperatorLocalStoredCollectorM2D(t *testing.T) {
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:9999/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-a:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
 					Source:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:9999/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-b:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
@@ -318,13 +318,13 @@ func TestOperatorLocalStoredCollectorM2D(t *testing.T) {
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:9999/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-a:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
 					Source:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:9999/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-b:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
@@ -355,13 +355,13 @@ func TestOperatorLocalStoredCollectorM2D(t *testing.T) {
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:9999/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-a:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
 					Source:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:9999/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-b:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
@@ -386,13 +386,13 @@ func TestOperatorLocalStoredCollectorM2D(t *testing.T) {
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:9999/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-a:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
 					Source:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:9999/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:9999/sometestimage-b:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
@@ -463,14 +463,14 @@ func TestOperatorLocalStoredCollectorD2M(t *testing.T) {
 			expectedError: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
-					Source:      "docker://localhost:9999/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:5000/test/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Source:      "docker://localhost:9999/sometestimage-a:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-a:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
-					Source:      "docker://localhost:9999/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:5000/test/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Source:      "docker://localhost:9999/sometestimage-b:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-b:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
@@ -505,14 +505,14 @@ func TestOperatorLocalStoredCollectorD2M(t *testing.T) {
 			expectedError: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
-					Source:      "docker://localhost:9999/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:5000/test/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Source:      "docker://localhost:9999/sometestimage-a:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-a:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
-					Source:      "docker://localhost:9999/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:5000/test/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Source:      "docker://localhost:9999/sometestimage-b:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-b:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
@@ -579,13 +579,13 @@ func TestOperatorLocalStoredCollectorM2M(t *testing.T) {
 			expectedResult: []v2alpha1.CopyImageSchema{
 				{
 					Source:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:5000/test/sometestimage-a:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-a:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
 					Source:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
-					Destination: "docker://localhost:5000/test/sometestimage-b:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+					Destination: "docker://localhost:5000/test/sometestimage-b:sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Origin:      "docker://sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeInvalid,
 				},


### PR DESCRIPTION
# Description

This issue addresses the standard for all mirrored images on digest for both additonalImages and operators
They will follow the tag as "algorithm-digest" i.e 

If I mirrored this additionalimage 
```
quay.io/openshifttest/hello-openshift@sha256:61b8f5e1a3b5dbd9e2c35fd448dc5106337d7a299873dd3a6f0cd8d4891ecc27
```

I should expect the tag to be in the form of

```
destination-registry/openshifttest/hello-openshift/sha256-61b8f5e1a3b5dbd9e2c35fd448dc5106337d7a299873dd3a6f0cd8d4891ecc27
```

And the same applies to operators. The standard has already been applied to release images and helm chart images

Fixes # OCPBUGS-44901

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Use the following isc 

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  additionalImages:
  - name: registry.redhat.io/ubi8/ubi:latest                        
  - name: quay.io/openshifttest/hello-openshift@sha256:61b8f5e1a3b5dbd9e2c35fd448dc5106337d7a299873dd3a6f0cd8d4891ecc27
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15
       packages:
        - name: devworkspace-operator


```

Execute a mirror to disk and disk to mirror

Once completed inspect the remote registry (as below)

**NB** 
Repeat the process for M2M (and inspect the tags as below)


## Expected Outcome

```
curl http://localhost:5000/v2/ocpbugs-44901/devworkspace/devworkspace-operator-bundle/tags/list jq
{"name":"ocpbugs-44901/devworkspace/devworkspace-operator-bundle","tags":["sha256-ceffc304833a94c89925da2b3bd5fe08b3286a650be48ee2b2f1a4bf144fb2f8"]}

curl http://localhost:5000/v2/ocpbugs-44901/devworkspace/devworkspace-project-clone-rhel8/tags/list 
{"name":"ocpbugs-44901/devworkspace/devworkspace-project-clone-rhel8","tags":["sha256-3617aed739692e98404debff8d79334860bbd0d936b25ce7b2e865889a6564fb"]}

curl http://localhost:5000/v2/ocpbugs-44901/devworkspace/devworkspace-rhel8-operator/tags/list 
{"name":"ocpbugs-44901/devworkspace/devworkspace-rhel8-operator","tags":["sha256-d4bf8d3bede52ce4c329a133969f423673dedba76308f7b216793014c245cebd"]}

curl http://localhost:5000/v2/ocpbugs-44901/openshift4/ose-kube-rbac-proxy/tags/list 
{"name":"ocpbugs-44901/openshift4/ose-kube-rbac-proxy","tags":["sha256-4488f5fdf6f10a551fe046e62cd4f3d856530cfb15831f7e1e2de531e7f2caeb"]}

curl http://localhost:5000/v2/ocpbugs-44901/ubi8-minimal/tags/list 
{"name":"ocpbugs-44901/ubi8-minimal","tags":["sha256-b93deceb59a58588d5b16429fc47f98920f84740a1f2ed6454e33275f0701b59"]}

curl http://localhost:5000/v2/ocpbugs-44901/openshifttest/hello-openshift/tags/list 
{"name":"ocpbugs-44901/openshifttest/hello-openshift","tags":["sha256-61b8f5e1a3b5dbd9e2c35fd448dc5106337d7a299873dd3a6f0cd8d4891ecc27"]}

```
**NB**
Only additionalImages that are digest based have the tag "sha256-xxx.."
Only operators and bundles that are digest based have the tag "sha256-xxx..."

