### PR TITLE
CLID-182: Add spinner to release collector mirror to disk or mirror t…

### DIFF
--- a/v2/internal/pkg/batch/concurrent_chan_worker.go
+++ b/v2/internal/pkg/batch/concurrent_chan_worker.go
@@ -302,23 +302,7 @@ func newSpinner(img v2alpha1.CopyImageSchema, localStorage string, p *mpb.Progre
 		imageText += emoji.RightArrow + "  " + hostNamespace(img.Destination) + " "
 	}
 
-	return p.AddSpinner(
-		1,
-		mpb.BarFillerMiddleware(spinners.PositionSpinnerLeft),
-		mpb.BarWidth(3),
-		mpb.PrependDecorators(
-			decor.OnComplete(spinners.EmptyDecorator(), emoji.SpinnerCheckMark),
-			decor.OnAbort(spinners.EmptyDecorator(), emoji.SpinnerCrossMark),
-		),
-		mpb.AppendDecorators(
-			decor.Name("("),
-			decor.Elapsed(decor.ET_STYLE_GO),
-			decor.Name(")"),
-			decor.Name(imageText),
-		),
-		mpb.BarFillerClearOnComplete(),
-		spinners.BarFillerClearOnAbort(),
-	)
+	return spinners.AddSpinner(p, imageText)
 }
 
 func newOverallProgress(p *mpb.Progress, total int) *mpb.Bar {

--- a/v2/internal/pkg/operator/filtered_collector.go
+++ b/v2/internal/pkg/operator/filtered_collector.go
@@ -16,10 +16,8 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/otiai10/copy"
 	"github.com/vbauerster/mpb/v8"
-	"github.com/vbauerster/mpb/v8/decor"
 
 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
-	"github.com/openshift/oc-mirror/v2/internal/pkg/emoji"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/image"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/spinners"
@@ -59,21 +57,7 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 			o.Log.Info("Collecting catalog %s", op.Catalog)
 		}
 		// prepare spinner
-		spinner := p.AddSpinner(
-			1, mpb.BarFillerMiddleware(spinners.PositionSpinnerLeft),
-			mpb.BarWidth(3),
-			mpb.PrependDecorators(
-				decor.OnComplete(spinners.EmptyDecorator(), emoji.SpinnerCheckMark),
-				decor.OnAbort(spinners.EmptyDecorator(), emoji.SpinnerCrossMark),
-			),
-			mpb.AppendDecorators(
-				decor.Name("("),
-				decor.Elapsed(decor.ET_STYLE_GO),
-				decor.Name(") Collecting catalog "+op.Catalog+" "),
-			),
-			mpb.BarFillerClearOnComplete(),
-			spinners.BarFillerClearOnAbort(),
-		)
+		spinner := spinners.AddSpinner(p, "Collecting catalog "+op.Catalog)
 
 		// CLID-27 ensure we pick up oci:// (on disk) catalogs
 		imgSpec, err := image.ParseRef(op.Catalog)

--- a/v2/internal/pkg/spinners/spinners.go
+++ b/v2/internal/pkg/spinners/spinners.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/vbauerster/mpb/v8"
 	"github.com/vbauerster/mpb/v8/decor"
+
+	"github.com/openshift/oc-mirror/v2/internal/pkg/emoji"
 )
 
 func PositionSpinnerLeft(original mpb.BarFiller) mpb.BarFiller {
@@ -27,4 +29,22 @@ func BarFillerClearOnAbort() mpb.BarOption {
 			return base.Fill(w, st)
 		})
 	})
+}
+
+func AddSpinner(progressBar *mpb.Progress, message string) *mpb.Bar {
+	return progressBar.AddSpinner(
+		1, mpb.BarFillerMiddleware(PositionSpinnerLeft),
+		mpb.BarWidth(3),
+		mpb.PrependDecorators(
+			decor.OnComplete(EmptyDecorator(), emoji.SpinnerCheckMark),
+			decor.OnAbort(EmptyDecorator(), emoji.SpinnerCrossMark),
+		),
+		mpb.AppendDecorators(
+			decor.Name("("),
+			decor.Elapsed(decor.ET_STYLE_GO),
+			decor.Name(") "+message+" "),
+		),
+		mpb.BarFillerClearOnComplete(),
+		BarFillerClearOnAbort(),
+	)
 }


### PR DESCRIPTION
…o mirror

# Description

This PR will help the user have an indication when release images are long to get pulled.

Github / Jira issue: [CLID-182](https://issues.redhat.com//browse/CLID-182)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Performed a mirror to disk workflow with an imageSetConfig requesting a single release mirroring.


## Expected Outcome
```
$ ./bin/oc-mirror --v2 -c config_logs/bugs.yaml file:///home/skhoury/45580/

2025/02/19 16:38:23  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/02/19 16:38:23  [INFO]   : ⚙️  setting up the environment for you...
2025/02/19 16:38:23  [INFO]   : 🔀 workflow mode: mirrorToDisk 
2025/02/19 16:38:23  [INFO]   : 🕵  going to discover the necessary images...
2025/02/19 16:38:23  [INFO]   : 🔍 collecting release images...
 ✓   (3m26s) Collecting release  
2025/02/19 16:41:51  [INFO]   : 🔍 collecting operator images...
2025/02/19 16:41:51  [INFO]   : 🔍 collecting additional images...
2025/02/19 16:41:51  [INFO]   : 🔍 collecting helm images...
```