### PR TITLE
OCPBUGS-52562: Ensure release collection does not include duplicates

### DIFF
--- a/v2/internal/pkg/release/signature.go
+++ b/v2/internal/pkg/release/signature.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -190,7 +191,13 @@ func (o SignatureSchema) GenerateReleaseSignatures(ctx context.Context, images [
 				return []v2alpha1.CopyImageSchema{}, fmt.Errorf("[GenerateReleaseSignatures] writing %w", ferr)
 			}
 		}
-		imgs = append(imgs, img)
+		// OCPBUGS-52562
+		// add a check to ensure there are no duplicates
+		// ideally it would be better to add this at the early stages of this process
+		// but due to the conversion of the 'Source' field in line 155 we have to do this after the fact
+		if !slices.Contains(imgs, img) {
+			imgs = append(imgs, img)
+		}
 	}
 	return imgs, nil
 }


### PR DESCRIPTION
# Description

Ensure release collection does not contain duplicates

Github / Jira issue:  OCPBUGS-52562

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

use the following imagesetconfig

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  platform:
    channels:
    - name: stable-4.17
      minVersion: 4.17.0
      maxVersion: 4.17.0
    - name: stable-4.16
      minVersion: 4.16.0
      maxVersion: 4.16.0
```
Execute a mirror-to-disk workflow

## Expected Outcome

Ensure there are no duplicates (viewed in the console outptut)