### PR TITLE
OCPBUGS-56117: Make v2 blockedImages use regular expressions

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"sort"
 	"strconv"
@@ -1178,11 +1179,18 @@ func excludeImages(images []v2alpha1.CopyImageSchema, excluded []v2alpha1.Image)
 		}
 		isInSlice := slices.ContainsFunc(excluded, func(excludedImage v2alpha1.Image) bool {
 			imgOrigin := image.Origin
+			imgDest := image.Destination
 			if strings.Contains(imgOrigin, "://") {
 				splittedImageOrigin := strings.Split(imgOrigin, "://")
 				imgOrigin = splittedImageOrigin[1]
 			}
-			return excludedImage.Name == imgOrigin
+			if strings.Contains(imgDest, "://") {
+				splittedImageDest := strings.Split(imgDest, "://")
+				imgDest = splittedImageDest[1]
+			}
+			matchesOrigin, _ := regexp.MatchString(excludedImage.Name, imgOrigin)
+			matchesDest, _ := regexp.MatchString(excludedImage.Name, imgDest)
+			return matchesOrigin || matchesDest
 		})
 		return isInSlice
 	})


### PR DESCRIPTION
# Description

This issue aligns functionality for `blockedImages` with v1, allowing the use of regular expressions for the selection of the images to exclude.

This alignment is important for [OCPSTRAT-1874](https://issues.redhat.com/browse/OCPSTRAT-1874), where the intention is to filter out from the release any components that are irrelevant to the use case such as cloud provider components. 

Because release components are referenced by digest, and that the destination image reference tag is the only one to contain the component name, the logic in `excludeImages` is checking both the origin and the destination references. 

Github / Jira issue: [OCPBUGS-56117](https://issues.redhat.com/browse/OCPBUGS-56117)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

With the imageSetConfig below , I performed a mirror to mirror in dry-run
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  platform:
    channels:
    - name: stable-4.18
    # release: registry.ci.openshift.org/ocp/release:4.19.0-0.ci-2025-05-12-074946
    blockedImages:
    - name: "(aws|gcp|azure|ibm|openstack)"

## Expected Outcome
mapping.txt generated doesn't contain aws, gcp, azure, etc images.

PS: @nidangavali 
* I haven't tested full workflows (m2m, m2d, d2m), 
* I haven' t tested regular expressions more than the one provided
* the scenario with `mirror.platform.release` replacing `mirror.platform.channels` cannot be tested yet, as blocked by OCPBUGS-56009, but this is specifically what the assisted installer team needs
