### PR TITLE
no-jira: v2/local_stored_collector: fix missing log argument

### DIFF
--- a/v2/internal/pkg/release/local_stored_collector.go
+++ b/v2/internal/pkg/release/local_stored_collector.go
@@ -250,8 +250,7 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v2
 			// graph image in the cache as a paliative.
 			shouldProceed := graphInCache || o.Opts.IsDeleteMode()
 			if err != nil && !o.Opts.IsDeleteMode() {
-				o.Log.Warn("unable to find graph image in local cache: SKIPPING. %v")
-				o.Log.Warn("%v", err)
+				o.Log.Warn("unable to find graph image in local cache: %v. SKIPPING", err)
 			}
 			if shouldProceed {
 				// OCPBUGS-26513: In order to get the destination for the graphDataImage


### PR DESCRIPTION
# Description

This change fixes the missing argument in the following log message:
```
2025/02/03 15:58:07  [WARN]   : unable to find graph image in local cache: SKIPPING. %!v(MISSING)
```

Github / Jira issue: 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.