### PR TITLE
OCPBUGS-45059: fixes the delete when catalog mirrored  with v1 from disk (oci://)

### DIFF
--- a/v2/internal/pkg/api/v2alpha1/type_internal.go
+++ b/v2/internal/pkg/api/v2alpha1/type_internal.go
@@ -193,6 +193,9 @@ type RelatedImage struct {
 	// if set should be used when mirroring
 	TargetCatalog string `json:"targetCatalog"`
 	RebuiltTag    string `json:"rebuiltTag"`
+	//Used to identify if a related image is from an operator catalog on disk (oci:// on ImageSetConfiguration)
+	//TODO remove me when the migration from oc-mirror v1 to v2 ends
+	OriginFromOperatorCatalogOnDisk bool
 }
 
 type CollectorSchema struct {

--- a/v2/internal/pkg/operator/common.go
+++ b/v2/internal/pkg/operator/common.go
@@ -181,14 +181,19 @@ func (o OperatorCollector) prepareD2MCopyBatch(images map[string][]v2alpha1.Rela
 				} else {
 					src = src + ":" + imgSpec.Algorithm + "-" + imgSpec.Digest
 				}
+				//TODO remove me when the migration from oc-mirror v1 to v2 ends
 				if o.generateV1DestTags {
-					hasher := fnv.New32a()
-					hasher.Reset()
-					_, err = hasher.Write([]byte(imgSpec.Reference))
-					if err != nil {
-						return result, fmt.Errorf("couldn't generate v1 tag for image (%s), skipping ", imgSpec.ReferenceWithTransport)
+					if img.OriginFromOperatorCatalogOnDisk {
+						dest = dest + ":" + imgSpec.Digest[0:6]
+					} else {
+						hasher := fnv.New32a()
+						hasher.Reset()
+						_, err = hasher.Write([]byte(imgSpec.Reference))
+						if err != nil {
+							return result, fmt.Errorf("couldn't generate v1 tag for image (%s), skipping ", imgSpec.ReferenceWithTransport)
+						}
+						dest = dest + ":" + fmt.Sprintf("%x", hasher.Sum32())
 					}
-					dest = dest + ":" + fmt.Sprintf("%x", hasher.Sum32())
 				} else {
 					dest = dest + ":" + imgSpec.Algorithm + "-" + imgSpec.Digest
 				}


### PR DESCRIPTION
# Description

When an operator catalog was mirrored with v1 and the catalog was on disk (oci:// on the ImageSetConfiguration) the delete feature was not working properly. The changes on this PR is to fix this bug.

Github / Jira issue: [OCPBUGS-45059](https://issues.redhat.com/browse/OCPBUGS-45059)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

With the following ImageSetConfiguration from oc-mirror v1

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
    - catalog: oci:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/testying/redhat-operator-index
      targetCatalog: "ocicatalog73452"
      targetTag: "v16"
      packages:
        - name: cluster-kube-descheduler-operator
```

Run mirror to mirror (m2m):

```
./bin/oc-mirror -c ./alex-tests/alex-isc/ocpbugs/ocpbugs-45059-v1.yaml docker://localhost:6000/437311 --dest-skip-tls --dest-use-http
```

Then with the following ImageSetConfiguration from oc-mirror v2
```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
    - catalog: oci:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/testying/redhat-operator-index
      targetCatalog: "ocicatalog73452"
      targetTag: "v16"
      packages:
        - name: cluster-kube-descheduler-operator
```

Run mirror to disk (m2d):

```
./bin/oc-mirror --v2 -c ./alex-tests/alex-isc/ocpbugs/ocpbugs-45059-v2.yaml file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/ocpbugs-45059-v2
```

Then with the following DeleteImageSetConfiguration

```
kind: DeleteImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
delete:
  operators:
    - catalog: oci:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/testying/redhat-operator-index
      targetCatalog: "ocicatalog73452"
      targetTag: "v16"
      packages:
        - name: cluster-kube-descheduler-operator
```

Run the diskToMirror delete generate

```
./bin/oc-mirror delete --generate --delete-v1-images -c /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-isc/ocpbugs/ocpbugs-45059-v2-delete.yaml --workspace file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/ocpbugs-45059-v2 docker://localhost:6000/437311 --v2
```

And lastly, the delete

```
./bin/oc-mirror delete --delete-yaml-file /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/ocpbugs-45059-v2/working-dir/delete/delete-images.yaml docker://localhost:6000/437311 --v2 --dest-tls-verify=false
```

## Expected Outcome
All the tags from the destination should be deleted (except the operator catalog image)