### PR TITLE
OCPBUGS-55374: Add console warning if bad umask is detected

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -193,8 +193,7 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 			// OCPBUGS-55374 (check current umask)
 			currentUmask := syscall.Umask(0)
 			syscall.Umask(currentUmask)
-			// 18 represents 22 in octal
-			if currentUmask != 18 {
+			if currentUmask != 0o022 {
 				log.Warn(emoji.Warning+"  Detected bad umask 00%o (oc-mirror requires a umask of 0022)", currentUmask)
 			}
 

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"text/template"
 	"time"
 
@@ -188,6 +189,15 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 		SilenceErrors: false,
 		SilenceUsage:  false,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+
+			// OCPBUGS-55374 (check current umask)
+			currentUmask := syscall.Umask(0)
+			syscall.Umask(currentUmask)
+			// 18 represents 22 in octal
+			if currentUmask != 18 {
+				log.Warn(emoji.Warning+"  Detected bad umask 00%o (oc-mirror requires a umask of 0022)", currentUmask)
+			}
+
 			log.Info(emoji.WavingHandSign + " Hello, welcome to oc-mirror")
 			log.Info(emoji.Gear + "  setting up the environment for you...")
 


### PR DESCRIPTION
# Description

From discusssions with our PM and the creator of the issue, we have agreed to add a warning message if a umask setting other than 0022 is detected

Github / Jira issue:  OCPBUGS-55374

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Set umask to 0077

## Expected Outcome 

Console output should show warning message

```
$ bin/oc-mirror --config test.yaml file://ocpbugs-51157 --v2
2025/06/19 09:48:54  [WARN]   : ⚠️  Detected bad umask 0077 (oc-mirror requires a umask of 0022)

```