### PR TITLE
CLID-301: add --cache-dir command line option

### DIFF
--- a/v2/docs/delete-functionality.md
+++ b/v2/docs/delete-functionality.md
@@ -154,7 +154,8 @@ For release image deletion it's recommended to be very specific with versions, i
 For operators its recommended to also ensure specific versions, also keep in mind that if only one package in a catalog is deleted, ensure that the actual catalog index is not deleted.
 
 If by accident the local cache is deleted, untar all the relevant <work-directory>/mirror-xxxx-sequence.tar.gz files and copy the docker contents to the local cache directory
-(default is ~/.oc-mirror/.cache), the local cache directory can be configured using the envar "OC_MIRROR_CACHE"
+(default is ~/.oc-mirror/.cache), the local cache directory can be configured using the envar "OC_MIRROR_CACHE" or the
+--cache-dir command line flag.
 
 If the remote registry is also deleted by accident, re-run the oc-mirror command using the --from flag (disk to mirror mode, it will use the contents of all the relevant .tar.gz files), this will ensure your remote registry is back to the original state.
 

--- a/v2/docs/delete-functionality.md
+++ b/v2/docs/delete-functionality.md
@@ -46,11 +46,11 @@ delete:
     - name: registry.redhat.io/ubi8/ubi-minimal@sha256:8bedbe742f140108897fb3532068e8316900d9814f399d676ac78b46e740e34e
 ```
 
-Its immediatley obvious that "kind" and "mirror" fields have changed compared to the ImageSetConfig, this is to ensure
+Its immediately obvious that "kind" and "mirror" fields have changed compared to the ImageSetConfig, this is to ensure
 that all the relevant filtering and validation are done correctly, without having to update the internal code drastically.
 
 The "delete" entry is the main entry, it contains the "platform", "operators" and "additionalImages" entries, these are used to filter the images
-to intentionaly delete these images.
+to intentionally delete these images.
 
 ### Command line examples
 
@@ -77,7 +77,7 @@ oc-mirror delete --config delete-image-set-config.yaml --workspace file://<previ
 # --delete-yaml-file for stage 2 is mandatory
 # --force-cache-delete is optional (default false)
 
-# once the generate stage has executed succesfully use the created delete yaml to delete the images from the remote registry
+# once the generate stage has executed successfully use the created delete yaml to delete the images from the remote registry
 # default setting for the delete-yaml-file is <previously-mirrored-work-folder>/delete/delete-images.yaml
 # delete remote registry only 
 oc-mirror delete --v2 --delete-yaml-file <previously-mirrored-work-folder>/delete/delete-images-v4.11.yaml docker://<remote-registry> 
@@ -92,18 +92,18 @@ oc-mirror delete --v2 --delete-yaml-file <previously-mirrored-work-folder>/delet
 The --generate flag is used to create the delete yaml files in stage 1.
 The file created can be found in the "previously-mirrored-work-folder/working-dir/delete/" folder 
 
-The flag --workspace has intentionlly been introduced as to avoid any similarity with the current oc-mirror workflow,
+The flag --workspace has intentionally been introduced as to avoid any similarity with the current oc-mirror workflow,
 ensuring no accidental deletion of images.
 
-The --workspace flag must have the `file://` prefix and with the path to the previosly mirrored images, this flag is mandatory when used with the --generate flag.
+The --workspace flag must have the `file://` prefix and with the path to the previously mirrored images, this flag is mandatory when used with the --generate flag.
 
 The --delete-id flag is used to create files in the delete folder with an id, it is optional when using the --generate flag.
 
 The delete command line has to point to the remote registry from which to delete images (generally the final argument of the command). This argument is mandatory for both stages, generate and delete. It must have a `docker://` prefix.
 
 **NB**
-The --force-cache-delete flag will delete the local cache. Before deleting the local cache , we recommend storing all previosly mirrored tar.gz files (i.e s3 bucket as an example) for recovery.
-Also note that no check is made to delete any dependant blobs in other images, so please take care when using this flag. Its always a good policy to validate the blobs that will be deleted, before exeuting the actual delete. 
+The --force-cache-delete flag will delete the local cache. Before deleting the local cache , we recommend storing all previously mirrored tar.gz files (i.e s3 bucket as an example) for recovery.
+Also note that no check is made to delete any dependant blobs in other images, so please take care when using this flag. Its always a good policy to validate the blobs that will be deleted, before executing the actual delete.
 
 An example of a "generated" delete yaml, (ubi8 image deletion):
 

--- a/v2/internal/pkg/cli/delete_test.go
+++ b/v2/internal/pkg/cli/delete_test.go
@@ -106,6 +106,7 @@ func TestExecutorCompleteDelete(t *testing.T) {
 
 		global := &mirror.GlobalOptions{
 			SecurePolicy: false,
+			CacheDir:     "/tmp/",
 		}
 
 		_, sharedOpts := mirror.SharedImageFlags()
@@ -135,8 +136,6 @@ func TestExecutorCompleteDelete(t *testing.T) {
 				LogsDir: "/tmp/",
 			},
 		}
-
-		t.Setenv(cacheEnvVar, "/tmp/")
 
 		defer os.RemoveAll("../../pkg/cli/test")
 		defer os.RemoveAll("../../pkg/cli/tmp")

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -240,6 +240,7 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 	cmd.Flags().UintVar(&ex.ParallelImageLayers, "parallel-layers", 10, "Indicates the number of image layers mirrored in parallel. Defaults to 10")
 	cmd.Flags().UintVar(&ex.ParallelImages, "parallel-images", 8, "Indicates the number of images mirrored in parallel. Defaults to 8")
 	cmd.Flags().StringVar(&opts.RootlessStoragePath, "rootless-storage-path", "", "Override the default container rootless storage path (usually in etc/containers/storage.conf)")
+	cmd.Flags().StringVar(&opts.Global.CacheDir, "cache-dir", "", "oc-mirror cache directory location. Default is $HOME")
 	// nolint: errcheck
 	cmd.Flags().AddFlagSet(&flagSharedOpts)
 	cmd.Flags().AddFlagSet(&flagRetryOpts)
@@ -348,6 +349,9 @@ func (o ExecutorSchema) Validate(dest []string) error {
 	if !slices.Contains([]string{"info", "debug", "trace", "error"}, o.Opts.Global.LogLevel) {
 		return fmt.Errorf("log-level has an invalid value %s , it should be one of (info,debug,trace, error)", o.Opts.Global.LogLevel)
 	}
+	if os.Getenv(cacheEnvVar) != "" && o.Opts.Global.CacheDir != "" {
+		return fmt.Errorf("either OC_MIRROR_CACHE or --cache-dir can be used but not both")
+	}
 	if strings.Contains(dest[0], fileProtocol) || strings.Contains(dest[0], dockerProtocol) {
 		return nil
 	} else {
@@ -445,6 +449,19 @@ func (o *ExecutorSchema) Complete(args []string) error {
 	err = o.setupWorkingDir()
 	if err != nil {
 		return err
+	}
+
+	if o.Opts.Global.CacheDir == "" {
+		// Default to the env var to keep previous behavior
+		o.Opts.Global.CacheDir = os.Getenv(cacheEnvVar)
+	}
+	if o.Opts.Global.CacheDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to setup default cache directory: %w", err)
+		}
+		// ensure cache dir exists
+		o.Opts.Global.CacheDir = homeDir
 	}
 
 	err = o.setupLocalStorageDir()
@@ -646,18 +663,7 @@ func (o *ExecutorSchema) isLocalStoragePortBound() bool {
 // setupLocalStorageDir - private utility to setup
 // the correct local storage directory
 func (o *ExecutorSchema) setupLocalStorageDir() error {
-
-	requestedCachePath := os.Getenv(cacheEnvVar)
-	if requestedCachePath == "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return err
-		}
-		// ensure cache dir exists
-		o.LocalStorageDisk = filepath.Join(homeDir, cacheRelativePath)
-	} else {
-		o.LocalStorageDisk = filepath.Join(requestedCachePath, cacheRelativePath)
-	}
+	o.LocalStorageDisk = filepath.Join(o.Opts.Global.CacheDir, cacheRelativePath)
 	err := os.MkdirAll(o.LocalStorageDisk, 0755)
 	if err != nil {
 		o.Log.Error("unable to setup folder for oc-mirror local storage: %v ", err)

--- a/v2/internal/pkg/cli/executor_test.go
+++ b/v2/internal/pkg/cli/executor_test.go
@@ -583,6 +583,7 @@ func TestExecutorComplete(t *testing.T) {
 
 		global := &mirror.GlobalOptions{
 			SecurePolicy: false,
+			CacheDir:     "/tmp/",
 		}
 
 		_, sharedOpts := mirror.SharedImageFlags()
@@ -607,8 +608,6 @@ func TestExecutorComplete(t *testing.T) {
 			MakeDir: MakeDir{},
 			LogsDir: "/tmp/",
 		}
-
-		t.Setenv(cacheEnvVar, "/tmp/")
 
 		// file protocol
 		err := ex.Complete([]string{"file:///tmp/test"})

--- a/v2/internal/pkg/mirror/options.go
+++ b/v2/internal/pkg/mirror/options.go
@@ -55,6 +55,7 @@ type GlobalOptions struct {
 	ForceCacheDelete   bool          // Used to force delete the local cache
 	DeleteID           string        // This flag is used to append to the artifacts created by the delete functionality
 	DeleteYaml         string        // This flag will use the contents of the indicated yaml as basis to delete the local cache and remote registry
+	CacheDir           string        // Path to the cache directory
 }
 
 type CopyOptions struct {


### PR DESCRIPTION
# Description

This should be easier for users to find since it's shown in the output of `--help` compared to the `OC_MIRROR_CACHE` env var.

Github / Jira issue: [CLID-301](https://issues.redhat.com//browse/CLID-301)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

```bash
$ ./bin/oc-mirror --v2 --help
[...]
Flags:
      --authfile string                path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json
      --cache-dir string               oc-mirror cache directory
  -c, --config string                  Path to imageset configuration file

$ OC_MIRROR_CACHE=/home/ ./bin/oc-mirror --v2 --cache-dir /tmp/ -c ~/Downloads/isc.yaml file:///tmp/banana

2025/01/23 13:31:44  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/01/23 13:31:44  [INFO]   : ⚙  setting up the environment for you...
2025/01/23 13:31:44  [ERROR]  : either OC_MIRROR_CACHE or --cache-dir can be used but not both

$ ./bin/oc-mirror --v2 --cache-dir ~/Downloads -c ~/Downloads/isc.yaml file://~/Downloads/mirror-cache-test

2025/01/23 13:35:31  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/01/23 13:35:31  [INFO]   : ⚙  setting up the environment for you...
2025/01/23 13:35:31  [INFO]   : 🔀 workflow mode: mirrorToDisk
2025/01/23 13:35:31  [INFO]   : 🕵  going to discover the necessary images...
2025/01/23 13:35:31  [INFO]   : 🔍 collecting release images...
^C

$ test -e ~/Downloads/.oc-mirror/.cache/
$ echo $?
0
```

The unit tests set the cache dir to `/tmp/` and they are still passing.

## Expected Outcome

Location of the cache dir can be set via the `--cache-dir` flag.