### PR TITLE
NO-JIRA: adds build-machinery-go as a tool dependency

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -9,7 +9,7 @@ GOMODCACHE=$(shell $(GO) env GOMODCACHE)
 BUILD_MACHINERY_VERSION=v0.0.0-20250414185254-3ce8e800ceda
 BUILD_MACHINERY_PATH=github.com/openshift/build-machinery-go
 
-$(shell $(GO) get ${BUILD_MACHINERY_PATH}@${BUILD_MACHINERY_VERSION})
+$(shell $(GO) get -tool ${BUILD_MACHINERY_PATH}@${BUILD_MACHINERY_VERSION})
 
 # Include the library makefile
 include $(addprefix ${GOMODCACHE}/${BUILD_MACHINERY_PATH}@${BUILD_MACHINERY_VERSION}/make/, \

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -243,3 +243,5 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 )
+
+tool github.com/openshift/build-machinery-go


### PR DESCRIPTION
# Description

This change adds `build-machinery-go` as a tool dependency in the oc-mirror v2. The modification ensures that the build machinery is properly managed as a tool dependency rather than a regular dependency, which prevents it from being included in the final binary and keeps the dependency tree cleaner.

The changes include:
- Updated the Makefile to use the `-tool` flag when fetching build-machinery-go
- Added build-machinery-go as a tool dependency in go.mod

This change improves the build process by properly categorizing build-time dependencies.

## Type of change

- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)

# How Has This Been Tested?

The changes were tested by:
1. Running `go mod tidy` to ensure the tool dependency is properly managed
2. Verifying that the build process still works correctly with the updated Makefile

## Expected Outcome
The build process should continue to work as expected, but with build-machinery-go properly managed as a tool dependency rather than a regular dependency. This should result in a cleaner dependency tree and prevent the build machinery from being included in the final binary and from being removed by `go mod tidy` in v2.