### PR TITLE
OCPBUGS-47688: Fix ITMS and IDMS generated when mirror dest contains …

### DIFF
--- a/v2/internal/pkg/clusterresources/clusterresources.go
+++ b/v2/internal/pkg/clusterresources/clusterresources.go
@@ -537,7 +537,7 @@ func (o *ClusterResourcesGenerator) UpdateServiceGenerator(graphImageRef, releas
 }
 
 func attemptNamespaceScope(srcImgSpec, dstImgSpec image.ImageSpec) (string, string) {
-	if strings.Contains(dstImgSpec.PathComponent, srcImgSpec.PathComponent) {
+	if strings.HasSuffix(dstImgSpec.PathComponent, srcImgSpec.PathComponent) {
 		return namespaceScope(srcImgSpec), namespaceScope(dstImgSpec)
 	} else {
 		return repositoryScope(srcImgSpec), repositoryScope(dstImgSpec)

--- a/v2/internal/pkg/clusterresources/clusterresources_test.go
+++ b/v2/internal/pkg/clusterresources/clusterresources_test.go
@@ -178,6 +178,22 @@ var (
 			Type:        v2alpha1.TypeOperatorRelatedImage,
 		},
 	}
+	imageListOCPBUGS47688 = []v2alpha1.CopyImageSchema{
+		//docker://quay.io/openshift-release-dev/ocp-release:4.17.9-x86_64=docker://sherinefedora:5000/release/newtest/openshift/release-images:4.17.9-x86_64
+		//docker://quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:024bb32ca49837b9ce58f0e1610e5bbb395df7ffaa90ddcffb8cf8ef1b3900dc=docker://sherinefedora:5000/release/newtest/openshift/release:4.17.9-x86_64-tools
+		{
+			Source:      "docker://localhost:55000/openshift/release-images:4.17.9-x86_64",
+			Destination: "docker://myregistry/openshift-release-dev/ocp-release/openshift/release-images:4.17.9-x86_64",
+			Origin:      "docker://quay.io/openshift-release-dev/ocp-release:4.17.9-x86_64",
+			Type:        v2alpha1.TypeOCPRelease,
+		},
+		{
+			Source:      "docker://localhost:55000/openshift/release:4.17.9-x86_64-tools",
+			Destination: "docker://myregistry/openshift-release-dev/ocp-release/openshift/release:4.17.9-x86_64-tools",
+			Origin:      "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:024bb32ca49837b9ce58f0e1610e5bbb395df7ffaa90ddcffb8cf8ef1b3900dc",
+			Type:        v2alpha1.TypeOCPRelease,
+		},
+	}
 )
 
 func TestIDMS_ITMSGenerator(t *testing.T) {
@@ -345,7 +361,7 @@ func TestGenerateIDMS(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			caseName: "Testing GemerateIDMS - digests only : should pass",
+			caseName: "Testing GenerateIDMS - digests only : should pass",
 			imgList:  imageListDigestsOnly,
 			expectedIdmsList: []confv1.ImageDigestMirrorSet{
 				{
@@ -356,6 +372,29 @@ func TestGenerateIDMS(t *testing.T) {
 							{
 								Source:  "quay.io/openshift-release-dev",
 								Mirrors: []confv1.ImageMirror{"myregistry/mynamespace/openshift-release-dev"},
+							},
+						},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			caseName: "Testing GenerateIDMS - OCPBUGS-47688 - should generate valid mirrors when destination has `release` in the url",
+			imgList:  imageListOCPBUGS47688,
+			expectedIdmsList: []confv1.ImageDigestMirrorSet{
+				{
+					TypeMeta:   v1.TypeMeta{Kind: "ImageDigestMirrorSet", APIVersion: "config.openshift.io/v1"},
+					ObjectMeta: v1.ObjectMeta{Name: "idms-release-0"},
+					Spec: confv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []confv1.ImageDigestMirrors{
+							{
+								Source:  "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
+								Mirrors: []confv1.ImageMirror{"myregistry/openshift-release-dev/ocp-release/openshift/release"},
+							},
+							{
+								Source:  "quay.io/openshift-release-dev/ocp-release",
+								Mirrors: []confv1.ImageMirror{"myregistry/openshift-release-dev/ocp-release/openshift/release-images"},
 							},
 						},
 					},
@@ -462,6 +501,25 @@ func TestGenerateITMS(t *testing.T) {
 							{
 								Source:  "quay.io/openshift-release-dev/ocp-release",
 								Mirrors: []confv1.ImageMirror{"myregistry/mynamespace/openshift/release-images"},
+							},
+						},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			caseName: "Testing GenerateITMS - OCPBUGS-47688 : should generate correct mirrors when destination contains `release`",
+			imgList:  imageListOCPBUGS47688,
+			expectedItmsList: []confv1.ImageTagMirrorSet{
+				{
+					TypeMeta:   v1.TypeMeta{Kind: "ImageTagMirrorSet", APIVersion: "config.openshift.io/v1"},
+					ObjectMeta: v1.ObjectMeta{Name: "itms-release-0"},
+					Spec: confv1.ImageTagMirrorSetSpec{
+						ImageTagMirrors: []confv1.ImageTagMirrors{
+							{
+								Source:  "quay.io/openshift-release-dev/ocp-release",
+								Mirrors: []confv1.ImageMirror{"myregistry/openshift-release-dev/ocp-release/openshift/release-images"},
 							},
 						},
 					},


### PR DESCRIPTION
…release namespace

# Description

The IDMS and ITMS applied to the cluster were not allowing the clusters to find the right mirrors for release images. Update of the cluster was failing with `manifest unknown` issues. 

The problem was coming from the way we construct the sources and mirrors in IDMS/ITMS, where we favor namespace scoped references to repository scoped references. 
Ex: when mirroring to `sherinefedora:5000/openshift-release-dev/ocp-release`, the release image `quay.io/openshift-release-dev/ocp-release:4.17.9-x86_64` is mirrored to `sherinefedora:5000/openshift-release-dev/ocp-release/openshift/release-images:4.17.9-x86_64`

The IDMS should instruct container runtimes to replace `quay.io/openshift-release-dev/ocp-release` by 
 `sherinefedora:5000/openshift-release-dev/ocp-release/openshift/release-images` .

Prior to the bug, IDMS contained `sherinefedora:5000/openshift-release-dev/ocp-release/openshift` for namespace 
`quay.io/openshift-release-dev`


Github / Jira issue: [OCPBUGS-47688](https://issues.redhat.com/browse/OCPBUGS-47688)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Perform mirror to mirror using the following command:
```bash
./bin/oc-mirror --v2 -c config_logs/bugs.yaml  docker://sherinefedora:5000/openshift-release-dev/ocp-release --workspace file:///home/skhoury/45580/
```

imagesetconfiguration:
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  platform:
    channels:
    - name: stable-4.17
      type: ocp
      minVersion: 4.17.9
      maxVersion: 4.17.9
```

## Expected Outcome
IDMS file
```yaml
apiVersion: config.openshift.io/v1
kind: ImageDigestMirrorSet
metadata:
  name: idms-release-0
spec:
  imageDigestMirrors:
  - mirrors:
    - sherinefedora:5000/openshift-release-dev/ocp-release/openshift/release-images
    source: quay.io/openshift-release-dev/ocp-release
  - mirrors:
    - sherinefedora:5000/openshift-release-dev/ocp-release/openshift/release
    source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
```
ITMS file
```yaml
apiVersion: config.openshift.io/v1
kind: ImageTagMirrorSet
metadata:
  name: itms-release-0
spec:
  imageTagMirrors:
  - mirrors:
    - sherinefedora:5000/openshift-release-dev/ocp-release/openshift/release-images
    source: quay.io/openshift-release-dev/ocp-release
```