### PR TITLE
CLID-370: clusterresources: remove `cs-` prefix

### DIFF
--- a/v2/internal/pkg/clusterresources/clusterresources.go
+++ b/v2/internal/pkg/clusterresources/clusterresources.go
@@ -282,7 +282,7 @@ func (o *ClusterResourcesGenerator) generateCatalogSource(catalogRef string, cat
 
 	pathComponents := strings.Split(catalogSpec.PathComponent, "/")
 	catalogRepository := pathComponents[len(pathComponents)-1]
-	catalogSourceName := "cs-" + catalogRepository + "-" + csSuffix
+	catalogSourceName := catalogRepository + "-" + csSuffix
 	// maybe needs some updating (i.e other unwanted characters !@# etc )
 	catalogSourceName = strings.Replace(catalogSourceName, ".", "-", -1)
 	errs := validation.IsDNS1035Label(catalogSourceName)

--- a/v2/internal/pkg/clusterresources/clusterresources_test.go
+++ b/v2/internal/pkg/clusterresources/clusterresources_test.go
@@ -639,7 +639,7 @@ func TestCatalogSourceGenerator(t *testing.T) {
 			t.Fatalf("output folder should contain 1 catalogsource yaml file")
 		}
 
-		expectedCSName := "cs-redhat-operator-index-v4-15"
+		expectedCSName := "redhat-operator-index-v4-15"
 		// check idmsFile has a name that is
 		// compliant with Kubernetes requested
 		// RFC-1035 + RFC1123
@@ -918,7 +918,7 @@ func TestCatalogSourceGenerator(t *testing.T) {
 			t.Fatalf("output folder should contain 1 catalogsource yaml file")
 		}
 
-		expectedCSName := "cs-redhat-operator-index-7c4ef7434c97"
+		expectedCSName := "redhat-operator-index-7c4ef7434c97"
 		// check catalogsource has a name that is
 		// compliant with Kubernetes requested
 		// RFC-1035 + RFC1123


### PR DESCRIPTION
# Description

Users are complaining that the `cs-` prefix breaks automations.

Github / Jira issue: [CLID-370](https://issues.redhat.com//browse/CLID-370)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

m2d + d2m
```
2025/06/05 10:23:50  [INFO]   : 📄 Generating CatalogSource file...
2025/06/05 10:23:50  [INFO]   : data/cs-prefix/working-dir/cluster-resources/redhat-operator-index-v4-14.yaml file created
```

## Expected Outcome

Catalog source without the `cs-` prefix