### PR TITLE
OCPBUGS-50680: v2/operator: refactor operator FilteredCollector

### DIFF
--- a/v2/internal/pkg/api/v2alpha1/type_internal.go
+++ b/v2/internal/pkg/api/v2alpha1/type_internal.go
@@ -3,6 +3,7 @@ package v2alpha1
 import (
 	"time"
 
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/property"
 )
 
@@ -49,8 +50,7 @@ type From struct {
 }
 
 // ImportPolicy
-type ImportPolicy struct {
-}
+type ImportPolicy struct{}
 
 // ReferencePolicy
 type ReferencePolicy struct {
@@ -106,8 +106,7 @@ type OperatorConfigSchema struct {
 type OperatorConfig struct {
 	User         string `json:"User"`
 	ExposedPorts struct {
-		TCP struct {
-		} `json:"tcp"`
+		TCP struct{} `json:"tcp"`
 	} `json:"ExposedPorts"`
 	Env        []string       `json:"Env"`
 	Entrypoint []string       `json:"Entrypoint"`
@@ -209,8 +208,8 @@ type CollectorSchema struct {
 }
 
 type CopyImageSchemaMap struct {
-	OperatorsByImage map[string]map[string]struct{} //key is the origin image name and value is an array of operators' name
-	BundlesByImage   map[string]map[string]string   //key is the image name and value is the bundle name
+	OperatorsByImage map[string]map[string]struct{} // key is the origin image name and value is an array of operators' name
+	BundlesByImage   map[string]map[string]string   // key is the image name and value is the bundle name
 }
 
 // CopyImageSchema
@@ -260,4 +259,6 @@ type CatalogFilterResult struct {
 	OperatorFilter     Operator
 	FilteredConfigPath string
 	ToRebuild          bool
+	DeclConfig         *declcfg.DeclarativeConfig
+	Digest             string
 }

--- a/v2/internal/pkg/operator/common_test.go
+++ b/v2/internal/pkg/operator/common_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestPrepareDeleteForV1(t *testing.T) {
-
 	log := clog.New("trace")
 
 	tempDir := t.TempDir()
@@ -76,8 +75,8 @@ func TestPrepareDeleteForV1(t *testing.T) {
 		})
 	}
 }
-func TestPrepareM2MCopyBatch(t *testing.T) {
 
+func TestPrepareM2MCopyBatch(t *testing.T) {
 	log := clog.New("trace")
 
 	tempDir := t.TempDir()
@@ -126,7 +125,6 @@ func TestPrepareM2MCopyBatch(t *testing.T) {
 			caseName: "OperatorImageCollector - Mirror to Mirror: related image by digest and tag should pass",
 			relatedImages: map[string][]v2alpha1.RelatedImage{
 				"operatorB": {
-
 					{
 						Name:  "kube-rbac-proxy",
 						Image: "gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1@sha256:d4883d7c622683b3319b5e6b3a7edfbf2594c18060131a8bf64504805f875522",
@@ -147,7 +145,6 @@ func TestPrepareM2MCopyBatch(t *testing.T) {
 		{
 			caseName: "OperatorImageCollector - Mirror to Mirror: catalog image nominal should pass",
 			relatedImages: map[string][]v2alpha1.RelatedImage{
-
 				"redhat-operator-index.045638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": {
 					{
 						Image:      "registry.redhat.io/redhat/redhat-operator-index:v4.17",
@@ -158,7 +155,6 @@ func TestPrepareM2MCopyBatch(t *testing.T) {
 			},
 			expectedError: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
-
 				{
 					Source:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.17",
 					Destination: "docker://localhost:9999/redhat/redhat-operator-index:v4.17",
@@ -178,7 +174,6 @@ func TestPrepareM2MCopyBatch(t *testing.T) {
 		{
 			caseName: "OperatorImageCollector - Mirror to Mirror: catalog image - targetTag should pass",
 			relatedImages: map[string][]v2alpha1.RelatedImage{
-
 				"redhat-operator-index.543218f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": {
 					{
 						Image:      "registry.redhat.io/redhat/certified-operators:v4.10",
@@ -190,7 +185,6 @@ func TestPrepareM2MCopyBatch(t *testing.T) {
 			},
 			expectedError: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
-
 				{
 					Source:      "docker://registry.redhat.io/redhat/certified-operators:v4.10",
 					Destination: "docker://localhost:9999/redhat/certified-operators:v4.10.0",
@@ -210,7 +204,6 @@ func TestPrepareM2MCopyBatch(t *testing.T) {
 		{
 			caseName: "OperatorImageCollector - Mirror to Mirror: catalog image - targetCatalog should pass",
 			relatedImages: map[string][]v2alpha1.RelatedImage{
-
 				"redhat-operator-index.123458f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": {
 					{
 						Image:         "registry.redhat.io/redhat/certified-operators:v4.14",
@@ -222,7 +215,6 @@ func TestPrepareM2MCopyBatch(t *testing.T) {
 			},
 			expectedError: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
-
 				{
 					Source:      "docker://registry.redhat.io/redhat/certified-operators:v4.14",
 					Destination: "docker://localhost:9999/12345/certified-operators-pinned:v4.14",
@@ -242,7 +234,6 @@ func TestPrepareM2MCopyBatch(t *testing.T) {
 		{
 			caseName: "OperatorImageCollector - Mirror to Mirror: catalog image - targetTag & targetCatalog should pass",
 			relatedImages: map[string][]v2alpha1.RelatedImage{
-
 				"certified-operators.f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": {
 					{
 						Image:         "registry.redhat.io/redhat/certified-operators:v4.17",
@@ -274,7 +265,6 @@ func TestPrepareM2MCopyBatch(t *testing.T) {
 		{
 			caseName: "OperatorImageCollector - Mirror to Mirror: oci catalog image - targetTag & targetCatalog should pass",
 			relatedImages: map[string][]v2alpha1.RelatedImage{
-
 				"catalog-on-disk2.f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": {
 					{
 						Name:          "coffee-shop-index",
@@ -288,7 +278,6 @@ func TestPrepareM2MCopyBatch(t *testing.T) {
 			},
 			expectedError: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
-
 				{
 					Source:      "oci://../../../tests/catalog-on-disk2",
 					Destination: "docker://localhost:9999/coffee-shop-index:v1.0",
@@ -308,8 +297,9 @@ func TestPrepareM2MCopyBatch(t *testing.T) {
 		{
 			caseName: "OperatorImageCollector - Mirror to Mirror: oci catalog image - targetCatalog should pass",
 			relatedImages: map[string][]v2alpha1.RelatedImage{
-				"catalog-on-disk3.f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": []v2alpha1.RelatedImage{
-					{Name: "tea-shop-index",
+				"catalog-on-disk3.f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": {
+					{
+						Name:          "tea-shop-index",
 						Image:         "oci://../../../tests/catalog-on-disk3",
 						Type:          v2alpha1.TypeOperatorCatalog,
 						TargetCatalog: "tea-shop-index",
@@ -319,7 +309,6 @@ func TestPrepareM2MCopyBatch(t *testing.T) {
 			},
 			expectedError: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
-
 				{
 					Source:      "oci://" + common.TestFolder + "catalog-on-disk3",
 					Destination: "docker://localhost:9999/tea-shop-index:latest",
@@ -339,8 +328,7 @@ func TestPrepareM2MCopyBatch(t *testing.T) {
 		{
 			caseName: "OperatorImageCollector - Mirror to Mirror: oci catalog image - targetTag should pass",
 			relatedImages: map[string][]v2alpha1.RelatedImage{
-
-				"catalog-on-disk1.f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": []v2alpha1.RelatedImage{
+				"catalog-on-disk1.f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": {
 					{
 						Name:       "catalog-on-disk1",
 						Image:      "oci://../../../tests/catalog-on-disk1",
@@ -352,7 +340,6 @@ func TestPrepareM2MCopyBatch(t *testing.T) {
 			},
 			expectedError: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
-
 				{
 					Source:      "oci://../../../tests/catalog-on-disk1",
 					Destination: "docker://localhost:9999/catalog-on-disk1:v1.1",
@@ -372,7 +359,6 @@ func TestPrepareM2MCopyBatch(t *testing.T) {
 		{
 			caseName: "OperatorImageCollector - Mirror to Mirror: oci catalog image nominal should pass",
 			relatedImages: map[string][]v2alpha1.RelatedImage{
-
 				"catalog-on-disk1.0987660452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": {
 					{
 						Name:       "catalog-on-disk4",
@@ -384,7 +370,6 @@ func TestPrepareM2MCopyBatch(t *testing.T) {
 			},
 			expectedError: false,
 			expectedResult: []v2alpha1.CopyImageSchema{
-
 				{
 					Source:      "oci://" + common.TestFolder + "catalog-on-disk4",
 					Destination: "docker://localhost:9999/catalog-on-disk4:latest",
@@ -404,7 +389,6 @@ func TestPrepareM2MCopyBatch(t *testing.T) {
 		{
 			caseName: "OperatorImageCollector - Mirror to Mirror: Full=true catalog image nominal should pass",
 			relatedImages: map[string][]v2alpha1.RelatedImage{
-
 				"redhat-operator-index.f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea": {
 					{
 						Image: "registry.redhat.io/redhat/redhat-operator-index:v4.18",
@@ -445,5 +429,57 @@ func TestPrepareM2MCopyBatch(t *testing.T) {
 			assert.ElementsMatch(t, testCase.expectedResult, res)
 		})
 	}
+}
 
+func TestOperatorCollector(t *testing.T) {
+	log := clog.New("trace")
+
+	t.Run("OperatorCollector - cachedCatalog", func(t *testing.T) {
+		op := OperatorCollector{
+			Log:              log,
+			LocalStorageFQDN: "localhost:5000",
+		}
+
+		t.Run("should succeed", func(t *testing.T) {
+			t.Run("with path component", func(t *testing.T) {
+				catalog := v2alpha1.Operator{
+					Catalog: "registry.redhat.io/redhat/redhat-operator-index:v4.17",
+				}
+				ref, err := op.cachedCatalog(catalog, "filteredTag")
+				assert.NoError(t, err)
+				assert.Equal(t, "docker://localhost:5000/redhat/redhat-operator-index:filteredTag", ref)
+			})
+			t.Run("with target catalog", func(t *testing.T) {
+				catalog := v2alpha1.Operator{
+					Catalog:       "registry.redhat.io/redhat/redhat-operator-index:v4.17",
+					TargetCatalog: "targetTag",
+				}
+				ref, err := op.cachedCatalog(catalog, "filteredTag")
+				assert.NoError(t, err)
+				assert.Equal(t, "docker://localhost:5000/targetTag:filteredTag", ref)
+			})
+			t.Run("with oci protocol", func(t *testing.T) {
+				catalog := v2alpha1.Operator{
+					Catalog: "oci://registry.redhat.io/redhat/redhat-operator-index",
+				}
+				ref, err := op.cachedCatalog(catalog, "filteredTag")
+				assert.NoError(t, err)
+				assert.Equal(t, "docker://localhost:5000/redhat-operator-index:filteredTag", ref)
+			})
+			t.Run("with empty filteredTag", func(t *testing.T) {
+				catalog := v2alpha1.Operator{
+					Catalog:       "registry.redhat.io/redhat/redhat-operator-index:v4.17",
+					TargetCatalog: "targetTag",
+				}
+				ref, err := op.cachedCatalog(catalog, "")
+				assert.NoError(t, err)
+				assert.Equal(t, "docker://localhost:5000/targetTag", ref)
+			})
+		})
+		t.Run("should fail when parsing reference fails", func(t *testing.T) {
+			ref, err := op.cachedCatalog(v2alpha1.Operator{}, "filteredTag")
+			assert.ErrorContains(t, err, "unable to determine cached reference for catalog")
+			assert.Empty(t, ref)
+		})
+	})
 }

--- a/v2/internal/pkg/operator/filtered_collector.go
+++ b/v2/internal/pkg/operator/filtered_collector.go
@@ -14,13 +14,11 @@ import (
 	"strings"
 
 	"github.com/containers/image/v5/types"
-	"github.com/opencontainers/go-digest"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/emoji"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/image"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/spinners"
-	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/otiai10/copy"
 	"github.com/vbauerster/mpb/v8"
 	"github.com/vbauerster/mpb/v8/decor"
@@ -35,22 +33,18 @@ type FilterCollector struct {
 // the image is downloaded (oci format) and the index.json is inspected
 // once unmarshalled, the links to manifests are inspected
 func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.CollectorSchema, error) {
-
-	var (
-		allImages       []v2alpha1.CopyImageSchema
-		label           string
-		catalogImageDir string
-		catalogName     string
-		rebuiltTag      string
-	)
 	o.Log.Debug(collectorPrefix+"setting copy option o.Opts.MultiArch=%s when collecting operator images", o.Opts.MultiArch)
 
 	relatedImages := make(map[string][]v2alpha1.RelatedImage)
-	collectorSchema := v2alpha1.CollectorSchema{}
-	copyImageSchemaMap := &v2alpha1.CopyImageSchemaMap{OperatorsByImage: make(map[string]map[string]struct{}), BundlesByImage: make(map[string]map[string]string)}
+	collectorSchema := v2alpha1.CollectorSchema{
+		CatalogToFBCMap: make(map[string]v2alpha1.CatalogFilterResult),
+	}
+	copyImageSchemaMap := &v2alpha1.CopyImageSchemaMap{
+		OperatorsByImage: make(map[string]map[string]struct{}),
+		BundlesByImage:   make(map[string]map[string]string),
+	}
 
 	for _, op := range o.Config.Mirror.Operators {
-		var catalogImage string
 		// download the operator index image
 		o.Log.Debug(collectorPrefix+"copying operator image %s", op.Catalog)
 
@@ -74,13 +68,7 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 			mpb.BarFillerClearOnComplete(),
 			spinners.BarFillerClearOnAbort(),
 		)
-		// CLID-47 double check that targetCatalog is valid
-		if op.TargetCatalog != "" && !v2alpha1.IsValidPathComponent(op.TargetCatalog) {
-			o.Log.Error(collectorPrefix+"invalid targetCatalog %s", op.TargetCatalog)
-			spinner.Abort(true)
-			spinner.Wait()
-			return v2alpha1.CollectorSchema{}, fmt.Errorf(collectorPrefix+"invalid targetCatalog %s", op.TargetCatalog)
-		}
+
 		// CLID-27 ensure we pick up oci:// (on disk) catalogs
 		imgSpec, err := image.ParseRef(op.Catalog)
 		if err != nil {
@@ -89,380 +77,15 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 			spinner.Wait()
 			return v2alpha1.CollectorSchema{}, err
 		}
-		//OCPBUGS-36214: For diskToMirror (and delete), access to the source registry is not guaranteed
-		catalogDigest := ""
-		if o.Opts.Mode == mirror.DiskToMirror || o.Opts.Mode == string(mirror.DeleteMode) {
-			d, err := o.catalogDigest(ctx, op)
-			if err != nil {
-				o.Log.Error(errMsg, err.Error())
-				spinner.Abort(true)
-				spinner.Wait()
-				return v2alpha1.CollectorSchema{}, err
-			}
-			catalogDigest = d
-		} else {
-			sourceCtx, err := o.Opts.SrcImage.NewSystemContext()
-			if err != nil {
-				spinner.Abort(true)
-				spinner.Wait()
-				return v2alpha1.CollectorSchema{}, err
-			}
-			d, err := o.Manifest.GetDigest(ctx, sourceCtx, imgSpec.ReferenceWithTransport)
-			// OCPBUGS-36548 (manifest unknown)
-			if err != nil {
-				spinner.Abort(true)
-				spinner.Wait()
-				o.Log.Warn(collectorPrefix+"catalog %s : SKIPPING", err.Error())
-				continue
-			}
-			catalogDigest = d
-		}
 
-		imageIndex := filepath.Join(imgSpec.ComponentName(), catalogDigest)
-		imageIndexDir := filepath.Join(o.Opts.Global.WorkingDir, operatorCatalogsDir, imageIndex)
-		configsDir := filepath.Join(imageIndexDir, operatorCatalogConfigDir)
-		catalogImageDir = filepath.Join(imageIndexDir, operatorCatalogImageDir)
-		filteredCatalogsDir := filepath.Join(imageIndexDir, operatorCatalogFilteredDir)
-
-		err = createFolders([]string{configsDir, catalogImageDir, filteredCatalogsDir})
-		if err != nil {
-			o.Log.Error(errMsg, err.Error())
-			spinner.Abort(true)
-			spinner.Wait()
-			return v2alpha1.CollectorSchema{}, err
-		}
-
-		var filteredDC *declcfg.DeclarativeConfig
-		var isAlreadyFiltered bool
-
-		filterDigest, err := digestOfFilter(op)
+		result, err := o.collectOperator(ctx, op, relatedImages, copyImageSchemaMap)
 		if err != nil {
 			spinner.Abort(true)
 			spinner.Wait()
 			return v2alpha1.CollectorSchema{}, err
 		}
-		rebuiltTag = filterDigest
-		var srcFilteredCatalog string
-		filterPath := filepath.Join(filteredCatalogsDir, filterDigest, "digest")
-		filteredImageDigest, err := os.ReadFile(filterPath)
-		if err == nil && len(filterDigest) > 0 {
-			srcFilteredCatalog, err = o.cachedCatalog(op, filterDigest)
-			if err != nil {
-				o.Log.Error(errMsg, err.Error())
-				spinner.Abort(true)
-				spinner.Wait()
-				return v2alpha1.CollectorSchema{}, err
-			}
-			isAlreadyFiltered = o.isAlreadyFiltered(ctx, srcFilteredCatalog, string(filteredImageDigest))
-		}
+		collectorSchema.CatalogToFBCMap[imgSpec.ReferenceWithTransport] = result
 
-		if isAlreadyFiltered {
-			filterConfigDir := filepath.Join(filteredCatalogsDir, filterDigest, operatorCatalogConfigDir)
-			filteredDC, err = o.ctlgHandler.getDeclarativeConfig(filterConfigDir)
-			if err != nil {
-				o.Log.Error(errMsg, err.Error())
-				spinner.Abort(true)
-				spinner.Wait()
-				return v2alpha1.CollectorSchema{}, err
-			}
-			if len(op.TargetCatalog) > 0 {
-				catalogName = op.TargetCatalog
-			} else {
-				catalogName = path.Base(imgSpec.Reference)
-			}
-			if imgSpec.Transport == ociProtocol {
-				// ensure correct oci format and directory lookup
-				sourceOCIDir, err := filepath.Abs(imgSpec.Reference)
-				if err != nil {
-					o.Log.Error(errMsg, err.Error())
-					return v2alpha1.CollectorSchema{}, err
-				}
-				catalogImage = ociProtocol + sourceOCIDir
-			} else {
-				catalogImage = op.Catalog
-			}
-			catalogDigest = string(filteredImageDigest)
-			if collectorSchema.CatalogToFBCMap == nil {
-				collectorSchema.CatalogToFBCMap = make(map[string]v2alpha1.CatalogFilterResult)
-			}
-			result := v2alpha1.CatalogFilterResult{
-				OperatorFilter:     op,
-				FilteredConfigPath: filterConfigDir,
-				ToRebuild:          false,
-			}
-			collectorSchema.CatalogToFBCMap[imgSpec.ReferenceWithTransport] = result
-
-		} else {
-			toRebuild := true
-			if imgSpec.Transport == ociProtocol {
-				if _, err := os.Stat(filepath.Join(catalogImageDir, "index.json")); errors.Is(err, os.ErrNotExist) {
-					// delete the existing directory and untarred cache contents
-					os.RemoveAll(catalogImageDir)
-					os.RemoveAll(configsDir)
-					// copy all contents to the working dir
-					err := copy.Copy(imgSpec.PathComponent, catalogImageDir)
-					if err != nil {
-						o.Log.Error(errMsg, err.Error())
-						spinner.Abort(true)
-						spinner.Wait()
-						return v2alpha1.CollectorSchema{}, err
-					}
-				}
-
-				if len(op.TargetCatalog) > 0 {
-					catalogName = op.TargetCatalog
-				} else {
-					catalogName = path.Base(imgSpec.Reference)
-				}
-			} else {
-				src := dockerProtocol + op.Catalog
-				dest := ociProtocolTrimmed + catalogImageDir
-
-				optsCopy := o.Opts
-				optsCopy.Stdout = io.Discard
-
-				err = o.Mirror.Run(ctx, src, dest, "copy", &optsCopy)
-
-				if err != nil {
-					o.Log.Error(errMsg, err.Error())
-				}
-			}
-
-			// it's in oci format so we can go directly to the index.json file
-			oci, err := o.Manifest.GetImageIndex(catalogImageDir)
-			if err != nil {
-				o.Log.Error(errMsg, err.Error())
-				spinner.Abort(true)
-				spinner.Wait()
-				return v2alpha1.CollectorSchema{}, err
-			}
-
-			if isMultiManifestIndex(*oci) && imgSpec.Transport == ociProtocol {
-				err = o.Manifest.ConvertIndexToSingleManifest(catalogImageDir, oci)
-				if err != nil {
-					o.Log.Error(errMsg, err.Error())
-					spinner.Abort(true)
-					spinner.Wait()
-					return v2alpha1.CollectorSchema{}, err
-				}
-
-				oci, err = o.Manifest.GetImageIndex(catalogImageDir)
-				if err != nil {
-					o.Log.Error(errMsg, err.Error())
-					spinner.Abort(true)
-					spinner.Wait()
-					return v2alpha1.CollectorSchema{}, err
-				}
-
-				sourceOCIDir, err := filepath.Abs(imgSpec.Reference)
-				if err != nil {
-					o.Log.Error(errMsg, err.Error())
-					return v2alpha1.CollectorSchema{}, err
-				}
-				catalogImage = ociProtocol + sourceOCIDir
-			} else {
-				catalogImage = op.Catalog
-			}
-
-			if len(oci.Manifests) == 0 {
-				o.Log.Error(collectorPrefix+"no manifests found for %s ", op.Catalog)
-				spinner.Abort(true)
-				spinner.Wait()
-				return v2alpha1.CollectorSchema{}, fmt.Errorf(collectorPrefix+"no manifests found for %s ", op.Catalog)
-			}
-
-			validDigest, err := digest.Parse(oci.Manifests[0].Digest)
-			if err != nil {
-				o.Log.Error(collectorPrefix+digestIncorrectMessage, op.Catalog, err.Error())
-				spinner.Abort(true)
-				spinner.Wait()
-				return v2alpha1.CollectorSchema{}, fmt.Errorf(collectorPrefix+"the digests seem to be incorrect for %s: %s ", op.Catalog, err.Error())
-			}
-
-			manifest := validDigest.Encoded()
-			o.Log.Debug(collectorPrefix+"manifest %s", manifest)
-			// read the operator image manifest
-			manifestDir := filepath.Join(catalogImageDir, blobsDir, manifest)
-			oci, err = o.Manifest.GetImageManifest(manifestDir)
-			if err != nil {
-				o.Log.Error(errMsg, err.Error())
-				spinner.Abort(true)
-				spinner.Wait()
-				return v2alpha1.CollectorSchema{}, err
-			}
-
-			// we need to check if oci returns multi manifests
-			// (from manifest list) also oci.Config will be nil
-			// we are only interested in the first manifest as all
-			// architecture "configs" will be exactly the same
-			if len(oci.Manifests) > 1 && oci.Config.Size == 0 {
-				subDigest, err := digest.Parse(oci.Manifests[0].Digest)
-				if err != nil {
-					o.Log.Error(collectorPrefix+digestIncorrectMessage, op.Catalog, err.Error())
-					spinner.Abort(true)
-					spinner.Wait()
-					return v2alpha1.CollectorSchema{}, fmt.Errorf(collectorPrefix+"the digests seem to be incorrect for %s: %s ", op.Catalog, err.Error())
-				}
-				manifestDir := filepath.Join(catalogImageDir, blobsDir, subDigest.Encoded())
-				oci, err = o.Manifest.GetImageManifest(manifestDir)
-				if err != nil {
-					o.Log.Error(collectorPrefix+"manifest %s: %s ", op.Catalog, err.Error())
-					spinner.Abort(true)
-					spinner.Wait()
-					return v2alpha1.CollectorSchema{}, fmt.Errorf(collectorPrefix+"manifest %s: %s ", op.Catalog, err.Error())
-				}
-			}
-
-			// read the config digest to get the detailed manifest
-			// looking for the lable to search for a specific folder
-			configDigest, err := digest.Parse(oci.Config.Digest)
-			if err != nil {
-				o.Log.Error(collectorPrefix+digestIncorrectMessage, op.Catalog, err.Error())
-				spinner.Abort(true)
-				spinner.Wait()
-				return v2alpha1.CollectorSchema{}, fmt.Errorf(collectorPrefix+"the digests seem to be incorrect for %s: %s ", op.Catalog, err.Error())
-			}
-			catalogDir := filepath.Join(catalogImageDir, blobsDir, configDigest.Encoded())
-			ocs, err := o.Manifest.GetOperatorConfig(catalogDir)
-			if err != nil {
-				o.Log.Error(errMsg, err.Error())
-				spinner.Abort(true)
-				spinner.Wait()
-				return v2alpha1.CollectorSchema{}, err
-			}
-
-			label = ocs.Config.Labels.OperatorsOperatorframeworkIoIndexConfigsV1
-			o.Log.Debug(collectorPrefix+"label %s", label)
-
-			// untar all the blobs for the operator
-			// if the layer with "label (from previous step) is found to a specific folder"
-			fromDir := strings.Join([]string{catalogImageDir, blobsDir}, "/")
-			err = o.Manifest.ExtractLayersOCI(fromDir, configsDir, label, oci)
-			if err != nil {
-				spinner.Abort(true)
-				spinner.Wait()
-				return v2alpha1.CollectorSchema{}, err
-			}
-
-			originalDC, err := o.ctlgHandler.getDeclarativeConfig(filepath.Join(configsDir, label))
-			if err != nil {
-				spinner.Abort(true)
-				spinner.Wait()
-				return v2alpha1.CollectorSchema{}, err
-			}
-
-			if !isFullCatalog(op) {
-
-				var filteredDigestPath string
-				var filterDigest string
-
-				filteredDC, err = filterCatalog(ctx, *originalDC, op)
-				if err != nil {
-					spinner.Abort(true)
-					spinner.Wait()
-					return v2alpha1.CollectorSchema{}, err
-				}
-
-				filterDigest, err = digestOfFilter(op)
-				if err != nil {
-					o.Log.Error(errMsg, err.Error())
-					spinner.Abort(true)
-					spinner.Wait()
-					return v2alpha1.CollectorSchema{}, err
-				}
-
-				if filterDigest != "" {
-					filteredDigestPath = filepath.Join(filteredCatalogsDir, filterDigest, operatorCatalogConfigDir)
-
-					err = createFolders([]string{filteredDigestPath})
-					if err != nil {
-						o.Log.Error(errMsg, err.Error())
-						spinner.Abort(true)
-						spinner.Wait()
-						return v2alpha1.CollectorSchema{}, err
-					}
-				}
-
-				err = saveDeclarativeConfig(*filteredDC, filteredDigestPath)
-				if err != nil {
-					spinner.Abort(true)
-					spinner.Wait()
-					return v2alpha1.CollectorSchema{}, err
-				}
-
-				if collectorSchema.CatalogToFBCMap == nil {
-					collectorSchema.CatalogToFBCMap = make(map[string]v2alpha1.CatalogFilterResult)
-				}
-				result := v2alpha1.CatalogFilterResult{
-					OperatorFilter:     op,
-					FilteredConfigPath: filteredDigestPath,
-					ToRebuild:          toRebuild,
-				}
-				collectorSchema.CatalogToFBCMap[imgSpec.ReferenceWithTransport] = result
-
-			} else {
-				rebuiltTag = ""
-				toRebuild = false
-				filteredDC = originalDC
-				if collectorSchema.CatalogToFBCMap == nil {
-					collectorSchema.CatalogToFBCMap = make(map[string]v2alpha1.CatalogFilterResult)
-				}
-				result := v2alpha1.CatalogFilterResult{
-					OperatorFilter:     op,
-					FilteredConfigPath: "", // this value is not relevant: no rebuilding required
-					ToRebuild:          toRebuild,
-				}
-				collectorSchema.CatalogToFBCMap[imgSpec.ReferenceWithTransport] = result
-			}
-		}
-
-		ri, err := o.ctlgHandler.getRelatedImagesFromCatalog(filteredDC, copyImageSchemaMap)
-		if err != nil {
-			if len(ri) == 0 {
-				spinner.Abort(true)
-				spinner.Wait()
-				continue
-			}
-		}
-
-		//OCPBUGS-45059
-		//TODO remove me when the migration from oc-mirror v1 to v2 ends
-		if imgSpec.Transport == ociProtocol && o.isDeleteOfV1CatalogFromDisk() {
-			addOriginFromOperatorCatalogOnDisk(&ri)
-		}
-
-		maps.Copy(relatedImages, ri)
-
-		var targetTag string
-		var targetCatalog string
-		if len(op.TargetTag) > 0 {
-			targetTag = op.TargetTag
-		} else if imgSpec.Transport == ociProtocol {
-			// for this case only, img.ParseRef(in its current state)
-			// will not be able to determine the digest.
-			// this leaves the oci imgSpec with no tag nor digest as it
-			// goes to prepareM2DCopyBatch/prepareD2MCopyBath. This is
-			// why we set the digest read from manifest in targetTag
-			targetTag = "latest"
-		}
-
-		if len(op.TargetCatalog) > 0 {
-			targetCatalog = op.TargetCatalog
-
-		}
-
-		componentName := imgSpec.ComponentName() + "." + catalogDigest
-
-		relatedImages[componentName] = []v2alpha1.RelatedImage{
-			{
-				Name:          catalogName,
-				Image:         catalogImage,
-				Type:          v2alpha1.TypeOperatorCatalog,
-				TargetTag:     targetTag,
-				TargetCatalog: targetCatalog,
-				RebuiltTag:    rebuiltTag,
-			},
-		}
 		spinner.Increment()
 		p.Wait()
 		if !o.Opts.Global.IsTerminal {
@@ -471,35 +94,26 @@ func (o *FilterCollector) OperatorImageCollector(ctx context.Context) (v2alpha1.
 	}
 
 	o.Log.Debug(collectorPrefix+"related images length %d ", len(relatedImages))
-	var count = 0
-	if o.Opts.Global.LogLevel == "debug" {
-		for _, v := range relatedImages {
-			count = count + len(v)
-		}
+	count := 0
+	for _, v := range relatedImages {
+		count += len(v)
 	}
 	o.Log.Debug(collectorPrefix+"images to copy (before duplicates) %d ", count)
+
 	var err error
+	var allImages []v2alpha1.CopyImageSchema
 	// check the mode
 	switch {
 	case o.Opts.IsMirrorToDisk():
 		allImages, err = o.prepareM2DCopyBatch(relatedImages)
-		if err != nil {
-			o.Log.Error(errMsg, err.Error())
-			return v2alpha1.CollectorSchema{}, err
-		}
 	case o.Opts.IsMirrorToMirror():
 		allImages, err = o.dispatchImagesForM2M(relatedImages)
-		if err != nil {
-			o.Log.Error(errMsg, err.Error())
-			return v2alpha1.CollectorSchema{}, err
-		}
 	case o.Opts.IsDiskToMirror() || o.Opts.Mode == string(mirror.DeleteMode):
 		allImages, err = o.prepareD2MCopyBatch(relatedImages)
-		if err != nil {
-			o.Log.Error(errMsg, err.Error())
-			return v2alpha1.CollectorSchema{}, err
-		}
-
+	}
+	if err != nil {
+		o.Log.Error(errMsg, err.Error())
+		return v2alpha1.CollectorSchema{}, err
 	}
 
 	collectorSchema.AllImages = allImages
@@ -538,7 +152,6 @@ func digestOfFilter(catalog v2alpha1.Operator) (string, error) {
 }
 
 func (o FilterCollector) isAlreadyFiltered(ctx context.Context, srcImage, filteredImageDigest string) bool {
-
 	imgSpec, err := image.ParseRef(srcImage)
 	if err != nil {
 		o.Log.Debug(errMsg, err.Error())
@@ -577,4 +190,234 @@ func addOriginFromOperatorCatalogOnDisk(relatedImages *map[string][]v2alpha1.Rel
 		}
 		(*relatedImages)[key] = images
 	}
+}
+
+func (o FilterCollector) collectOperator(
+	ctx context.Context,
+	op v2alpha1.Operator,
+	relatedImages map[string][]v2alpha1.RelatedImage,
+	copyImageSchemaMap *v2alpha1.CopyImageSchemaMap,
+) (v2alpha1.CatalogFilterResult, error) {
+	// CLID-47 double check that targetCatalog is valid
+	if op.TargetCatalog != "" && !v2alpha1.IsValidPathComponent(op.TargetCatalog) {
+		return v2alpha1.CatalogFilterResult{}, fmt.Errorf("invalid targetCatalog %s", op.TargetCatalog)
+	}
+
+	// CLID-27 ensure we pick up oci:// (on disk) catalogs
+	imgSpec, err := image.ParseRef(op.Catalog)
+	if err != nil {
+		return v2alpha1.CatalogFilterResult{}, err
+	}
+
+	catalogDigest, err := o.getCatalogDigest(ctx, op)
+	if err != nil {
+		// OCPBUGS-36548 (manifest unknown)
+		return v2alpha1.CatalogFilterResult{}, err
+	}
+
+	result, err := o.filterOperator(ctx, op, imgSpec, catalogDigest)
+	if err != nil {
+		return v2alpha1.CatalogFilterResult{}, err
+	}
+
+	ri, err := o.ctlgHandler.getRelatedImagesFromCatalog(result.DeclConfig, copyImageSchemaMap)
+	if err != nil {
+		return v2alpha1.CatalogFilterResult{}, err
+	}
+	o.Log.Debug("Found %d related images for catalog %q", len(ri), op.Catalog)
+
+	// OCPBUGS-45059
+	// TODO: remove me when the migration from oc-mirror v1 to v2 ends
+	if imgSpec.Transport == ociProtocol && o.isDeleteOfV1CatalogFromDisk() {
+		addOriginFromOperatorCatalogOnDisk(&ri)
+	}
+
+	maps.Copy(relatedImages, ri)
+
+	targetTag := op.TargetTag
+	if len(targetTag) == 0 && imgSpec.Transport == ociProtocol {
+		// for this case only, img.ParseRef(in its current state)
+		// will not be able to determine the digest.
+		// this leaves the oci imgSpec with no tag nor digest as it
+		// goes to prepareM2DCopyBatch/prepareD2MCopyBath. This is
+		// why we set the digest read from manifest in targetTag
+		targetTag = "latest"
+	}
+
+	catalogName := op.TargetCatalog
+	if len(catalogName) == 0 {
+		catalogName = path.Base(imgSpec.Reference)
+	}
+
+	catalogImage := op.Catalog
+	if imgSpec.Transport == ociProtocol {
+		// ensure correct oci format and directory lookup
+		sourceOCIDir, err := filepath.Abs(imgSpec.Reference)
+		if err != nil {
+			o.Log.Error(errMsg, err.Error())
+			return v2alpha1.CatalogFilterResult{}, err
+		}
+		catalogImage = ociProtocol + sourceOCIDir
+	}
+
+	rebuiltTag := ""
+	if result.ToRebuild {
+		tag, err := digestOfFilter(op)
+		if err != nil {
+			return v2alpha1.CatalogFilterResult{}, err
+		}
+		rebuiltTag = tag
+	}
+
+	componentName := imgSpec.ComponentName() + "." + result.Digest
+	relatedImages[componentName] = []v2alpha1.RelatedImage{
+		{
+			Name:          catalogName,
+			Image:         catalogImage,
+			Type:          v2alpha1.TypeOperatorCatalog,
+			TargetTag:     targetTag,
+			TargetCatalog: op.TargetCatalog,
+			RebuiltTag:    rebuiltTag,
+		},
+	}
+
+	return result, nil
+}
+
+func (o FilterCollector) getCatalogDigest(ctx context.Context, op v2alpha1.Operator) (string, error) {
+	// OCPBUGS-36214: For diskToMirror (and delete), access to the source registry is not guaranteed
+	if o.Opts.IsDiskToMirror() || o.Opts.IsDeleteMode() {
+		return o.catalogDigest(ctx, op)
+	}
+
+	imgSpec, err := image.ParseRef(op.Catalog)
+	if err != nil {
+		return "", err
+	}
+
+	srcCtx, err := o.Opts.SrcImage.NewSystemContext()
+	if err != nil {
+		return "", err
+	}
+
+	return o.Manifest.GetDigest(ctx, srcCtx, imgSpec.ReferenceWithTransport)
+}
+
+func (o FilterCollector) filterOperator(ctx context.Context, op v2alpha1.Operator, imgSpec image.ImageSpec, catalogDigest string) (v2alpha1.CatalogFilterResult, error) {
+	o.Log.Debug("Filtering catalog %q", op.Catalog)
+	imageIndexDir := filepath.Join(o.Opts.Global.WorkingDir, operatorCatalogsDir, imgSpec.ComponentName(), catalogDigest)
+	filteredCatalogsDir := filepath.Join(imageIndexDir, operatorCatalogFilteredDir)
+
+	filterDigest, err := digestOfFilter(op)
+	if err != nil {
+		return v2alpha1.CatalogFilterResult{}, err
+	}
+
+	filteredImageDigest, err := os.ReadFile(filepath.Join(filteredCatalogsDir, filterDigest, "digest"))
+	if err != nil {
+		// If there was an error reading the digest file, we assume the catalog has not been filtered
+		o.Log.Debug("Catalog has not been filtered previously")
+	} else { // digest read
+		srcFilteredCatalog, err := o.cachedCatalog(op, filterDigest)
+		if err != nil {
+			return v2alpha1.CatalogFilterResult{}, err
+		}
+
+		if o.isAlreadyFiltered(ctx, srcFilteredCatalog, string(filteredImageDigest)) {
+			filterConfigDir := filepath.Join(filteredCatalogsDir, filterDigest, operatorCatalogConfigDir)
+			filteredDC, err := o.ctlgHandler.getDeclarativeConfig(filterConfigDir)
+			if err != nil {
+				return v2alpha1.CatalogFilterResult{}, fmt.Errorf("retrieve filtered catalog config from %s: %w", filterConfigDir, err)
+			}
+			return v2alpha1.CatalogFilterResult{
+				OperatorFilter:     op,
+				FilteredConfigPath: filterConfigDir,
+				ToRebuild:          false,
+				DeclConfig:         filteredDC,
+				Digest:             string(filteredImageDigest),
+			}, nil
+		}
+	}
+
+	if err := o.ensureCatalogInOCIFormat(ctx, imgSpec, op.Catalog, imageIndexDir); err != nil {
+		return v2alpha1.CatalogFilterResult{}, err
+	}
+
+	// It's now in oci format so we can go directly to the index.json file
+	dcPath, err := o.extractOCIConfigLayers(op.Catalog, imgSpec, imageIndexDir)
+	if err != nil {
+		return v2alpha1.CatalogFilterResult{}, err
+	}
+
+	originalDC, err := o.ctlgHandler.getDeclarativeConfig(dcPath)
+	if err != nil {
+		return v2alpha1.CatalogFilterResult{}, err
+	}
+
+	// No filtering needs to be done if we're copying the whole catalog
+	if isFullCatalog(op) {
+		return v2alpha1.CatalogFilterResult{
+			OperatorFilter:     op,
+			FilteredConfigPath: "", // this value is not relevant: no rebuilding
+			ToRebuild:          false,
+			DeclConfig:         originalDC,
+			Digest:             catalogDigest,
+		}, nil
+	}
+
+	filteredDC, err := filterCatalog(ctx, *originalDC, op)
+	if err != nil {
+		return v2alpha1.CatalogFilterResult{}, err
+	}
+
+	filteredDigestPath := filepath.Join(filteredCatalogsDir, filterDigest, operatorCatalogConfigDir)
+	if err := createFolders([]string{filteredDigestPath}); err != nil {
+		return v2alpha1.CatalogFilterResult{}, err
+	}
+
+	if err := saveDeclarativeConfig(*filteredDC, filteredDigestPath); err != nil {
+		return v2alpha1.CatalogFilterResult{}, err
+	}
+
+	return v2alpha1.CatalogFilterResult{
+		OperatorFilter:     op,
+		FilteredConfigPath: filteredDigestPath,
+		ToRebuild:          true,
+		DeclConfig:         filteredDC,
+		Digest:             catalogDigest,
+	}, nil
+}
+
+func (o FilterCollector) ensureCatalogInOCIFormat(ctx context.Context, imgSpec image.ImageSpec, catalog, imageIndexDir string) error {
+	o.Log.Debug("Ensuring catalog is in OCI format")
+	catalogImageDir := filepath.Join(imageIndexDir, operatorCatalogImageDir)
+
+	if imgSpec.Transport != ociProtocol {
+		opts := o.Opts
+		opts.Stdout = io.Discard
+
+		src := dockerProtocol + catalog
+		dest := ociProtocolTrimmed + catalogImageDir
+
+		// Prepare folders
+		if err := createFolders([]string{catalogImageDir}); err != nil {
+			return err
+		}
+		return o.Mirror.Run(ctx, src, dest, mirror.CopyMode, &opts)
+	}
+
+	o.Log.Debug("Catalog %q already in OCI format", catalog)
+	if _, err := os.Stat(filepath.Join(catalogImageDir, "index.json")); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// delete the existing directory and untarred cache contents
+			os.RemoveAll(catalogImageDir)
+			os.RemoveAll(filepath.Join(imageIndexDir, operatorCatalogConfigDir))
+			// copy all contents to the working dir
+			return copy.Copy(imgSpec.PathComponent, catalogImageDir)
+		} else {
+			// FIXME: what to do here?
+		}
+	}
+
+	return nil
 }

--- a/v2/internal/pkg/operator/filtered_collector_test.go
+++ b/v2/internal/pkg/operator/filtered_collector_test.go
@@ -3,7 +3,6 @@ package operator
 import (
 	"context"
 	"os"
-
 	"path/filepath"
 	"testing"
 
@@ -17,74 +16,72 @@ import (
 	"github.com/openshift/oc-mirror/v2/internal/pkg/common"
 )
 
-var (
-	nominalConfigM2M = v2alpha1.ImageSetConfiguration{
-		ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
-			Mirror: v2alpha1.Mirror{
-				Operators: []v2alpha1.Operator{
-					{
-						Catalog: "registry.redhat.io/redhat/community-operator-index:v4.18",
-						Full:    true,
-					},
-					{
-						Catalog:       "registry.redhat.io/redhat/redhat-operator-index:v4.17",
-						TargetCatalog: "redhat/redhat-filtered-index",
-						IncludeConfig: v2alpha1.IncludeConfig{
-							Packages: []v2alpha1.IncludePackage{
-								{Name: "op1"},
-							},
+var nominalConfigM2M = v2alpha1.ImageSetConfiguration{
+	ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+		Mirror: v2alpha1.Mirror{
+			Operators: []v2alpha1.Operator{
+				{
+					Catalog: "registry.redhat.io/redhat/community-operator-index:v4.18",
+					Full:    true,
+				},
+				{
+					Catalog:       "registry.redhat.io/redhat/redhat-operator-index:v4.17",
+					TargetCatalog: "redhat/redhat-filtered-index",
+					IncludeConfig: v2alpha1.IncludeConfig{
+						Packages: []v2alpha1.IncludePackage{
+							{Name: "op1"},
 						},
 					},
-					{
-						Catalog:       "registry.redhat.io/redhat/certified-operators:v4.17",
-						Full:          true,
-						TargetCatalog: "redhat/certified-operators-pinned",
-						TargetTag:     "v4.17.0-20241114",
-						IncludeConfig: v2alpha1.IncludeConfig{
-							Packages: []v2alpha1.IncludePackage{
-								{Name: "op1"},
-							},
+				},
+				{
+					Catalog:       "registry.redhat.io/redhat/certified-operators:v4.17",
+					Full:          true,
+					TargetCatalog: "redhat/certified-operators-pinned",
+					TargetTag:     "v4.17.0-20241114",
+					IncludeConfig: v2alpha1.IncludeConfig{
+						Packages: []v2alpha1.IncludePackage{
+							{Name: "op1"},
 						},
 					},
-					{
-						Catalog: "oci://" + common.TestFolder + "catalog-on-disk1",
-						IncludeConfig: v2alpha1.IncludeConfig{
-							Packages: []v2alpha1.IncludePackage{
-								{Name: "op1"},
-							},
+				},
+				{
+					Catalog: "oci://" + common.TestFolder + "catalog-on-disk1",
+					IncludeConfig: v2alpha1.IncludeConfig{
+						Packages: []v2alpha1.IncludePackage{
+							{Name: "op1"},
 						},
 					},
-					{
-						Catalog:       "oci://" + common.TestFolder + "catalog-on-disk2",
-						Full:          true,
-						TargetCatalog: "coffee-shop-index",
-						IncludeConfig: v2alpha1.IncludeConfig{
-							Packages: []v2alpha1.IncludePackage{
-								{Name: "op1"},
-							},
+				},
+				{
+					Catalog:       "oci://" + common.TestFolder + "catalog-on-disk2",
+					Full:          true,
+					TargetCatalog: "coffee-shop-index",
+					IncludeConfig: v2alpha1.IncludeConfig{
+						Packages: []v2alpha1.IncludePackage{
+							{Name: "op1"},
 						},
 					},
-					{
-						Catalog:       "oci://" + common.TestFolder + "catalog-on-disk3",
-						TargetCatalog: "tea-shop-index",
-						TargetTag:     "v3.14",
-						IncludeConfig: v2alpha1.IncludeConfig{
-							Packages: []v2alpha1.IncludePackage{
-								{Name: "op1"},
-							},
+				},
+				{
+					Catalog:       "oci://" + common.TestFolder + "catalog-on-disk3",
+					TargetCatalog: "tea-shop-index",
+					TargetTag:     "v3.14",
+					IncludeConfig: v2alpha1.IncludeConfig{
+						Packages: []v2alpha1.IncludePackage{
+							{Name: "op1"},
 						},
 					},
 				},
 			},
 		},
-	}
-)
+	},
+}
 
 func TestFilterCollectorM2D(t *testing.T) {
 	log := clog.New("trace")
 
 	tempDir := t.TempDir()
-	defer os.RemoveAll(tempDir)
+
 	type testCase struct {
 		caseName       string
 		config         v2alpha1.ImageSetConfiguration
@@ -94,6 +91,9 @@ func TestFilterCollectorM2D(t *testing.T) {
 
 	ctx := context.Background()
 	manifest := &MockManifest{Log: log}
+
+	testDir, err := filepath.Abs(common.TestFolder)
+	assert.NoError(t, err, "should get tests/ absolute path")
 
 	testCases := []testCase{
 		{
@@ -140,9 +140,9 @@ func TestFilterCollectorM2D(t *testing.T) {
 					RebuiltTag:  "4dab2467f35b4d9c9ba7c2a7823de8bd",
 				},
 				{
-					Source:      "oci://" + common.TestFolder + "simple-test-bundle",
+					Source:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Destination: "docker://localhost:9999/simple-test-bundle:latest",
-					Origin:      "oci://" + common.TestFolder + "simple-test-bundle",
+					Origin:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Type:        v2alpha1.TypeOperatorCatalog,
 					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
 				},
@@ -172,9 +172,9 @@ func TestFilterCollectorM2D(t *testing.T) {
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
-					Source:      "oci://" + common.TestFolder + "simple-test-bundle",
+					Source:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Destination: "docker://localhost:9999/simple-test-bundle:v4.14",
-					Origin:      "oci://" + common.TestFolder + "simple-test-bundle",
+					Origin:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Type:        v2alpha1.TypeOperatorCatalog,
 					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
 				},
@@ -210,9 +210,9 @@ func TestFilterCollectorM2D(t *testing.T) {
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
-					Source:      "oci://" + common.TestFolder + "simple-test-bundle",
+					Source:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Destination: "docker://localhost:9999/test-catalog:v4.14",
-					Origin:      "oci://" + common.TestFolder + "simple-test-bundle",
+					Origin:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Type:        v2alpha1.TypeOperatorCatalog,
 					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
 				},
@@ -273,11 +273,15 @@ func TestFilterCollectorM2D(t *testing.T) {
 		_ = New(log, "working-dir", ex.Config, ex.Opts, ex.Mirror, manifest)
 	})
 }
+
 func TestFilterCollectorD2M(t *testing.T) {
 	log := clog.New("trace")
 
 	tempDir := t.TempDir()
-	defer os.RemoveAll(tempDir)
+
+	testDir, err := filepath.Abs(common.TestFolder)
+	assert.NoError(t, err, "should get tests/ absolute path")
+
 	type testCase struct {
 		caseName       string
 		config         v2alpha1.ImageSetConfiguration
@@ -290,9 +294,11 @@ func TestFilterCollectorD2M(t *testing.T) {
 	os.RemoveAll(common.TestFolder + "operator-images")
 	os.RemoveAll(common.TestFolder + "tmp/")
 
-	//copy tests/hold-test-fake to working-dir
-	err := copy.Copy(common.TestFolder+"working-dir-fake/hold-operator/redhat-operator-index/v4.14", filepath.Join(tempDir, "working-dir", operatorImageExtractDir, "redhat-operator-index/f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"))
-	if err != nil {
+	// copy tests/hold-test-fake to working-dir
+	if err := copy.Copy(
+		filepath.Join(common.TestFolder, "working-dir-fake", "hold-operator", "redhat-operator-index", "v4.14"),
+		filepath.Join(tempDir, "working-dir", operatorImageExtractDir, "redhat-operator-index", "f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"),
+	); err != nil {
 		t.Fatalf("should not fail")
 	}
 
@@ -323,7 +329,7 @@ func TestFilterCollectorD2M(t *testing.T) {
 				{
 					Source:      "docker://localhost:9999/simple-test-bundle:9fadc6c70adb4b2571f66f674a876279",
 					Destination: "docker://localhost:5000/test/simple-test-bundle:latest",
-					Origin:      "oci://" + common.TestFolder + "simple-test-bundle",
+					Origin:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Type:        v2alpha1.TypeOperatorCatalog,
 					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
 				},
@@ -367,7 +373,7 @@ func TestFilterCollectorD2M(t *testing.T) {
 				{
 					Source:      "docker://localhost:9999/test-catalog:9fadc6c70adb4b2571f66f674a876279",
 					Destination: "docker://localhost:5000/test/test-catalog:v4.14",
-					Origin:      "oci://" + common.TestFolder + "simple-test-bundle",
+					Origin:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Type:        v2alpha1.TypeOperatorCatalog,
 					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
 				},
@@ -388,14 +394,16 @@ func TestFilterCollectorD2M(t *testing.T) {
 			assert.ElementsMatch(t, testCase.expectedResult, res.AllImages)
 		})
 	}
-
 }
 
 func TestFilterCollectorM2M(t *testing.T) {
 	log := clog.New("trace")
 
 	tempDir := t.TempDir()
-	defer os.RemoveAll(tempDir)
+
+	testDir, err := filepath.Abs(common.TestFolder)
+	assert.NoError(t, err, "should get tests/ absolute path")
+
 	type testCase struct {
 		caseName       string
 		config         v2alpha1.ImageSetConfiguration
@@ -408,30 +416,38 @@ func TestFilterCollectorM2M(t *testing.T) {
 	os.RemoveAll(common.TestFolder + "operator-images")
 	os.RemoveAll(common.TestFolder + "tmp/")
 
-	//copy tests/hold-test-fake to working-dir
-	err := copy.Copy(common.TestFolder+"working-dir-fake/hold-operator/redhat-operator-index/v4.14", filepath.Join(tempDir, "working-dir", operatorImageExtractDir, "redhat/redhat-operator-index/f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"))
-	if err != nil {
+	// copy tests/hold-test-fake to working-dir
+	if err := copy.Copy(
+		filepath.Join(common.TestFolder, "working-dir-fake", "hold-operator", "redhat-operator-index", "v4.14"),
+		filepath.Join(tempDir, "working-dir", operatorImageExtractDir, "redhat", "redhat-operator-index", "f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"),
+	); err != nil {
 		t.Fatalf("should not fail")
 	}
 
 	os.MkdirAll(common.TestFolder+"/catalog-on-disk1", 0755)
 	os.MkdirAll(common.TestFolder+"/catalog-on-disk2", 0755)
 	os.MkdirAll(common.TestFolder+"/catalog-on-disk3", 0755)
-	//copy tests/hold-test-fake to working-dir
-	err = copy.Copy(common.TestFolder+"/oci-image", common.TestFolder+"/catalog-on-disk1")
-	if err != nil {
-		t.Fatalf("should not fail")
-	}
-	err = copy.Copy(common.TestFolder+"/oci-image", common.TestFolder+"/catalog-on-disk2")
-	if err != nil {
-		t.Fatalf("should not fail")
-	}
-	err = copy.Copy(common.TestFolder+"/oci-image", common.TestFolder+"/catalog-on-disk3")
-	if err != nil {
+	// copy tests/hold-test-fake to working-dir
+	if err := copy.Copy(
+		filepath.Join(common.TestFolder, "oci-image"),
+		filepath.Join(common.TestFolder, "catalog-on-disk1"),
+	); err != nil {
 		t.Fatalf("should not fail")
 	}
 	defer os.RemoveAll(common.TestFolder + "/catalog-on-disk1")
+	if err := copy.Copy(
+		filepath.Join(common.TestFolder, "oci-image"),
+		filepath.Join(common.TestFolder, "catalog-on-disk2"),
+	); err != nil {
+		t.Fatalf("should not fail")
+	}
 	defer os.RemoveAll(common.TestFolder + "/catalog-on-disk2")
+	if err := copy.Copy(
+		filepath.Join(common.TestFolder, "oci-image"),
+		filepath.Join(common.TestFolder, "catalog-on-disk3"),
+	); err != nil {
+		t.Fatalf("should not fail")
+	}
 	defer os.RemoveAll(common.TestFolder + "/catalog-on-disk3")
 
 	testCases := []testCase{
@@ -485,23 +501,23 @@ func TestFilterCollectorM2M(t *testing.T) {
 					RebuiltTag:  "65af60f894902a1758a30ae262c0e39e",
 				},
 				{
-					Source:      "oci://" + common.TestFolder + "catalog-on-disk1",
+					Source:      "oci://" + filepath.Join(testDir, "catalog-on-disk1"),
 					Destination: "docker://localhost:9999/catalog-on-disk1:latest",
-					Origin:      "oci://" + common.TestFolder + "catalog-on-disk1",
+					Origin:      "oci://" + filepath.Join(testDir, "catalog-on-disk1"),
 					Type:        v2alpha1.TypeOperatorCatalog,
 					RebuiltTag:  "fc2e113a1d6f0dbe89bd2bc5c83886e3",
 				},
 				{
-					Source:      "oci://" + common.TestFolder + "catalog-on-disk2",
+					Source:      "oci://" + filepath.Join(testDir, "catalog-on-disk2"),
 					Destination: "docker://localhost:9999/coffee-shop-index:latest",
-					Origin:      "oci://" + common.TestFolder + "catalog-on-disk2",
+					Origin:      "oci://" + filepath.Join(testDir, "catalog-on-disk2"),
 					Type:        v2alpha1.TypeOperatorCatalog,
 					RebuiltTag:  "421035ded2cb0e83f50ee6445b1466a5",
 				},
 				{
-					Source:      "oci://" + common.TestFolder + "catalog-on-disk3",
+					Source:      "oci://" + filepath.Join(testDir, "catalog-on-disk3"),
 					Destination: "docker://localhost:9999/tea-shop-index:v3.14",
-					Origin:      "oci://" + common.TestFolder + "catalog-on-disk3",
+					Origin:      "oci://" + filepath.Join(testDir, "catalog-on-disk3"),
 					Type:        v2alpha1.TypeOperatorCatalog,
 					RebuiltTag:  "d81a7ad49cabfc8aa050edaf56f25a3f",
 				},
@@ -523,21 +539,21 @@ func TestFilterCollectorM2M(t *testing.T) {
 				{
 					Source:      "docker://localhost:9999/catalog-on-disk1:fc2e113a1d6f0dbe89bd2bc5c83886e3",
 					Destination: "docker://localhost:5000/test/catalog-on-disk1:latest",
-					Origin:      "oci://" + common.TestFolder + "catalog-on-disk1",
+					Origin:      "oci://" + filepath.Join(testDir, "catalog-on-disk1"),
 					Type:        v2alpha1.TypeOperatorCatalog,
 					RebuiltTag:  "fc2e113a1d6f0dbe89bd2bc5c83886e3",
 				},
 				{
 					Source:      "docker://localhost:9999/coffee-shop-index:421035ded2cb0e83f50ee6445b1466a5",
 					Destination: "docker://localhost:5000/test/coffee-shop-index:latest",
-					Origin:      "oci://" + common.TestFolder + "catalog-on-disk2",
+					Origin:      "oci://" + filepath.Join(testDir, "catalog-on-disk2"),
 					Type:        v2alpha1.TypeOperatorCatalog,
 					RebuiltTag:  "421035ded2cb0e83f50ee6445b1466a5",
 				},
 				{
 					Source:      "docker://localhost:9999/tea-shop-index:d81a7ad49cabfc8aa050edaf56f25a3f",
 					Destination: "docker://localhost:5000/test/tea-shop-index:v3.14",
-					Origin:      "oci://" + common.TestFolder + "catalog-on-disk3",
+					Origin:      "oci://" + filepath.Join(testDir, "catalog-on-disk3"),
 					Type:        v2alpha1.TypeOperatorCatalog,
 					RebuiltTag:  "d81a7ad49cabfc8aa050edaf56f25a3f",
 				},
@@ -560,7 +576,6 @@ func TestFilterCollectorM2M(t *testing.T) {
 			assert.ElementsMatch(t, testCase.expectedResult, res.AllImages)
 		})
 	}
-
 }
 
 func setupFilterCollector_DiskToMirror(tempDir string, log clog.PluggableLoggerInterface) *FilterCollector {
@@ -591,13 +606,15 @@ func setupFilterCollector_DiskToMirror(tempDir string, log clog.PluggableLoggerI
 	}
 
 	ex := &FilterCollector{
-		OperatorCollector{Log: log,
+		OperatorCollector{
+			Log:              log,
 			Mirror:           &MockMirror{Fail: false},
 			Config:           nominalConfigD2M,
 			Manifest:         manifest,
 			Opts:             d2mOpts,
 			LocalStorageFQDN: "localhost:9999",
-			ctlgHandler:      handler},
+			ctlgHandler:      handler,
+		},
 	}
 
 	return ex
@@ -630,7 +647,8 @@ func setupFilterCollector_MirrorToDisk(tempDir string, log clog.PluggableLoggerI
 	}
 
 	ex := &FilterCollector{
-		OperatorCollector{Log: log,
+		OperatorCollector{
+			Log:              log,
 			Mirror:           &MockMirror{Fail: false},
 			Config:           nominalConfigM2D,
 			Manifest:         manifest,


### PR DESCRIPTION
# Description

Refactor the FilteredCollector for Operators so we can return errors in case we fail to collect some operator. We still try to collect all operators but we return all errors found at the end of collection.

Github / Jira issue: OCPBUGS-50680

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.