### PR TITLE
NO-JIRA:  only save graph data if it's valid json

### DIFF
--- a/v2/internal/pkg/release/core-cincinnati.go
+++ b/v2/internal/pkg/release/core-cincinnati.go
@@ -530,12 +530,12 @@ func getGraphData(ctx context.Context, cs CincinnatiSchema) (graph graph, err er
 		return graph, &Error{Reason: "ResponseFailed", Message: err.Error(), cause: err}
 	}
 
-	if err := writeGraphDataToFile(body, *uri, cs.CincinnatiParams.GraphDataDir); err != nil {
-		return graph, err
-	}
-
 	if err = json.Unmarshal(body, &graph); err != nil {
 		return graph, &Error{Reason: "ResponseInvalid", Message: err.Error(), cause: err}
+	}
+
+	if err := writeGraphDataToFile(body, *uri, cs.CincinnatiParams.GraphDataDir); err != nil {
+		return graph, err
 	}
 
 	return graph, nil

--- a/v2/internal/pkg/release/core-cincinnati.go
+++ b/v2/internal/pkg/release/core-cincinnati.go
@@ -471,14 +471,16 @@ func getGraphData(ctx context.Context, cs CincinnatiSchema) (graph graph, err er
 		arch := queryValues.Get("arch")
 		channel := queryValues.Get("channel")
 		filename := fmt.Sprintf("%s-%s.json", arch, channel)
+		filepath := path.Join(cs.CincinnatiParams.GraphDataDir, filename)
 
-		fileData, err := os.ReadFile(path.Join(cs.CincinnatiParams.GraphDataDir, filename))
+		fileData, err := os.ReadFile(filepath)
 		if err != nil {
 			return graph, &Error{Reason: "ReadFileFailed", Message: err.Error(), cause: err}
 		}
 
 		if err = json.Unmarshal(fileData, &graph); err != nil {
-			return graph, &Error{Reason: "ResponseInvalid", Message: err.Error(), cause: err}
+			errMsg := fmt.Sprintf("could not parse graph data %s: %v", filepath, err)
+			return graph, &Error{Reason: "GraphDataInvalid", Message: errMsg, cause: err}
 		}
 
 		return graph, nil


### PR DESCRIPTION
# Description

* If we save the graph data to disk before checking it's valid, we can run into unmarshaling errors later like:

    ```
    2025/02/05 02:14:36  [ERROR]  : [GetReleaseReferenceImages] error list [APIRequestError: channel "stable-4.16": ResponseInvalid: invalid character 'a' after top-level value]
    ```
*  Just returning unmarshaling errors is not very useful information:

    ```
    ResponseInvalid: invalid character 'a' after top-level value
    ```
    Let's add more context to that error when reading graph data from the
    working dir so we know which is the offending file.

Github / Jira issue: 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.