### PR TITLE
OCPBUGS-50685: fix: make the spinner trigger after semaphore is released

### DIFF
--- a/v2/internal/pkg/batch/concurrent_chan_worker.go
+++ b/v2/internal/pkg/batch/concurrent_chan_worker.go
@@ -93,9 +93,10 @@ func (o *ChannelConcurrentBatch) Worker(ctx context.Context, collectorSchema v2a
 			default:
 			}
 
+			semaphore <- struct{}{}
+
 			sp := newSpinner(img, opts.LocalStorageFQDN, p)
 
-			semaphore <- struct{}{}
 			wg.Add(1)
 			go func(cancelCtx context.Context, semaphore chan struct{}, results chan<- GoroutineResult, spinner *mpb.Bar) {
 				defer wg.Done()


### PR DESCRIPTION
# Description

Before this fix the spinner was being triggered before the semaphore was locked. 

Because of that the output was giving the wrong feeling that even when `--parallel-images=1`, two images were being triggered.

Github / Jira issue: [OCPBUGS-50685](https://issues.redhat.com/browse/OCPBUGS-50685)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

m2d with `--parallel-images=1`
```
./bin/oc-mirror -c ./alex-tests/alex-isc/ocpbugs/ocpbugs-50685.yaml file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/ocpbugs-50685 --v2 --parallel-images=1
````

## Expected Outcome
Only one go-routine triggered at a time.