### PR TITLE
OCPBUGS-56009: Bug fix for no release signature found

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -271,6 +271,7 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.Global.StrictArchiving, "strict-archive", false, "If set, generates archives that are strictly less than archiveSize (set in the imageSetConfig). Mirroring will exit in error if a file being archived exceed archiveSize(GB)")
 	cmd.Flags().StringVar(&opts.RootlessStoragePath, "rootless-storage-path", "", "Override the default container rootless storage path (usually in etc/containers/storage.conf)")
 	cmd.Flags().BoolVar(&opts.RemoveSignatures, "remove-signatures", true, "Do not copy image signature")
+	cmd.Flags().BoolVar(&opts.Global.IgnoreReleaseSignature, "ignore-release-signature", false, "Ignore release signature")
 	HideFlags(cmd)
 
 	ex.Opts.Stdout = cmd.OutOrStdout()
@@ -311,6 +312,7 @@ func HideFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().MarkHidden("parallel-batch-images")
 	cmd.PersistentFlags().MarkHidden("cpu-prof")
 	cmd.PersistentFlags().MarkHidden("mem-prof")
+	cmd.PersistentFlags().MarkHidden("ignore-release-signature")
 }
 
 // Validate - cobra validation

--- a/v2/internal/pkg/mirror/options.go
+++ b/v2/internal/pkg/mirror/options.go
@@ -29,36 +29,37 @@ type ErrorShouldDisplayUsage struct {
 }
 
 type GlobalOptions struct {
-	LogLevel           string        // one of info, debug, trace
-	PolicyPath         string        // Path to a signature verification policy file
-	SecurePolicy       bool          // Use an "allow everything" signature verification policy
-	RegistriesDirPath  string        // Path to a "registries.d" registry configuration directory
-	OverrideArch       string        // Architecture to use for choosing images, instead of the runtime one
-	OverrideOS         string        // OS to use for choosing images, instead of the runtime one
-	OverrideVariant    string        // Architecture variant to use for choosing images, instead of the runtime one
-	CommandTimeout     time.Duration // Timeout for the command execution
-	RegistriesConfPath string        // Path to the "registries.conf" file
-	TmpDir             string        // Path to use for big temporary files
-	WorkingDir         string        // working directory
-	From               string        // local storage for diskToMirror workflow
-	Port               uint16        // HTTP port used by oc-mirror's local storage instance
-	ConfigPath         string        // Path to use for imagesetconfig
-	Quiet              bool          // Suppress output information when copying images
-	Force              bool          // Force the copy/mirror even if there is nothing to update
-	V2                 bool          // Redirect the flow to oc-mirror v2 - PLEASE DO NOT USE that. V2 is still under development and it is not ready to be used.
-	CpuProf            bool          // Enable CPU profiling
-	MemProf            bool          // Enable Memory profiling
-	MaxNestedPaths     int           // Sets the maximum allowed path-components on the destination registry
-	StrictArchiving    bool          // If set, generates archives that are strictly less than `archiveSize`, failing for files that exceed that limit.
-	SinceString        string        // Sets the date since which all content mirrored after is included in the archive
-	Since              time.Time     // Sets the date since which all content mirrored after is included in the archive
-	DeleteGenerate     bool          // Used to generate the delete-images.yaml file , mandatory fist step in the delete workflow
-	DeleteDestination  string        // Used primarily for delete - denotes the remote registry to delete from
-	ForceCacheDelete   bool          // Used to force delete the local cache
-	DeleteID           string        // This flag is used to append to the artifacts created by the delete functionality
-	DeleteYaml         string        // This flag will use the contents of the indicated yaml as basis to delete the local cache and remote registry
-	CacheDir           string        // Path to the cache directory
-	IsTerminal         bool          // Whether we're running in a terminal console or not
+	LogLevel               string        // one of info, debug, trace
+	PolicyPath             string        // Path to a signature verification policy file
+	SecurePolicy           bool          // Use an "allow everything" signature verification policy
+	RegistriesDirPath      string        // Path to a "registries.d" registry configuration directory
+	OverrideArch           string        // Architecture to use for choosing images, instead of the runtime one
+	OverrideOS             string        // OS to use for choosing images, instead of the runtime one
+	OverrideVariant        string        // Architecture variant to use for choosing images, instead of the runtime one
+	CommandTimeout         time.Duration // Timeout for the command execution
+	RegistriesConfPath     string        // Path to the "registries.conf" file
+	TmpDir                 string        // Path to use for big temporary files
+	WorkingDir             string        // working directory
+	From                   string        // local storage for diskToMirror workflow
+	Port                   uint16        // HTTP port used by oc-mirror's local storage instance
+	ConfigPath             string        // Path to use for imagesetconfig
+	Quiet                  bool          // Suppress output information when copying images
+	Force                  bool          // Force the copy/mirror even if there is nothing to update
+	V2                     bool          // Redirect the flow to oc-mirror v2 - PLEASE DO NOT USE that. V2 is still under development and it is not ready to be used.
+	CpuProf                bool          // Enable CPU profiling
+	MemProf                bool          // Enable Memory profiling
+	MaxNestedPaths         int           // Sets the maximum allowed path-components on the destination registry
+	StrictArchiving        bool          // If set, generates archives that are strictly less than `archiveSize`, failing for files that exceed that limit.
+	SinceString            string        // Sets the date since which all content mirrored after is included in the archive
+	Since                  time.Time     // Sets the date since which all content mirrored after is included in the archive
+	DeleteGenerate         bool          // Used to generate the delete-images.yaml file , mandatory fist step in the delete workflow
+	DeleteDestination      string        // Used primarily for delete - denotes the remote registry to delete from
+	ForceCacheDelete       bool          // Used to force delete the local cache
+	DeleteID               string        // This flag is used to append to the artifacts created by the delete functionality
+	DeleteYaml             string        // This flag will use the contents of the indicated yaml as basis to delete the local cache and remote registry
+	CacheDir               string        // Path to the cache directory
+	IsTerminal             bool          // Whether we're running in a terminal console or not
+	IgnoreReleaseSignature bool          // Ignore release signatures, used primarily for qe testing unpublished signatures
 }
 
 type CopyOptions struct {

--- a/v2/internal/pkg/release/signature.go
+++ b/v2/internal/pkg/release/signature.go
@@ -50,7 +50,6 @@ func NewSignatureClient(log clog.PluggableLoggerInterface, config v2alpha1.Image
 // GenerateReleaseSignatures
 func (o SignatureSchema) GenerateReleaseSignatures(ctx context.Context, images []v2alpha1.CopyImageSchema) ([]v2alpha1.CopyImageSchema, error) {
 	var imgs []v2alpha1.CopyImageSchema
-	var data []byte
 	// set up http object
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: false},
@@ -59,6 +58,7 @@ func (o SignatureSchema) GenerateReleaseSignatures(ctx context.Context, images [
 	httpClient := &http.Client{Transport: tr}
 
 	for _, img := range images {
+		var data []byte
 		imgSpec, err := image.ParseRef(img.Source)
 		if err != nil {
 			return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] parsing image digest")
@@ -68,132 +68,129 @@ func (o SignatureSchema) GenerateReleaseSignatures(ctx context.Context, images [
 		// OCPBUGS-56009
 		// not worrying about code complexity as this module will eventually be deprecated
 		// in favor of the cosign signature work
-		// nolint: nestif
 		if o.Opts.Global.IgnoreReleaseSignature && len(o.Config.Mirror.Platform.Release) > 0 {
 			imgs = append(imgs, img)
-		} else {
-			if digest != "" {
-				o.Log.Debug("signature digest %s", digest)
-				// check if the image is in the cache else
-				// do a lookup and download it to cache
-				sigFiles, err := os.ReadDir(o.Opts.Global.WorkingDir + SignatureDir)
-				if err != nil {
-					o.Log.Debug("[GenerateReleaseSignatures] no directory found for signatures %w", err)
-				}
-				for _, file := range sigFiles {
-					if strings.Contains(file.Name(), digest) {
-						data, err = os.ReadFile(o.Opts.Global.WorkingDir + SignatureDir + file.Name())
-						if err != nil {
-							o.Log.Warn("[GenerateReleaseSignatures] could not read %s %w", file.Name(), err)
-						}
-						break
-					}
-				}
-			} else {
-				return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] parsing image digest")
+			continue
+		}
+		// nolint: nestif
+		if digest != "" {
+			o.Log.Debug("signature digest %s", digest)
+			// check if the image is in the cache else
+			// do a lookup and download it to cache
+			sigFiles, err := os.ReadDir(o.Opts.Global.WorkingDir + SignatureDir)
+			if err != nil {
+				o.Log.Debug("[GenerateReleaseSignatures] no directory found for signatures %w", err)
 			}
-
-			// we dont have the current digest in cache
-			if len(data) == 0 {
-				// see above nolint comment
-				// nolint: noctx
-				req, _ := http.NewRequest("GET", SignatureURL+"sha256="+digest+"/signature-1", nil)
-				req.Header.Set(ContentType, ApplicationJson)
-				resp, err := httpClient.Do(req)
-				if err != nil {
-					return []v2alpha1.CopyImageSchema{}, fmt.Errorf("http request %w", err)
-				}
-				defer func() {
-					if resp != nil && resp.Body != nil {
-						resp.Body.Close()
-					}
-				}()
-				if resp.StatusCode == http.StatusOK {
-					o.Log.Debug("response from signature lookup %d", resp.StatusCode)
-					data, err = io.ReadAll(resp.Body)
+			for _, file := range sigFiles {
+				if strings.Contains(file.Name(), digest) {
+					data, err = os.ReadFile(o.Opts.Global.WorkingDir + SignatureDir + file.Name())
 					if err != nil {
-						return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] reading response body %w", err)
+						o.Log.Warn("[GenerateReleaseSignatures] could not read %s %w", file.Name(), err)
 					}
+					break
 				}
-			}
-
-			if len(data) > 0 {
-				pkBytes := []byte(o.pgpKey)
-
-				keyring, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(pkBytes))
-				// keyring, err := openpgp.ReadKeyRing(bytes.NewReader([]byte(pkBytes)))
-				if err != nil {
-					o.Log.Error("%v", err)
-				}
-				o.Log.Debug("keyring %v", keyring)
-
-				md, err := openpgp.ReadMessage(bytes.NewReader(data), keyring, nil, nil)
-				if err != nil {
-					o.Log.Error("%v could not read the message:", err)
-				}
-				if md == nil {
-					return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] unable to read signature message for %s image %s", digest, img.Source)
-				}
-				if !md.IsSigned {
-					return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] message was not signed for %s image %s", digest, img.Source)
-				}
-				if md.SignatureError != nil {
-					return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] signature error for %s image %s", digest, img.Source)
-				}
-				if md.SignedBy == nil {
-					return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] invalid signature for %s image %s", digest, img.Source)
-				}
-
-				// update the image with the actual reference from the contents json
-				signSchema, err := parser.ParseJsonReader[v2alpha1.SignatureContentSchema](md.UnverifiedBody)
-				if err != nil {
-					return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] unmarshal json %w", err)
-				}
-				img.Source = signSchema.Critical.Identity.DockerReference
-				o.Log.Debug("image found : %s", signSchema.Critical.Identity.DockerReference)
-
-				o.Log.Trace("field isEncrypted %v", md.IsEncrypted)
-				o.Log.Trace("field EencryptedToKeyIds %v", md.EncryptedToKeyIds)
-				o.Log.Trace("field IsSymmetricallyEncrypted %v", md.IsSymmetricallyEncrypted)
-				o.Log.Trace("field DecryptedWith %v", md.DecryptedWith)
-				o.Log.Trace("field IsSigned %v", md.IsSigned)
-				o.Log.Trace("field SignedByKeyId %v", md.SignedByKeyId)
-				o.Log.Trace("field SignedBy %v", md.SignedBy)
-				o.Log.Trace("field LiteralData %v", md.LiteralData)
-				o.Log.Trace("field SignatureError %v", md.SignatureError)
-				o.Log.Trace("field Signature %v", md.Signature)
-				// o.Log.Trace("field SignatureV3 %v", md.SignatureV3.IssuerKeyId)
-				// o.Log.Trace("field SignatureV3 %v", md.SignatureV3.CreationTime)
-
-				if md.Signature != nil {
-					if md.Signature.SigLifetimeSecs != nil {
-						expiry := md.Signature.CreationTime.Add(time.Duration(*md.Signature.SigLifetimeSecs) * time.Second)
-						if time.Now().After(expiry) {
-							o.Log.Debug("signature expired on %v ", expiry)
-						}
-					}
-				} else if md.SignatureV3 == nil {
-					return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] unexpected openpgp.MessageDetails: neither Signature nor SignatureV3 is set for %s image %s", digest, img.Source)
-				}
-
-				// write signature to cache
-				newImgSpec, err := image.ParseRef(img.Source)
-				if err != nil {
-					return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] could not parse identity docker reference image %w", err)
-				}
-				sigFilePath := fmt.Sprintf("%s%s/%s-sha256-%s", o.Opts.Global.WorkingDir, SignatureDir, newImgSpec.Tag, digest)
-				if _, err := os.Stat(sigFilePath); err != nil {
-					ferr := os.WriteFile(sigFilePath, data, 0600)
-					if ferr != nil {
-						return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] writing %w", ferr)
-					}
-				}
-				imgs = append(imgs, img)
-				data = nil
-			} else {
-				return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] no signature found for %s image %s", digest, img.Source)
 			}
 		}
+
+		// we dont have the current digest in cache
+		// nolint: nestif
+		if len(data) == 0 {
+			// see above nolint comment
+			req, _ := http.NewRequestWithContext(ctx, "GET", SignatureURL+"sha256="+digest+"/signature-1", nil)
+			req.Header.Set(ContentType, ApplicationJson)
+			resp, err := httpClient.Do(req)
+			if err != nil {
+				return []v2alpha1.CopyImageSchema{}, fmt.Errorf("http request %w", err)
+			}
+			defer func() {
+				if resp != nil && resp.Body != nil {
+					resp.Body.Close()
+				}
+			}()
+			if resp.StatusCode == http.StatusOK {
+				o.Log.Debug("response from signature lookup %d", resp.StatusCode)
+				data, err = io.ReadAll(resp.Body)
+				if err != nil {
+					return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] reading response body %w", err)
+				}
+			}
+		}
+
+		if len(data) == 0 {
+			return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] no signature found for %s image %s", digest, img.Source)
+		}
+
+		pkBytes := []byte(o.pgpKey)
+
+		keyring, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(pkBytes))
+		// keyring, err := openpgp.ReadKeyRing(bytes.NewReader([]byte(pkBytes)))
+		if err != nil {
+			o.Log.Error("%v", err)
+		}
+		o.Log.Debug("keyring %v", keyring)
+
+		md, err := openpgp.ReadMessage(bytes.NewReader(data), keyring, nil, nil)
+		if err != nil {
+			o.Log.Error("%v could not read the message:", err)
+		}
+		if md == nil {
+			return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] unable to read signature message for %s image %s", digest, img.Source)
+		}
+		if !md.IsSigned {
+			return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] message was not signed for %s image %s", digest, img.Source)
+		}
+		if md.SignatureError != nil {
+			return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] signature error for %s image %s", digest, img.Source)
+		}
+		if md.SignedBy == nil {
+			return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] invalid signature for %s image %s", digest, img.Source)
+		}
+
+		// update the image with the actual reference from the contents json
+		signSchema, err := parser.ParseJsonReader[v2alpha1.SignatureContentSchema](md.UnverifiedBody)
+		if err != nil {
+			return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] unmarshal json %w", err)
+		}
+		img.Source = signSchema.Critical.Identity.DockerReference
+		o.Log.Debug("image found : %s", signSchema.Critical.Identity.DockerReference)
+
+		o.Log.Trace("field isEncrypted %v", md.IsEncrypted)
+		o.Log.Trace("field EencryptedToKeyIds %v", md.EncryptedToKeyIds)
+		o.Log.Trace("field IsSymmetricallyEncrypted %v", md.IsSymmetricallyEncrypted)
+		o.Log.Trace("field DecryptedWith %v", md.DecryptedWith)
+		o.Log.Trace("field IsSigned %v", md.IsSigned)
+		o.Log.Trace("field SignedByKeyId %v", md.SignedByKeyId)
+		o.Log.Trace("field SignedBy %v", md.SignedBy)
+		o.Log.Trace("field LiteralData %v", md.LiteralData)
+		o.Log.Trace("field SignatureError %v", md.SignatureError)
+		o.Log.Trace("field Signature %v", md.Signature)
+		// o.Log.Trace("field SignatureV3 %v", md.SignatureV3.IssuerKeyId)
+		// o.Log.Trace("field SignatureV3 %v", md.SignatureV3.CreationTime)
+
+		if md.Signature != nil {
+			if md.Signature.SigLifetimeSecs != nil {
+				expiry := md.Signature.CreationTime.Add(time.Duration(*md.Signature.SigLifetimeSecs) * time.Second)
+				if time.Now().After(expiry) {
+					o.Log.Debug("signature expired on %v ", expiry)
+				}
+			}
+		} else if md.SignatureV3 == nil {
+			return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] unexpected openpgp.MessageDetails: neither Signature nor SignatureV3 is set for %s image %s", digest, img.Source)
+		}
+
+		// write signature to cache
+		newImgSpec, err := image.ParseRef(img.Source)
+		if err != nil {
+			return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] could not parse identity docker reference image %w", err)
+		}
+		sigFilePath := fmt.Sprintf("%s%s/%s-sha256-%s", o.Opts.Global.WorkingDir, SignatureDir, newImgSpec.Tag, digest)
+		if _, err := os.Stat(sigFilePath); err != nil {
+			ferr := os.WriteFile(sigFilePath, data, 0600)
+			if ferr != nil {
+				return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] writing %w", ferr)
+			}
+		}
+		imgs = append(imgs, img)
 	}
 	return imgs, nil
 }

--- a/v2/internal/pkg/release/signature.go
+++ b/v2/internal/pkg/release/signature.go
@@ -65,125 +65,134 @@ func (o SignatureSchema) GenerateReleaseSignatures(ctx context.Context, images [
 		}
 		digest := imgSpec.Digest
 
-		if digest != "" {
-			o.Log.Debug("signature digest %s", digest)
-			// check if the image is in the cache else
-			// do a lookup and download it to cache
-			sigFiles, err := os.ReadDir(o.Opts.Global.WorkingDir + SignatureDir)
-			if err != nil {
-				o.Log.Debug("[GenerateReleaseSignatures] no directory found for signatures %v", err)
-			}
-			for _, file := range sigFiles {
-				if strings.Contains(file.Name(), digest) {
-					data, err = os.ReadFile(o.Opts.Global.WorkingDir + SignatureDir + file.Name())
-					if err != nil {
-						o.Log.Warn("[GenerateReleaseSignatures] could not read %s %v", file.Name(), err)
-					}
-					break
-				}
-			}
-		} else {
-			return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] parsing image digest")
-		}
-
-		// we dont have the current digest in cache
-		if len(data) == 0 {
-			req, _ := http.NewRequest("GET", SignatureURL+"sha256="+digest+"/signature-1", nil)
-			// req.Header.Set("Authorization", "Basic "+generic.Token)
-			req.Header.Set(ContentType, ApplicationJson)
-			resp, err := httpClient.Do(req)
-			if err != nil {
-				return []v2alpha1.CopyImageSchema{}, fmt.Errorf("http request %v", err)
-			}
-			defer func() {
-				if resp != nil && resp.Body != nil {
-					resp.Body.Close()
-				}
-			}()
-			if resp.StatusCode == http.StatusOK {
-				o.Log.Debug("response from signature lookup %d", resp.StatusCode)
-				data, err = io.ReadAll(resp.Body)
-				if err != nil {
-					return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] reading response body %v", err)
-				}
-			}
-		}
-
-		if len(data) > 0 {
-			pkBytes := []byte(o.pgpKey)
-
-			keyring, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(pkBytes))
-			// keyring, err := openpgp.ReadKeyRing(bytes.NewReader([]byte(pkBytes)))
-			if err != nil {
-				o.Log.Error("%v", err)
-			}
-			o.Log.Debug("keyring %v", keyring)
-
-			md, err := openpgp.ReadMessage(bytes.NewReader(data), keyring, nil, nil)
-			if err != nil {
-				o.Log.Error("%v could not read the message:", err)
-			}
-			if md == nil {
-				return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] unable to read signature message for %s image %s", digest, img.Source)
-			}
-			if !md.IsSigned {
-				return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] message was not signed for %s image %s", digest, img.Source)
-			}
-			if md.SignatureError != nil {
-				return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] signature error for %s image %s", digest, img.Source)
-			}
-			if md.SignedBy == nil {
-				return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] invalid signature for %s image %s", digest, img.Source)
-			}
-
-			// update the image with the actual reference from the contents json
-			signSchema, err := parser.ParseJsonReader[v2alpha1.SignatureContentSchema](md.UnverifiedBody)
-			if err != nil {
-				return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] unmarshal json %w", err)
-			}
-			img.Source = signSchema.Critical.Identity.DockerReference
-			o.Log.Debug("image found : %s", signSchema.Critical.Identity.DockerReference)
-
-			o.Log.Trace("field isEncrypted %v", md.IsEncrypted)
-			o.Log.Trace("field EencryptedToKeyIds %v", md.EncryptedToKeyIds)
-			o.Log.Trace("field IsSymmetricallyEncrypted %v", md.IsSymmetricallyEncrypted)
-			o.Log.Trace("field DecryptedWith %v", md.DecryptedWith)
-			o.Log.Trace("field IsSigned %v", md.IsSigned)
-			o.Log.Trace("field SignedByKeyId %v", md.SignedByKeyId)
-			o.Log.Trace("field SignedBy %v", md.SignedBy)
-			o.Log.Trace("field LiteralData %v", md.LiteralData)
-			o.Log.Trace("field SignatureError %v", md.SignatureError)
-			o.Log.Trace("field Signature %v", md.Signature)
-			// o.Log.Trace("field SignatureV3 %v", md.SignatureV3.IssuerKeyId)
-			// o.Log.Trace("field SignatureV3 %v", md.SignatureV3.CreationTime)
-
-			if md.Signature != nil {
-				if md.Signature.SigLifetimeSecs != nil {
-					expiry := md.Signature.CreationTime.Add(time.Duration(*md.Signature.SigLifetimeSecs) * time.Second)
-					if time.Now().After(expiry) {
-						o.Log.Debug("signature expired on %v ", expiry)
-					}
-				}
-			} else if md.SignatureV3 == nil {
-				return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] unexpected openpgp.MessageDetails: neither Signature nor SignatureV3 is set for %s image %s", digest, img.Source)
-			}
-
-			// write signature to cache
-			newImgSpec, err := image.ParseRef(img.Source)
-			if err != nil {
-				return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] could not parse identity docker reference image %v", err)
-			}
-			sigFilePath := fmt.Sprintf("%s%s/%s-sha256-%s", o.Opts.Global.WorkingDir, SignatureDir, newImgSpec.Tag, digest)
-			if _, err := os.Stat(sigFilePath); err != nil {
-				ferr := os.WriteFile(sigFilePath, data, 0644)
-				if ferr != nil {
-					return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] writing %v", ferr)
-				}
-			}
+		// OCPBUGS-56009
+		// not worrying about code complexity as this module will eventually be deprecated
+		// in favor of the cosign signature work
+		// nolint: nestif
+		if o.Opts.Global.IgnoreReleaseSignature {
 			imgs = append(imgs, img)
-			data = nil
 		} else {
-			return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] no signature found for %s image %s", digest, img.Source)
+			if digest != "" {
+				o.Log.Debug("signature digest %s", digest)
+				// check if the image is in the cache else
+				// do a lookup and download it to cache
+				sigFiles, err := os.ReadDir(o.Opts.Global.WorkingDir + SignatureDir)
+				if err != nil {
+					o.Log.Debug("[GenerateReleaseSignatures] no directory found for signatures %w", err)
+				}
+				for _, file := range sigFiles {
+					if strings.Contains(file.Name(), digest) {
+						data, err = os.ReadFile(o.Opts.Global.WorkingDir + SignatureDir + file.Name())
+						if err != nil {
+							o.Log.Warn("[GenerateReleaseSignatures] could not read %s %w", file.Name(), err)
+						}
+						break
+					}
+				}
+			} else {
+				return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] parsing image digest")
+			}
+
+			// we dont have the current digest in cache
+			if len(data) == 0 {
+				// see above nolint comment
+				// nolint: noctx
+				req, _ := http.NewRequest("GET", SignatureURL+"sha256="+digest+"/signature-1", nil)
+				req.Header.Set(ContentType, ApplicationJson)
+				resp, err := httpClient.Do(req)
+				if err != nil {
+					return []v2alpha1.CopyImageSchema{}, fmt.Errorf("http request %w", err)
+				}
+				defer func() {
+					if resp != nil && resp.Body != nil {
+						resp.Body.Close()
+					}
+				}()
+				if resp.StatusCode == http.StatusOK {
+					o.Log.Debug("response from signature lookup %d", resp.StatusCode)
+					data, err = io.ReadAll(resp.Body)
+					if err != nil {
+						return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] reading response body %w", err)
+					}
+				}
+			}
+
+			if len(data) > 0 {
+				pkBytes := []byte(o.pgpKey)
+
+				keyring, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(pkBytes))
+				// keyring, err := openpgp.ReadKeyRing(bytes.NewReader([]byte(pkBytes)))
+				if err != nil {
+					o.Log.Error("%v", err)
+				}
+				o.Log.Debug("keyring %v", keyring)
+
+				md, err := openpgp.ReadMessage(bytes.NewReader(data), keyring, nil, nil)
+				if err != nil {
+					o.Log.Error("%v could not read the message:", err)
+				}
+				if md == nil {
+					return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] unable to read signature message for %s image %s", digest, img.Source)
+				}
+				if !md.IsSigned {
+					return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] message was not signed for %s image %s", digest, img.Source)
+				}
+				if md.SignatureError != nil {
+					return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] signature error for %s image %s", digest, img.Source)
+				}
+				if md.SignedBy == nil {
+					return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] invalid signature for %s image %s", digest, img.Source)
+				}
+
+				// update the image with the actual reference from the contents json
+				signSchema, err := parser.ParseJsonReader[v2alpha1.SignatureContentSchema](md.UnverifiedBody)
+				if err != nil {
+					return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] unmarshal json %w", err)
+				}
+				img.Source = signSchema.Critical.Identity.DockerReference
+				o.Log.Debug("image found : %s", signSchema.Critical.Identity.DockerReference)
+
+				o.Log.Trace("field isEncrypted %v", md.IsEncrypted)
+				o.Log.Trace("field EencryptedToKeyIds %v", md.EncryptedToKeyIds)
+				o.Log.Trace("field IsSymmetricallyEncrypted %v", md.IsSymmetricallyEncrypted)
+				o.Log.Trace("field DecryptedWith %v", md.DecryptedWith)
+				o.Log.Trace("field IsSigned %v", md.IsSigned)
+				o.Log.Trace("field SignedByKeyId %v", md.SignedByKeyId)
+				o.Log.Trace("field SignedBy %v", md.SignedBy)
+				o.Log.Trace("field LiteralData %v", md.LiteralData)
+				o.Log.Trace("field SignatureError %v", md.SignatureError)
+				o.Log.Trace("field Signature %v", md.Signature)
+				// o.Log.Trace("field SignatureV3 %v", md.SignatureV3.IssuerKeyId)
+				// o.Log.Trace("field SignatureV3 %v", md.SignatureV3.CreationTime)
+
+				if md.Signature != nil {
+					if md.Signature.SigLifetimeSecs != nil {
+						expiry := md.Signature.CreationTime.Add(time.Duration(*md.Signature.SigLifetimeSecs) * time.Second)
+						if time.Now().After(expiry) {
+							o.Log.Debug("signature expired on %v ", expiry)
+						}
+					}
+				} else if md.SignatureV3 == nil {
+					return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] unexpected openpgp.MessageDetails: neither Signature nor SignatureV3 is set for %s image %s", digest, img.Source)
+				}
+
+				// write signature to cache
+				newImgSpec, err := image.ParseRef(img.Source)
+				if err != nil {
+					return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] could not parse identity docker reference image %w", err)
+				}
+				sigFilePath := fmt.Sprintf("%s%s/%s-sha256-%s", o.Opts.Global.WorkingDir, SignatureDir, newImgSpec.Tag, digest)
+				if _, err := os.Stat(sigFilePath); err != nil {
+					ferr := os.WriteFile(sigFilePath, data, 0600)
+					if ferr != nil {
+						return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] writing %w", ferr)
+					}
+				}
+				imgs = append(imgs, img)
+				data = nil
+			} else {
+				return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] no signature found for %s image %s", digest, img.Source)
+			}
 		}
 	}
 	return imgs, nil

--- a/v2/internal/pkg/release/signature.go
+++ b/v2/internal/pkg/release/signature.go
@@ -69,7 +69,7 @@ func (o SignatureSchema) GenerateReleaseSignatures(ctx context.Context, images [
 		// not worrying about code complexity as this module will eventually be deprecated
 		// in favor of the cosign signature work
 		// nolint: nestif
-		if o.Opts.Global.IgnoreReleaseSignature {
+		if o.Opts.Global.IgnoreReleaseSignature && len(o.Config.Mirror.Platform.Release) > 0 {
 			imgs = append(imgs, img)
 		} else {
 			if digest != "" {


### PR DESCRIPTION
# Description

This fix addresses the issue when no signature is found (or published) for a specific release image (typical use case is in prow build piplines)

Github / Jira issue:  OCPBUGS-56009

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Locally using the following isc 

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  platform:
    release: quay.io/oc-mirror/release/test-release-index@sha256:f81792339c8b5934191d18a53b18bc1d584e01a9f37d59c0aa6905b00200aa1b
```
And using the oc-mirror  with the flag --ignore-release-signature (for all flows  mirror-to-disk, disk-to-mirror, mirror-to-mirror)

## Expected Outcome
No signature error's expected