### PR TITLE
OCPBUGS-52960: v2: fix setting version during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ include $(addprefix ${GOMODCACHE}/${BUILD_MACHINERY_PATH}@${BUILD_MACHINERY_VERS
 	targets/openshift/deps-gomod.mk \
 )
 
-GO_LD_EXTRAFLAGS=$(call version-ldflags,github.com/openshift/oc-mirror/v2/pkg/version)
+GO_LD_EXTRAFLAGS=$(call version-ldflags,github.com/openshift/oc-mirror/v2/internal/pkg/version)
 
 GO_MOD_FLAGS = -mod=readonly
 GO_BUILD_PACKAGES := ./cmd/...


### PR DESCRIPTION
# Description

We were specifying the wrong path to the `version` pkg during build, resulting in the `oc-mirror --v2 version` command having no version info:

```
❯ ./bin/oc-mirror --v2 version

2025/03/11 13:27:13  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/03/11 13:27:13  [INFO]   : ⚙️  setting up the environment for you...
WARNING: This version information is deprecated and will be replaced with the output from --short. Use --output=yaml|json to get the full version.
Client Version: version.Info{Major:"", Minor:"", GitVersion:"v0.0.0-unknown", GitCommit:"", GitTreeState:"", BuildDate:"", GoVersion:"go1.23.6", Compiler:"gc", Platform:"linux/amd64"}
```


Github / Jira issue: OCPBUGS-52960

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

```
oc-mirror --v2 version
```

## Expected Outcome

Version info in the output:
```
❯ ./bin/oc-mirror --v2 version

2025/03/11 13:28:13  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/03/11 13:28:13  [INFO]   : ⚙️  setting up the environment for you...
WARNING: This version information is deprecated and will be replaced with the output from --short. Use --output=yaml|json to get the full version.
Client Version: version.Info{Major:"", Minor:"", GitVersion:"v0.0.0-unknown-40a885eb", GitCommit:"40a885eb", GitTreeState:"clean", BuildDate:"2025-03-11T12:27:49Z", GoVersion:"go1.23.6", Compiler:"gc", Platform:"linux/amd64"}
```