### PR TITLE
OCPBUGS-56378: disables the signature verification on operator catalog collection

### DIFF
--- a/v2/internal/pkg/operator/filtered_collector.go
+++ b/v2/internal/pkg/operator/filtered_collector.go
@@ -389,6 +389,7 @@ func (o FilterCollector) ensureCatalogInOCIFormat(ctx context.Context, imgSpec i
 		opts := o.Opts
 		opts.Stdout = io.Discard
 		opts.RemoveSignatures = true
+		opts.Global.SecurePolicy = false
 
 		src := dockerProtocol + catalog
 		dest := ociProtocolTrimmed + catalogImageDir


### PR DESCRIPTION
# Description

Currently the signature verification for operator catalog image during collection is failing. This is happening because during the collection phase the operator catalog image is converted to OCI format, so the signature verification will fail because it does not match the original image. 

This PR disables the signature verification of the operator catalog image during the collection phase.

Github / Jira issue: [OCPBUGS-56378](https://issues.redhat.com/browse/OCPBUGS-56378)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

With the following ImageSetConfiguration

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
      packages:
       - name: aws-load-balancer-operator
       - name: 3scale-operator
       - name: node-observability-operator
```  

Run `m2d` with the following command:

```
./bin/oc-mirror -c ./alex-tests/alex-isc/ocpbugs-56378.yaml file://alex-tests/ocpbugs-56378 --v2 --secure-policy=true
```

## Expected Outcome
No issues should happen during the collection phase for the operator catalog image.