### PR TITLE
OCPBUGS-50559: v2: disable spinners when not running in a tty

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -29,6 +29,7 @@ require (
 	golang.org/x/crypto v0.32.0
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/sync v0.10.0
+	golang.org/x/term v0.28.0
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.17.0
 	k8s.io/api v0.32.0
@@ -241,7 +242,6 @@ require (
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/oauth2 v0.25.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
-	golang.org/x/term v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.7.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241209162323-e6fa225c2576 // indirect

--- a/v2/internal/pkg/mirror/options.go
+++ b/v2/internal/pkg/mirror/options.go
@@ -56,6 +56,7 @@ type GlobalOptions struct {
 	DeleteID           string        // This flag is used to append to the artifacts created by the delete functionality
 	DeleteYaml         string        // This flag will use the contents of the indicated yaml as basis to delete the local cache and remote registry
 	CacheDir           string        // Path to the cache directory
+	IsTerminal         bool          // Whether we're running in a terminal console or not
 }
 
 type CopyOptions struct {

--- a/v2/internal/pkg/operator/filtered_collector.go
+++ b/v2/internal/pkg/operator/filtered_collector.go
@@ -54,8 +54,11 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 		// download the operator index image
 		o.Log.Debug(collectorPrefix+"copying operator image %s", op.Catalog)
 
+		if !o.Opts.Global.IsTerminal {
+			o.Log.Debug("Collecting catalog %s", op.Catalog)
+		}
 		// prepare spinner
-		p := mpb.New()
+		p := mpb.New(mpb.ContainerOptional(mpb.WithOutput(io.Discard), !o.Opts.Global.IsTerminal))
 		spinner := p.AddSpinner(
 			1, mpb.BarFillerMiddleware(spinners.PositionSpinnerLeft),
 			mpb.BarWidth(3),
@@ -460,6 +463,9 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 		}
 		spinner.Increment()
 		p.Wait()
+		if !o.Opts.Global.IsTerminal {
+			o.Log.Info("Collected catalog %s", op.Catalog)
+		}
 	}
 
 	o.Log.Debug(collectorPrefix+"related images length %d ", len(relatedImages))


### PR DESCRIPTION
# Description

If oc-mirror is run behind a CI/CD pipeline or if output is redirected to a file/pipe, the spinners' output is not shown and it looks like oc-mirror is not making any progress. By using a regular log line instead, we can still show some progress logs in those cases.

Github / Jira issue: 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

m2d with `| grep ''` to force a non-tty output.

## Expected Outcome

Log lines are printed as images are copied (or fail to copy).