### PR TITLE
OCPBUGS-57197: [release-4.18] v2/cli: always remove past archives before m2d

### DIFF
--- a/v2/internal/pkg/archive/archive.go
+++ b/v2/internal/pkg/archive/archive.go
@@ -31,10 +31,6 @@ type MirrorArchive struct {
 // any files that exceed the maxArchiveSize specified in the imageSetConfig will
 // cause the BuildArchive method to stop and return in error.
 func NewMirrorArchive(opts *mirror.CopyOptions, destination, iscPath, workingDir, cacheDir string, maxSize int64, logg clog.PluggableLoggerInterface) (*MirrorArchive, error) {
-	err := removePastArchives(destination)
-	if err != nil {
-		logg.Warn("unable to delete past archives from %s: %v", destination, err)
-	}
 	// create the history interface
 	history, err := history.NewHistory(workingDir, opts.Global.Since, logg, history.OSFileCreator{})
 	if err != nil {
@@ -189,7 +185,7 @@ func (o *MirrorArchive) addBlobsDiff(collectedBlobs, historyBlobs map[string]str
 	return blobsInDiff, nil
 }
 
-func removePastArchives(destination string) error {
+func RemovePastArchives(destination string) error {
 	if _, err := os.Stat(destination); err != nil {
 		// Destination directory doesn't exist: no-op
 		if errors.Is(err, fs.ErrNotExist) {

--- a/v2/internal/pkg/archive/archive_test.go
+++ b/v2/internal/pkg/archive/archive_test.go
@@ -17,8 +17,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type mockBlobGatherer struct{}
-type mockHistory struct{}
+type (
+	mockBlobGatherer struct{}
+	mockHistory      struct{}
+)
 
 var expectedTarContents = []string{
 	// is in history // "docker/registry/v2/blobs/sha256/2e/2e39d55595ea56337b5b788e96e6afdec3db09d2759d903cbe120468187c4644/data",
@@ -238,7 +240,6 @@ func TestArchive_AddBlobsDiff(t *testing.T) {
 	actualAddedBlobs, err := ma.addBlobsDiff(collectedBlobs, historyBlobs, map[string]string{})
 	assert.NoError(t, err, "call addBlobsDiff should not return an error")
 	assert.Equal(t, expectedAddedBlobs, actualAddedBlobs)
-
 }
 
 func TestArchive_RemovePastMirrors(t *testing.T) {
@@ -280,7 +281,7 @@ func TestArchive_RemovePastMirrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.caseName, func(t *testing.T) {
-			err := removePastArchives(tc.destination)
+			err := RemovePastArchives(tc.destination)
 			if err != nil {
 				assert.Equal(t, tc.expectedError, err.Error())
 			} else {
@@ -298,6 +299,7 @@ func TestArchive_RemovePastMirrors(t *testing.T) {
 		})
 	}
 }
+
 func assertContents(t *testing.T, archiveFile string, expectedTarContents []string) bool {
 	actualTarContents := []string{}
 	chunkFile, err := os.Open(archiveFile)
@@ -328,7 +330,6 @@ func assertContents(t *testing.T, archiveFile string, expectedTarContents []stri
 		}
 	}
 	return assert.ElementsMatch(t, expectedTarContents, actualTarContents)
-
 }
 
 // //////     Mocks       ////////
@@ -398,7 +399,6 @@ func (mbg mockBlobGatherer) GatherBlobs(ctx context.Context, imgRef string) (map
 
 func (m mockHistory) Read() (map[string]string, error) {
 	historyMap := map[string]string{
-
 		"sha256:2e39d55595ea56337b5b788e96e6afdec3db09d2759d903cbe120468187c4644": "",
 		"sha256:94343313ec1512ab02267e4bc3ce09eecb01fda5bf26c56e2f028ecc72e80b18": "",
 		"sha256:4c0f6aace7053de3b9c1476b33c9a763e45a099c8c7ae9117773c9a8e5b8506b": "",
@@ -410,7 +410,6 @@ func (m mockHistory) Read() (map[string]string, error) {
 
 func (m mockHistory) Append(inputMap map[string]string) (map[string]string, error) {
 	historyMap := map[string]string{
-
 		"sha256:2e39d55595ea56337b5b788e96e6afdec3db09d2759d903cbe120468187c4644": "",
 		"sha256:94343313ec1512ab02267e4bc3ce09eecb01fda5bf26c56e2f028ecc72e80b18": "",
 		"sha256:4c0f6aace7053de3b9c1476b33c9a763e45a099c8c7ae9117773c9a8e5b8506b": "",

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -490,6 +490,9 @@ func (o *ExecutorSchema) Complete(args []string) error {
 	o.Batch = batch.New(batch.ChannelConcurrentWorker, o.Log, o.LogsDir, o.Mirror, o.Opts.ParallelImages)
 
 	if o.Opts.IsMirrorToDisk() {
+		if err := archive.RemovePastArchives(rootDir); err != nil {
+			return fmt.Errorf("unable to delete past archives from %s: %w", rootDir, err)
+		}
 		if o.Opts.Global.StrictArchiving {
 			o.MirrorArchiver, err = archive.NewMirrorArchive(o.Opts, rootDir, o.Opts.Global.ConfigPath, o.Opts.Global.WorkingDir, o.LocalStorageDisk, o.Config.ImageSetConfigurationSpec.ArchiveSize, o.Log)
 			if err != nil {


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/oc-mirror/pull/1152

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Github / Jira issue: 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.