### PR TITLE
OCPBUGS-50503: oc-mirror fails with error `unknown image: reference n…

### DIFF
--- a/v2/internal/pkg/release/local_stored_collector.go
+++ b/v2/internal/pkg/release/local_stored_collector.go
@@ -181,6 +181,7 @@ func (o *LocalStorageCollector) ReleaseImageCollector(ctx context.Context) ([]v2
 		}
 
 		for _, releaseImg := range releaseImages {
+
 			releaseRef, err := image.ParseRef(releaseImg.Image)
 			if err != nil {
 				return []v2alpha1.CopyImageSchema{}, fmt.Errorf(errMsg, err.Error())
@@ -409,7 +410,7 @@ func (o *LocalStorageCollector) ReleaseImage(ctx context.Context) (string, error
 	if len(o.Releases) == 0 {
 		releaseImages, _, err := o.identifyReleases(ctx)
 		if err != nil {
-			return "", fmt.Errorf("[release collector] could not establish the destination for the release image: %v", err)
+			return "", fmt.Errorf("[release collector] could not find release images (from disk cache): %v", err)
 		}
 		o.Releases = []string{}
 		for _, img := range releaseImages {
@@ -424,7 +425,18 @@ func (o *LocalStorageCollector) ReleaseImage(ctx context.Context) (string, error
 				Type:  v2alpha1.TypeOCPRelease,
 			},
 		}
-		releaseTag := o.Releases[0][:strings.LastIndex(o.Releases[0], ":")]
+		// OCPBUGS-50503
+		// This could be a digest also
+		imgSpec, err := image.ParseRef(o.Releases[0])
+		if err != nil {
+			return "", fmt.Errorf("[release collector] could not parse release image %s", o.Releases[0])
+		}
+		releaseTag := ""
+		if imgSpec.IsImageByDigestOnly() {
+			releaseTag = imgSpec.Digest
+		} else {
+			releaseTag = imgSpec.Tag
+		}
 
 		releaseCopyImage, err := o.prepareD2MCopyBatch(releaseRelatedImage, releaseTag)
 		if err != nil {


### PR DESCRIPTION
…ame is empty`

# Description

This fix addresses the issue when using digest based release images in the ImageSetConfig.

Github / Jira issue: [OCPBUGS-50503](https://issues.redhat.com/browse/OCPBUGS-50503)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Tested locally using this ImageSetConfig

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  platform:
    graph: true
    release: quay.io/openshift-release-dev/ocp-release@sha256:e0907823bc8989b02bb1bd55d5f08262dd0e4846173e792c14e7684fbd476c0d

```

Execute a mirror-to-mirror 

```
bin/oc-mirror --config release-digest.yaml --workspace file://release-test docker://localhost:5000/release-test --v2 --dest-tls-verify=false
```

Executed m2d and d2m 

## Expected Outcome

In all flows oc-mirror should execute without any errros