### PR TITLE
OCPBUGS-55076: adds code to handle signature errors in the archive pkg

### DIFF
--- a/v2/internal/pkg/archive/error.go
+++ b/v2/internal/pkg/archive/error.go
@@ -1,13 +1,48 @@
 package archive
 
 import (
+	"errors"
 	"fmt"
+
+	"github.com/openshift/oc-mirror/v2/internal/pkg/errcode"
 )
+
+type ArchiveError struct {
+	ReleaseErr       error
+	OperatorErr      error
+	AdditionalImgErr error
+	HelmErr          error
+}
 
 type SignatureBlobGathererError struct {
 	SigError error
 }
 
-func (e SignatureBlobGathererError) Error() string {
+func (e *SignatureBlobGathererError) Error() string {
 	return fmt.Sprintf("signature error: %s", e.SigError)
+}
+
+func (e *ArchiveError) Error() string {
+	return fmt.Sprintf("archive error: %s", errors.Join(e.ReleaseErr, e.OperatorErr, e.AdditionalImgErr, e.HelmErr))
+}
+
+func (e *ArchiveError) ExitCode() int {
+	if e == nil {
+		return 0
+	}
+
+	exitCode := 0
+	if e.ReleaseErr != nil {
+		exitCode |= errcode.ReleaseErr
+	}
+	if e.OperatorErr != nil {
+		exitCode |= errcode.OperatorErr
+	}
+	if e.AdditionalImgErr != nil {
+		exitCode |= errcode.AdditionalImgErr
+	}
+	if e.HelmErr != nil {
+		exitCode |= errcode.HelmErr
+	}
+	return exitCode
 }

--- a/v2/internal/pkg/archive/image-blob-gatherer_test.go
+++ b/v2/internal/pkg/archive/image-blob-gatherer_test.go
@@ -64,7 +64,7 @@ func TestImageBlobGatherer_GatherBlobs(t *testing.T) {
 					isParentImage: true,
 				},
 			},
-			expectedErrorType: SignatureBlobGathererError{},
+			expectedErrorType: &SignatureBlobGathererError{},
 			expectedBlobs: map[string]struct{}{
 				"sha256:467829ca4ff134ef9762a8f69647fdf2515b974dfc94a8474c493a45ef922e51": {},
 				"sha256:728191dbaae078c825ffb518e15d33956353823d4da6c2e81fe9b1ed60ddef7d": {},


### PR DESCRIPTION
# Description

When running `m2d` with `--remove-signatures=false`, failing to add a release signature (except the graph image which does not have a signature) to the archive should stop the workflow.

Github / Jira issue: [OCPBUGS-55076](https://issues.redhat.com/browse/OCPBUGS-55076)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Developed unit tests for each scenario.

## Expected Outcome
Unit tests should pass.