### PR TITLE
OCPBUGS-52588: fix: error when no related image was found

### DIFF
--- a/v2/internal/pkg/operator/catalog_handler.go
+++ b/v2/internal/pkg/operator/catalog_handler.go
@@ -221,6 +221,11 @@ func (o catalogHandler) getRelatedImagesFromCatalog(dc *declcfg.DeclarativeConfi
 		}
 		relatedImages[bundle.Name] = ris
 	}
+
+	if len(relatedImages) == 0 {
+		errs = append(errs, errors.New("no related images found"))
+	}
+
 	return relatedImages, errors.Join(errs...)
 }
 


### PR DESCRIPTION
# Description

If no related was found for a catalog, the collection for this catalog should fail instead of passing as it is currently happening.

Github / Jira issue: [OCPBUGS-52588](https://issues.redhat.com/browse/OCPBUGS-52588)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

With the following ImageSetConfiguration (which contains only one invalid operator):

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.17
      packages:
       - name: netscaler-operator 
```

## Expected Outcome
`m2d` should fail:

```
aguidi@fedora:~/go/src/github.com/aguidirh/oc-mirror$ ./bin/oc-mirror -c ./alex-tests/alex-isc/ocpbugs/ocpbugs-52588.yaml file://alex-tests/ocpbugs-52588 --v2

2025/03/10 17:21:52  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/03/10 17:21:52  [INFO]   : ⚙️  setting up the environment for you...
2025/03/10 17:21:52  [INFO]   : 🔀 workflow mode: mirrorToDisk 
2025/03/10 17:21:52  [INFO]   : 🕵  going to discover the necessary images...
2025/03/10 17:21:52  [INFO]   : 🔍 collecting release images...
2025/03/10 17:21:52  [INFO]   : 🔍 collecting operator images...
 ✗   (1m21s) Collecting catalog registry.redhat.io/redhat/redhat-operator-index:v4.17 
2025/03/10 17:23:14  [INFO]   : 👋 Goodbye, thank you for using oc-mirror
2025/03/10 17:23:14  [ERROR]  : collect catalog "registry.redhat.io/redhat/redhat-operator-index:v4.17": no related images found 
```

`m2m` should fail: 

```
aguidi@fedora:~/go/src/github.com/aguidirh/oc-mirror$ ./bin/oc-mirror -c ./alex-tests/alex-isc/ocpbugs/ocpbugs-52588.yaml --workspace file://alex-tests/ocpbugs-52588 docker://localhost:6000 --dest-tls-verify=false --v2

2025/03/10 17:25:58  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/03/10 17:25:58  [INFO]   : ⚙️  setting up the environment for you...
2025/03/10 17:25:58  [INFO]   : 🔀 workflow mode: mirrorToMirror 
2025/03/10 17:25:58  [INFO]   : 🕵  going to discover the necessary images...
2025/03/10 17:25:58  [INFO]   : 🔍 collecting release images...
2025/03/10 17:25:58  [INFO]   : 🔍 collecting operator images...
 ✗   (1m4s) Collecting catalog registry.redhat.io/redhat/redhat-operator-index:v4.17 
2025/03/10 17:27:03  [INFO]   : 👋 Goodbye, thank you for using oc-mirror
2025/03/10 17:27:03  [ERROR]  : collect catalog "registry.redhat.io/redhat/redhat-operator-index:v4.17": no related images found 
```