### PR TITLE
OCPBUGS-44714: don't clear cluster-resources dir on `delete --generate`

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -731,10 +731,12 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 
 	// create cluster-resources directory and clean it
 	o.Log.Trace("creating cluster-resources directory %s ", o.Opts.Global.WorkingDir+"/"+clusterResourcesDir)
-	err = os.RemoveAll(o.Opts.Global.WorkingDir + "/" + clusterResourcesDir)
-	if err != nil {
-		o.Log.Error(" setupWorkingDir for cluster resources: failed to clear folder %s: %v ", o.Opts.Global.WorkingDir+"/"+clusterResourcesDir, err)
-		return err
+	if !o.Opts.IsDeleteMode() {
+		err = os.RemoveAll(o.Opts.Global.WorkingDir + "/" + clusterResourcesDir)
+		if err != nil {
+			o.Log.Error(" setupWorkingDir for cluster resources: failed to clear folder %s: %v ", o.Opts.Global.WorkingDir+"/"+clusterResourcesDir, err)
+			return err
+		}
 	}
 	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+clusterResourcesDir, 0755)
 	if err != nil {

--- a/v2/internal/pkg/cli/executor_test.go
+++ b/v2/internal/pkg/cli/executor_test.go
@@ -826,7 +826,6 @@ func TestExecutorSetupWorkingDir(t *testing.T) {
 		ex.MakeDir = MockMakeDir{Fail: true, Dir: operatorImageExtractDir}
 		err = ex.setupWorkingDir()
 		assert.Equal(t, "forced mkdir hold-operator error", err.Error())
-
 	})
 }
 


### PR DESCRIPTION
# Description

The manifests which are generated under working-dir/cluster-resources (IDMS,ITMS etc) shouldn't be deleted automatically.

Github / Jira issue: OCPBUGS-44714

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

```bash
$ touch /mirror-v2-data/working-dir/cluster-resources/do-not-delete-me.txt
$ ./bin/oc-mirror delete --generate --v2 -c /tmp/disc.yaml docker://example.com --workspace file:///mirror-v2-data
$ test -e /mirror-v2-data/working-dir/cluster-resources/do-not-delete-me.txt
```

## Expected Outcome

Files under working-dir/cluster-resources are not deleted.