### PR TITLE
OCPBUGS-49991: fixes bundle related images being skipped

### DIFF
--- a/v2/internal/pkg/operator/filtered_collector.go
+++ b/v2/internal/pkg/operator/filtered_collector.go
@@ -415,9 +415,11 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 
 		ri, err := o.ctlgHandler.getRelatedImagesFromCatalog(filteredDC, copyImageSchemaMap)
 		if err != nil {
-			spinner.Abort(true)
-			spinner.Wait()
-			return v2alpha1.CollectorSchema{}, err
+			if len(ri) == 0 {
+				spinner.Abort(true)
+				spinner.Wait()
+				continue
+			}
 		}
 
 		//OCPBUGS-45059


### PR DESCRIPTION
# Description

This PR fixes the bug where a bundle related image could be skipped during the collection. The operator would not work as expected because of missing related images.

Github / Jira issue: [OCPBUGS-49991](https://issues.redhat.com/browse/OCPBUGS-49991)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

With the following ImageSetConfiguration:

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/community-operator-index:v4.13
      packages:
       - name: openshift-nfd-operator
       - name: kuadrant-operator
       - name: argocd-operator
```

Run `m2d`

## Expected Outcome
Only the `argocd-operator` will be mirrored. The `openshift-nfd-operator` and `kuadrant-operator` will be skipped on the collector phase because of issues on its related images.

NOTE: this PR does not add the errors on the collector phase to the error file. This behavior will be added in a future PR.