### PR TITLE
OCPBUGS-54443: v2/cli: always remove past archives before m2d

### DIFF
--- a/v2/internal/pkg/archive/archive.go
+++ b/v2/internal/pkg/archive/archive.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
@@ -31,7 +32,6 @@ type MirrorArchive struct {
 // any files that exceed the maxArchiveSize specified in the imageSetConfig will
 // cause the BuildArchive method to stop and return in error.
 func NewMirrorArchive(opts *mirror.CopyOptions, destination, iscPath, workingDir, cacheDir string, maxSize int64, logg clog.PluggableLoggerInterface) (*MirrorArchive, error) {
-
 	err := removePastArchives(destination)
 	if err != nil {
 		logg.Warn("unable to delete past archives from %s: %v", destination, err)
@@ -69,7 +69,6 @@ func NewMirrorArchive(opts *mirror.CopyOptions, destination, iscPath, workingDir
 // any files that exceed the maxArchiveSize specified in the imageSetConfig will
 // be added to standalone archives, and flagged in a warning at the end of the execution
 func NewPermissiveMirrorArchive(opts *mirror.CopyOptions, destination, iscPath, workingDir, cacheDir string, maxSize int64, logg clog.PluggableLoggerInterface) (*MirrorArchive, error) {
-
 	// create the history interface
 	history, err := history.NewHistory(workingDir, opts.Global.Since, logg, history.OSFileCreator{})
 	if err != nil {
@@ -192,17 +191,21 @@ func (o *MirrorArchive) addBlobsDiff(collectedBlobs, historyBlobs map[string]str
 }
 
 func removePastArchives(destination string) error {
-	_, err := os.Stat(destination)
-	if err == nil {
-		files, err := filepath.Glob(filepath.Join(destination, "mirror_*.tar"))
-		if err != nil {
-			return fmt.Errorf("error getting glob matches %w", err)
+	if _, err := os.Stat(destination); err != nil {
+		// Destination directory doesn't exist: no-op
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
 		}
-		for _, file := range files {
-			err := os.Remove(file)
-			if err != nil {
-				return fmt.Errorf("error removing files %w", err)
-			}
+		return fmt.Errorf("failed to get past archives: %w", err)
+	}
+	const globPat string = "mirror_*.tar"
+	files, err := filepath.Glob(filepath.Join(destination, globPat))
+	if err != nil {
+		return fmt.Errorf("error getting glob %q matches: %w", globPat, err)
+	}
+	for _, file := range files {
+		if err := os.Remove(file); err != nil {
+			return fmt.Errorf("error removing tar file: %w", err)
 		}
 	}
 	return nil

--- a/v2/internal/pkg/archive/archive.go
+++ b/v2/internal/pkg/archive/archive.go
@@ -32,10 +32,6 @@ type MirrorArchive struct {
 // any files that exceed the maxArchiveSize specified in the imageSetConfig will
 // cause the BuildArchive method to stop and return in error.
 func NewMirrorArchive(opts *mirror.CopyOptions, destination, iscPath, workingDir, cacheDir string, maxSize int64, logg clog.PluggableLoggerInterface) (*MirrorArchive, error) {
-	err := removePastArchives(destination)
-	if err != nil {
-		logg.Warn("unable to delete past archives from %s: %v", destination, err)
-	}
 	// create the history interface
 	history, err := history.NewHistory(workingDir, opts.Global.Since, logg, history.OSFileCreator{})
 	if err != nil {
@@ -190,7 +186,7 @@ func (o *MirrorArchive) addBlobsDiff(collectedBlobs, historyBlobs map[string]str
 	return blobsInDiff, nil
 }
 
-func removePastArchives(destination string) error {
+func RemovePastArchives(destination string) error {
 	if _, err := os.Stat(destination); err != nil {
 		// Destination directory doesn't exist: no-op
 		if errors.Is(err, fs.ErrNotExist) {

--- a/v2/internal/pkg/archive/archive_test.go
+++ b/v2/internal/pkg/archive/archive_test.go
@@ -281,12 +281,11 @@ func TestArchive_RemovePastMirrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.caseName, func(t *testing.T) {
-			err := removePastArchives(tc.destination)
+			err := RemovePastArchives(tc.destination)
 			if err != nil {
 				assert.Equal(t, tc.expectedError, err.Error())
 			} else if tc.expectedError != "" {
 				t.Fatal("should fail but passed instead")
-
 			}
 			if _, err := os.Stat(tc.destination); err == nil {
 				entries, err := os.ReadDir(tc.destination)

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -478,6 +478,9 @@ func (o *ExecutorSchema) Complete(args []string) error {
 	o.Batch = batch.New(batch.ChannelConcurrentWorker, o.Log, o.LogsDir, o.Mirror, o.Opts.ParallelImages)
 
 	if o.Opts.IsMirrorToDisk() {
+		if err := archive.RemovePastArchives(rootDir); err != nil {
+			return fmt.Errorf("unable to delete past archives from %s: %w", rootDir, err)
+		}
 		if o.Opts.Global.StrictArchiving {
 			o.MirrorArchiver, err = archive.NewMirrorArchive(o.Opts, rootDir, o.Opts.Global.ConfigPath, o.Opts.Global.WorkingDir, o.LocalStorageDisk, o.Config.ImageSetConfigurationSpec.ArchiveSize, o.Log)
 			if err != nil {


### PR DESCRIPTION
# Description

We were cleaning up past archives only when strict archiving was set. This could generate a situation where, after a first run when X archive files were created, the second run with a diff of Y archives, Y < X, would just overwrite the first Y archives but leave the remaining X-Y in the working dir. Running d2m would copy all the X archives, causing weird failures.

Github / Jira issue: OCPBUGS-54443

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

1. Run m2d
2. Copy `mirror_000001.tar` into `mirror_00000[2-5].tar`
3. Run m2d again and check that the tar files were deleted. 

## Expected Outcome

Archive files are deleted before m2d runs.