### PR TITLE
OCPBUGS-54653: delete: continue on errors

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -981,6 +981,8 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 		// Except for release errors, we want to continue the image collection
 		// and return all errors at the end. These variables hold the errors
 		// found for each collection type.
+		// NOTE: that doesn't apply to `delete` which works on a best-effort basis
+		releaseErr       error
 		operatorErr      error
 		additionalImgErr error
 		helmErr          error
@@ -994,8 +996,11 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 	// collect releases
 	releaseImgs, err := o.Release.ReleaseImageCollector(ctx)
 	if err != nil {
-		// Release image errors are fatal: we don't want to continue collection when they happen.
-		return v2alpha1.CollectorSchema{}, &CollectionError{ReleaseErr: err}
+		if !o.Opts.IsDelete() {
+			// Release image errors are fatal: we don't want to continue collection when they happen.
+			return v2alpha1.CollectorSchema{}, &CollectionError{ReleaseErr: err}
+		}
+		releaseErr = err
 	}
 	// exclude blocked images
 	releaseImgs = excludeImages(releaseImgs, o.Config.Mirror.BlockedImages)
@@ -1060,8 +1065,9 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 
 	o.Log.Debug("collection time     : %v", time.Since(startTime))
 
-	if operatorErr != nil || additionalImgErr != nil || helmErr != nil {
-		return v2alpha1.CollectorSchema{}, &CollectionError{
+	if releaseErr != nil || operatorErr != nil || additionalImgErr != nil || helmErr != nil {
+		return collectorSchema, &CollectionError{
+			ReleaseErr:       releaseErr,
 			OperatorErr:      operatorErr,
 			AdditionalImgErr: additionalImgErr,
 			HelmErr:          helmErr,

--- a/v2/internal/pkg/delete/delete_images.go
+++ b/v2/internal/pkg/delete/delete_images.go
@@ -2,6 +2,7 @@ package delete
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -123,6 +124,7 @@ func (o DeleteImages) DeleteRegistryImages(deleteImageList v2alpha1.DeleteImageL
 		increment = 2
 	}
 
+	allErrs := []error{}
 	for _, img := range deleteImageList.Items {
 		// OCPBUGS-43489
 		// Verify that the "delete" destination is set correctly
@@ -131,17 +133,20 @@ func (o DeleteImages) DeleteRegistryImages(deleteImageList v2alpha1.DeleteImageL
 		// Reverts OCPBUGS-44448
 		imgSpecName, err := image.ParseRef(img.ImageName)
 		if err != nil {
-			return err
+			allErrs = append(allErrs, fmt.Errorf("parse image name %q: %w", img.ImageName, err))
+			continue
 		}
 		imgSpecRef, err := image.ParseRef(img.ImageReference)
 		if err != nil {
-			return err
+			allErrs = append(allErrs, fmt.Errorf("parse imag eref %q: %w", img.ImageReference, err))
+			continue
 		}
 		// remove dockerProtocol
 		name := strings.Split(o.Opts.Global.DeleteDestination, dockerProtocol)
 		// this should not occur - but just incase
 		if len(name) < 2 {
-			return fmt.Errorf("delete destination is not well formed (%s) - missing dockerProtocol?", o.Opts.Global.DeleteDestination)
+			allErrs = append(allErrs, fmt.Errorf("delete destination is not well formed (%s) - missing dockerProtocol?", o.Opts.Global.DeleteDestination))
+			continue
 		}
 		assembleName := name[1] + "/" + imgSpecName.PathComponent
 		// check image type for release or release content
@@ -153,7 +158,8 @@ func (o DeleteImages) DeleteRegistryImages(deleteImageList v2alpha1.DeleteImageL
 		}
 		// check the assembled name against the reference name
 		if assembleName != imgSpecRef.Name {
-			return fmt.Errorf("delete destination %s does not match values found in the delete-images yaml file (please verify full name)", o.Opts.Global.DeleteDestination)
+			allErrs = append(allErrs, fmt.Errorf("delete destination %s does not match values found in the delete-images yaml file (please verify full name)", o.Opts.Global.DeleteDestination))
+			continue
 		}
 		cis := v2alpha1.CopyImageSchema{
 			Origin:      img.ImageName,
@@ -189,10 +195,11 @@ func (o DeleteImages) DeleteRegistryImages(deleteImageList v2alpha1.DeleteImageL
 	if !o.Opts.Global.DeleteGenerate && len(o.Opts.Global.DeleteDestination) > 0 {
 		if _, err := o.Batch.Worker(context.Background(), collectorSchema, o.Opts); err != nil {
 			o.Log.Warn("error during registry deletion: %v", err)
+			allErrs = append(allErrs, err)
 		}
 	}
 
-	return nil
+	return errors.Join(allErrs...)
 }
 
 // ReadDeleteMetaData - read the list of images to delete


### PR DESCRIPTION
# Description

This change makes the delete command work on a best-effort basis: it will generate a file and delete the images it can and return all errors found at the end instead of stopping on the first error.

Github / Jira issue: OCPBUGS-54653

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

See PR comments.

## Expected Outcome

`oc-mirror --v2 delete` doesn't stop at the first failure.