### PR TITLE
OCPBUGS-52969: remove TechPreview mentions of v2 in --help

### DIFF
--- a/pkg/cli/mirror/options.go
+++ b/pkg/cli/mirror/options.go
@@ -58,8 +58,8 @@ func (o *MirrorOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.DryRun, "dry-run", o.DryRun, "Print actions without mirroring images")
 	fs.BoolVar(&o.SourceSkipTLS, "source-skip-tls", o.SourceSkipTLS, "Disable TLS validation for source registry")
 	fs.BoolVar(&o.DestSkipTLS, "dest-skip-tls", o.DestSkipTLS, "Disable TLS validation for destination registry")
-	fs.BoolVar(&o.V2, "v2", o.V2, "Redirect the flow to oc-mirror v2 - This is Tech Preview, it is still under development and it is not production ready.")
-	fs.BoolVar(&o.V1, "v1", o.V1, "Redirect the flow to oc-mirror v1 - This flag is going to redirect the flow to v1 (legacy code) when v2 becomes the default (still under development).")
+	fs.BoolVar(&o.V2, "v2", o.V2, "Redirect the flow to oc-mirror v2")
+	fs.BoolVar(&o.V1, "v1", o.V1, "Redirect the flow to oc-mirror v1 (legacy code). Please migrate to v2")
 	fs.BoolVar(&o.SourcePlainHTTP, "source-use-http", o.SourcePlainHTTP, "Use plain HTTP for source registry")
 	fs.BoolVar(&o.DestPlainHTTP, "dest-use-http", o.DestPlainHTTP, "Use plain HTTP for destination registry")
 	fs.BoolVar(&o.SkipVerification, "skip-verification", o.SkipVerification, "Skip verifying the integrity of the retrieved content."+

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -261,7 +261,7 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.Global.WorkingDir, "workspace", "", "oc-mirror workspace where resources and internal artifacts are generated")
 	cmd.MarkPersistentFlagDirname("workspace")
 	cmd.PersistentFlags().Uint16VarP(&opts.Global.Port, "port", "p", 55000, "HTTP port used by oc-mirror's local storage instance")
-	cmd.PersistentFlags().BoolVar(&opts.Global.V2, "v2", false, "Redirect the flow to oc-mirror v2 - This is Tech Preview, it is still under development and it is not production ready")
+	cmd.PersistentFlags().BoolVar(&opts.Global.V2, "v2", false, "Redirect the flow to oc-mirror v2")
 	cmd.PersistentFlags().UintVar(&opts.ParallelLayerImages, "parallel-layers", maxParallelLayerDownloads, "Indicates the number of image layers mirrored in parallel")
 	cmd.PersistentFlags().UintVar(&opts.ParallelImages, "parallel-images", maxParallelImageDownloads, "Indicates the number of images mirrored in parallel")
 	cmd.PersistentFlags().BoolVar(&opts.Global.CpuProf, "cpu-prof", false, "Enable CPU profiling")


### PR DESCRIPTION
# Description

As of 4.18, oc-mirror --v2 is GA.

Github / Jira issue: 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

```
$ oc-mirror --help
$ oc-mirror --v2 --help
```

## Expected Outcome

No mentions of v2 being TechPreview.