### PR TITLE
WRKLDS-1592: Use internal implementation for auth.APIVersions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require golang.org/x/sys v0.31.0 // indirect
 require (
 	github.com/containerd/errdefs v0.3.0
 	github.com/distribution/distribution/v3 v3.0.0-beta.1
+	github.com/google/go-cmp v0.7.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/openshift/api v0.0.0-20240529192326-16d44e6d3e7d
 	github.com/openshift/cincinnati-operator v1.0.2-0.20220126212014-b56cf3346609
@@ -133,7 +134,6 @@ require (
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/cel-go v0.22.0 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-intervals v0.0.2 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect


### PR DESCRIPTION
# Description

This repository uses `github.com/distribution/distribution/v3/registry/client/auth` package, which is no longer public. Breaking a public contract should not happen, but it did. This issue would prevent future dependency upgrade when needed, so it must be handled eventually.

The only function actually being used is [auth.APIVersions](https://github.com/distribution/distribution/blob/a44f1fb058533f3f840037ebf29c0fea377ebbc6/internal/client/auth/api_version.go#L26-L38), which is rather simple, so the chosen solution is to reimplement the function in `pkg/metadata/storage/registry.go` as `apiVersions`, hence removing the dependency.

Github / Jira issue: 

https://issues.redhat.com/browse/WRKLDS-1592

## Type of change

Please delete options that are not relevant.

- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)

# How Has This Been Tested?

I added unit tests, which might feel as a bit extra work, then run `make test`.
Let me know in case they are not needed or there is a better way to test this, thanks.