### PR TITLE
OCPBUGS-59396: v2/archive: handle 0b mirror archive files

### DIFF
--- a/v2/internal/pkg/archive/unarchive.go
+++ b/v2/internal/pkg/archive/unarchive.go
@@ -62,11 +62,14 @@ func (o MirrorUnArchiver) Unarchive() error {
 	isTerminal := term.IsTerminal(int(os.Stdout.Fd()))
 	p := mpb.New(mpb.PopCompletedMode())
 	for i, chunkPath := range o.archiveFiles {
+		stat, _ := os.Stat(chunkPath)
+		if stat.Size() == 0 {
+			return fmt.Errorf("empty archive file %q", chunkPath)
+		}
 		if !isTerminal {
 			// FIXME: replace this by a proper log call
 			fmt.Printf("Extracting chunk file (%d / %d): %s\n", i+1, len(o.archiveFiles), chunkPath)
 		}
-		stat, _ := os.Stat(chunkPath)
 		bar := p.AddBar(stat.Size(),
 			mpb.PrependDecorators(
 				decor.Name(chunkPath+" "),
@@ -74,6 +77,7 @@ func (o MirrorUnArchiver) Unarchive() error {
 			),
 			mpb.AppendDecorators(decor.Elapsed(decor.ET_STYLE_GO)),
 		)
+		bar.EnableTriggerComplete()
 
 		if err := o.unarchiveChunkTarFile(chunkPath, bar); err != nil {
 			bar.Abort(false)


### PR DESCRIPTION
# Description

When m2d fails, a 0b `mirror_0000X.tar` file can still be created. If one attempts to run d2m with that file, `oc-mirror` will hang forever because a progress bar of 0 total size doesn't detect it has completed.

Since a 0b tar file is a probable sign of missing mirror data, let's return an error to indicate the problematic file. If users want to force `oc-mirror` to continue anyway, they can remove the offending file.

Fixes #1217

Github / Jira issue: OCPBUGS-59396

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

```
❯ ~/prjs/github.com/openshift/oc-mirror/v2/build/oc-mirror --config isc.yaml --from file://data/invalid-digest docker://localhost:5000
2025/07/16 17:27:14  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/07/16 17:27:14  [INFO]   : ⚙️  setting up the environment for you...
2025/07/16 17:27:14  [INFO]   : 🔀 workflow mode: diskToMirror 
2025/07/16 17:27:14  [INFO]   : 📦 Extracting mirror archive(s)...
2025/07/16 17:27:14  [ERROR]  :  empty archive file "data/invalid-digest/mirror_000001.tar" 
2025/07/16 17:27:14  [INFO]   : mirror time     : 649.706µs
2025/07/16 17:27:14  [INFO]   : 👋 Goodbye, thank you for using oc-mirror
2025/07/16 17:27:14  [ERROR]  : [Executor] empty archive file "data/invalid-digest/mirror_000001.tar" 

❯ ~/prjs/github.com/openshift/oc-mirror/v2/build/oc-mirror --config isc.yaml --from file://data/catalog-filter docker://localhost:5000
2025/07/16 17:41:36  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/07/16 17:41:36  [INFO]   : ⚙️  setting up the environment for you...
2025/07/16 17:41:36  [INFO]   : 🔀 workflow mode: diskToMirror 
2025/07/16 17:41:36  [INFO]   : 📦 Extracting mirror archive(s)...
data/catalog-filter/mirror_000001.tar (6.3 GiB / 6.3 GiB) [=================================================================================] 5s
2025/07/16 17:41:42  [INFO]   : 🕵  going to discover the necessary images...
[...]
```

## Expected Outcome
`oc-mirror` doesn't hang indefinitely with a 0b tar file.