### PR TITLE
OCPBUGS-55489: [v2] oc-mirror sets unintended executable flag on some…

### DIFF
--- a/v2/internal/pkg/archive/permissive_adder.go
+++ b/v2/internal/pkg/archive/permissive_adder.go
@@ -29,7 +29,7 @@ type permissiveAdder struct {
 func newPermissiveAdder(maxSize int64, destination string, logger clog.PluggableLoggerInterface) (*permissiveAdder, error) {
 	chunk := 1
 	archiveFileName := fmt.Sprintf(archiveFileNameFormat, archiveFilePrefix, chunk)
-	err := os.MkdirAll(destination, 0755)
+	err := os.MkdirAll(destination, 0766)
 	if err != nil {
 		return &permissiveAdder{}, err
 	}

--- a/v2/internal/pkg/archive/strict_adder.go
+++ b/v2/internal/pkg/archive/strict_adder.go
@@ -26,7 +26,7 @@ type strictAdder struct {
 func newStrictAdder(maxSize int64, destination string, logger clog.PluggableLoggerInterface) (*strictAdder, error) {
 	chunk := 1
 	archiveFileName := fmt.Sprintf(archiveFileNameFormat, archiveFilePrefix, chunk)
-	err := os.MkdirAll(destination, 0755)
+	err := os.MkdirAll(destination, 0766)
 	if err != nil {
 		return &strictAdder{}, err
 	}

--- a/v2/internal/pkg/archive/unarchive.go
+++ b/v2/internal/pkg/archive/unarchive.go
@@ -51,11 +51,11 @@ func NewArchiveExtractor(archivePath, workingDir, cacheDir string) (MirrorUnArch
 // * working-dir to workingDir
 func (o MirrorUnArchiver) Unarchive() error {
 	// make sure workingDir exists
-	if err := os.MkdirAll(o.workingDir, 0755); err != nil {
+	if err := os.MkdirAll(o.workingDir, 0766); err != nil {
 		return fmt.Errorf("unable to create working dir %q: %w", o.workingDir, err)
 	}
 	// make sure cacheDir exists
-	if err := os.MkdirAll(o.cacheDir, 0755); err != nil {
+	if err := os.MkdirAll(o.cacheDir, 0766); err != nil {
 		return fmt.Errorf("unable to create cache dir %q: %w", o.cacheDir, err)
 	}
 
@@ -171,13 +171,13 @@ func createFileWithProgress(parentDir string, header *tar.Header, reader *tar.Re
 	}
 	proxyReader := bar.ProxyReader(reader)
 	defer proxyReader.Close()
-	return writeFile(descriptor, proxyReader, header.FileInfo().Mode()|0755)
+	return writeFile(descriptor, proxyReader, header.FileInfo().Mode()|0766)
 }
 
 func writeFile(filePath string, reader io.Reader, perm os.FileMode) error {
 	// make sure all the parent directories exist
 	descriptorParent := filepath.Dir(filePath)
-	if err := os.MkdirAll(descriptorParent, 0755); err != nil {
+	if err := os.MkdirAll(descriptorParent, 0766); err != nil {
 		return fmt.Errorf("unable to create parent directory for %s: %w", filePath, err)
 	}
 

--- a/v2/internal/pkg/cli/dryrun.go
+++ b/v2/internal/pkg/cli/dryrun.go
@@ -17,7 +17,7 @@ func (o *ExecutorSchema) DryRun(ctx context.Context, allImages []v2alpha1.CopyIm
 	os.RemoveAll(outDir)
 
 	// create logs directory
-	err := o.MakeDir.makeDirAll(outDir, 0755)
+	err := o.MakeDir.makeDirAll(outDir, 0766)
 	if err != nil {
 		o.Log.Error(" %v ", err)
 		return err

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -681,7 +681,7 @@ func (o *ExecutorSchema) isLocalStoragePortBound() bool {
 // the correct local storage directory
 func (o *ExecutorSchema) setupLocalStorageDir() error {
 	o.LocalStorageDisk = filepath.Join(o.Opts.Global.CacheDir, cacheRelativePath)
-	err := os.MkdirAll(o.LocalStorageDisk, 0755)
+	err := os.MkdirAll(o.LocalStorageDisk, 0766)
 	if err != nil {
 		o.Log.Error("unable to setup folder for oc-mirror local storage: %v ", err)
 		return err
@@ -693,7 +693,7 @@ func (o *ExecutorSchema) setupLocalStorageDir() error {
 // all the relevant working directory structures
 func (o *ExecutorSchema) setupWorkingDir() error {
 	// ensure working dir exists
-	err := o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir, 0755)
+	err := o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir, 0744)
 	if err != nil {
 		o.Log.Error(" setupWorkingDir %v ", err)
 		return err
@@ -701,7 +701,7 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 
 	// create signatures directory
 	o.Log.Trace("creating signatures directory %s ", o.Opts.Global.WorkingDir+"/"+signaturesDir)
-	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+signaturesDir, 0755)
+	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+signaturesDir, 0744)
 	if err != nil {
 		o.Log.Error(" setupWorkingDir for signatures %v ", err)
 		return err
@@ -709,7 +709,7 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 
 	// create release-images directory
 	o.Log.Trace("creating release images directory %s ", o.Opts.Global.WorkingDir+"/"+releaseImageDir)
-	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+releaseImageDir, 0755)
+	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+releaseImageDir, 0744)
 	if err != nil {
 		o.Log.Error(" setupWorkingDir for release images %v ", err)
 		return err
@@ -717,7 +717,7 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 
 	// create release cache dir
 	o.Log.Trace("creating release cache directory %s ", o.Opts.Global.WorkingDir+"/"+releaseImageExtractDir)
-	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+releaseImageExtractDir, 0755)
+	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+releaseImageExtractDir, 0744)
 	if err != nil {
 		o.Log.Error(" setupWorkingDir for release cache %v ", err)
 		return err
@@ -725,14 +725,14 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 
 	// create cincinnati graph dir
 	o.Log.Trace("creating cincinnati graph data directory %s ", path.Join(o.Opts.Global.WorkingDir, releaseImageExtractDir, cincinnatiGraphDataDir))
-	err = o.MakeDir.makeDirAll(path.Join(o.Opts.Global.WorkingDir, releaseImageExtractDir, cincinnatiGraphDataDir), 0755)
+	err = o.MakeDir.makeDirAll(path.Join(o.Opts.Global.WorkingDir, releaseImageExtractDir, cincinnatiGraphDataDir), 0744)
 	if err != nil {
 		o.Log.Error(" setupWorkingDir for cincinnati graph data directory %v ", err)
 		return err
 	}
 
 	o.Log.Trace("creating operator cache directory %s ", filepath.Join(o.Opts.Global.WorkingDir, operatorCatalogsDir))
-	err = o.MakeDir.makeDirAll(filepath.Join(o.Opts.Global.WorkingDir, operatorCatalogsDir), 0755)
+	err = o.MakeDir.makeDirAll(filepath.Join(o.Opts.Global.WorkingDir, operatorCatalogsDir), 0744)
 	if err != nil {
 		o.Log.Error(" setupWorkingDir for operator cache %v ", err)
 		return err
@@ -746,13 +746,13 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 			return err
 		}
 	}
-	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+clusterResourcesDir, 0755)
+	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+clusterResourcesDir, 0744)
 	if err != nil {
 		o.Log.Error(" setupWorkingDir for cluster resources %v ", err)
 		return err
 	}
 
-	err = o.MakeDir.makeDirAll(filepath.Join(o.Opts.Global.WorkingDir, helmDir, helmChartDir), 0755)
+	err = o.MakeDir.makeDirAll(filepath.Join(o.Opts.Global.WorkingDir, helmDir, helmChartDir), 0744)
 	if err != nil {
 		o.Log.Error(" setupWorkingDir for helm directory %v ", err)
 		return err
@@ -990,13 +990,13 @@ func (o *ExecutorSchema) setupLogsLevelAndDir() error {
 	os.RemoveAll(o.LogsDir)
 
 	// create logs directory
-	err := o.MakeDir.makeDirAll(o.LogsDir, 0755)
+	err := o.MakeDir.makeDirAll(o.LogsDir, 0744)
 	if err != nil {
 		o.Log.Error(" %v ", err)
 		return err
 	}
 
-	l, err := os.OpenFile(filepath.Join(o.LogsDir, "oc-mirror.log"), os.O_CREATE|os.O_APPEND|os.O_RDWR, 0666)
+	l, err := os.OpenFile(filepath.Join(o.LogsDir, "oc-mirror.log"), os.O_CREATE|os.O_APPEND|os.O_RDWR, 0644)
 	if err != nil {
 		panic(err)
 	}

--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -693,7 +693,7 @@ func (o *ExecutorSchema) setupLocalStorageDir() error {
 // all the relevant working directory structures
 func (o *ExecutorSchema) setupWorkingDir() error {
 	// ensure working dir exists
-	err := o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir, 0744)
+	err := o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir, 0766)
 	if err != nil {
 		o.Log.Error(" setupWorkingDir %v ", err)
 		return err
@@ -701,7 +701,7 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 
 	// create signatures directory
 	o.Log.Trace("creating signatures directory %s ", o.Opts.Global.WorkingDir+"/"+signaturesDir)
-	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+signaturesDir, 0744)
+	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+signaturesDir, 0766)
 	if err != nil {
 		o.Log.Error(" setupWorkingDir for signatures %v ", err)
 		return err
@@ -709,7 +709,7 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 
 	// create release-images directory
 	o.Log.Trace("creating release images directory %s ", o.Opts.Global.WorkingDir+"/"+releaseImageDir)
-	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+releaseImageDir, 0744)
+	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+releaseImageDir, 0766)
 	if err != nil {
 		o.Log.Error(" setupWorkingDir for release images %v ", err)
 		return err
@@ -717,7 +717,7 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 
 	// create release cache dir
 	o.Log.Trace("creating release cache directory %s ", o.Opts.Global.WorkingDir+"/"+releaseImageExtractDir)
-	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+releaseImageExtractDir, 0744)
+	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+releaseImageExtractDir, 0766)
 	if err != nil {
 		o.Log.Error(" setupWorkingDir for release cache %v ", err)
 		return err
@@ -725,14 +725,14 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 
 	// create cincinnati graph dir
 	o.Log.Trace("creating cincinnati graph data directory %s ", path.Join(o.Opts.Global.WorkingDir, releaseImageExtractDir, cincinnatiGraphDataDir))
-	err = o.MakeDir.makeDirAll(path.Join(o.Opts.Global.WorkingDir, releaseImageExtractDir, cincinnatiGraphDataDir), 0744)
+	err = o.MakeDir.makeDirAll(path.Join(o.Opts.Global.WorkingDir, releaseImageExtractDir, cincinnatiGraphDataDir), 0766)
 	if err != nil {
 		o.Log.Error(" setupWorkingDir for cincinnati graph data directory %v ", err)
 		return err
 	}
 
 	o.Log.Trace("creating operator cache directory %s ", filepath.Join(o.Opts.Global.WorkingDir, operatorCatalogsDir))
-	err = o.MakeDir.makeDirAll(filepath.Join(o.Opts.Global.WorkingDir, operatorCatalogsDir), 0744)
+	err = o.MakeDir.makeDirAll(filepath.Join(o.Opts.Global.WorkingDir, operatorCatalogsDir), 0766)
 	if err != nil {
 		o.Log.Error(" setupWorkingDir for operator cache %v ", err)
 		return err
@@ -746,19 +746,19 @@ func (o *ExecutorSchema) setupWorkingDir() error {
 			return err
 		}
 	}
-	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+clusterResourcesDir, 0744)
+	err = o.MakeDir.makeDirAll(o.Opts.Global.WorkingDir+"/"+clusterResourcesDir, 0766)
 	if err != nil {
 		o.Log.Error(" setupWorkingDir for cluster resources %v ", err)
 		return err
 	}
 
-	err = o.MakeDir.makeDirAll(filepath.Join(o.Opts.Global.WorkingDir, helmDir, helmChartDir), 0744)
+	err = o.MakeDir.makeDirAll(filepath.Join(o.Opts.Global.WorkingDir, helmDir, helmChartDir), 0766)
 	if err != nil {
 		o.Log.Error(" setupWorkingDir for helm directory %v ", err)
 		return err
 	}
 
-	err = o.MakeDir.makeDirAll(filepath.Join(o.Opts.Global.WorkingDir, helmDir, helmIndexesDir), 0755)
+	err = o.MakeDir.makeDirAll(filepath.Join(o.Opts.Global.WorkingDir, helmDir, helmIndexesDir), 0766)
 	if err != nil {
 		o.Log.Error(" setupWorkingDir for helm directory %v ", err)
 		return err
@@ -990,7 +990,7 @@ func (o *ExecutorSchema) setupLogsLevelAndDir() error {
 	os.RemoveAll(o.LogsDir)
 
 	// create logs directory
-	err := o.MakeDir.makeDirAll(o.LogsDir, 0744)
+	err := o.MakeDir.makeDirAll(o.LogsDir, 0766)
 	if err != nil {
 		o.Log.Error(" %v ", err)
 		return err

--- a/v2/internal/pkg/clusterresources/clusterresources.go
+++ b/v2/internal/pkg/clusterresources/clusterresources.go
@@ -174,7 +174,7 @@ func writeMirrorSet[T confv1.ImageDigestMirrorSet | confv1.ImageTagMirrorSet](mi
 	// save IDMS struct to file
 	if _, err := os.Stat(msFilePath); errors.Is(err, os.ErrNotExist) {
 		log.Debug("%s does not exist, creating it", msFilePath)
-		err := os.MkdirAll(filepath.Dir(msFilePath), 0744)
+		err := os.MkdirAll(filepath.Dir(msFilePath), 0766)
 		if err != nil {
 			return err
 		}
@@ -473,7 +473,7 @@ func (o *ClusterResourcesGenerator) generateClusterCatalog(catalogRef string) er
 	// save ClusterCatalog struct to file
 	if _, err := os.Stat(ccFileName); errors.Is(err, os.ErrNotExist) {
 		o.Log.Debug("%s does not exist, creating it", ccFileName)
-		if err := os.MkdirAll(filepath.Dir(ccFileName), 0744); err != nil {
+		if err := os.MkdirAll(filepath.Dir(ccFileName), 0766); err != nil {
 			return err
 		}
 		o.Log.Debug("%s dir created", filepath.Dir(ccFileName))
@@ -645,7 +645,7 @@ func (o *ClusterResourcesGenerator) UpdateServiceGenerator(graphImageRef, releas
 
 	if _, err := os.Stat(osusPath); errors.Is(err, os.ErrNotExist) {
 		o.Log.Debug("%s does not exist, creating it", osusPath)
-		err := os.MkdirAll(filepath.Dir(osusPath), 0744)
+		err := os.MkdirAll(filepath.Dir(osusPath), 0766)
 		if err != nil {
 			return err
 		}

--- a/v2/internal/pkg/clusterresources/clusterresources.go
+++ b/v2/internal/pkg/clusterresources/clusterresources.go
@@ -174,7 +174,7 @@ func writeMirrorSet[T confv1.ImageDigestMirrorSet | confv1.ImageTagMirrorSet](mi
 	// save IDMS struct to file
 	if _, err := os.Stat(msFilePath); errors.Is(err, os.ErrNotExist) {
 		log.Debug("%s does not exist, creating it", msFilePath)
-		err := os.MkdirAll(filepath.Dir(msFilePath), 0755)
+		err := os.MkdirAll(filepath.Dir(msFilePath), 0744)
 		if err != nil {
 			return err
 		}
@@ -338,7 +338,7 @@ func (o *ClusterResourcesGenerator) generateCatalogSource(catalogRef string, cat
 	// save IDMS struct to file
 	if _, err := os.Stat(csFileName); errors.Is(err, os.ErrNotExist) {
 		o.Log.Debug("%s does not exist, creating it", csFileName)
-		err := os.MkdirAll(filepath.Dir(csFileName), 0755)
+		err := os.MkdirAll(filepath.Dir(csFileName), 0744)
 		if err != nil {
 			return err
 		}
@@ -473,7 +473,7 @@ func (o *ClusterResourcesGenerator) generateClusterCatalog(catalogRef string) er
 	// save ClusterCatalog struct to file
 	if _, err := os.Stat(ccFileName); errors.Is(err, os.ErrNotExist) {
 		o.Log.Debug("%s does not exist, creating it", ccFileName)
-		if err := os.MkdirAll(filepath.Dir(ccFileName), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(ccFileName), 0744); err != nil {
 			return err
 		}
 		o.Log.Debug("%s dir created", filepath.Dir(ccFileName))
@@ -645,7 +645,7 @@ func (o *ClusterResourcesGenerator) UpdateServiceGenerator(graphImageRef, releas
 
 	if _, err := os.Stat(osusPath); errors.Is(err, os.ErrNotExist) {
 		o.Log.Debug("%s does not exist, creating it", osusPath)
-		err := os.MkdirAll(filepath.Dir(osusPath), 0755)
+		err := os.MkdirAll(filepath.Dir(osusPath), 0744)
 		if err != nil {
 			return err
 		}

--- a/v2/internal/pkg/delete/delete_images.go
+++ b/v2/internal/pkg/delete/delete_images.go
@@ -54,7 +54,7 @@ func (o DeleteImages) WriteDeleteMetaData(ctx context.Context, images []v2alpha1
 		discYamlFile = filepath.Join(o.Opts.Global.WorkingDir, strings.ReplaceAll(discYaml, ".", "-"+o.Opts.Global.DeleteID+"."))
 	}
 	// create the delete folder
-	err := os.MkdirAll(o.Opts.Global.WorkingDir+deleteDir, 0755)
+	err := os.MkdirAll(o.Opts.Global.WorkingDir+deleteDir, 0766)
 	if err != nil {
 		o.Log.Error("%v ", err)
 	}
@@ -75,7 +75,8 @@ func (o DeleteImages) WriteDeleteMetaData(ctx context.Context, images []v2alpha1
 	if err != nil {
 		o.Log.Error(deleteImagesErrMsg, err)
 	}
-	err = os.WriteFile(filename, ymlData, 0755)
+	// nolint:gosec // G306: no sensitive data
+	err = os.WriteFile(filename, ymlData, 0766)
 	if err != nil {
 		o.Log.Error(deleteImagesErrMsg, err)
 	}
@@ -98,7 +99,8 @@ func (o DeleteImages) WriteDeleteMetaData(ctx context.Context, images []v2alpha1
 	if err != nil {
 		o.Log.Error("%v ", err)
 	}
-	err = os.WriteFile(discYamlFile, discYamlData, 0755)
+	// nolint:gosec // G306: no sensitive data
+	err = os.WriteFile(discYamlFile, discYamlData, 0766)
 	if err != nil {
 		o.Log.Error(deleteImagesErrMsg, err)
 	}

--- a/v2/internal/pkg/helm/local_stored_collector.go
+++ b/v2/internal/pkg/helm/local_stored_collector.go
@@ -274,7 +274,7 @@ func repoAdd(chartRepo v2alpha1.Repository) error {
 	// Update temp file with chart entry
 	helmFile.Update(&entry)
 
-	if err := helmFile.WriteFile(lsc.Helm.settings.RepositoryConfig, 0644); err != nil {
+	if err := helmFile.WriteFile(lsc.Helm.settings.RepositoryConfig, 0766); err != nil {
 		return fmt.Errorf("error writing helm repo file: %s %w", strings.TrimSpace(chartRepo.Name), err)
 	}
 
@@ -304,13 +304,13 @@ func createIndexFile(indexURL string) (helmrepo.IndexFile, error) {
 
 	indexDir := filepath.Join(lsc.Opts.Global.WorkingDir, helmDir, helmIndexesDir, namespace)
 
-	if err := os.MkdirAll(indexDir, 0755); err != nil {
+	if err := os.MkdirAll(indexDir, 0766); err != nil {
 		return indexFile, err
 	}
 
 	indexFilePath := filepath.Join(indexDir, "index.yaml")
 
-	if err := indexFile.WriteFile(indexFilePath, 0644); err != nil {
+	if err := indexFile.WriteFile(indexFilePath, 0666); err != nil {
 		return indexFile, fmt.Errorf("error writing helm index file: %s", err.Error())
 	}
 

--- a/v2/internal/pkg/helm/local_stored_collector.go
+++ b/v2/internal/pkg/helm/local_stored_collector.go
@@ -310,7 +310,7 @@ func createIndexFile(indexURL string) (helmrepo.IndexFile, error) {
 
 	indexFilePath := filepath.Join(indexDir, "index.yaml")
 
-	if err := indexFile.WriteFile(indexFilePath, 0666); err != nil {
+	if err := indexFile.WriteFile(indexFilePath, 0644); err != nil {
 		return indexFile, fmt.Errorf("error writing helm index file: %s", err.Error())
 	}
 

--- a/v2/internal/pkg/history/history.go
+++ b/v2/internal/pkg/history/history.go
@@ -31,7 +31,7 @@ func NewHistory(workingDir string, before time.Time, logg clog.PluggableLoggerIn
 	}
 	historyDir := filepath.Join(workingDir, historyPath)
 
-	err := os.MkdirAll(historyDir, 0755)
+	err := os.MkdirAll(historyDir, 0766)
 	if err != nil {
 		return history{}, fmt.Errorf("error creating directories %w", err)
 	}

--- a/v2/internal/pkg/imagebuilder/catalog_builder.go
+++ b/v2/internal/pkg/imagebuilder/catalog_builder.go
@@ -125,7 +125,8 @@ func (c GCRCatalogBuilder) RebuildCatalog(ctx context.Context, catalogCopyRef v2
 	if err != nil {
 		return fmt.Errorf("error building catalog %s : %v", catalogCopyRef.Origin, err)
 	}
-	err = os.WriteFile(filepath.Join(filteredDir, "digest"), []byte(digest), 0755)
+	// nolint:gosec // G306: no sensitive data
+	err = os.WriteFile(filepath.Join(filteredDir, "digest"), []byte(digest), 0766)
 	if err != nil {
 		return err
 	}

--- a/v2/internal/pkg/manifest/oci-manifest.go
+++ b/v2/internal/pkg/manifest/oci-manifest.go
@@ -129,12 +129,14 @@ func untar(gzipStream io.Reader, path string, cfgDirName string) error {
 			switch header.Typeflag {
 			case tar.TypeDir:
 				if header.Name != "./" {
-					if err := os.MkdirAll(filepath.Join(path, header.Name), 0755); err != nil {
+					// nolint:gosec // G305: file traversal (zip slip vulnerability : tar created by oc-mirror)
+					if err := os.MkdirAll(filepath.Join(path, header.Name), 0766); err != nil {
 						return fmt.Errorf("untar: Mkdir() failed: %w", err)
 					}
 				}
 			case tar.TypeReg:
-				err := os.MkdirAll(filepath.Dir(filepath.Join(path, header.Name)), 0755)
+				// nolint:gosec // G305: file traversal (zip slip vulnerability : tar created by oc-mirror)
+				err := os.MkdirAll(filepath.Dir(filepath.Join(path, header.Name)), 0766)
 				if err != nil {
 					return fmt.Errorf("untar: Create() failed: %w", err)
 				}

--- a/v2/internal/pkg/operator/filtered_collector.go
+++ b/v2/internal/pkg/operator/filtered_collector.go
@@ -120,7 +120,7 @@ func createFolders(paths []string) error {
 	var errs []error
 	for _, path := range paths {
 		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
-			err = os.MkdirAll(path, 0755)
+			err = os.MkdirAll(path, 0766)
 			if err != nil {
 				errs = append(errs, err)
 			}

--- a/v2/internal/pkg/registriesd/registriesd.go
+++ b/v2/internal/pkg/registriesd/registriesd.go
@@ -70,7 +70,7 @@ func GetWorkingDirRegistrydConfigPath(workingDir string) string {
 }
 
 func copyDefaultConfigsToWorkingDir(defaultRegistrydConfigPath, customRegistrydConfigPath string) error {
-	if err := os.MkdirAll(filepath.Dir(customRegistrydConfigPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(customRegistrydConfigPath), 0766); err != nil {
 		return fmt.Errorf("error creating folder %s %w", filepath.Dir(customRegistrydConfigPath), err)
 	}
 
@@ -114,7 +114,7 @@ func fileName(registryURL string) string {
 }
 
 func createRegistryConfigFile(registryFileAbsPath, registryHost string) error {
-	err := os.MkdirAll(filepath.Dir(registryFileAbsPath), 0755)
+	err := os.MkdirAll(filepath.Dir(registryFileAbsPath), 0766)
 	if err != nil {
 		return fmt.Errorf("error creating cache")
 	}

--- a/v2/internal/pkg/release/graph.go
+++ b/v2/internal/pkg/release/graph.go
@@ -31,7 +31,7 @@ func (o *LocalStorageCollector) CreateGraphImage(ctx context.Context, url string
 
 	// save graph data in a container layer modifying UID and GID to root.
 	archiveDestination := filepath.Join(o.Opts.Global.WorkingDir, graphArchive)
-	graphLayer, err := imagebuilder.LayerFromGzipByteArray(body, archiveDestination, buildGraphDataDir, 0644, 0, 0)
+	graphLayer, err := imagebuilder.LayerFromGzipByteArray(body, archiveDestination, buildGraphDataDir, 0766, 0, 0)
 	if err != nil {
 		return "", err
 	}

--- a/v2/internal/pkg/release/graph.go
+++ b/v2/internal/pkg/release/graph.go
@@ -31,7 +31,7 @@ func (o *LocalStorageCollector) CreateGraphImage(ctx context.Context, url string
 
 	// save graph data in a container layer modifying UID and GID to root.
 	archiveDestination := filepath.Join(o.Opts.Global.WorkingDir, graphArchive)
-	graphLayer, err := imagebuilder.LayerFromGzipByteArray(body, archiveDestination, buildGraphDataDir, 0766, 0, 0)
+	graphLayer, err := imagebuilder.LayerFromGzipByteArray(body, archiveDestination, buildGraphDataDir, 0644, 0, 0)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
… synchronized files

# Description

Ensures all created artifacts have only read attribute set

Github / Jira issue:  OCPBUGS-55489

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Execute mirror-to-disk and then disk-to-mirror

## Expected Outcome

Validate that all created files have following file attribute (group and others) i.e 0X44

i.e 

```
$ ls -la ocpbugs-5489/working-dir/cluster-resources
total 12
drwxr--r--. 1 lzuccarelli lzuccarelli 206 Jul  7 11:23 .
drwxr--r--. 1 lzuccarelli lzuccarelli 172 Jul  7 11:23 ..
-rw-r--r--. 1 lzuccarelli lzuccarelli 466 Jul  7 11:23 cc-redhat-operator-index-sha256-11d0b.yaml
-rw-r--r--. 1 lzuccarelli lzuccarelli 468 Jul  7 11:23 cs-redhat-operator-index-sha256-11d0b.yaml
-rw-r--r--. 1 lzuccarelli lzuccarelli 946 Jul  7 11:23 idms-oc-mirror.yaml

```
