### PR TITLE
OCPBUGS-56088: changes the signature mirroring default to disabled

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -270,7 +270,7 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 	cmd.Flags().IntVar(&opts.Global.MaxNestedPaths, "max-nested-paths", 0, "Number of nested paths, for destination registries that limit nested paths")
 	cmd.Flags().BoolVar(&opts.Global.StrictArchiving, "strict-archive", false, "If set, generates archives that are strictly less than archiveSize (set in the imageSetConfig). Mirroring will exit in error if a file being archived exceed archiveSize(GB)")
 	cmd.Flags().StringVar(&opts.RootlessStoragePath, "rootless-storage-path", "", "Override the default container rootless storage path (usually in etc/containers/storage.conf)")
-	cmd.Flags().BoolVar(&opts.RemoveSignatures, "remove-signatures", false, "Do not copy image signature")
+	cmd.Flags().BoolVar(&opts.RemoveSignatures, "remove-signatures", true, "Do not copy image signature")
 	HideFlags(cmd)
 
 	ex.Opts.Stdout = cmd.OutOrStdout()


### PR DESCRIPTION
# Description

Changes the signature mirroring default to disabled.

Fixes [OCPBUGS-56088](https://issues.redhat.com/browse/OCPBUGS-56088)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
./bin/oc-mirror --v2 --help
```

## Expected Outcome

```
--remove-signatures              Do not copy image signature (default true)
```