### PR TITLE
OCPBUGS-49798: exposes the parallel-layers flag

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -284,7 +284,6 @@ func HideFlags(cmd *cobra.Command) {
 	cmd.Flags().MarkHidden("src-registry-token")
 	cmd.Flags().MarkHidden("src-shared-blob-dir")
 	cmd.Flags().MarkHidden("src-username")
-	cmd.Flags().MarkHidden("parallel-layers")
 	cmd.Flags().MarkHidden("parallel-batch-images")
 }
 


### PR DESCRIPTION
# Description

This PR adds the flag parallel-layers to the `--help` 

Github / Jira issue: [OCPBUGS-49798](https://issues.redhat.com/browse/OCPBUGS-49798)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

```
oc-mirror --v2 --help
```

```
oc-mirror delete --v2 --help
```

## Expected Outcome
The `parallel-layers` flag should be show in both commands above.