### PR TITLE
OCPBUGS-56398: Bug fix not to overwrite log files

### DIFF
--- a/v2/internal/pkg/batch/common.go
+++ b/v2/internal/pkg/batch/common.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"time"
 
 	"github.com/openshift/oc-mirror/v2/internal/pkg/errcode"
 	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
@@ -44,9 +43,8 @@ func (err *BatchError) ExitCode() int {
 	return exitCode
 }
 
-func saveErrors(logger clog.PluggableLoggerInterface, logsDir string, errArray []mirrorErrorSchema) (string, error) {
+func saveErrors(logger clog.PluggableLoggerInterface, logsDir, timestamp string, errArray []mirrorErrorSchema) (string, error) {
 	if len(errArray) > 0 {
-		timestamp := time.Now().Format("20060102_150405")
 		filename := fmt.Sprintf("mirroring_errors_%s.txt", timestamp)
 		file, err := os.Create(filepath.Join(logsDir, filename))
 		if err != nil {

--- a/v2/internal/pkg/batch/concurrent_chan_worker.go
+++ b/v2/internal/pkg/batch/concurrent_chan_worker.go
@@ -34,10 +34,11 @@ const (
 )
 
 type ChannelConcurrentBatch struct {
-	Log           clog.PluggableLoggerInterface
-	LogsDir       string
-	Mirror        mirror.MirrorInterface
-	MaxGoroutines uint
+	Log              clog.PluggableLoggerInterface
+	LogsDir          string
+	Mirror           mirror.MirrorInterface
+	MaxGoroutines    uint
+	SynchedTimeStamp string
 }
 
 type GoroutineResult struct {
@@ -207,7 +208,7 @@ func (o *ChannelConcurrentBatch) Worker(ctx context.Context, collectorSchema v2a
 			additionalImgCountDiff: collectorSchema.TotalAdditionalImages - copiedImages.TotalAdditionalImages,
 			helmCountDiff:          collectorSchema.TotalHelmImages - copiedImages.TotalHelmImages,
 		}
-		filename, err := saveErrors(o.Log, o.LogsDir, errArray)
+		filename, err := saveErrors(o.Log, o.LogsDir, o.SynchedTimeStamp, errArray)
 		if err != nil {
 			batchErr.source = fmt.Errorf(errMsgHeader+" - unable to log these errors in %s/%s: %w", workerPrefix, o.LogsDir, filename, err)
 		} else {

--- a/v2/internal/pkg/batch/new.go
+++ b/v2/internal/pkg/batch/new.go
@@ -14,6 +14,7 @@ func New(workerType string,
 	logsDir string,
 	mirror mirror.MirrorInterface,
 	batchSize uint,
+	timestamp string,
 ) BatchInterface {
-	return &ChannelConcurrentBatch{Log: log, LogsDir: logsDir, Mirror: mirror, MaxGoroutines: batchSize}
+	return &ChannelConcurrentBatch{Log: log, LogsDir: logsDir, Mirror: mirror, MaxGoroutines: batchSize, SynchedTimeStamp: timestamp}
 }

--- a/v2/internal/pkg/cli/const.go
+++ b/v2/internal/pkg/cli/const.go
@@ -18,7 +18,7 @@ const (
 	operatorImageExtractDir       string = "hold-operator"
 	operatorCatalogsDir           string = "operator-catalogs"
 	signaturesDir                 string = "signatures"
-	registryLogFilename           string = "registry.log"
+	registryLogFilename           string = "registry-%s.log"
 	startMessage                  string = "starting local storage on localhost:%v"
 	dryRunOutDir                  string = "dry-run"
 	mappingFile                   string = "mapping.txt"

--- a/v2/internal/pkg/cli/delete.go
+++ b/v2/internal/pkg/cli/delete.go
@@ -239,7 +239,7 @@ func (o *DeleteSchema) CompleteDelete(args []string) error {
 	releaseSignatureClient := release.NewSignatureClient(o.Log, o.Config, *o.Opts)
 	cn := release.NewCincinnati(o.Log, o.Manifest, &o.Config, *o.Opts, client, false, releaseSignatureClient)
 	o.Release = release.New(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest, cn, o.ImageBuilder)
-	o.Batch = batch.New(batch.ChannelConcurrentWorker, o.Log, o.LogsDir, o.Mirror, o.Opts.ParallelImages)
+	o.Batch = batch.New(batch.ChannelConcurrentWorker, o.Log, o.LogsDir, o.Mirror, o.Opts.ParallelImages, o.SynchedTimeStamp)
 	o.Operator = operator.NewWithFilter(o.Log, o.LogsDir, o.Config, *o.Opts, o.Mirror, o.Manifest)
 
 	o.AdditionalImages = additional.New(o.Log, o.Config, *o.Opts, o.Mirror, o.Manifest)


### PR DESCRIPTION
# Description

This bug fixes ensures the log files are not overwritten (for same working-dir) for consecutive executions by using a timestamp in the files

Github / Jira issue:  OCPBUGS-56398

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Execute a mirror-to-disk  workflow

## Expected Outcome

log files should have timestamps fro each consecutive execution

i.e 

```
ls -la ocpbugs-56398/working-dir/logs/
total 464
drwxr-xr-x. 1 lzuccarelli lzuccarelli    114 Jul  3 10:18 .
drwxr-xr-x. 1 lzuccarelli lzuccarelli    172 Jul  3 10:18 ..
-rw-r--r--. 1 lzuccarelli lzuccarelli   1095 Jul  3 10:18 oc-mirror-20250703_101806.log
-rw-r--r--. 1 lzuccarelli lzuccarelli 469138 Jul  3 10:18 registry-20250703_101806.log
```
