### PR TITLE
CLID-389: v2: validate access to destination registry

### DIFF
--- a/v2/internal/pkg/cli/executor_test.go
+++ b/v2/internal/pkg/cli/executor_test.go
@@ -927,6 +927,76 @@ func TestExcludeImages(t *testing.T) {
 	}
 }
 
+func TestExecutorCheckRegistryAccess(t *testing.T) {
+	const validRegistry = "localhost:5000"
+	testFolder := t.TempDir()
+	regCfg, err := setupRegForTest(testFolder)
+	assert.NoError(t, err, "failed to parse local registry config")
+	reg, err := registry.NewRegistry(context.Background(), regCfg)
+	assert.NoError(t, err, "failed to create local registry service")
+	global := &mirror.GlobalOptions{
+		SecurePolicy: false,
+		Force:        true,
+		WorkingDir:   filepath.Join(testFolder, "tests"),
+	}
+	fsShared, sharedOpts := mirror.SharedImageFlags()
+	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
+	fsDest, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
+	opts := &mirror.CopyOptions{
+		Global:    global,
+		DestImage: destOpts,
+	}
+	ex := &ExecutorSchema{
+		Log:                 clog.New("debug"),
+		LocalStorageService: *reg,
+		Opts:                opts,
+	}
+
+	go ex.startLocalRegistry()
+	// Make sure registry has started up
+	time.Sleep(5 * time.Second)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		ex.stopLocalRegistry(ctx)
+	})
+
+	t.Run("checkRegistryAccess should fail when", func(t *testing.T) {
+		t.Run("cannot resolve registry hostname", func(t *testing.T) {
+			const invalidRegistry = "invalid-registry-url.io"
+			err := ex.checkRegistryAccess(context.TODO(), invalidRegistry)
+			assert.ErrorContains(t, err, "no such host")
+		})
+		t.Run("registry is not accessible", func(t *testing.T) {
+			const invalidRegistry = "localhost:9999"
+			err := ex.checkRegistryAccess(context.TODO(), invalidRegistry)
+			assert.ErrorContains(t, err, "connect: connection refused")
+		})
+		t.Run("http registry but tls-verify=true", func(t *testing.T) {
+			err := ex.checkRegistryAccess(context.TODO(), validRegistry)
+			assert.ErrorContains(t, err, "http: server gave HTTP response to HTTPS client")
+		})
+		t.Run("invalid creds", func(t *testing.T) {
+			err := fsShared.Set("authfile", "/tmp/invalid-creds.json")
+			assert.NoError(t, err, "should set flag")
+			t.Cleanup(func() { _ = fsShared.Set("authfile", "") })
+			err = ex.checkRegistryAccess(context.TODO(), "quay.io/redhat")
+			assert.ErrorContains(t, err, "unable to retrieve auth token: invalid username/password: unauthorized")
+		})
+	})
+
+	t.Run("checkRegistryAccess should succeed", func(t *testing.T) {
+		t.Run("against local http registry when tls-verify=false ", func(t *testing.T) {
+			err := fsDest.Set("dest-tls-verify", "false")
+			assert.NoError(t, err, "should set flag")
+			t.Cleanup(func() { _ = fsDest.Set("dest-tls-verify", "") })
+			err = ex.checkRegistryAccess(context.TODO(), validRegistry)
+			assert.NoError(t, err)
+		})
+		// TODO: add HTTPS and cert tests
+	})
+}
+
 // setup mocks
 
 type Mirror struct {


### PR DESCRIPTION
# Description

Check that we can authenticate against the destination registry with the given credentials.

Github / Jira issue: [CLID-389](https://issues.redhat.com//browse/CLID-389)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

* Innaccessible registry:
```
❯ ~/prjs/github.com/openshift/oc-mirror/bin/oc-mirror --v2 --config catalog-isc.yaml --from file://data/catalog-filter-fail docker://localhost:6000/data --log-level=debug --dest-tls-verify=false
2025/06/30 16:00:13  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/06/30 16:00:13  [INFO]   : ⚙️  setting up the environment for you...
[...]
2025/06/30 16:00:13  [ERROR]  : [Executor] checking registry "localhost:6000/data" access: failed to authenticate: pinging container registry localhost:6000: Get "http://localhost:6000/v2/": dial tcp [::1]:6000: connect: connection refused
```
* Cannot access http registry:
```
❯ ~/prjs/github.com/openshift/oc-mirror/bin/oc-mirror --v2 --config catalog-isc.yaml --from file://data/catalog-filter-fail docker://localhost:5000/data --log-level=debug
2025/06/30 15:57:47  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/06/30 15:57:47  [INFO]   : ⚙️  setting up the environment for you...
[...]
2025/06/30 15:57:47  [ERROR]  : [Executor] checking registry "localhost:5000/data" access: failed to authenticate: pinging container registry localhost:5000: Get "https://localhost:5000/v2/": http: server gave HTTP response to HTTPS client 
```
* Invalid hostname:
```
❯ ~/prjs/github.com/openshift/oc-mirror/v2/build/oc-mirror --config catalog-isc.yaml --from file://data/catalog-filter-fail docker://invalid-registry.io/redhat --log-level=debug
2025/06/30 16:10:46  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/06/30 16:10:46  [INFO]   : ⚙️  setting up the environment for you...
[...]
2025/06/30 16:10:46  [ERROR]  : [Executor] checking registry "invalid-registry.io/redhat" access: failed to authenticate: pinging container registry invalid-registry.io: Get "https://invalid-registry.io/v2/": dial tcp: lookup invalid-registry.io: no such host 
```
* Invalid creds:
```
❯ ~/prjs/github.com/openshift/oc-mirror/v2/build/oc-mirror --config catalog-isc.yaml --from file://data/catalog-filter-fail docker://quay.io/redhat --log-level=debug --authfile /tmp/invalid-auth.json 
2025/06/30 16:14:20  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/06/30 16:14:20  [INFO]   : ⚙️  setting up the environment for you...
[...]
2025/06/30 16:14:21  [ERROR]  : [Executor] checking registry "quay.io/redhat" access: failed to authenticate: unable to retrieve auth token: invalid username/password: unauthorized: access to the requested resource is not authorized
```
* All good:
```
❯ ~/prjs/github.com/openshift/oc-mirror/bin/oc-mirror --v2 --config catalog-isc.yaml --from file://data/catalog-filter-fail docker://localhost:5000/data --log-level=debug --dest-tls-verify=false
2025/06/30 15:59:15  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/06/30 15:59:15  [INFO]   : ⚙️  setting up the environment for you...
2025/06/30 15:59:15  [INFO]   : Verified we can authenticate against registry "localhost:5000/data"
2025/06/30 15:59:15  [INFO]   : 🔀 workflow mode: diskToMirror 
2025/06/30 15:59:15  [DEBUG]  : helm.New opts.SrcImage.TlsVerify false
```

## Expected Outcome

Access to destination registry is checked before mirroring starts.