### PR TITLE
OCPBUGS-54220: v2/imgbuilder: use --authfile when set

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1600,6 +1600,7 @@ github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXt
 github.com/fullstorydev/grpcurl v1.6.0/go.mod h1:ZQ+ayqbKMJNhzLmbpCiurTVlaK2M/3nqZCxaQ2Ze/sM=
 github.com/fullstorydev/grpcurl v1.8.9/go.mod h1:PNNKevV5VNAV2loscyLISrEnWQI61eqR0F8l3bVadAA=
 github.com/fullstorydev/grpcurl v1.9.1/go.mod h1:i8gKLIC6s93WdU3LSmkE5vtsCxyRmihUj5FK1cNW5EM=
+github.com/fvbommel/sortorder v1.1.0 h1:fUmoe+HLsBTctBDoaBwpQo5N+nrCp8g/BjKb/6ZQmYw=
 github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fxamacker/cbor/v2 v2.5.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fzipp/gocyclo v0.3.1/go.mod h1:DJHO6AUmbdqj2ET4Z9iArSuwWgYDRryYt2wASxc7x3E=
@@ -2389,7 +2390,6 @@ github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qq
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/rogpeppe/go-internal v1.6.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
-github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rqlite/gorqlite v0.0.0-20230708021416-2acd02b70b79/go.mod h1:xF/KoXmrRyahPfo5L7Szb5cAAUl53dMWBh9cMruGEZg=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.9.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
@@ -2442,8 +2442,6 @@ github.com/sherine-k/catalog-filter v0.0.1 h1:4XATs+3jzB+p/OQkikdxJePVigjlyRqbLh
 github.com/sherine-k/catalog-filter v0.0.1/go.mod h1:brrCOvEmD3aCujZVM6AVzPbHrJuBeFK9VMFnZED5ZcU=
 github.com/sherine-k/catalog-filter v0.0.2-0.20241126124527-d48d6997e9f2/go.mod h1:brrCOvEmD3aCujZVM6AVzPbHrJuBeFK9VMFnZED5ZcU=
 github.com/sherine-k/catalog-filter v0.0.2/go.mod h1:brrCOvEmD3aCujZVM6AVzPbHrJuBeFK9VMFnZED5ZcU=
-github.com/sherine-k/catalog-filter v0.0.4 h1:UWM3XaktjbvKw5ktC2NoxQLP+6KNbvaplwiAaVV411g=
-github.com/sherine-k/catalog-filter v0.0.4/go.mod h1:NQ667IgdlOYYHeLwppvrtm5TtYIn7b3CCyYKGT2e3rI=
 github.com/shibumi/go-pathspec v1.3.0/go.mod h1:Xutfslp817l2I1cZvgcfeMQJG5QnU2lh5tVaaMCl3jE=
 github.com/shirou/gopsutil/v3 v3.21.10/go.mod h1:t75NhzCZ/dYyPQjyQmrAYP6c8+LCdFANeBMdLPCNnew=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -38,6 +38,8 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
+require github.com/docker/cli v27.5.0+incompatible
+
 require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
@@ -72,7 +74,6 @@ require (
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/docker/cli v27.5.0+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker v27.5.0+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.8.2 // indirect

--- a/v2/internal/pkg/imagebuilder/builder.go
+++ b/v2/internal/pkg/imagebuilder/builder.go
@@ -13,9 +13,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	cimagetypesv5 "github.com/containers/image/v5/types"
+	"github.com/docker/cli/cli/config"
+	dockertypes "github.com/docker/cli/cli/config/types"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -52,15 +55,72 @@ func (e ErrInvalidReference) Error() string {
 	return fmt.Sprintf("target reference %q must have a tag reference", e.image)
 }
 
+type customKeyChain struct {
+	mu       sync.Mutex
+	authFile string
+}
+
+func newCustomKeyChain(authFile string) *customKeyChain {
+	return &customKeyChain{sync.Mutex{}, authFile}
+}
+
+// This is basically the defaultKeyChain from go-containerregistry but using a custom authfile
+func (ck *customKeyChain) Resolve(target authn.Resource) (authn.Authenticator, error) { //nolint:ireturn // as expected by go-containerregistry
+	ck.mu.Lock()
+	defer ck.mu.Unlock()
+
+	f, err := os.Open(ck.authFile)
+	if err != nil {
+		return nil, fmt.Errorf("open custom authfile: %w", err)
+	}
+	defer f.Close()
+	var empty dockertypes.AuthConfig
+	cf, err := config.LoadFromReader(f)
+	if err != nil {
+		return nil, fmt.Errorf("load custom auth file: %w", err)
+	}
+	for _, key := range []string{target.String(), target.RegistryStr()} {
+		if key == name.DefaultRegistry {
+			key = authn.DefaultAuthKey
+		}
+
+		cfg, err := cf.GetAuthConfig(key)
+		if err != nil {
+			return nil, fmt.Errorf("get creds from auth file: %w", err)
+		}
+		cfg.ServerAddress = ""
+		if cfg != empty {
+			return authn.FromConfig(authn.AuthConfig{
+				Username:      cfg.Username,
+				Password:      cfg.Password,
+				Auth:          cfg.Auth,
+				IdentityToken: cfg.IdentityToken,
+				RegistryToken: cfg.RegistryToken,
+			}), nil
+		}
+	}
+	return authn.Anonymous, nil
+}
+
 // NewImageBuilder creates a new instance of an ImageBuilder.
-func NewBuilder(logger log.PluggableLoggerInterface, opts mirror.CopyOptions) ImageBuilderInterface {
+func NewBuilder(logger log.PluggableLoggerInterface, opts mirror.CopyOptions) *ImageBuilder {
 	// preparing name options for pulling the ubi9 image:
 	// - no need to set defaultRegistry because we are using a fully qualified image name
 	nameOptions := []name.Option{
 		name.StrictValidation,
 	}
+	kcs := []authn.Keychain{}
+	if opts.DestImage != nil {
+		ctx, err := opts.DestImage.NewSystemContext()
+		if err == nil && ctx.AuthFilePath != "" {
+			// OCPBUGS-54220: make sure a custom authfile is picked up by go-containerregistry
+			kcs = append(kcs, newCustomKeyChain(ctx.AuthFilePath))
+		}
+	}
+	// this will try to find .docker/config first, $XDG_RUNTIME_DIR/containers/auth.json second
+	kcs = append(kcs, authn.DefaultKeychain)
 	remoteOptions := []remote.Option{
-		remote.WithAuthFromKeychain(authn.DefaultKeychain), // this will try to find .docker/config first, $XDG_RUNTIME_DIR/containers/auth.json second
+		remote.WithAuthFromKeychain(authn.NewMultiKeychain(kcs...)),
 		remote.WithContext(context.TODO()),
 		// doesn't seem possible to use registries.conf here.
 	}


### PR DESCRIPTION
# Description

Right now the go-containerregistry lib is using the default docker+podman locations. If oc-mirror is run with `--authfile` pointing to a custom location, it will be used for other images except the graph image.

This change adds a custom keychain with the contents of --authfile so it is picked up by go-containerregistry.

Fixes #1122

Github / Jira issue: OCPBUGS-54220

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?
m2m with `--authfile` set
```
unset DOCKER_CONFIG
unset REGISTRY_AUTH_FILE
rm -f ~/.docker/config.json ~/.config/containers/auth.json ${XDG_RUNTIME_DIR}/containers/auth.json
❯ ~/prjs/github.com/openshift/oc-mirror-return-values/bin/oc-mirror --v2 --config gisc.yaml --workspace file://data/pull-secret --authfile ~/prjs/oc-mirror/pull-secret.json docker://quay.io/<user>/<namespace>
[...]
 ✓   () graph-image:latest ➡️  docker://quay.io/<user>/<namespace>
```

## Expected Outcome

No authentication errors because the custom authfile is used.