### PR TITLE
CLID-321: Add annotations to resources generated by oc-mirror v2

### DIFF
--- a/v2/internal/pkg/api/kubernetes/core/type_configmap.go
+++ b/v2/internal/pkg/api/kubernetes/core/type_configmap.go
@@ -17,6 +17,9 @@ type ObjectMeta struct {
 
 	// +optional
 	Labels map[string]string `json:"labels,omitempty" protobuf:"bytes,11,rep,name=labels"`
+
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty" protobuf:"bytes,12,rep,name=annotations"`
 }
 
 // ConfigMap holds configuration data for pods to consume.

--- a/v2/internal/pkg/clusterresources/clusterresources_test.go
+++ b/v2/internal/pkg/clusterresources/clusterresources_test.go
@@ -661,8 +661,9 @@ func TestCatalogSourceGenerator(t *testing.T) {
 				Kind:       "CatalogSource",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      expectedCSName,
-				Namespace: "openshift-marketplace",
+				Name:        expectedCSName,
+				Namespace:   "openshift-marketplace",
+				Annotations: generateOcMirrorAnnotations(),
 			},
 			Spec: ofv1alpha1.CatalogSourceSpec{
 				SourceType: "grpc",
@@ -670,7 +671,14 @@ func TestCatalogSourceGenerator(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, expectedCS, actualCS, "contents of catalogSource file incorrect")
+		// assert actualCS, skipping annotation createdAt
+		assert.Equal(t, expectedCS.TypeMeta, actualCS.TypeMeta, "contents of catalogSource file incorrect (TypeMeta)")
+		assert.Equal(t, expectedCS.Spec, actualCS.Spec, "contents of catalogSource file incorrect (Spec)")
+		assert.Equal(t, expectedCS.ObjectMeta.Name, actualCS.ObjectMeta.Name, "contents of catalogSource file incorrect (Name)")
+		assert.Equal(t, expectedCS.ObjectMeta.Namespace, actualCS.ObjectMeta.Namespace, "contents of catalogSource file incorrect (Namespace)")
+		assert.Equal(t, len(expectedCS.ObjectMeta.Annotations), len(actualCS.ObjectMeta.Annotations), "contents of catalogSource file incorrect (Annotations)")
+		assert.Equal(t, expectedCS.ObjectMeta.Annotations["createdBy"], actualCS.ObjectMeta.Annotations["createdBy"], "contents of catalogSource file incorrect (Annotations.createdBy)")
+		assert.Equal(t, expectedCS.ObjectMeta.Annotations["oc-mirror_version"], actualCS.ObjectMeta.Annotations["oc-mirror_version"], "contents of catalogSource file incorrect (Annotations.oc-mirror_version)")
 	})
 
 	t.Run("Testing GenerateCatalogSource with template: should pass", func(t *testing.T) {
@@ -728,8 +736,9 @@ func TestCatalogSourceGenerator(t *testing.T) {
 				Kind:       "CatalogSource",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      strings.TrimSuffix(csFiles[0].Name(), ".yaml"),
-				Namespace: "openshift-marketplace",
+				Name:        strings.TrimSuffix(csFiles[0].Name(), ".yaml"),
+				Namespace:   "openshift-marketplace",
+				Annotations: generateOcMirrorAnnotations(),
 			},
 			Spec: ofv1alpha1.CatalogSourceSpec{
 				SourceType: "grpc",
@@ -841,8 +850,9 @@ func TestCatalogSourceGenerator(t *testing.T) {
 					Kind:       "CatalogSource",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      strings.TrimSuffix(csFiles[0].Name(), ".yaml"),
-					Namespace: "openshift-marketplace",
+					Name:        strings.TrimSuffix(csFiles[0].Name(), ".yaml"),
+					Namespace:   "openshift-marketplace",
+					Annotations: generateOcMirrorAnnotations(),
 				},
 				Spec: ofv1alpha1.CatalogSourceSpec{
 					SourceType: "grpc",
@@ -850,7 +860,14 @@ func TestCatalogSourceGenerator(t *testing.T) {
 				},
 			}
 
-			assert.Equal(t, expectedCS, actualCS, "contents of catalogSource file incorrect")
+			// assert actualCS, skipping annotation createdAt
+			assert.Equal(t, expectedCS.TypeMeta, actualCS.TypeMeta, "contents of catalogSource file incorrect (TypeMeta)")
+			assert.Equal(t, expectedCS.Spec, actualCS.Spec, "contents of catalogSource file incorrect (Spec)")
+			assert.Equal(t, expectedCS.ObjectMeta.Name, actualCS.ObjectMeta.Name, "contents of catalogSource file incorrect (Name)")
+			assert.Equal(t, expectedCS.ObjectMeta.Namespace, actualCS.ObjectMeta.Namespace, "contents of catalogSource file incorrect (Namespace)")
+			assert.Equal(t, len(expectedCS.ObjectMeta.Annotations), len(actualCS.ObjectMeta.Annotations), "contents of catalogSource file incorrect (Annotations)")
+			assert.Equal(t, expectedCS.ObjectMeta.Annotations["createdBy"], actualCS.ObjectMeta.Annotations["createdBy"], "contents of catalogSource file incorrect (Annotations.createdBy)")
+			assert.Equal(t, expectedCS.ObjectMeta.Annotations["oc-mirror_version"], actualCS.ObjectMeta.Annotations["oc-mirror_version"], "contents of catalogSource file incorrect (Annotations.oc-mirror_version)")
 
 		}
 	})
@@ -921,8 +938,9 @@ func TestCatalogSourceGenerator(t *testing.T) {
 				Kind:       "CatalogSource",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      expectedCSName,
-				Namespace: "openshift-marketplace",
+				Name:        expectedCSName,
+				Namespace:   "openshift-marketplace",
+				Annotations: generateOcMirrorAnnotations(),
 			},
 			Spec: ofv1alpha1.CatalogSourceSpec{
 				SourceType: "grpc",
@@ -1031,7 +1049,8 @@ func TestClusterCatalogGenerator(t *testing.T) {
 				Kind:       ofv1.ClusterCatalogKind,
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: expectedCCName,
+				Name:        expectedCCName,
+				Annotations: generateOcMirrorAnnotations(),
 			},
 			Spec: ofv1.ClusterCatalogSpec{
 				Source: ofv1.CatalogSource{
@@ -1043,7 +1062,14 @@ func TestClusterCatalogGenerator(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, expectedCC, actualCC, "contents of clusterCatalog file incorrect")
+		// assert actualCS, skipping annotation createdAt
+		assert.Equal(t, expectedCC.TypeMeta, actualCC.TypeMeta, "contents of catalogSource file incorrect (TypeMeta)")
+		assert.Equal(t, expectedCC.Spec, actualCC.Spec, "contents of catalogSource file incorrect (Spec)")
+		assert.Equal(t, expectedCC.ObjectMeta.Name, actualCC.ObjectMeta.Name, "contents of catalogSource file incorrect (Name)")
+		assert.Equal(t, expectedCC.ObjectMeta.Namespace, actualCC.ObjectMeta.Namespace, "contents of catalogSource file incorrect (Namespace)")
+		assert.Equal(t, len(expectedCC.ObjectMeta.Annotations), len(actualCC.ObjectMeta.Annotations), "contents of catalogSource file incorrect (Annotations)")
+		assert.Equal(t, expectedCC.ObjectMeta.Annotations["createdBy"], actualCC.ObjectMeta.Annotations["createdBy"], "contents of catalogSource file incorrect (Annotations.createdBy)")
+		assert.Equal(t, expectedCC.ObjectMeta.Annotations["oc-mirror_version"], actualCC.ObjectMeta.Annotations["oc-mirror_version"], "contents of catalogSource file incorrect (Annotations.oc-mirror_version)")
 	})
 
 	t.Run("Testing GenerateClusterCatalog with catalog using a digest as tag : should pass", func(t *testing.T) {
@@ -1114,7 +1140,8 @@ func TestClusterCatalogGenerator(t *testing.T) {
 				Kind:       ofv1.ClusterCatalogKind,
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: expectedCCName,
+				Name:        expectedCCName,
+				Annotations: generateOcMirrorAnnotations(),
 			},
 			Spec: ofv1.ClusterCatalogSpec{
 				Source: ofv1.CatalogSource{
@@ -1126,7 +1153,14 @@ func TestClusterCatalogGenerator(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, expectedCC, actualCC, "contents of clusterCatalog file incorrect")
+		// assert actualCS, skipping annotation createdAt
+		assert.Equal(t, expectedCC.TypeMeta, actualCC.TypeMeta, "contents of catalogSource file incorrect (TypeMeta)")
+		assert.Equal(t, expectedCC.Spec, actualCC.Spec, "contents of catalogSource file incorrect (Spec)")
+		assert.Equal(t, expectedCC.ObjectMeta.Name, actualCC.ObjectMeta.Name, "contents of catalogSource file incorrect (Name)")
+		assert.Equal(t, expectedCC.ObjectMeta.Namespace, actualCC.ObjectMeta.Namespace, "contents of catalogSource file incorrect (Namespace)")
+		assert.Equal(t, len(expectedCC.ObjectMeta.Annotations), len(actualCC.ObjectMeta.Annotations), "contents of catalogSource file incorrect (Annotations)")
+		assert.Equal(t, expectedCC.ObjectMeta.Annotations["createdBy"], actualCC.ObjectMeta.Annotations["createdBy"], "contents of catalogSource file incorrect (Annotations.createdBy)")
+		assert.Equal(t, expectedCC.ObjectMeta.Annotations["oc-mirror_version"], actualCC.ObjectMeta.Annotations["oc-mirror_version"], "contents of catalogSource file incorrect (Annotations.oc-mirror_version)")
 	})
 }
 


### PR DESCRIPTION
# Description

This PR helps add an annotation to all cluster resources generated by oc-mirror.
Right now the annotation is `author: oc-mirror` , but let's discuss what is the right annotation to use. 

This way, on a cluster, when users need to remove/update/view IDMS/ITMS/CatalogSource generated by oc-mirror they could use:
```bash
oc get idms jsonpath='{.items[?(@.metadata.annotations.author=oc-mirror)].metadata.name}'
```

Github / Jira issue: [CLID-321](https://issues.redhat.com/browse/CLID-321)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

I tested this only for additionalImages.
```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  additionalImages: 
  - name: registry.redhat.io/ubi9/ubi-micro:latest
```

## Expected Outcome
```yaml
---
apiVersion: config.openshift.io/v1
kind: ImageTagMirrorSet
metadata:
  annotations:
    author: oc-mirror
  name: itms-generic-0
spec:
  imageTagMirrors:
  - mirrors:
    - sherinefedora:5000/ubi9
    source: registry.redhat.io/ubi9
status: {}
```