### PR TITLE
OCPBUGS-49990: v2/release: error out for kubevirt/graph image errors

### DIFF
--- a/v2/internal/pkg/archive/archive_test.go
+++ b/v2/internal/pkg/archive/archive_test.go
@@ -51,6 +51,8 @@ var expectedTarContents = []string{
 	"docker/registry/v2/repositories/ubi8/ubi/_uploads/97e2891e-4cb2-4289-a87a-e9b8cd006d20/hashstates/sha256/0",
 	"docker/registry/v2/repositories/ubi8/ubi/_uploads/97e2891e-4cb2-4289-a87a-e9b8cd006d20/startedat",
 	"isc",
+	"working-dir-fake/hold-release/ocp-release/v4.13.10/release-manifests/0000_50_installer_coreos-bootimages.yaml",
+	"working-dir-fake/hold-release/ocp-release/v4.13.9/release-manifests/0000_50_installer_coreos-bootimages.yaml",
 	"working-dir-fake/hold-release/ocp-release/4.14.1-x86_64/release-manifests/image-references",
 	"working-dir-fake/hold-release/ocp-release/4.14.1-x86_64/release-manifests/release-metadata",
 	"working-dir-fake/hold-release/ocp-release/4.14.1-x86_64/release-manifests/0000_50_installer_coreos-bootimages.yaml",

--- a/v2/tests/working-dir-fake/hold-release/ocp-release/v4.13.10/release-manifests/0000_50_installer_coreos-bootimages.yaml
+++ b/v2/tests/working-dir-fake/hold-release/ocp-release/v4.13.10/release-manifests/0000_50_installer_coreos-bootimages.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+data:
+  releaseVersion: 0.0.1-snapshot
+  stream: |
+    {
+      "stream": "rhcos-4.15",
+      "metadata": {
+        "last-modified": "2024-03-07T20:02:01Z",
+        "generator": "plume cosa2stream 743c05b"
+      },
+      "architectures": {
+        "x86_64": {
+          "images": {
+            "kubevirt": {
+              "release": "415.92.202402201450-0",
+              "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.15-9.2-kubevirt",
+              "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:729265d5ef6ed6a45bcd55c46877e3acb9eae3f49c78cd795d5b53aa85e3775b"
+            }
+          },
+          "rhel-coreos-extensions": {
+            "azure-disk": {
+              "release": "415.92.202402201450-0",
+              "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-415.92.202402201450-0-azure.x86_64.vhd"
+            }
+          }
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  creationTimestamp: null
+  name: coreos-bootimages
+  namespace: openshift-machine-config-operator

--- a/v2/tests/working-dir-fake/hold-release/ocp-release/v4.13.9/release-manifests/0000_50_installer_coreos-bootimages.yaml
+++ b/v2/tests/working-dir-fake/hold-release/ocp-release/v4.13.9/release-manifests/0000_50_installer_coreos-bootimages.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+data:
+  releaseVersion: 0.0.1-snapshot
+  stream: |
+    {
+      "stream": "rhcos-4.15",
+      "metadata": {
+        "last-modified": "2024-03-07T20:02:01Z",
+        "generator": "plume cosa2stream 743c05b"
+      },
+      "architectures": {
+        "x86_64": {
+          "images": {
+            "kubevirt": {
+              "release": "415.92.202402201450-0",
+              "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.15-9.2-kubevirt",
+              "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:729265d5ef6ed6a45bcd55c46877e3acb9eae3f49c78cd795d5b53aa85e3775b"
+            }
+          },
+          "rhel-coreos-extensions": {
+            "azure-disk": {
+              "release": "415.92.202402201450-0",
+              "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-415.92.202402201450-0-azure.x86_64.vhd"
+            }
+          }
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  creationTimestamp: null
+  name: coreos-bootimages
+  namespace: openshift-machine-config-operator


### PR DESCRIPTION
# Description

If requested by users in the ImageSetConfiguration and these resources are not found, either in the mirror or in the local cache, `oc-mirror` should error out instead of just printing a warning and continuing.

Github / Jira issue: 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.