### PR TITLE
OCPBUGS-50617: oc-mirror does not create signature files

### DIFF
--- a/v2/.golangci.yaml
+++ b/v2/.golangci.yaml
@@ -122,10 +122,7 @@ linters-settings:
 
   goconst:
     ignore-tests: true
-<<<<<<< HEAD
 
   wrapcheck:
     ignorePackageGlobs:
       - github.com/openshift/oc-mirror/v2/*
-=======
->>>>>>> 62ee6b0e (Add digest functionality for release images by tag)

--- a/v2/.golangci.yaml
+++ b/v2/.golangci.yaml
@@ -122,7 +122,10 @@ linters-settings:
 
   goconst:
     ignore-tests: true
+<<<<<<< HEAD
 
   wrapcheck:
     ignorePackageGlobs:
       - github.com/openshift/oc-mirror/v2/*
+=======
+>>>>>>> 62ee6b0e (Add digest functionality for release images by tag)

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -18,7 +18,7 @@ build-dev:
 	chmod 755 build/uid_entrypoint.sh
 
 verify:
-	golangci-lint run -c .golangci.yaml --deadline=30m
+	golangci-lint run -c .golangci.yaml 
 
 test:
 	mkdir -p tests/results

--- a/v2/internal/pkg/cli/delete.go
+++ b/v2/internal/pkg/cli/delete.go
@@ -232,7 +232,7 @@ func (o *DeleteSchema) CompleteDelete(args []string) error {
 
 	client, _ := release.NewOCPClient(uuid.New(), o.Log)
 	signature := release.NewSignatureClient(o.Log, o.Config, *o.Opts)
-	cn := release.NewCincinnati(o.Log, &o.Config, *o.Opts, client, false, signature)
+	cn := release.NewCincinnati(o.Log, o.Manifest, &o.Config, *o.Opts, client, false, signature)
 	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.ImageBuilder)
 	o.Batch = batch.New(batch.ChannelConcurrentWorker, o.Log, o.LogsDir, o.Mirror, o.Opts.ParallelImages)
 	o.Operator = operator.NewWithFilter(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest)

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -483,7 +483,7 @@ func (o *ExecutorSchema) Complete(args []string) error {
 	o.ImageBuilder = imagebuilder.NewBuilder(o.Log, *o.Opts)
 	o.CatalogBuilder = imagebuilder.NewGCRCatalogBuilder(o.Log, *o.Opts)
 	signature := release.NewSignatureClient(o.Log, o.Config, *o.Opts)
-	cn := release.NewCincinnati(o.Log, &o.Config, *o.Opts, client, false, signature)
+	cn := release.NewCincinnati(o.Log, o.Manifest, &o.Config, *o.Opts, client, false, signature)
 	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.ImageBuilder)
 	o.Operator = operator.NewWithFilter(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest)
 	o.AdditionalImages = additional.New(o.Log, o.Config, *o.Opts, o.Mirror, o.Manifest)

--- a/v2/internal/pkg/release/cincinnati_test.go
+++ b/v2/internal/pkg/release/cincinnati_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 
 	"github.com/containers/image/v5/types"
+
 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
 	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
-	"github.com/openshift/oc-mirror/v2/internal/pkg/manifest"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
 )
 
@@ -24,7 +24,7 @@ func TestGetReleaseReferenceImages(t *testing.T) {
 	log := clog.New("trace")
 
 	tmpDir := t.TempDir()
-	os.MkdirAll(tmpDir+"/"+"hold-release/cincinnati-graph-data/", 0755)
+	_ = os.MkdirAll(tmpDir+"/"+"hold-release/cincinnati-graph-data/", 0755)
 	defer os.RemoveAll(tmpDir)
 
 	global := &mirror.GlobalOptions{SecurePolicy: false}
@@ -213,7 +213,7 @@ func TestGetReleaseReferenceImages(t *testing.T) {
 
 type mockManifest struct{}
 
-func NewManifest() manifest.ManifestInterface {
+func NewManifest() mockManifest {
 	return mockManifest{}
 }
 

--- a/v2/internal/pkg/release/local_stored_collector_test.go
+++ b/v2/internal/pkg/release/local_stored_collector_test.go
@@ -197,7 +197,7 @@ func TestReleaseLocalStoredCollector(t *testing.T) {
 		client := &ocpClient{}
 		client.SetQueryParams(ex.Config.Mirror.Platform.Architectures[0], ex.Config.Mirror.Platform.Channels[0].Name, "")
 		sig := MockCincinnati{}
-		cn := NewCincinnati(ex.Log, &ex.Config, ex.Opts, client, false, sig)
+		cn := NewCincinnati(ex.Log, nil, &ex.Config, ex.Opts, client, false, sig)
 
 		ex.Cincinnati = cn
 


### PR DESCRIPTION
# Description

This fix addresses the issue in signature verification for rc (release-candidate) images but skips engineering candidate images (this will be updated once we have the full cosign feature implemented in oc-mirror refer to [OCPSTRAT-1869](https://issues.redhat.com/browse/OCPSTRAT-1869) ) 

An update to this issue is check if we can get a digest from the image by tag

Github / Jira issue:  [OCPBUGS-50617](https://issues.redhat.com/browse/OCPBUGS-50617)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Verified locally using the following imagesetconfig

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  platform:
    graph: true
    release: quay.io/openshift-release-dev/ocp-release@sha256:e0907823bc8989b02bb1bd55d5f08262dd0e4846173e792c14e7684fbd476c0d

```

Then with the following imagesetconfig

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  platform:
    graph: true
    release: quay.io/openshift-release-dev/ocp-release:4.19.0-ec.1-x86_64
```

## Expected Outcome

This should pass the signature verification and also create and download the relevant signature files for the first imagesetconfig 

 In the d2m phase inspect the  <working-dir>/signatures directory as well as  <working-dir>/cluster-resources directory


