### PR TITLE
no-jira: stop `wraperr` linter from treating our code as external lib

### DIFF
--- a/v2/.golangci.yaml
+++ b/v2/.golangci.yaml
@@ -122,3 +122,7 @@ linters-settings:
 
   goconst:
     ignore-tests: true
+
+  wrapcheck:
+    ignorePackageGlobs:
+      - github.com/openshift/oc-mirror/v2/*


### PR DESCRIPTION
# Description

We just want to check for error wrapping in errors coming from external libs, not our own code (for now).

This should avoid unnecessary around wrapping our own errors.

Github / Jira issue: 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
No `wrapcheck` lint errors from our own code.