### PR TITLE
OCPBUGS-55374: fix to inform user of bad umask

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"text/template"
 	"time"
 
@@ -190,6 +191,13 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			log.Info(emoji.WavingHandSign + " Hello, welcome to oc-mirror")
 			log.Info(emoji.Gear + "  setting up the environment for you...")
+
+			// OCPBUGS-55374 (check current umask)
+			currentUmask := syscall.Umask(0)
+			// 18 represents 22 in octal
+			if currentUmask != 18 {
+				return fmt.Errorf("bad umask setting (should be set to 0022)")
+			}
 
 			// Validate and set common flags
 			if len(opts.Global.WorkingDir) > 0 && !strings.Contains(opts.Global.WorkingDir, fileProtocol) {


### PR DESCRIPTION
# Description

Fix to inform user of bad umask

Github / Jira issue:  OPCBUGS-55374

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Set umask 

```
umask 0077
```

## Expected Outcome

Execute oc mirror
Should inform client of bad umask setting (Error message)