### PR TITLE
OCPBUGS-45215: cli: fix log level validation

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -350,8 +350,8 @@ func (o ExecutorSchema) Validate(dest []string) error {
 	if o.Opts.MaxParallelDownloads > 64 {
 		o.Log.Warn("⚠️ --max-parallel-downloads set to %d: %d > %d. Flag ignored. Setting max-parallel-downloads = %d", o.Opts.MaxParallelDownloads, o.Opts.MaxParallelDownloads, limitOverallParallelDownloads, limitOverallParallelDownloads)
 	}
-	if !slices.Contains([]string{"info", "debug", "trace"}, o.Opts.Global.LogLevel) {
-		return fmt.Errorf("log-level has an invalid value %s , it should be one of (info,debug,trace)", o.Opts.Global.LogLevel)
+	if !slices.Contains([]string{"info", "debug", "trace", "error"}, o.Opts.Global.LogLevel) {
+		return fmt.Errorf("log-level has an invalid value %s , it should be one of (info,debug,trace,error)", o.Opts.Global.LogLevel)
 	}
 	if strings.Contains(dest[0], fileProtocol) || strings.Contains(dest[0], dockerProtocol) {
 		return nil


### PR DESCRIPTION
# Description

`error` is a valid log level but it was not being considered during level validation.

Github / Jira issue: OCPBUGS-45215

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

```bash
 $ ./bin/oc-mirror --config /dev/null file:///dev/null --v2 --log-level banana

2025/01/08 12:41:08  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/01/08 12:41:08  [INFO]   : ⚙️  setting up the environment for you...
2025/01/08 12:41:08  [ERROR]  : log-level has an invalid value banana , it should be one of (info,debug,trace,error)

 $ ./bin/oc-mirror --config /dev/null file:///dev/null --v2 --log-level error

2025/01/08 12:41:20  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/01/08 12:41:20  [INFO]   : ⚙️  setting up the environment for you...
2025/01/08 12:41:20  [ERROR]  :  config GVK not recognized: /, Kind=
```

## Expected Outcome
"error" is accepted as a valid log level.