### PR TITLE
OCPBUGS-56642: update the Dockerfile to work with the 1.23 go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex \
      && ARCH=$(arch | sed 's|x86_64|amd64|g' | sed 's|aarch64|arm64|g')         \
      && dnf install -y --nodocs --setopt=install_weak_deps=false ${DNF_LIST}    \
      && dnf clean all -y                                                        \
-     && GO_VERSION=go1.19.5                                                     \
+     && GO_VERSION=go1.23.5                                                     \
      && curl -sL https://golang.org/dl/${GO_VERSION}.linux-${ARCH}.tar.gz       \
         | tar xzvf - --directory /usr/local/                                    \
      && /usr/local/go/bin/go version                                            \
@@ -42,6 +42,7 @@ ENTRYPOINT ["make"]
 CMD []
 
 ENV PATH="/root/platform/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+ENV GOROOT="/usr/local/go"
 
 LABEL \
   name="go-toolset"                                                             \


### PR DESCRIPTION
# Description

Testing with Dockerfile failed on Power.
We had to update the Dockerfile to use 1.23

Github / Jira issue: https://issues.redhat.com/browse/OCPBUGS-56642

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.