### PR TITLE
OCPBUGS-55078: skips signature mirroring for rebuilt operator catalogs

### DIFF
--- a/v2/internal/pkg/batch/concurrent_chan_worker.go
+++ b/v2/internal/pkg/batch/concurrent_chan_worker.go
@@ -142,7 +142,7 @@ func (o *ChannelConcurrentBatch) Worker(ctx context.Context, collectorSchema v2a
 								options.RemoveSignatures = true
 							}
 
-							err = o.Mirror.Run(timeoutCtx, img.Source, img.Destination, mirror.Mode(opts.Function), &options)
+							err = o.Mirror.Run(timeoutCtx, img.Source, img.Destination, mirror.Mode(opts.Function), &options) //nolint:contextcheck
 
 							switch {
 							case err == nil:


### PR DESCRIPTION
# Description

Currently the original signature of an operator catalog is being mirrored to the target registry even when an operator catalogs was rebuilt. The signature of a rebuilt operator catalog is invalid as the operator catalog image differs from the original. 

This PR fixes this issue skipping the signature mirroring for operator catalogs rebuilt.

Github / Jira issue: [OCPBUGS-55078](https://issues.redhat.com/browse/OCPBUGS-55078)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

With the following Image Set Configuration:

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
      packages:
       - name: aws-load-balancer-operator
       - name: 3scale-operator
       - name: node-observability-operator
```

Run `m2d/d2m` or `m2m` with the flag `--remove-signatures=false`

## Expected Outcome

Signatures for the operator catalogs should not be mirrored as in the example below:

```
Fetching tags for repository: redhat/redhat-operator-index
{
  "name": "redhat/redhat-operator-index",
  "tags": [
    "v4.18"
  ]
}
```

While the signatures for `aws-load-balancer-operator`,  `3scale-operator` and `node-observability-operator` (and their dependent images) should be in the target registry.