### PR TITLE
OCPBUGS-49723: v2/clusterresources: remove ClusterCatalog namespace

### DIFF
--- a/v2/internal/pkg/clusterresources/clusterresources.go
+++ b/v2/internal/pkg/clusterresources/clusterresources.go
@@ -436,8 +436,7 @@ func (o *ClusterResourcesGenerator) generateClusterCatalog(catalogRef string) er
 			Kind:       ofv1.ClusterCatalogKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterCatalogName,
-			Namespace: "openshift-marketplace",
+			Name: clusterCatalogName,
 		},
 		Spec: ofv1.ClusterCatalogSpec{
 			Source: ofv1.CatalogSource{

--- a/v2/internal/pkg/clusterresources/clusterresources_test.go
+++ b/v2/internal/pkg/clusterresources/clusterresources_test.go
@@ -1055,8 +1055,7 @@ func TestClusterCatalogGenerator(t *testing.T) {
 				Kind:       ofv1.ClusterCatalogKind,
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      expectedCCName,
-				Namespace: "openshift-marketplace",
+				Name: expectedCCName,
 			},
 			Spec: ofv1.ClusterCatalogSpec{
 				Source: ofv1.CatalogSource{
@@ -1143,8 +1142,7 @@ func TestClusterCatalogGenerator(t *testing.T) {
 				Kind:       ofv1.ClusterCatalogKind,
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      expectedCCName,
-				Namespace: "openshift-marketplace",
+				Name: expectedCCName,
 			},
 			Spec: ofv1.ClusterCatalogSpec{
 				Source: ofv1.CatalogSource{


### PR DESCRIPTION
# Description

It is a cluster-wide resource, so we don't need to set the namespace.


Github / Jira issue: OCPBUGS-49723

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.