### PR TITLE
OCPBUGS-49893: v2: do not generate tarball if copy errors

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -812,11 +812,14 @@ func (o *ExecutorSchema) RunMirrorToDisk(cmd *cobra.Command, args []string) erro
 		}
 
 		// prepare tar.gz when mirror to disk
-		o.Log.Info(emoji.Package + " Preparing the tarball archive...")
-		// next, generate the archive
-		err = o.MirrorArchiver.BuildArchive(cmd.Context(), copiedSchema.AllImages)
-		if err != nil {
-			return err
+		if batchError == nil && len(copiedSchema.AllImages) > 0 {
+			o.Log.Info(emoji.Package + " Preparing the tarball archive...")
+			// next, generate the archive
+			if err = o.MirrorArchiver.BuildArchive(cmd.Context(), copiedSchema.AllImages); err != nil {
+				return err
+			}
+		} else {
+			o.Log.Info(emoji.Package + " There were copy errors or no images were copied, skipping tarball generation")
 		}
 	} else {
 		err = o.DryRun(cmd.Context(), collectorSchema.AllImages)


### PR DESCRIPTION
# Description

If there was an error during the image copying and/or no images were copied, we should not generate a tarball or we could give the wrong impression that oc-mirror succeeded despite the errors.

Github / Jira issue: OCPBUGS-49893

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

```
$ yq e nisc.yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redat-invalid-operator:v4.16
      packages:
        - name: redhat-invalid-package
  additionalImages:
    - name: registry.redhat.io/invalid/invalid:latest
    - name: registry.redhat.io/ubi8/ubi:latest

$ ./bin/oc-mirror --v2 --config nisc.yaml file:///ocpbugs-49893 --log-level debug
[...]
2025/02/19 20:09:50  [DEBUG]  : 📦 There were copy errors or no images were copied, skipping tarball generation
2025/02/19 20:09:50  [INFO]   : mirror time     : 8.241237053s
2025/02/19 20:09:50  [WARN]   : [Worker] some errors occurred during the mirroring.
         Please review /ocpbugs-49893/working-dir/logs/mirroring_errors_20250219_200950.txt for a list of mirroring errors.
         You may consider:
         * removing images or operators that cause the error from the image set config, and retrying
         * keeping the image set config (images are mandatory for you), and retrying
         * mirroring the failing images manually, if retries also fail.
2025/02/19 20:09:50  [INFO]   : 👋 Goodbye, thank you for using oc-mirror
```

## Expected Outcome

No tarball generated if copy errors and/or no images copied.