### PR TITLE
OCPBUGS-56718: Use rebuilt catalog image when set (regression bug fix)

### DIFF
--- a/v2/internal/pkg/operator/filtered_collector.go
+++ b/v2/internal/pkg/operator/filtered_collector.go
@@ -325,7 +325,7 @@ func (o FilterCollector) filterOperator(ctx context.Context, op v2alpha1.Operato
 		return v2alpha1.CatalogFilterResult{
 			OperatorFilter:     op,
 			FilteredConfigPath: filterConfigDir,
-			ToRebuild:          false,
+			ToRebuild:          true,
 			DeclConfig:         filteredDC,
 			Digest:             string(filteredImageDigest),
 		}, nil


### PR DESCRIPTION
# Description

This fix addresses a regression that when using a filtered catalog the original catalog index was being mirrored retaher than the rebuilt filtered catalog index

Github / Jira issue:  OCPBUGS-56718

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

I tested locally with the following imagesetconfig files

```
apiVersion: mirror.openshift.io/v2alpha1
kind: ImageSetConfiguration
archiveSize: 2
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
      packages:
       - name: openshift-cert-manager-operator
         channels:
         - name: stable-v1  
    - catalog: registry.redhat.io/redhat/certified-operator-index:v4.17
      packages:
        - name: hspc-operator
          channels:
            - name: stable
              minVersion: 1.15.0
```

Using mirror-to-disk, disk-to-mirror and mirror-to-mirror workflows

Then using this imagesteconfig 

```
- catalog: registry.redhat.io/redhat/redhat-operator-index@sha256:35ea076da9001466a5e4078934fc4a26308488b3424930f8c3a7134f929c5866
        packages:
        - name: rhods-operator
          defaultChannel: fast
          channels:
            - name: fast
              minVersion: 2.17.0
              maxVersion: 2.17.0
        - name: cincinnati-operator
          channels:
            - name: v1
```

Use the exact flow as described abaove

## Expected Outcome

Use the following method to verify the correct catalog has been mirrored to the remote registry. Execute the follwoing command line sequence after a disk-to-mirror and mirror-to-mirror flow

podman pull <remote-registry>/<namespace>/<xxxx-operator-index:<version>

As an example I had the following

```
podman pull localhost:5000/ocpbugs-56718/redhat/redhat-operator-index:v4.18 --tls-verify=false
```
Then execute a run

```
podman run -d --name redhat-catalog localhost:5000/ocpbugs-56718/redhat/redhat-operator-index:v4.18
```
Finally copy the /configs contents

```
podman cp redhat-catalog:/configs .
```
Inspect the configs directory

```
$ ls -la configs/
total 12
drwxr-xr-x. 1 lzuccarelli lzuccarelli   62 Jan  1  1970 .
drwxr-xr-x. 1 lzuccarelli lzuccarelli 1004 May 29 15:38 ..
drwxr-xr-x. 1 lzuccarelli lzuccarelli   24 Jan  1  1970 openshift-cert-manager-operator
```
