### PR TITLE
OCPBUGS-57387: v2/archive: fix sanitization of `.`

### DIFF
--- a/v2/internal/pkg/archive/unarchive_test.go
+++ b/v2/internal/pkg/archive/unarchive_test.go
@@ -241,3 +241,66 @@ func prepareFakeTar(tarFile *os.File) error {
 	err = prepareFakeTarCacheDir(tarFile)
 	return err
 }
+
+func TestSanitizeArchivePath(t *testing.T) {
+	cases := []struct {
+		name        string
+		basedir     string
+		filepath    string
+		expected    string
+		expectedErr bool
+	}{
+		{
+			name:     "absolute path",
+			basedir:  "/workdir",
+			filepath: "path/to/file",
+			expected: "/workdir/path/to/file",
+		},
+		{
+			name:     "relative to current path",
+			basedir:  "./workdir",
+			filepath: "path/to/file",
+			expected: "workdir/path/to/file",
+		},
+		{
+			name:     "current dir as '.'",
+			basedir:  ".",
+			filepath: "path/to/file",
+			expected: "path/to/file",
+		},
+		{
+			name:     "filepath starts with '.'",
+			basedir:  ".",
+			filepath: "./path/to/file",
+			expected: "path/to/file",
+		},
+		{
+			name:     "hidden file in '.'",
+			basedir:  ".",
+			filepath: ".hidden",
+			expected: ".hidden",
+		},
+		{
+			name:     "non-tainted '..'",
+			basedir:  "/workdir",
+			filepath: "../workdir/path/to/file",
+			expected: "/workdir/path/to/file",
+		},
+		{
+			name:        "tainted '..'",
+			basedir:     ".",
+			filepath:    "../../../../../../../../../../../../etc/shadow",
+			expectedErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := sanitizeArchivePath(tc.basedir, tc.filepath)
+			if tc.expectedErr {
+				assert.ErrorContains(t, err, "content filepath is tainted")
+			} else if assert.NoError(t, err, res) {
+				assert.Equal(t, tc.expected, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Without special consideration, `--workdir .` will cause path sanitization to fail because of how Golang handles `.` after `filepath.Clean`.

Github / Jira issue: OCPBUGS-57387

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome

No unarchive errors when `--workdir .` is used.