### PR TITLE
CLID-280: WIP: Copy signatures during M2M

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -433,8 +433,8 @@ func (o *ExecutorSchema) Complete(args []string) error {
 
 	// make sure we always get multi-arch images
 	o.Opts.MultiArch = "all"
-	// for the moment, mirroring doesn't verify signatures. Expected in CLID-26
-	o.Opts.RemoveSignatures = true
+	// forcing signature verification always
+	o.Opts.RemoveSignatures = false
 
 	o.Opts.ParallelLayerImages = maxParallelLayerDownloads
 	if o.ParallelImageLayers > 0 {

--- a/v2/internal/pkg/operator/filtered_collector.go
+++ b/v2/internal/pkg/operator/filtered_collector.go
@@ -217,6 +217,7 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 
 				optsCopy := o.Opts
 				optsCopy.Stdout = io.Discard
+				optsCopy.RemoveSignatures = true
 
 				err = o.Mirror.Run(ctx, src, dest, "copy", &optsCopy)
 

--- a/v2/internal/pkg/release/local_stored_collector.go
+++ b/v2/internal/pkg/release/local_stored_collector.go
@@ -84,6 +84,7 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v2
 
 				optsCopy := o.Opts
 				optsCopy.Stdout = io.Discard
+				optsCopy.RemoveSignatures = true
 
 				err = o.Mirror.Run(ctx, src, dest, "copy", &optsCopy)
 				if err != nil {


### PR DESCRIPTION
This PR is NOT TO BE MERGED.

This is just a POC of what would be needed to start copying / verifying signatures. 

The goal of the PR is to initiate discussions with the rest of the OCP community around how signature verification will look like on a disconnected cluster. 

One of the priorities is to confirm the system configuration for signature lookup and verification.

This PR demonstrates how to perform a mirror to mirror workflow with signature mirroring :

**Command used:**
```bash
./bin/oc-mirror --v2 -c v2config.yaml --workspace file:///home/skhoury/45580/ docker://sherinefedora:5000
```

**ImageSetConfig - v2config.yaml**
```yaml
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.17
      packages:
      - name: devworkspace-operator


kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
```

**/etc/containers/registries.d/registry.redhat.io.yaml**
```yaml
docker:
  registry.redhat.io:
    use-sigstore-attachments: true
```
:warning: Note that we are not using `lookaside` here. 
:question: Is this going to be the OCP node default configuration as well?  [OCPSTRAT-1245](https://issues.redhat.com/browse/OCPSTRAT-1245)

**/etc/containers/registries.d/registry.redhat.io.yaml**
```yaml
docker:
  registry.redhat.io:
    use-sigstore-attachments: true
```

**/etc/containers/registries.d/sherinefedora:5000.yaml**
```yaml
docker:
  "sherinefedora:5000":
    use-sigstore-attachments: true
```
:warning: This is the destination registry. Red Hat default configuration might not provide such a file. oc-mirror documentation needs to cover this?

**/etc/containers/registries.d/localhost:55000.yaml**
```yaml
docker:
     "localhost:55000":
         use-sigstore-attachments: true
```
:warning: This is the oc-mirror internal cache. By default it uses port 55000 , but this can be overridden by the user. We need to think about how best to set this configuration file, here or in `$HOME/.config/containers/registries.d` (no root permissions required)

**/etc/containers/policy.json**
```json
{
    "default": [
        {
            "type": "insecureAcceptAnything"
        }
    ],
    "transports": {
        "docker": {
          "registry.redhat.io/redhat/certified-operator-index": [
            {
              "type": "signedBy",
              "keyType": "GPGKeys",
              "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-isv"
            }
          ],
          "registry.redhat.io/redhat/community-operator-index": [
            {
              "type": "signedBy",
              "keyType": "GPGKeys",
              "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-isv"
            }
          ],
          "registry.redhat.io/redhat/redhat-marketplace-index": [
            {
              "type": "signedBy",
              "keyType": "GPGKeys",
              "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-isv"
            }
          ],
	    "registry.access.redhat.com": [
		{
		    "type": "signedBy",
		    "keyType": "GPGKeys",
		    "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
		}
	    ],
	    "registry.redhat.io": [
		{
		    "type": "signedBy",
		    "keyType": "GPGKeys",
		    "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
		}
	    ]
	},
        "docker-daemon": {
	    "": [
		{
		    "type": "insecureAcceptAnything"
		}
	    ]
	}
    }
}
```

**Console output**
```
2025/02/04 10:58:53  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/02/04 10:58:53  [INFO]   : ⚙️  setting up the environment for you...
2025/02/04 10:58:53  [INFO]   : 🔀 workflow mode: mirrorToMirror 
2025/02/04 10:58:53  [INFO]   : 🕵  going to discover the necessary images...
2025/02/04 10:58:53  [INFO]   : 🔍 collecting release images...
2025/02/04 10:58:53  [INFO]   : 🔍 collecting operator images...
 ✓   (0s) Collecting catalog registry.redhat.io/redhat/redhat-operator-index:v4.17 
2025/02/04 10:58:54  [INFO]   : 🔍 collecting additional images...
2025/02/04 10:58:54  [INFO]   : 🔍 collecting helm images...
2025/02/04 10:58:54  [INFO]   : 🔂 rebuilding catalogs
2025/02/04 10:58:54  [INFO]   : 🚀 Start copying the images...
2025/02/04 10:58:54  [INFO]   : 📌 images to copy 7 
 ✓   (0s) redhat-operator-index:v4.17 ➡️  sherinefedora:5000/redhat/ 
 ✓ (3s) devworkspace-operator-bundle@sha256:085fe1841e55a06190f79f7d9c17f19b20d6b6155e28de1d567d3f68ca95ff81 ➡️  sherinefedora:500…
 ✓   (8s) redhat-operator-index:v4.17 ➡️  cache 
 ✓ (19s) devworkspace-rhel9-operator@sha256:73472149035bc7f0c4ecaf911f68bd391a36d45a21238fd2f46a839ab9e77dcd ➡️  sherinefedora:500…
 ✓ (22s) ose-kube-rbac-proxy@sha256:1fc9d5afd6c486643f127ef8f4f8ef09eb8d206422b496a4cd365f0b4ab0a2c2 ➡️  sherinefedora:5000/opensh…
 ✓ (36s) devworkspace-project-clone-rhel9@sha256:afa28466d9b8c9d6421bb7789bccb68ecde9ea2c38617825e75c53ba357d4b76 ➡️  sherinefedor…
7 / 7 (37s) [=======================================================================================================================] 100 %
 ✓   (37s) ubi-minimal@sha256:b87097994ed62fbf1de70bc75debe8dacf3ea6e00dd577d74503ef66452c59d6 ➡️  sherinefedora:5000/ubi9/ 
2025/02/04 10:59:32  [INFO]   : === Results ===
2025/02/04 10:59:32  [INFO]   :  ✓  7 / 7 operator images mirrored successfully
2025/02/04 10:59:32  [INFO]   : 📄 Generating IDMS file...
2025/02/04 10:59:32  [INFO]   : /home/skhoury/45580/working-dir/cluster-resources/idms-oc-mirror.yaml file created
2025/02/04 10:59:32  [INFO]   : 📄 No images by tag were mirrored. Skipping ITMS generation.
2025/02/04 10:59:32  [INFO]   : 📄 Generating CatalogSource file...
2025/02/04 10:59:32  [INFO]   : /home/skhoury/45580/working-dir/cluster-resources/cs-redhat-operator-index-v4-17.yaml file created
2025/02/04 10:59:32  [INFO]   : 📄 Generating ClusterCatalog file...
2025/02/04 10:59:32  [INFO]   : /home/skhoury/45580/working-dir/cluster-resources/cc-redhat-operator-index-v4-17.yaml file created
2025/02/04 10:59:32  [INFO]   : mirror time     : 38.550461664s
2025/02/04 10:59:32  [INFO]   : 👋 Goodbye, thank you for using oc-mirror
```

**Verification of signature mirroring**
```bash
$ curl https://sherinefedora:5000/v2/openshift4/ose-kube-rbac-proxy/tags/list | jq
{
  "name": "openshift4/ose-kube-rbac-proxy",
  "tags": [
    "a366ef7",
    "sha256-1fc9d5afd6c486643f127ef8f4f8ef09eb8d206422b496a4cd365f0b4ab0a2c2",
    "sha256-1fc9d5afd6c486643f127ef8f4f8ef09eb8d206422b496a4cd365f0b4ab0a2c2.sig",
    "sha256-4488f5fdf6f10a551fe046e62cd4f3d856530cfb15831f7e1e2de531e7f2caeb",
    "sha256-4840b301e261cfb291697d907d98b177ba57a122e5563e42c8d831d3c42e5ef6.sig",
    "sha256-863efdda55c3da31afbf622c67b7336d61e73ee96ca762676c4b7d98f1e8f98c.sig",
    "sha256-c9c6c66b59e1775217ae048446b123817db2a8bc6ee729914101916dc29bcd3c.sig",
    "sha256-e4fd184a8691e7b8d2d8da561cec09e87f2825b66774fffeb50da6a9e0b515ff.sig"
  ]
}
```

