### PR TITLE
OKD compatibility - Allow custom value for SignatureURL

### DIFF
--- a/docs/examples/imageset-config-okd.yaml
+++ b/docs/examples/imageset-config-okd.yaml
@@ -1,10 +1,15 @@
-# This example demonstrates how to mirror the latest
-# okd release.
+# This example demonstrates how to mirror an okd release.
+# To pass signatures verification, be sure to set the following env variables
+# OCP_SIGNATURE_URL="https://storage.googleapis.com/openshift-ci-release/releases/signatures/openshift/release/"
+# OCP_SIGNATURE_VERIFICATION_PK="/path/to/PK" (recovered from "https://raw.githubusercontent.com/openshift/cluster-update-keys/master/keys/verifier-public-key-openshift-ci-4")
 ---
-apiVersion: mirror.openshift.io/v1alpha2
+apiVersion: mirror.openshift.io/v2alpha1
 kind: ImageSetConfiguration
 mirror:
   platform:
+    graph: false 
     channels:
-      - name: okd
+      - name: 4-stable
+        minVersion: 4.18.0-okd-scos.8
+        maxVersion: 4.18.0-okd-scos.8
         type: okd

--- a/v2/internal/pkg/release/cincinnati.go
+++ b/v2/internal/pkg/release/cincinnati.go
@@ -17,10 +17,10 @@ import (
 )
 
 const (
-	SignatureURL    string = "https://mirror.openshift.com/pub/openshift-v4/signatures/openshift/release/"
-	SignatureDir    string = "/signatures/"
-	ContentType     string = "Content-Type"
-	ApplicationJson string = "application/json"
+	defaultSignatureURL string = "https://mirror.openshift.com/pub/openshift-v4/signatures/openshift/release/"
+	SignatureDir        string = "/signatures/"
+	ContentType         string = "Content-Type"
+	ApplicationJson     string = "application/json"
 )
 
 var (

--- a/v2/internal/pkg/release/signature.go
+++ b/v2/internal/pkg/release/signature.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -88,7 +89,16 @@ func (o SignatureSchema) GenerateReleaseSignatures(ctx context.Context, images [
 
 		// we dont have the current digest in cache
 		if len(data) == 0 {
-			req, _ := http.NewRequest("GET", SignatureURL+"sha256="+digest+"/signature-1", nil)
+			signatureURL := defaultSignatureURL
+			if signatureURLOvr := os.Getenv("OCP_SIGNATURE_URL"); len(signatureURLOvr) != 0 {
+				if parsedURL, err := url.ParseRequestURI(signatureURLOvr); err != nil {
+					o.Log.Debug("Invalid URL provided in OCP_SIGNATURE_URL: %s, falling back to default SignatureURL", signatureURLOvr)
+				} else {
+					o.Log.Debug("OCP_SIGNATURE_URL environment variable set: using %s as base URL for signature retrieval", signatureURLOvr)
+					signatureURL = parsedURL.String()
+				}
+			}
+			req, _ := http.NewRequest("GET", signatureURL+"sha256="+digest+"/signature-1", nil)
 			// req.Header.Set("Authorization", "Basic "+generic.Token)
 			req.Header.Set(ContentType, ApplicationJson)
 			resp, err := httpClient.Do(req)


### PR DESCRIPTION
# Description

Allow to use OCP_SIGNATURE_URL env variable for release signature checks. Combined with OCP_SIGNATURE_VERIFICATION_PK, OKD support is back with oc-mirror --v2.

Github / Jira issue: #507

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested with example provided in docs/examples/imageset-config-okd.yaml

## Expected Outcome

No [GenerateReleaseSignatures] invalid signature from [Executor]