### PR TITLE
OCPBUGS-48559: [release-4.13] e2e: use same version of crane as in go.mod

### DIFF
--- a/test/e2e/lib/util.sh
+++ b/test/e2e/lib/util.sh
@@ -44,7 +44,7 @@ function cleanup_conn() {
 # install_deps will install crane and registry2 in go bin dir
 function install_deps() {
   pushd ${DATA_TMP}
-  GOFLAGS=-mod=mod go install github.com/google/go-containerregistry/cmd/crane@latest
+  GOFLAGS=-mod=mod go install github.com/google/go-containerregistry/cmd/crane@v0.10.0
   popd
   crane export registry:2 registry2.tar
   tar xvf registry2.tar bin/registry


### PR DESCRIPTION
# Description

`go install` ignores go.mod, so it's possible to install a version not compatible with the system Golang version when using `@latest`.

This should fix the following error in CI for older branches:
```
/go/src/github.com/openshift/oc-mirror/test/e2e/operator-test.17343 /go/src/github.com/openshift/oc-mirror
go: downloading github.com/google/go-containerregistry v0.20.3
go: github.com/google/go-containerregistry/cmd/crane@latest: github.com/google/go-containerregistry@v0.20.3 requires go >= 1.23.0 (running go 1.22.9; GOTOOLCHAIN=local)
/go/src/github.com/openshift/oc-mirror/test/e2e/lib/util.sh: line 17: PID_DISCONN: unbound variable
```

Github / Jira issue: 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.