### PR TITLE
CLID-351: Update Makefile for static build of oc-mirror binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ cross-build-linux-arm64:
 cross-build: cross-build-linux-amd64 cross-build-linux-ppc64le cross-build-linux-s390x cross-build-linux-arm64
 .PHONY: cross-build
 
+
 hack-build: clean
 	./hack/build.sh
 .PHONY: hack-build
@@ -119,3 +120,9 @@ build:
 	mkdir -p $(GO_BUILD_BINDIR)
 	go build $(GO_MOD_FLAGS) $(GO_BUILD_FLAGS) $(GO_LD_FLAGS) -o $(GO_BUILD_BINDIR) ./...
 .PHONY: build
+
+build-static:
+	mkdir -p $(GO_BUILD_BINDIR)
+	DISABLE_GO=1 go build $(GO_MOD_FLAGS) $(GO_BUILD_FLAGS) -ldflags="-extldflags=-static"  $(GO_LD_FLAGS) -o $(GO_BUILD_BINDIR) ./...
+.PHONY: build-static
+

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,5 @@ build:
 
 build-static:
 	mkdir -p $(GO_BUILD_BINDIR)
-	DISABLE_GO=1 go build $(GO_MOD_FLAGS) $(GO_BUILD_FLAGS) -ldflags="-extldflags=-static"  $(GO_LD_FLAGS) -o $(GO_BUILD_BINDIR) ./...
+	DISABLE_CGO=1 GO_ENABLED=0 go build $(GO_MOD_FLAGS) $(GO_BUILD_FLAGS) -ldflags="-extldflags=-static"  $(GO_LD_FLAGS) -o $(GO_BUILD_BINDIR) ./...
 .PHONY: build-static
-


### PR DESCRIPTION
# Description

Include static build in the Makefile recipe. This will be used in the integration testing container

Github / Jira issue:  [CLID-351](https://issues.redhat.com//browse/CLID-351)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Locally with integration container

## Expected Outcome
