### PR TITLE
OCPBUGS-55966: v2/archive: print unarchive progress

### DIFF
--- a/v2/internal/pkg/archive/unarchive.go
+++ b/v2/internal/pkg/archive/unarchive.go
@@ -33,7 +33,6 @@ func NewArchiveExtractor(archivePath, workingDir, cacheDir string) (MirrorUnArch
 		return MirrorUnArchiver{}, err
 	}
 	for _, chunk := range files {
-
 		if rxp.MatchString(chunk.Name()) {
 			ae.archiveFiles = append(ae.archiveFiles, filepath.Join(archivePath, chunk.Name()))
 		}
@@ -45,82 +44,96 @@ func NewArchiveExtractor(archivePath, workingDir, cacheDir string) (MirrorUnArch
 // * docker/v2* to cacheDir
 // * working-dir to workingDir
 func (o MirrorUnArchiver) Unarchive() error {
+	// make sure workingDir exists
+	if err := os.MkdirAll(o.workingDir, 0755); err != nil {
+		return fmt.Errorf("unable to create working dir %q: %w", o.workingDir, err)
+	}
+	// make sure cacheDir exists
+	if err := os.MkdirAll(o.cacheDir, 0755); err != nil {
+		return fmt.Errorf("unable to create cache dir %q: %w", o.cacheDir, err)
+	}
+
 	for _, chunkPath := range o.archiveFiles {
-		chunkFile, err := os.Open(chunkPath)
-		if err != nil {
+		if err := o.unarchiveChunkTarFile(chunkPath); err != nil {
 			return err
 		}
-		defer chunkFile.Close()
-		reader := tar.NewReader(chunkFile)
-		// make sure workingDir exists
-		err = os.MkdirAll(o.workingDir, 0755)
+	}
+
+	return nil
+}
+
+func (o MirrorUnArchiver) unarchiveChunkTarFile(chunkPath string) error {
+	chunkFile, err := os.Open(chunkPath)
+	if err != nil {
+		return fmt.Errorf("unable to open chunk tar file: %w", err)
+	}
+	defer chunkFile.Close()
+	workingDirParent := filepath.Dir(o.workingDir)
+	reader := tar.NewReader(chunkFile)
+	for {
+		header, err := reader.Next()
+
+		// break the infinite loop when EOF
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
 		if err != nil {
-			return fmt.Errorf(errMessageFolder, o.workingDir, err)
+			return fmt.Errorf("error reading archive %s: %w", chunkFile.Name(), err)
 		}
-		// make sure cacheDir exists
-		err = os.MkdirAll(o.cacheDir, 0755)
-		if err != nil {
-			return fmt.Errorf(errMessageFolder, o.cacheDir, err)
+
+		if header == nil {
+			continue
 		}
-		for {
-			header, err := reader.Next()
 
-			// break the infinite loop when EOF
-			if errors.Is(err, io.EOF) {
-				break
-			}
-
-			if err != nil {
-				return fmt.Errorf("error reading archive %s: %v", chunkFile.Name(), err)
-			}
-
-			if header == nil {
-				continue
-			}
-			// taking only files into account
-			// because we are considering that all parent folders will be
-			// created recursively, and that, to the best of our knowledge
-			// the archive doesn't include any symbolic links
-
-			// for the moment we ignore imageSetConfig that is
-			// included in the tar
-			// as well as any other files that are not
-			// working-dir or cache
-
-			if header.Typeflag == tar.TypeReg {
-				descriptor := ""
-				// case file belongs to working-dir
-				if strings.Contains(header.Name, workingDirectory) {
-					workingDirParent := filepath.Dir(o.workingDir)
-					descriptor = filepath.Join(workingDirParent, header.Name)
-				} else if strings.Contains(header.Name, cacheFilePrefix) {
-					// case file belongs to the cache
-					descriptor = filepath.Join(o.cacheDir, header.Name)
-				} else {
-					continue
-				}
-				// make sure all the parent directories exist
-				descriptorParent := filepath.Dir(descriptor)
-				if err := os.MkdirAll(descriptorParent, 0755); err != nil {
-					return fmt.Errorf(errMessageFolder, descriptorParent, err)
-				}
-				// if it's a file create it, making sure it's at least writable and executable by the user
-				// since with every UnArchive, we should be able to rewrite the file
-				f, err := os.OpenFile(descriptor, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode)|0755)
-				if err != nil {
-					return fmt.Errorf("unable to create file %s: %v", descriptor, err)
-				}
-				// copy  contents
-				if _, err := io.Copy(f, reader); err != nil {
-					return fmt.Errorf("error copying file %s: %v", descriptor, err)
-				}
-
-				// manually close here after each file operation; defering would cause each file close
-				// to wait until all operations have completed.
-				f.Close()
-
-			}
+		// taking only files into account because we are considering that all
+		// parent folders will be created recursively, and that, to the best of
+		// our knowledge the archive doesn't include any symbolic links
+		if header.Typeflag != tar.TypeReg {
+			continue
 		}
+
+		// for the moment we ignore imageSetConfig that is included in the tar
+		// as well as any other files that are not working-dir or cache
+
+		descriptor := ""
+		// case file belongs to working-dir
+		if strings.Contains(header.Name, workingDirectory) {
+			workingDirParent := filepath.Dir(o.workingDir)
+			descriptor = filepath.Join(workingDirParent, header.Name)
+		} else if strings.Contains(header.Name, cacheFilePrefix) {
+			// case file belongs to the cache
+			descriptor = filepath.Join(o.cacheDir, header.Name)
+		} else {
+			continue
+		}
+		// if it's a file create it
+		// make sure it's at least writable and executable by the user
+		// since with every UnArchive, we should be able to rewrite the file
+		if err := writeFile(descriptor, reader, header.FileInfo().Mode()|0755); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeFile(filePath string, reader *tar.Reader, perm os.FileMode) error {
+	// make sure all the parent directories exist
+	descriptorParent := filepath.Dir(filePath)
+	if err := os.MkdirAll(descriptorParent, 0755); err != nil {
+		return fmt.Errorf("unable to create parent directory for %s: %w", filePath, err)
+	}
+
+	f, err := os.OpenFile(filePath, os.O_CREATE|os.O_RDWR, perm)
+	if err != nil {
+		return fmt.Errorf("unable to create file %s: %w", filePath, err)
+	}
+	defer f.Close()
+
+	// copy  contents
+	if _, err := io.Copy(f, reader); err != nil {
+		return fmt.Errorf("error copying file %s: %w", filePath, err)
 	}
 
 	return nil

--- a/v2/internal/pkg/archive/unarchive_test.go
+++ b/v2/internal/pkg/archive/unarchive_test.go
@@ -46,11 +46,9 @@ func TestUnArchiver_UnArchive(t *testing.T) {
 
 		assert.DirExists(t, filepath.Join(testFolder, "dst", "working-dir"))
 		assert.DirExists(t, filepath.Join(testFolder, "dst", "cache-dir"))
-
 	})
 
 	t.Run("unarchive with 1 archive: should pass", func(t *testing.T) {
-
 		testFolder := t.TempDir()
 		defer os.RemoveAll(testFolder)
 
@@ -76,8 +74,9 @@ func TestUnArchiver_UnArchive(t *testing.T) {
 func TestUnArchiver_NoArchive(t *testing.T) {
 	testFolder := t.TempDir()
 	defer os.RemoveAll(testFolder)
-	o, err := NewArchiveExtractor(testFolder, "dst", "none")
-
+	workingDir := t.TempDir()
+	cacheDir := t.TempDir()
+	o, err := NewArchiveExtractor(testFolder, workingDir, cacheDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +104,7 @@ func TestUnArchiver_WorkingDirError(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = o.Unarchive()
-	assert.Equal(t, "unable to create folder /dst: mkdir /dst: permission denied", err.Error())
+	assert.Equal(t, "unable to create working dir \"/dst\": mkdir /dst: permission denied", err.Error())
 }
 
 func TestUnArchiver_CacheDirError(t *testing.T) {
@@ -126,7 +125,7 @@ func TestUnArchiver_CacheDirError(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = o.Unarchive()
-	assert.Equal(t, "unable to create folder /dst: mkdir /dst: permission denied", err.Error())
+	assert.Equal(t, "unable to create cache dir \"/dst\": mkdir /dst: permission denied", err.Error())
 }
 
 func prepareFakeTarWorkingDir(tarFile *os.File) error {
@@ -232,8 +231,8 @@ func prepareFakeTarCacheDir(tarFile *os.File) error {
 	}
 	tarWriter.Close()
 	return nil
-
 }
+
 func prepareFakeTar(tarFile *os.File) error {
 	err := prepareFakeTarWorkingDir(tarFile)
 	if err != nil {
@@ -241,5 +240,4 @@ func prepareFakeTar(tarFile *os.File) error {
 	}
 	err = prepareFakeTarCacheDir(tarFile)
 	return err
-
 }

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -880,6 +880,7 @@ func (o *ExecutorSchema) RunMirrorToMirror(cmd *cobra.Command, args []string) er
 // RunDiskToMirror execute the disk to mirror functionality
 func (o *ExecutorSchema) RunDiskToMirror(cmd *cobra.Command, args []string) error {
 	// extract the archive
+	o.Log.Info(emoji.Package + " Extracting mirror archive(s)...")
 	if err := o.MirrorUnArchiver.Unarchive(); err != nil {
 		o.Log.Error(" %v ", err)
 		return err


### PR DESCRIPTION
# Description
Populating the cache registry takes 2 hours for 300GBs of container content. This means oc-mirror v2 has no output on the CLI for 2 hours. Users see this as a stuck process.

Github / Jira issue: OCPBUGS-55966

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?
```
❯ ~/prjs/github.com/openshift/oc-mirror-return-values/v2/build/oc-mirror --config isc.yaml --from file://data/untar-progress docker://localhost:5000 --log-level debug
2025/05/09 02:08:27  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/05/09 02:08:27  [INFO]   : ⚙️  setting up the environment for you...
2025/05/09 02:08:27  [INFO]   : 🔀 workflow mode: diskToMirror 
2025/05/09 02:08:27  [DEBUG]  : helm.New opts.SrcImage.TlsVerify false
2025/05/09 02:08:27  [DEBUG]  : local storage registry will log to ~/prjs/oc-mirror/data/untar-progress/working-dir/logs/registry.log
2025/05/09 02:08:27  [INFO]   : 📦 Extracting mirror archive(s)...
data/untar-progress/mirror_000001.tar (28.3 GiB / 28.3 GiB) [==============================================================================================================================] 28s
data/untar-progress/mirror_000002.tar (28.3 GiB / 28.3 GiB) [==============================================================================================================================] 31s
2025/05/09 02:09:27  [DEBUG]  : starting local storage on localhost:55000
2025/05/09 02:09:27  [INFO]   : 🕵  going to discover the necessary images...
2025/05/09 02:09:27  [INFO]   : 🔍 collecting release images...
```

## Expected Outcome
Progress output durring mirror archive extraction.