### PR TITLE
[release-4.19] OCPBUGS-55701: v2/imgbuilder: use --authfile when set

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -38,7 +38,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
-require github.com/docker/cli v28.0.4+incompatible // indirect
+require github.com/docker/cli v28.0.4+incompatible
 
 require (
 	dario.cat/mergo v1.0.1 // indirect


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/oc-mirror/pull/1136 due to merge conflicts.

# Description

Right now the go-containerregistry lib is using the default docker+podman locations. If oc-mirror is run with `--authfile` pointing to a custom location, it will be used for other images except the graph image.

This change adds a custom keychain with the contents of --authfile so it is picked up by go-containerregistry.

Github / Jira issue: OCPBUGS-55701

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.