### PR TITLE
OCPBUGS-43825: Fix graph image not deletable if mirrored by m2m

### DIFF
--- a/v2/internal/pkg/mirror/options.go
+++ b/v2/internal/pkg/mirror/options.go
@@ -152,6 +152,9 @@ func (cp CopyOptions) IsMirrorToMirror() bool {
 func (cp CopyOptions) IsDiskToMirror() bool {
 	return cp.Mode == DiskToMirror
 }
+func (cp CopyOptions) IsDeleteMode() bool {
+	return cp.Function == string(DeleteMode)
+}
 
 // noteCloseFailure returns (possibly-nil) err modified to account for (non-nil) closeErr.
 // The error for closeErr is annotated with description (which is not a format string)

--- a/v2/internal/pkg/release/local_stored_collector.go
+++ b/v2/internal/pkg/release/local_stored_collector.go
@@ -242,10 +242,18 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v2
 			}
 			// OCPBUGS-38037: Check the graph image is in the cache before adding it
 			graphInCache, err := o.imageExists(ctx, graphRelatedImage.Image)
-			if err != nil || !graphInCache {
+			// OCPBUGS-43825: The check graphInCache is relevant for DiskToMirror workflow only, not for delete workflow
+			// In delete workflow, the graph image might have been mirrored with M2M, and the graph image might have
+			// therefore been pushed directly to the destination registry. It will not exist in the cache, and that should be ok.
+			// Nevertheless, in DiskToMirror, and as explained in OCPBUGS-38037, the graphInCache check is important
+			// because in enclave environment, the Cincinnati API may not have been called, so we rely on the existance of the
+			// graph image in the cache as a paliative.
+			shouldProceed := graphInCache || o.Opts.IsDeleteMode()
+			if err != nil && !o.Opts.IsDeleteMode() {
 				o.Log.Warn("unable to find graph image in local cache: SKIPPING. %v")
 				o.Log.Warn("%v", err)
-			} else {
+			}
+			if shouldProceed {
 				// OCPBUGS-26513: In order to get the destination for the graphDataImage
 				// into `o.GraphDataImage`, we call `prepareD2MCopyBatch` on an array
 				// containing only the graph image. This way we can easily identify the destination


### PR DESCRIPTION
# Description

Fixes # OCPBUGS-43825

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Performed the scenario described in the bug: M2M with graph = true, followed by delete workflow

## Expected Outcome
No warnings appear during `delete --generate`
delete-images.yaml contains the graph image