### PR TITLE
OCPBUGS-58193: v2/archive: error d2m when no tar files found

### DIFF
--- a/v2/internal/pkg/archive/unarchive.go
+++ b/v2/internal/pkg/archive/unarchive.go
@@ -22,6 +22,8 @@ type MirrorUnArchiver struct {
 	archiveFiles []string
 }
 
+const mirrorTarRegex = archiveFilePrefix + "_[0-9]{6}\\.tar"
+
 func NewArchiveExtractor(archivePath, workingDir, cacheDir string) (MirrorUnArchiver, error) {
 	ae := MirrorUnArchiver{
 		workingDir: workingDir,
@@ -32,14 +34,14 @@ func NewArchiveExtractor(archivePath, workingDir, cacheDir string) (MirrorUnArch
 		return MirrorUnArchiver{}, err
 	}
 
-	rxp, err := regexp.Compile(archiveFilePrefix + "_[0-9]{6}\\.tar")
-	if err != nil {
-		return MirrorUnArchiver{}, err
-	}
+	rxp := regexp.MustCompile(mirrorTarRegex)
 	for _, chunk := range files {
 		if rxp.MatchString(chunk.Name()) {
 			ae.archiveFiles = append(ae.archiveFiles, filepath.Join(archivePath, chunk.Name()))
 		}
+	}
+	if len(ae.archiveFiles) == 0 {
+		return MirrorUnArchiver{}, fmt.Errorf("no tar archives matching %q found in %q", mirrorTarRegex, archivePath)
 	}
 	return ae, nil
 }

--- a/v2/internal/pkg/archive/unarchive_test.go
+++ b/v2/internal/pkg/archive/unarchive_test.go
@@ -76,14 +76,8 @@ func TestUnArchiver_NoArchive(t *testing.T) {
 	defer os.RemoveAll(testFolder)
 	workingDir := t.TempDir()
 	cacheDir := t.TempDir()
-	o, err := NewArchiveExtractor(testFolder, workingDir, cacheDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = o.Unarchive()
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, err := NewArchiveExtractor(testFolder, workingDir, cacheDir)
+	assert.ErrorContains(t, err, "no tar archives matching")
 }
 
 func TestUnArchiver_WorkingDirError(t *testing.T) {

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -186,10 +186,9 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 		Long:          mirrorlongDesc,
 		Example:       mirrorExamples,
 		Args:          cobra.MinimumNArgs(1),
-		SilenceErrors: false,
+		SilenceErrors: true,
 		SilenceUsage:  false,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-
 			// OCPBUGS-55374 (check current umask)
 			currentUmask := syscall.Umask(0)
 			syscall.Umask(currentUmask)
@@ -232,6 +231,10 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 			if err := ex.Validate(args); err != nil {
 				return err
 			}
+
+			// NOTE: We don't want help output on errors from here onwards
+			cmd.SilenceUsage = true
+
 			if err := ex.Complete(args); err != nil {
 				return err
 			}


### PR DESCRIPTION
# Description

If we don't error out right away, the error message returned gives no clue about the actual reason for the failure:
```
2025/06/27 10:21:45  [ERROR]  : [Executor] collection error: collect catalog "registry.redhat.io/redhat/redhat-operator-index:v4.18": get manifest: error when creating a new image source: reading manifest v4.18 in localhost:55000/redhat/redhat-operator-index: manifest unknown
```

Github / Jira issue: OCPBUGS-58193

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

```fish
❯ ~/prjs/github.com/openshift/oc-mirror/bin/oc-mirror --v2 --config catalog-isc.yaml --from file://data/catalog-filter-fail docker://localhost:5000/data --dest-tls-verify=false --log-level=debug
2025/06/27 14:31:30  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/06/27 14:31:30  [INFO]   : ⚙️  setting up the environment for you...
2025/06/27 14:31:30  [INFO]   : 🔀 workflow mode: diskToMirror 
2025/06/27 14:31:30  [DEBUG]  : helm.New opts.SrcImage.TlsVerify false
Error: no tar archives matching "mirror_[0-9]{6}\\.tar" found in data/catalog-filter-fail
[...]
```

## Expected Outcome

Error message about tar files not found.