### PR TITLE
NO-JIRA: Revert "v2: remove build-machinery-go as a dependency  (#1197)

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -9,7 +9,7 @@ GOMODCACHE=$(shell $(GO) env GOMODCACHE)
 BUILD_MACHINERY_VERSION=v0.0.0-20250414185254-3ce8e800ceda
 BUILD_MACHINERY_PATH=github.com/openshift/build-machinery-go
 
-$(shell $(GO) mod download ${BUILD_MACHINERY_PATH}@${BUILD_MACHINERY_VERSION})
+$(shell $(GO) get ${BUILD_MACHINERY_PATH}@${BUILD_MACHINERY_VERSION})
 
 # Include the library makefile
 include $(addprefix ${GOMODCACHE}/${BUILD_MACHINERY_PATH}@${BUILD_MACHINERY_VERSION}/make/, \

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -159,6 +159,7 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opencontainers/runtime-spec v1.2.1 // indirect
 	github.com/opencontainers/selinux v1.12.0 // indirect
+	github.com/openshift/build-machinery-go v0.0.0-20250414185254-3ce8e800ceda // indirect
 	github.com/operator-framework/api v0.27.0 // indirect
 	github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -368,6 +368,8 @@ github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplU
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
 github.com/openshift/api v0.0.0-20240529192326-16d44e6d3e7d h1:MVt1daCTh1h0FEQweeaEgDRW4wiNbqDX8NzfGKZIAJc=
 github.com/openshift/api v0.0.0-20240529192326-16d44e6d3e7d/go.mod h1:OOh6Qopf21pSzqNVCB5gomomBXb8o5sGKZxG2KNpaXM=
+github.com/openshift/build-machinery-go v0.0.0-20250414185254-3ce8e800ceda h1:Yjnmq1n4zf1pTwao3EAgkG5o++6iOuxfxGVDwj2Kfrs=
+github.com/openshift/build-machinery-go v0.0.0-20250414185254-3ce8e800ceda/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/operator-framework/api v0.27.0 h1:OrVaGKZJvbZo58HTv2guz7aURkhVKYhFqZ/6VpifiXI=
 github.com/operator-framework/api v0.27.0/go.mod h1:lg2Xx+S8NQWGYlEOvFwQvH46E5EK5IrAIL7HWfAhciM=
 github.com/operator-framework/operator-registry v1.47.0 h1:Imr7X/W6FmXczwpIOXfnX8d6Snr1dzwWxkMG+lLAfhg=


### PR DESCRIPTION
This reverts commit 41a6eb3865ef86f482937e2f60184711da6b967c.

# Description
This change seems to relate to a build error:
```
Makefile:15: /cachi2/output/deps/gomod/pkg/mod/github.com/openshift/build-machinery-go@v0.0.0-20250414185254-3ce8e800ceda/make/targets/openshift/deps-gomod.mk: No such file or directory
make[1]: *** No rule to make target '/cachi2/output/deps/gomod/pkg/mod/github.com/openshift/build-machinery-go@v0.0.0-20250414185254-3ce8e800ceda/make/targets/openshift/deps-gomod.mk'.  Stop.
make[1]: Leaving directory '/go/src/github.com/openshift/oc-mirror/v2'
make: *** [Makefile:114: build] Error 2
subprocess exited with status 2
subprocess exited with status 2
Error: building at STEP "RUN . /cachi2/cachi2.env &&     make build": exit status 2
```
Proposing a revert. [Thread](https://redhat-internal.slack.com/archives/C02JW6VCYS1/p1751610588336069)

Github / Jira issue: 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.