### PR TITLE
CLID-325: adds cpu and memory profiling / removes the race from build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,5 +117,5 @@ vet:
 
 build: 
 	mkdir -p $(GO_BUILD_BINDIR)
-	go build $(GO_MOD_FLAGS) $(GO_BUILD_FLAGS) $(GO_LD_FLAGS) -race -o $(GO_BUILD_BINDIR) ./...
+	go build $(GO_MOD_FLAGS) $(GO_BUILD_FLAGS) $(GO_LD_FLAGS) -o $(GO_BUILD_BINDIR) ./...
 .PHONY: build

--- a/cmd/oc-mirror/main.go
+++ b/cmd/oc-mirror/main.go
@@ -1,17 +1,86 @@
 package main
 
 import (
+	"os"
+	"runtime/pprof"
+	"slices"
+
 	"github.com/openshift/oc-mirror/pkg/cli/mirror"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 func main() {
+	cpuProfArg := slices.Contains(os.Args, "--cpu-prof")
+	memProfArg := slices.Contains(os.Args, "--mem-prof")
+
+	var cpuProfileFile, memProfileFile *os.File
+	var err error
+
+	if cpuProfArg {
+		cpuProfileFile, err = cpuProf()
+		defer stopCloseCpuProf(cpuProfileFile)
+		if err != nil {
+			stopCloseCpuProf(cpuProfileFile)
+			os.Exit(1)
+		}
+	}
+
 	rootCmd := mirror.NewMirrorCmd()
-	checkErr(rootCmd.Execute())
+	err = rootCmd.Execute()
+	if err != nil && cpuProfArg {
+		stopCloseCpuProf(cpuProfileFile)
+	}
+	checkErr(err)
+
+	if memProfArg {
+		memProfileFile, err = memProf()
+		defer memProfileFile.Close()
+		if err != nil {
+			memProfileFile.Close()
+			os.Exit(1)
+		}
+	}
 }
 
 func checkErr(err error) {
 	if err != nil {
 		kcmdutil.CheckErr(err)
 	}
+}
+
+func cpuProf() (*os.File, error) {
+	var cpuProfileFile *os.File
+	var err error
+
+	cpuProfileFile, err = os.Create("cpu.prof")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := pprof.StartCPUProfile(cpuProfileFile); err != nil {
+		return cpuProfileFile, err
+	}
+
+	return cpuProfileFile, nil
+}
+
+func stopCloseCpuProf(cpuProfileFile *os.File) {
+	pprof.StopCPUProfile()
+	cpuProfileFile.Close()
+}
+
+func memProf() (*os.File, error) {
+	var memProfileFile *os.File
+	var err error
+
+	memProfileFile, err = os.Create("mem.prof")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := pprof.WriteHeapProfile(memProfileFile); err != nil {
+		return memProfileFile, err
+	}
+
+	return memProfileFile, nil
 }

--- a/v2/hack/run_and_pprof.sh
+++ b/v2/hack/run_and_pprof.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+usage() {
+    echo "Usage: $0 [-m] [-c] [-d diff_base_file1 diff_base_file2] [-no-run] -- [oc-mirror args]"
+    echo "  -m       Enable memory profiling (--mem-prof)"
+    echo "  -c       Enable CPU profiling (--cpu-prof)"
+    echo "  -d diff_base_file1 diff_base_file2"
+    echo "           Specify two files for comparison with -diff_base"
+    echo "  -no-run  Skip running oc-mirror"
+    echo "  --       Delimit script arguments from oc-mirror arguments"
+    echo "  [oc-mirror args]       Arguments to be passed to oc-mirror"
+    exit 1
+}
+
+cleanup() {
+    if [[ ! -z $MEM_PROF_PID ]]; then
+        kill $MEM_PROF_PID
+        wait $MEM_PROF_PID 2>/dev/null
+    fi
+    if [[ ! -z $CPU_PROF_PID ]]; then
+        kill $CPU_PROF_PID
+        wait $CPU_PROF_PID 2>/dev/null
+    fi
+    if [[ ! -z $PROF_DIFF_PID ]]; then
+        kill $PROF_DIFF_PID
+        wait $PROF_DIFF_PID 2>/dev/null
+    fi
+}
+
+trap cleanup EXIT
+
+MEM_PROF=""
+CPU_PROF=""
+PROF_DIFF_FILES=()
+NO_RUN=false
+
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        -m)
+            MEM_PROF="--mem-prof"
+            shift
+            ;;
+        -c)
+            CPU_PROF="--cpu-prof"
+            shift
+            ;;
+        -d)
+            PROF_DIFF_FILES=("$2" "$3")
+            if [ ${#PROF_DIFF_FILES[@]} -ne 2 ]; then
+                usage
+            fi
+            PROF_DIFF="-diff_base=${PROF_DIFF_FILES[0]} ${PROF_DIFF_FILES[1]}"
+            shift
+            shift
+            shift
+            ;;
+        -no-run)
+            NO_RUN=true
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+if [[ $NO_RUN == false && $# -eq 0 ]]; then
+    usage
+fi
+
+if [[ $NO_RUN == false ]]; then
+    ./bin/oc-mirror $@ $MEM_PROF $CPU_PROF
+else
+    echo "Skipping oc-mirror execution as per no-run option."
+fi
+
+if [[ ! -z $MEM_PROF ]]; then
+    go tool pprof -http=:6775 mem.prof &
+    MEM_PROF_PID=$!
+fi
+
+if [[ ! -z $CPU_PROF ]]; then
+    go tool pprof -http=:6776 cpu.prof &
+    CPU_PROF_PID=$!
+fi
+
+if [[ ! -z $PROF_DIFF ]]; then
+    go tool pprof -http=:6777 $PROF_DIFF &
+    PROF_DIFF_PID=$!
+fi
+
+wait

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -264,6 +264,8 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.Global.V2, "v2", false, "Redirect the flow to oc-mirror v2 - This is Tech Preview, it is still under development and it is not production ready")
 	cmd.PersistentFlags().UintVar(&opts.ParallelLayerImages, "parallel-layers", maxParallelLayerDownloads, "Indicates the number of image layers mirrored in parallel")
 	cmd.PersistentFlags().UintVar(&opts.ParallelImages, "parallel-images", maxParallelImageDownloads, "Indicates the number of images mirrored in parallel")
+	cmd.PersistentFlags().BoolVar(&opts.Global.CpuProf, "cpu-prof", false, "Enable CPU profiling")
+	cmd.PersistentFlags().BoolVar(&opts.Global.MemProf, "mem-prof", false, "Enable Memory profiling")
 	cmd.PersistentFlags().AddFlagSet(&flagSharedOpts)
 	cmd.PersistentFlags().AddFlagSet(&flagRetryOpts)
 	cmd.PersistentFlags().AddFlagSet(&flagDepTLS)
@@ -318,6 +320,8 @@ func HideFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().MarkHidden("src-shared-blob-dir")
 	cmd.PersistentFlags().MarkHidden("src-username")
 	cmd.PersistentFlags().MarkHidden("parallel-batch-images")
+	cmd.PersistentFlags().MarkHidden("cpu-prof")
+	cmd.PersistentFlags().MarkHidden("mem-prof")
 }
 
 // Validate - cobra validation

--- a/v2/internal/pkg/mirror/options.go
+++ b/v2/internal/pkg/mirror/options.go
@@ -46,6 +46,8 @@ type GlobalOptions struct {
 	Quiet              bool          // Suppress output information when copying images
 	Force              bool          // Force the copy/mirror even if there is nothing to update
 	V2                 bool          // Redirect the flow to oc-mirror v2 - PLEASE DO NOT USE that. V2 is still under development and it is not ready to be used.
+	CpuProf            bool          // Enable CPU profiling
+	MemProf            bool          // Enable Memory profiling
 	MaxNestedPaths     int           // Sets the maximum allowed path-components on the destination registry
 	StrictArchiving    bool          // If set, generates archives that are strictly less than `archiveSize`, failing for files that exceed that limit.
 	SinceString        string        // Sets the date since which all content mirrored after is included in the archive


### PR DESCRIPTION
# Description

This PR removes the `-race` from the build target on the Make file to improve the performance.

Also this PR adds the cpu and memory profiling. Both profiles are enabled by using `--cpu-prof` and `--mem-prof` flags during the workflows (m2m/d2m/m2m).

Two new profile files are generated at the same place where the command line was run named `cpu.prof` and `mem.prof`. Both files will be used by the new bash script command `run_and_pprof.sh` added under `v2/hack/`.

The bash script will launch a web browser on `127.0.0.1:6775` for cpu profiling, `127.0.0.1:6776` for mem profiling and `127.0.0.1:6775` for diff profiling, where the graphs can be analysed. 

In the web browser it is possible to filter the graphs, for example by `focus`, `ignore` or `show_from`. These filters the graph only for specific areas of the code or ignore some specific area. They accept the package name, the file name or a regex.

In order to check performance improvements the bash script contains a `-d` option where it is possible to compare two profiles of the same kind.

See more flags available [here](https://github.com/google/pprof/blob/main/doc/README.md).

Github / Jira issue: [CLID-325](https://issues.redhat.com/browse/CLID-325)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Run an oc-mirror flow by using the bash script:

```
Usage: ./v2/hack/run_and_pprof.sh [-m] [-c] [-d diff_base_file1 diff_base_file2] [-no-run] -- [oc-mirror args]
  -m       Enable memory profiling (--mem-prof)
  -c       Enable CPU profiling (--cpu-prof)
  -d diff_base_file1 diff_base_file2
           Specify two files for comparison with -diff_base
  -no-run  Skip running oc-mirror
  --       Delimit script arguments from oc-mirror arguments
  [oc-mirror args]       Arguments to be passed to oc-mirror
```

```
./v2/hack/run_and_pprof.sh -m -c -- -c ./alex-tests/alex-isc/isc.yaml file://alex-tests/pprof --v2
```

## Expected Outcome
* collector phase is faster
* The web browser should open with the graphs based on the profiling specified (`-c`, `-m`, `-d`).