### PR TITLE
OCPBUGS-49730: fixes the infinite loop when no images to mirror

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -1141,6 +1141,11 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 	execTime := endTime.Sub(startTime)
 	o.Log.Debug("collection time     : %v", execTime)
 
+	if len(collectorSchema.AllImages) == 0 {
+		o.Log.Info(emoji.Exclamation + " No images to mirror...")
+		return v2alpha1.CollectorSchema{}, errors.New("no images to copy")
+	}
+
 	return collectorSchema, nil
 }
 

--- a/v2/internal/pkg/emoji/const.go
+++ b/v2/internal/pkg/emoji/const.go
@@ -19,5 +19,5 @@ const (
 	SpinnerCrossMark            string = "\x1b[1;91m ✗ \x1b[0m" //✗
 	Gear                        string = "\u2699\uFE0F"         // ⚙️
 	Warning                     string = "\U000026A0\U0000FE0F" // ⚠️
-
+	Exclamation                 string = "\U00002757"           //❗
 )


### PR DESCRIPTION
# Description

There was a bug with an infinite loop when there was no images to mirror.

Github / Jira issue: [OCPBUGS-49730](https://issues.redhat.com/browse/OCPBUGS-49730)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

With the following ImageSetConfiguration (where the catalog path on disk does not exist)

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
    - catalog: oci:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/openshift-tests-private/redhat-operator-index
      targetCatalog: "ocicatalog73452"
      targetTag: "v16"
      packages:
        - name: cluster-kube-descheduler-operator
```

Run the m2d

```
./bin/oc-mirror -c ./alex-tests/alex-isc/ocpbugs/ocpbugs-49730.yaml file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/ocpbugs-49730 --v2
```

## Expected Outcome
The flow should stop before the mirroring with the following message:

```
2025/02/03 14:06:23  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/02/03 14:06:23  [INFO]   : ⚙️  setting up the environment for you...
2025/02/03 14:06:23  [INFO]   : 🔀 workflow mode: mirrorToDisk 
2025/02/03 14:06:23  [INFO]   : 🕵  going to discover the necessary images...
2025/02/03 14:06:23  [INFO]   : 🔍 collecting release images...
2025/02/03 14:06:23  [INFO]   : 🔍 collecting operator images...
 ✗   () Collecting catalog oci:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/openshift-tests-private/redhat-operator-index 
2025/02/03 14:06:23  [WARN]   : [OperatorImageCollector] catalog invalid source name oci:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/openshift-tests-private/redhat-operator-index: lstat /home/aguidi/go/src/github.com/aguidirh/oc-mirror/openshift-tests-private: no such file or directory : SKIPPING
2025/02/03 14:06:23  [INFO]   : 🔍 collecting additional images...
2025/02/03 14:06:23  [INFO]   : 🔍 collecting helm images...
2025/02/03 14:06:23  [INFO]   : ❗ No images to mirror...
2025/02/03 14:06:23  [INFO]   : 👋 Goodbye, thank you for using oc-mirror
2025/02/03 14:06:23  [ERROR]  : no images to copy 
aguidi@fedora:~/go/src/github.com/aguidirh/oc-mirror
```