### PR TITLE
OCPBUGS-57370: v2/defaults Fix rate limiting issues by enabling exponential backoff retries

### DIFF
--- a/v2/internal/pkg/cli/const.go
+++ b/v2/internal/pkg/cli/const.go
@@ -27,7 +27,7 @@ const (
 	helmDir                       string = "helm"
 	helmChartDir                  string = "charts"
 	helmIndexesDir                string = "indexes"
-	maxParallelLayerDownloads     uint   = 10
-	maxParallelImageDownloads     uint   = 8
+	maxParallelLayerDownloads     uint   = 5
+	maxParallelImageDownloads     uint   = 4
 	limitOverallParallelDownloads uint   = 200
 )

--- a/v2/internal/pkg/mirror/options.go
+++ b/v2/internal/pkg/mirror/options.go
@@ -273,7 +273,7 @@ func RetryFlags() (pflag.FlagSet, *retry.Options) {
 	opts := retry.Options{}
 	fs := pflag.FlagSet{}
 	fs.IntVar(&opts.MaxRetry, "retry-times", 5, "the number of times to possibly retry")
-	fs.DurationVar(&opts.Delay, "retry-delay", 0, "delay between 2 retries")
+	fs.DurationVar(&opts.Delay, "retry-delay", 0, "delay between 2 retries (default 0 uses exponential backoff, set value uses constant delay)")
 	return fs, &opts
 }
 

--- a/v2/internal/pkg/mirror/options.go
+++ b/v2/internal/pkg/mirror/options.go
@@ -272,8 +272,8 @@ func ImageSrcFlags(global *GlobalOptions, shared *SharedImageOptions, deprecated
 func RetryFlags() (pflag.FlagSet, *retry.Options) {
 	opts := retry.Options{}
 	fs := pflag.FlagSet{}
-	fs.IntVar(&opts.MaxRetry, "retry-times", 2, "the number of times to possibly retry")
-	fs.DurationVar(&opts.Delay, "retry-delay", time.Second, "delay between 2 retries")
+	fs.IntVar(&opts.MaxRetry, "retry-times", 5, "the number of times to possibly retry")
+	fs.DurationVar(&opts.Delay, "retry-delay", 0, "delay between 2 retries")
 	return fs, &opts
 }
 


### PR DESCRIPTION
# Description

This PR fixes rate limiting issues that occur during mirror operations when oc-mirror sends too many requests to container registries, resulting in "too many requests" errors.

The change sets the default `--retry-delay` to 0 seconds to force the containers/image library to use its built-in exponential backoff retry strategy instead of fixed 1-second delays. This provides smarter retry timing that adapts to rate limiting responses from container registries.

This change works in conjunction with:
- Increased `--retry-times` for more retry attempts
- Reduced `maxParallelLayerDownloads` and `maxParallelImageDownloads` to limit concurrent requests

Github / Jira issue: [OCPBUGS-57370](https://issues.redhat.com/browse/OCPBUGS-57370)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Since this is not an issue that is always happening, it is not easy to test it manually. 

It is possible to see less images are being copied during the worker phase because of the reduced `maxParallelImageDownloads`

## Expected Outcome

It is expected that customers are going to face the issue with `too many request` less often with this bug fix.