### PR TITLE
OCPBUGS-43489: Fix for deleting of local cache using --force-cache-de…

### DIFF
--- a/v2/internal/pkg/cli/delete.go
+++ b/v2/internal/pkg/cli/delete.go
@@ -353,7 +353,7 @@ func (o *DeleteSchema) startLocalRegistryGarbageCollect() error {
 
 	opts := storage.GCOpts{
 		DryRun:         false,
-		RemoveUntagged: false,
+		RemoveUntagged: true,
 	}
 
 	// used for the garbage-collect

--- a/v2/internal/pkg/delete/delete_images.go
+++ b/v2/internal/pkg/delete/delete_images.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -50,16 +51,20 @@ func (o DeleteImages) WriteDeleteMetaData(images []v2alpha1.CopyImageSchema) err
 		o.Log.Error("%v ", err)
 	}
 
+	duplicates := []string{}
 	var items []v2alpha1.DeleteItem
 	for _, img := range images {
-
-		item := v2alpha1.DeleteItem{
-			ImageName:      img.Origin,
-			ImageReference: img.Destination,
-			Type:           img.Type,
+		if slices.Contains(duplicates, img.Origin) {
+			o.Log.Debug("duplicate image found %s", img.Origin)
+		} else {
+			duplicates = append(duplicates, img.Origin)
+			item := v2alpha1.DeleteItem{
+				ImageName:      img.Origin,
+				ImageReference: img.Destination,
+				Type:           img.Type,
+			}
+			items = append(items, item)
 		}
-
-		items = append(items, item)
 	}
 
 	// sort the items

--- a/v2/internal/pkg/delete/delete_images.go
+++ b/v2/internal/pkg/delete/delete_images.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/archive"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/batch"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/image"
 	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/manifest"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
@@ -113,6 +114,37 @@ func (o DeleteImages) DeleteRegistryImages(deleteImageList v2alpha1.DeleteImageL
 	var batchError error
 
 	for _, img := range deleteImageList.Items {
+		// OCPBUGS-43489
+		// Verify that the "delete" destination is set correctly
+		// It does not hurt to check each entry :)
+		// This will avoid the error "Image may not exist or is not stored with a v2 Schema in a v2 registry"
+		// Reverts OCPBUGS-44448
+		imgSpecName, err := image.ParseRef(img.ImageName)
+		if err != nil {
+			return err
+		}
+		imgSpecRef, err := image.ParseRef(img.ImageReference)
+		if err != nil {
+			return err
+		}
+		// remove dockerProtocol
+		name := strings.Split(o.Opts.Global.DeleteDestination, dockerProtocol)
+		// this should not occur - but just incase
+		if len(name) < 2 {
+			return fmt.Errorf("delete destination is not well formed (%s) - missing dockerProtocol?", o.Opts.Global.DeleteDestination)
+		}
+		assembleName := name[1] + "/" + imgSpecName.PathComponent
+		// check image type for release or release content
+		switch img.Type {
+		case v2alpha1.TypeOCPReleaseContent:
+			assembleName = name[1] + "/openshift/release"
+		case v2alpha1.TypeOCPRelease:
+			assembleName = name[1] + "/openshift/release-images"
+		}
+		// check the assembled name against the reference name
+		if assembleName != imgSpecRef.Name {
+			return fmt.Errorf("delete destination %s does not match values found in the delete-images yaml file (please verify full name)", o.Opts.Global.DeleteDestination)
+		}
 		cis := v2alpha1.CopyImageSchema{
 			Origin:      img.ImageName,
 			Destination: img.ImageReference,
@@ -124,7 +156,7 @@ func (o DeleteImages) DeleteRegistryImages(deleteImageList v2alpha1.DeleteImageL
 		if o.Opts.Global.ForceCacheDelete {
 			cis := v2alpha1.CopyImageSchema{
 				Origin:      img.ImageName,
-				Destination: strings.Replace(img.ImageReference, o.Opts.Global.DeleteDestination, dockerProtocol+o.LocalStorageFQDN, -1),
+				Destination: strings.ReplaceAll(img.ImageReference, o.Opts.Global.DeleteDestination, dockerProtocol+o.LocalStorageFQDN),
 				Type:        img.Type,
 			}
 			o.Log.Debug("deleting images local cache %v", cis.Destination)

--- a/v2/internal/pkg/delete/delete_images_test.go
+++ b/v2/internal/pkg/delete/delete_images_test.go
@@ -22,7 +22,7 @@ func TestAllDeleteImages(t *testing.T) {
 		SecurePolicy:      false,
 		Quiet:             false,
 		WorkingDir:        common.TestFolder,
-		DeleteDestination: "docker://myregistry",
+		DeleteDestination: "docker://localhost:5000/myregistry",
 	}
 
 	_, sharedOpts := mirror.SharedImageFlags()
@@ -71,7 +71,7 @@ func TestAllDeleteImages(t *testing.T) {
 		if err != nil {
 			t.Fatal("should not fail")
 		}
-		assert.Equal(t, "docker://localhost:55000/openshift-release-dev/ocp-v4.0-art-dev@sha256:c4b775cbe8eec55de2c163919c6008599e2aebe789ed93ada9a307e800e3f1e2", data.Items[0].ImageReference)
+		assert.Equal(t, "docker://localhost:5000/myregistry/openshift/release:4.15.12-x86_64-agent-installer-api-server", data.Items[0].ImageReference)
 	})
 
 	t.Run("Testing DeleteRegistryImages : should pass", func(t *testing.T) {

--- a/v2/tests/delete/delete-images.yaml
+++ b/v2/tests/delete/delete-images.yaml
@@ -1,8 +1,6 @@
 apiVersion: mirror.openshift.io/v2alpha1
 kind: DeleteImageList
 items: 
-  - imageReference: docker://localhost:55000/openshift-release-dev/ocp-v4.0-art-dev@sha256:c4b775cbe8eec55de2c163919c6008599e2aebe789ed93ada9a307e800e3f1e2
-    imageName: agent-installer-api-server
-    relatedBlobs:
-    - sha256:aad3e79a2bac9129db69d0c6d921e12934fb8c3826d8bcd0ef368c8647c4e8a5
-    - sha256:c4b775cbe8eec55de2c163919c6008599e2aebe789ed93ada9a307e800e3f1e2
+  - imageName: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c32a883a6ca7b2e7a58b9dd99a5e8d056bdbbc9d79d8486b2e4c7e07c3dc4512
+    imageReference: docker://localhost:5000/myregistry/openshift/release:4.15.12-x86_64-agent-installer-api-server
+    type: ocpReleaseContent


### PR DESCRIPTION
…lete flag

# Description

This addresses the issue  when using the *--force-cache-delete* flag when executing a delete for images on a remote registry

Github / Jira issue:  OCPBUGS-43489

**NB** This fix reverts the changes made in OCPBUGS-44448 -  (the route cause actually  was a problem with the  *Delete Destination* )

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Tested using the following ImageSetConfig

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  platform:
    graph: true # Required for the OSUS ooperator
    architectures:
    - amd64
    -  s390x
    channels:
    - name: stable-4.15
      minVersion: '4.15.38'
      maxVersion: '4.15.38'
      shortestPath: true
  helm:
    repositories:
      - name: sbo
        url: https://redhat-developer.github.io/service-binding-operator-helm-chart/
  additionalImages:
  - name: registry.redhat.io/ubi8/ubi:latest
  - name: quay.io/openshifttest/hello-openshift@sha256:61b8f5e1a3b5dbd9e2c35fd448dc5106337d7a299873dd3a6f0cd8d4891ecc27
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index@sha256:a44ae9bb5ff9a4a988a8bf219011c463c4f9e764f0d9aced17b2d399729ebd4a
    packages:
    - name: devworkspace-operator 
```

The DeleteImageSetConfig to use 

```
kind: DeleteImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
delete:
  platform:
    graph: true # Required for the OSUS ooperator
    architectures:
    - amd64
    - s390x
    channels:
    - name: stable-4.15
      minVersion: '4.15.38'
      maxVersion: '4.15.38'
      shortestPath: true
  helm:
    repositories:
      - name: sbo
        url: https://redhat-developer.github.io/service-binding-operator-helm-chart/
  additionalImages:
  - name: registry.redhat.io/ubi8/ubi:latest
  - name: quay.io/openshifttest/hello-openshift@sha256:61b8f5e1a3b5dbd9e2c35fd448dc5106337d7a299873dd3a6f0cd8d4891ecc27
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index@sha256:a44ae9bb5ff9a4a988a8bf219011c463c4f9e764f0d9aced17b2d399729ebd4a
    packages:
    - name: devworkspace-operator
```

Execute a mirror to disk and then a disk to mirror workflow

Execute the delete generate command (using the deleteimagesetconfig)

```
bin/oc-mirror delete --config delete-ying.yaml --generate --workspace file://ocpbugs-43489 docker://localhost:5000/ocpbugs-43489/abc --v2 --dest-tls-verify=false
```
And finally execute the actual delete with --force-cache-delete flag

```
bin/oc-mirror delete --v2 --delete-yaml-file  ocpbugs-43489/working-dir/delete/delete-images.yaml docker://localhost:5000/ocpbugs-43489 --dest-tls-verify=false --src-tls-verify=false --loglevel info
```

**NB** - take note that the destination  `docker://localhost:5000/ocpbugs-43489` is set correctly for all workflows (disk to mirror, generate and delete) - this was one of the route cause for the deletion of local cache not to work. The delete functionality i.e using --delete-yaml-file flag) will check for each entry in the *delete-file* if the destination was set correctly.

**NB** - I also tested using mirror to mirror (note that as their is no data in cache using the --force-cache-delete flag will fail) for this workflow. This was just to ensure in mirror to mirror mode the remote registry delete will still work


## Expected Outcome

Console output has been truncated for brevity !!

```
bin/oc-mirror delete --v2 --delete-yaml-file  ocpbugs-43489/working-dir/delete/delete-images.yaml --force-cache-delete=true docker://localhost:5000/ocpbugs-43489 --dest-tls-verify=false --src-tls-verify=false --loglevel info

2024/12/16 17:42:38  [INFO]   : 👋 Hello, welcome to oc-mirror
2024/12/16 17:42:38  [INFO]   : ⚙️  setting up the environment for you...
2024/12/16 17:42:38  [INFO]   : 🔀 workflow mode: diskToMirror / delete
2024/12/16 17:42:38  [INFO]   : 👀 Reading delete file...
2024/12/16 17:42:38  [INFO]   : 🚀 Start deleting the images...
2024/12/16 17:42:38  [INFO]   : images to delete 420 

...

2024/12/16 17:42:41  [INFO]   : === Results ===
2024/12/16 17:42:41  [INFO]   : ✅ 420 / 420 images deleted successfully
2024/12/16 17:42:41  [INFO]   : delete time     : 3.276656776s
devworkspace/devworkspace-operator-bundle
devworkspace/devworkspace-project-clone-rhel8
devworkspace/devworkspace-rhel8-operator
openshift/graph-image
openshift/release
openshift/release-images
openshift4/ose-kube-rbac-proxy
openshifttest/hello-openshift
redhat/redhat-operator-index
redhat/redhat-operator-index: marking manifest sha256:a44ae9bb5ff9a4a988a8bf219011c463c4f9e764f0d9aced17b2d399729ebd4a 
redhat/redhat-operator-index: marking blob sha256:2db11a9c3610869faeb35965d609de00c16efb086576efc4f5b79ec56a928e35
redhat/redhat-operator-index: marking blob sha256:3059f6068401e6b82194cb486bf75573bd18356796e1010a73d575704723cc31
redhat/redhat-operator-index: marking blob sha256:6b7b2d301bf29dd5fcbffe73060e5b0b6fe970b13a56fd85349c0533cbcab7ab
redhat/redhat-operator-index: marking blob sha256:cf6e7635d7d4d047eca9fe2a7b2c48415aa597677d230cbb9767d3aa776cbb6e
redhat/redhat-operator-index: marking blob sha256:1afd94375c6c02855cdb7db70b4e951cd93797ab6d210034f2d13918e293afa4
redhat/redhat-operator-index: marking blob sha256:b8f54f04d135cc6f405bf8cecf9aa22b22ad2538353a4a46997d8b60330c6442
redhat/redhat-operator-index: marking manifest sha256:b2126ab21a373bfe79b24f2038b951781bf0091401dfaa0bfa6972fdb62b8ae5 
redhat/redhat-operator-index: marking blob sha256:be751f1d8444f5b4235abf1e32ea6d5d65f99b2a49d246a40533f3fb754bd852
redhat/redhat-operator-index: marking blob sha256:d2e660c9d793d805f0bf62ed924d4b81bb06351ca5776f0aa9add281528c6893
redhat/redhat-operator-index: marking blob sha256:38c7eb68cd95287b725e731f02fda4c78a3301aa74693762ad3b9a3074a0c8f6
redhat/redhat-operator-index: marking blob sha256:fbdc7da75f8f14a7ea7c64f849eac3d94b25f9c3722d0d237c38022f34c1ba76
redhat-developer/servicebinding-operator
ubi8/ubi
ubi8-minimal
manifest eligible for deletion: {devworkspace/devworkspace-project-clone-rhel8 sha256:b7b541a2000546f10f141fe203d1f4bb5487e40d51f967033caf3ea7e9ac9cf4 []}
manifest eligible for deletion: {devworkspace/devworkspace-project-clone-rhel8 sha256:cdba9117ea59418f24035a7782b47631a9f68e310a6c821e00b3f49661f24bc6 []}
manifest eligible for deletion: {devworkspace/devworkspace-project-clone-rhel8 sha256:e9919811707fa7955865850148d91b31f3ab9b445f627fe1df9af08ca9d677e4 []}
manifest eligible for deletion: {devworkspace/devworkspace-rhel8-operator sha256:8b88e6b3914241689af2c233fcd39ef135b373b2704cc3a45e933d82ef4cad69 []}
manifest eligible for deletion: {devworkspace/devworkspace-rhel8-operator sha256:aff078de40769006b1c3857774fa85571a8b1b04b604c2d63a73aea59b5c0920 []}
manifest eligible for deletion: {devworkspace/devworkspace-rhel8-operator sha256:fb864e2ca88f4f868f0e0b3ae60712016131aec26f0196e3ae3a6b3c3567b53b []}
manifest eligible for deletion: {openshift/graph-image sha256:8084e8528cbb8a1ab5da588efa6948919eac32f5e41a8fa4e641995423b3cc59 []}
manifest eligible for deletion: {openshift/graph-image sha256:a6ad2753e2a5f7b7063c075e70d5b4da9c3519bc833bc75c46c5dcc06f51270e []}
manifest eligible for deletion: {openshift/graph-image sha256:c41dda107b857123829bcf6d1cc4831d76793113b92a9b841b638331e25debfc []}
manifest eligible for deletion: {openshift/graph-image sha256:cdee0bdea2f335c3c8673ac8ead42bbb060bcf13495703763ed62ea8896fc582 []}
manifest eligible for deletion: {openshift4/ose-kube-rbac-proxy sha256:0fdf642f5a9fdc1faa2aa8be2c74424920f725dba666ba5fea0d18792be541d2 []}
manifest eligible for deletion: {openshift4/ose-kube-rbac-proxy sha256:56d60955e60b698e93a51b266910908099510320bc4b7e8e2b5d9db9a57af2d4 []}
manifest eligible for deletion: {openshift4/ose-kube-rbac-proxy sha256:bba75f2509f2da9905b97657c5c42349ac942ffd5dbad0bf849688894cdb2712 []}
manifest eligible for deletion: {openshift4/ose-kube-rbac-proxy sha256:f93025a2014c3d7b6a311d8037410bfba1c68ba945ba78e36a75e9f8b61203b6 []}
manifest eligible for deletion: {openshifttest/hello-openshift sha256:685a0ca5f33d9f921966c9d9f5922e266affbf93dde0c156709ecdea362f88f4 []}
manifest eligible for deletion: {openshifttest/hello-openshift sha256:a51d6da571b2e1f57249f4d966af65cbfb361dad66cde7121c1bb656ab196269 []}
manifest eligible for deletion: {redhat/redhat-operator-index sha256:c79a10b46d5cf13cac12767ad37f585e0ad01defab67bbfb684cc62f15e740ab [a9c5719b4fa96a801ed763b824fc3e53 sha256-a44ae9bb5ff9a4a988a8bf219011c463c4f9e764f0d9aced17b2d399729ebd4a]}
manifest eligible for deletion: {redhat/redhat-operator-index sha256:f9a3306bc971f66fbe2a867430e52219089da141b360794557bf45a8169d5766 [a9c5719b4fa96a801ed763b824fc3e53 sha256-a44ae9bb5ff9a4a988a8bf219011c463c4f9e764f0d9aced17b2d399729ebd4a]}
manifest eligible for deletion: {ubi8/ubi sha256:17b8ee77f5c03bedf40bfe23557d35f2c2f67be11b78a8a7a6aec0db4d818a25 []}
manifest eligible for deletion: {ubi8/ubi sha256:2c7b6717d87dc33cffe01729e1e10e17e61f5792c7347c4d3bf2c22c0b5d134c []}
manifest eligible for deletion: {ubi8/ubi sha256:37e0f1200d58f83d58c52a0fde105926033d0c9fedc067b78bdcd4fea5d1bb98 []}
manifest eligible for deletion: {ubi8/ubi sha256:645731ab048d175d849e67d8685474833ea399da327212744c1e6cb2fc1c1b82 []}
manifest eligible for deletion: {ubi8-minimal sha256:71aa34f37215ba9201587c834776212b86ec9a72ab3d83a77e6a00dbb535e043 []}
manifest eligible for deletion: {ubi8-minimal sha256:a49924d9d685a35b2d0817ffe9c84f3429d97e9ad29ed3816c389f45564c9e19 []}
manifest eligible for deletion: {ubi8-minimal sha256:a6a6611a34a96eead491bc3c611a82da4bb4ce47950657346f796eb55611e18d []}
manifest eligible for deletion: {ubi8-minimal sha256:f230ad5c30adc6210195636fb6d3dae89fe7ac64a5e107edcdf9a70cf3e5539b []}

12 blobs marked, 795 blobs and 26 manifests eligible for deletion
...

2024/12/16 17:42:43  [INFO]   : 📝 Remember to execute a garbage collect (or similar) on your remote repository
2024/12/16 17:42:43  [INFO]   : 👋 Goodbye, thank you for using oc-mirror
```