### PR TITLE
OCPBUGS-55100: implements registries.d file as specified in containers/image docs

### DIFF
--- a/v2/internal/pkg/api/v2alpha1/type_internal.go
+++ b/v2/internal/pkg/api/v2alpha1/type_internal.go
@@ -210,7 +210,6 @@ type CollectorSchema struct {
 type CopyImageSchemaMap struct {
 	OperatorsByImage map[string]map[string]struct{} // key is the origin image name and value is an array of operators' name
 	BundlesByImage   map[string]map[string]string   // key is the image name and value is the bundle name
-	RegistriesHost   map[string]struct{}
 }
 
 // CopyImageSchema

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
 	"slices"
 	"sort"
 	"strconv"
@@ -774,8 +773,10 @@ func (o *ExecutorSchema) RunMirrorToDisk(cmd *cobra.Command, args []string) erro
 		return err
 	}
 
+	regs := mandatoryRegistries(o.Opts)
+
 	if !o.Opts.RemoveSignatures {
-		if err := registriesd.PrepareRegistrydCustomDir(o.Opts.Global.WorkingDir, o.Opts.Global.RegistriesDirPath, collectorSchema.CopyImageSchemaMap.RegistriesHost); err != nil {
+		if err := registriesd.PrepareRegistrydCustomDir(o.Opts.Global.WorkingDir, o.Opts.Global.RegistriesDirPath, regs); err != nil {
 			return err
 		}
 	}
@@ -824,8 +825,10 @@ func (o *ExecutorSchema) RunMirrorToMirror(cmd *cobra.Command, args []string) er
 		return err
 	}
 
+	regs := mandatoryRegistries(o.Opts)
+
 	if !o.Opts.RemoveSignatures {
-		if err := registriesd.PrepareRegistrydCustomDir(o.Opts.Global.WorkingDir, o.Opts.Global.RegistriesDirPath, collectorSchema.CopyImageSchemaMap.RegistriesHost); err != nil {
+		if err := registriesd.PrepareRegistrydCustomDir(o.Opts.Global.WorkingDir, o.Opts.Global.RegistriesDirPath, regs); err != nil {
 			return err
 		}
 	}
@@ -905,8 +908,10 @@ func (o *ExecutorSchema) RunDiskToMirror(cmd *cobra.Command, args []string) erro
 		return err
 	}
 
+	regs := mandatoryRegistries(o.Opts)
+
 	if !o.Opts.RemoveSignatures {
-		if err := registriesd.PrepareRegistrydCustomDir(o.Opts.Global.WorkingDir, o.Opts.Global.RegistriesDirPath, collectorSchema.CopyImageSchemaMap.RegistriesHost); err != nil {
+		if err := registriesd.PrepareRegistrydCustomDir(o.Opts.Global.WorkingDir, o.Opts.Global.RegistriesDirPath, regs); err != nil {
 			return err
 		}
 	}
@@ -1079,14 +1084,6 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 
 	collectorSchema.AllImages = allRelatedImages
 
-	if !o.Opts.RemoveSignatures {
-		if regHostMap, err := getRegistries(&collectorSchema); err == nil {
-			collectorSchema.CopyImageSchemaMap.RegistriesHost = regHostMap
-		} else {
-			return v2alpha1.CollectorSchema{}, err
-		}
-	}
-
 	o.Log.Debug("collection time     : %v", time.Since(startTime))
 
 	if operatorErr != nil || additionalImgErr != nil || helmErr != nil {
@@ -1239,54 +1236,15 @@ func exitCodeFromError(err error) int {
 	return errcode.GenericErr
 }
 
-func getRegistries(collectorSchema *v2alpha1.CollectorSchema) (map[string]struct{}, error) {
-	if regHostMap, err := registryHostMap(&collectorSchema.AllImages); err != nil {
-		return nil, err
-	} else {
-		if reflect.ValueOf(collectorSchema.CopyImageSchemaMap).IsZero() {
-			collectorSchema.CopyImageSchemaMap = v2alpha1.CopyImageSchemaMap{}
-		}
-		return regHostMap, nil
-	}
-}
+func mandatoryRegistries(opts *mirror.CopyOptions) map[string]struct{} {
+	regs := make(map[string]struct{})
+	regs[opts.LocalStorageFQDN] = struct{}{}
+	regs["default"] = struct{}{}
 
-func registryHostMap(allImages *[]v2alpha1.CopyImageSchema) (map[string]struct{}, error) {
-	var errs []error
-	registriesHost := make(map[string]struct{})
-
-	for _, image := range *allImages {
-		var srcHost, destHost string
-		var err error
-
-		if !isDiskDestination(image.Source) {
-			if srcHost, err = extractHostName(image.Source); err != nil {
-				errs = append(errs, err)
-			} else {
-				registriesHost[srcHost] = struct{}{}
-			}
-		}
-
-		if !isDiskDestination(image.Destination) {
-			if destHost, err = extractHostName(image.Destination); err != nil {
-				errs = append(errs, err)
-			} else {
-				registriesHost[destHost] = struct{}{}
-			}
-		}
+	if !opts.IsMirrorToDisk() {
+		dest, _ := strings.CutPrefix(opts.Destination, consts.DockerProtocol)
+		regs[dest] = struct{}{}
 	}
 
-	return registriesHost, errors.Join(errs...)
-}
-
-func extractHostName(path string) (string, error) {
-	ref, err := image.ParseRef(path)
-	if err == nil {
-		return ref.Domain, nil
-	} else {
-		return "", fmt.Errorf("error extracting host name: %w", err)
-	}
-}
-
-func isDiskDestination(registryURL string) bool {
-	return strings.HasPrefix(registryURL, consts.FileProtocol) || strings.HasPrefix(registryURL, consts.DirProtocol) || strings.HasPrefix(registryURL, consts.Oci)
+	return regs
 }

--- a/v2/internal/pkg/registriesd/error.go
+++ b/v2/internal/pkg/registriesd/error.go
@@ -1,0 +1,13 @@
+package registriesd
+
+import (
+	"fmt"
+)
+
+type configUnmarshalError struct {
+	err error
+}
+
+func (e configUnmarshalError) Error() string {
+	return fmt.Sprintf("registriesd config unmarshal error: %s", e.err)
+}

--- a/v2/internal/pkg/registriesd/registriesd.go
+++ b/v2/internal/pkg/registriesd/registriesd.go
@@ -11,6 +11,8 @@ import (
 	"github.com/containers/storage/pkg/fileutils"
 	"github.com/otiai10/copy"
 	"sigs.k8s.io/yaml"
+
+	"github.com/openshift/oc-mirror/v2/internal/pkg/parser"
 )
 
 const (
@@ -164,14 +166,10 @@ func loadRegistryConfigFiles(customizableRegistriesDir string) ([]registryConfig
 		}
 
 		filePath := filepath.Join(customizableRegistriesDir, file.Name())
-		configFileBytes, err := os.ReadFile(filePath)
-		if err != nil {
-			return nil, fmt.Errorf("error reading registry config file %w", err)
-		}
 
 		var registryConfigStruct registryConfiguration
-		if err = yaml.Unmarshal(configFileBytes, &registryConfigStruct); err != nil {
-			return nil, configUnmarshalError{err: fmt.Errorf("error unmarshaling registriesd config file %w", err)}
+		if registryConfigStruct, err = parser.ParseYamlFile[registryConfiguration](filePath); err != nil {
+			return nil, configUnmarshalError{err: err}
 		}
 		configFiles = append(configFiles, registryConfigStruct)
 	}

--- a/v2/internal/pkg/registriesd/types.go
+++ b/v2/internal/pkg/registriesd/types.go
@@ -2,14 +2,15 @@ package registriesd
 
 type registryConfiguration struct {
 	// The key is a namespace, using fully-expanded Docker reference format or parent namespaces (per dockerReference.PolicyConfiguration*),
-	Docker map[string]registryNamespace `json:"docker"`
+	Docker        map[string]registryNamespace `json:"docker,omitempty"`
+	DefaultDocker *registryNamespace           `json:"default-docker,omitempty"`
 }
 
 // registryNamespace defines lookaside locations for a single namespace.
 type registryNamespace struct {
-	Lookaside              string `json:"lookaside"`                // For reading, and if LookasideStaging is not present, for writing.
-	LookasideStaging       string `json:"lookaside-staging"`        // For writing only.
-	SigStore               string `json:"sigstore"`                 // For compatibility, deprecated in favor of Lookaside.
-	SigStoreStaging        string `json:"sigstore-staging"`         // For compatibility, deprecated in favor of LookasideStaging.
-	UseSigstoreAttachments bool   `json:"use-sigstore-attachments"` // originally , this had omitempty, so the type was *bool
+	Lookaside              string `json:"lookaside,omitempty"`         // For reading, and if LookasideStaging is not present, for writing.
+	LookasideStaging       string `json:"lookaside-staging,omitempty"` // For writing only.
+	SigStore               string `json:"sigstore,omitempty"`          // For compatibility, deprecated in favor of Lookaside.
+	SigStoreStaging        string `json:"sigstore-staging,omitempty"`  // For compatibility, deprecated in favor of LookasideStaging.
+	UseSigstoreAttachments bool   `json:"use-sigstore-attachments"`    // originally , this had omitempty, so the type was *bool
 }


### PR DESCRIPTION
# Description

This PR implements the signature mirroring mechanism as specified in the [containers/image docs](https://github.com/containers/image/blob/main/docs/containers-registries.d.5.md), which allows a more granular way of disabling/enabling signature mirroring by transport, registry, namespace and image.

Github / Jira issue: [OCPBUGS-55100](https://issues.redhat.com/browse/OCPBUGS-55100)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

With the following ImageSetConfiguration:

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  platform:
    channels:
    - name: stable-4.18
      minVersion: 4.18.1
      maxVersion: 4.18.1
    graph: true
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
      packages:
       - name: aws-load-balancer-operator
  additionalImages: 
   - name: quay.io/rh_ee_aguidi/multi-platform-container:latest
   - name: quay.io/rh_ee_aguidi/empty-image:latest
  helm:
    repositories:
      - name: cosigned
        url: https://sigstore.github.io/helm-charts
        charts:
          - name: cosigned
            version: 0.1.23
```

And with the following gcr.io.yaml on $HOME/.config/containers/registries.d/

```
docker:
     gcr.io:
         use-sigstore-attachments: false
```

Run m2d/d2m or m2m.

## Expected Outcome
All the images should have signatures, except the ones disabled by configuration (coming from gcr.io `projectsigstore/cosigned` and `projectsigstore/policy-webhook`) and the rebuilt images (catalog image and graph image).