### PR TITLE
OCPBUGS-51157: Bug fix for invalid release image does not cause mirro…

### DIFF
--- a/v2/internal/pkg/release/cincinnati.go
+++ b/v2/internal/pkg/release/cincinnati.go
@@ -266,6 +266,11 @@ func (o *CincinnatiSchema) GetReleaseReferenceImages(ctx context.Context) ([]v2a
 		}
 	}
 
+	// OCPBUGS-51157
+	if len(allImages) == 0 {
+		return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GetReleaseReferenceImages] no release images found")
+	}
+
 	imgs, err := o.Signature.GenerateReleaseSignatures(ctx, allImages)
 	if err != nil {
 		return []v2alpha1.CopyImageSchema{}, fmt.Errorf("%w", err)


### PR DESCRIPTION
…ring errors

# Description

Addresses the issue when no release images are found (exit with an error) 

Github / Jira issue:  OCPBUGS-51157

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Tested with the following isc 

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  platform:
    channels:
      - name: ocp-4.32
        minVersion: 4.42.99
        maxVersion: 4.42.100
    graph: true

```

Also tested for regression (i.e with valid known working release version)


## Expected Outcome
For both mirror-to-disk and mirror-to-mirror  oc-mirror v2 should exit with an error