### PR TITLE
OCPBUGS-57461,OCPBUGS-56718: v2/operator: add rebuilt catalog to tar file

### DIFF
--- a/v2/internal/pkg/operator/filtered_collector.go
+++ b/v2/internal/pkg/operator/filtered_collector.go
@@ -250,7 +250,7 @@ func (o FilterCollector) collectOperator( //nolint:cyclop // TODO: this needs fu
 	}
 
 	rebuiltTag := ""
-	if result.ToRebuild {
+	if !isFullCatalog(op) {
 		tag, err := digestOfFilter(op)
 		if err != nil {
 			return v2alpha1.CatalogFilterResult{}, err


### PR DESCRIPTION
# Description

We always want to use the filtered catalog tag, unless the catalog is not being filtered.

This fixes a regression introduced by https://github.com/openshift/oc-mirror/pull/1093

Github / Jira issue: OCPBUGS-57461

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.