### PR TITLE
OCPBUGS-44103: bump oc fork version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -266,6 +266,6 @@ replace github.com/apcera/gssapi => github.com/openshift/gssapi v0.0.0-201610102
 
 replace github.com/openshift/library-go => github.com/aguidirh/library-go v0.0.0-20240911111857-f8fdb642dea5
 
-replace github.com/openshift/oc => github.com/aguidirh/oc v0.0.0-20240911114505-f06afaaa9cd4
+replace github.com/openshift/oc => github.com/aguidirh/oc v0.0.1
 
 replace github.com/distribution/distribution/v3 => github.com/aguidirh/distribution/v3 v3.0.0-beta.1.ocmirror1

--- a/go.sum
+++ b/go.sum
@@ -859,8 +859,8 @@ github.com/aguidirh/distribution/v3 v3.0.0-beta.1.ocmirror1 h1:/UsfVGVrtbsD4N0Lh
 github.com/aguidirh/distribution/v3 v3.0.0-beta.1.ocmirror1/go.mod h1:IcvaJQ0kCbNUrffwSTSblDLCb1IKa1FkZF/1cCstzhs=
 github.com/aguidirh/library-go v0.0.0-20240911111857-f8fdb642dea5 h1:89Qy0b27BXOgF0T7FxFhTxk0IDL/qry2FqXr/sVhvxA=
 github.com/aguidirh/library-go v0.0.0-20240911111857-f8fdb642dea5/go.mod h1:HUFcTET58RjthS3VZVQw1mqCofklZa3EdBEoxDooAZM=
-github.com/aguidirh/oc v0.0.0-20240911114505-f06afaaa9cd4 h1:z5Ev2iaO8ZcUx75EMHatRUtkhFIYGBn4Gy9grO5Yo9s=
-github.com/aguidirh/oc v0.0.0-20240911114505-f06afaaa9cd4/go.mod h1:qPruyC9vtw2CKOWJ0EVGR3E9iSobdjN7hpAEfqqBZPE=
+github.com/aguidirh/oc v0.0.1 h1:f2qa+WrF2jRHQUDGvnE0wJizHMWC9494ISQ1k/ikryU=
+github.com/aguidirh/oc v0.0.1/go.mod h1:qPruyC9vtw2CKOWJ0EVGR3E9iSobdjN7hpAEfqqBZPE=
 github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm/4RlzPXRlREEwqTHAN3T56Bv2ITsFT3gY=
 github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T13YZdzov6OU0A1+RfKZiZN9ca6VeKdBdyDV+BY97Tk=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=

--- a/go.work.sum
+++ b/go.work.sum
@@ -859,6 +859,7 @@ github.com/a8m/expect v1.0.0/go.mod h1:4IwSCMumY49ScypDnjNbYEjgVeqy1/U2cEs3Lat96
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/aguidirh/oc v0.0.0-20240905134549-4457c8e8f14b/go.mod h1:sczdFTJmC+Wi37rOD8gRNEuRIBGUzbbOb8DQ2dxL1Gc=
+github.com/aguidirh/oc v0.0.1/go.mod h1:qPruyC9vtw2CKOWJ0EVGR3E9iSobdjN7hpAEfqqBZPE=
 github.com/akavel/rsrc v0.10.2/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/akrylysov/pogreb v0.10.2/go.mod h1:pNs6QmpQ1UlTJKDezuRWmaqkgUE2TuU0YTWyqJZ7+lI=
 github.com/alecthomas/assert/v2 v2.2.2/go.mod h1:pXcQ2Asjp247dahGEmsZ6ru0UVwnkhktn7S0bBDLxvQ=


### PR DESCRIPTION
# Description

The bumped version can now handle the `ocischema.DeserializedImageIndex` manifest type.

Without this fix, oc-mirror v1 fails with:
```
oc-mirror failed with error: the manifest type *ocischema.DeserializedImageIndex is not supported
```

Github / Jira issue: OCPBUGS-44103

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

```
$ yq e /tmp/isc.yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.16
      packages:
        - name: openstack-operator
          channels:
            - name: stable-v1.0
              minVersion: 1.0.4
              maxVersion: 1.0.4
$ ./bin/oc-mirror --config /tmp/isc.yaml file:////oc-mirror-ocpbugs-49990-2
```

## Expected Outcome

No `DeserializedImageIndex` errors.