### PR TITLE
OCPBUGS-50963: v2: don't clean cluster resources on dry-run mode

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -738,9 +738,8 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 
 	// create cluster-resources directory and clean it
 	o.Log.Trace("creating cluster-resources directory %s ", o.Opts.Global.WorkingDir+"/"+clusterResourcesDir)
-	if !o.Opts.IsDeleteMode() {
-		err = os.RemoveAll(o.Opts.Global.WorkingDir + "/" + clusterResourcesDir)
-		if err != nil {
+	if !o.Opts.IsDeleteMode() && !o.Opts.IsDryRun {
+		if err = os.RemoveAll(o.Opts.Global.WorkingDir + "/" + clusterResourcesDir); err != nil {
 			o.Log.Error(" setupWorkingDir for cluster resources: failed to clear folder %s: %v ", o.Opts.Global.WorkingDir+"/"+clusterResourcesDir, err)
 			return err
 		}


### PR DESCRIPTION
# Description

The --dry-run mode implies no changes to existing resources like previously generated cluster-resources.

Github / Jira issue: OCPBUGS-50963

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

```
$ touch oc-mirror-data/working-dir/cluster-resources/DONOTDELETEME
$ ./bin/oc-mirror --v2 --config isc.yaml --from file:///oc-mirror-data/ docker://localhost:5000/ocpbugs-50963 --dry-run
$ test -f oc-mirror-data/working-dir/cluster-resources/DONOTDELETEME
$ echo $?
0
$ ./bin/oc-mirror --v2 --config isc.yaml --from file:///oc-mirror-data/ docker://localhost:5000/ocpbugs-50963
$ test -f oc-mirror-data/working-dir/cluster-resources/DONOTDELETEME
$ echo $?
1
```

## Expected Outcome

working-dir/cluster-resources are not deleted when in `--dry-run` mode.