### PR TITLE
OCPBUGS-54622: cli/delete: fix workflow mode name output

### DIFF
--- a/v2/internal/pkg/cli/delete.go
+++ b/v2/internal/pkg/cli/delete.go
@@ -209,7 +209,7 @@ func (o *DeleteSchema) CompleteDelete(args []string) error {
 
 	// ensure mirror and batch worker use delete logic
 	o.Opts.Function = string(mirror.DeleteMode)
-	o.Log.Info(emoji.TwistedRighwardsArrows+" workflow mode: %s / %s", o.Opts.Mode, o.Opts.Function)
+	o.Log.Info(emoji.TwistedRighwardsArrows+" workflow mode: %s", o.Opts.Function)
 
 	if o.Opts.Global.DeleteGenerate {
 		err = o.setupWorkingDir()


### PR DESCRIPTION
# Description

Showing `delete` is enough and less confusing than `diskToMirror / delete` which is just an implementation detail.

Github / Jira issue: OCPBUGS-54622

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Check output of `oc-mirror --v2 delete`

## Expected Outcome
"workflow mode" shows `delete` instead of `diskToMirror / delete`