### PR TITLE
OCPBUGS-59646: revert #1220 and print a warning instead

### DIFF
--- a/cmd/oc-mirror/main.go
+++ b/cmd/oc-mirror/main.go
@@ -23,10 +23,13 @@ var mirrorV2 embed.FS
 
 func main() {
 	if slices.Contains(os.Args, "--v2") {
-		err := runOcMirrorV2(os.Args)
-		var exitErr *exec.ExitError
-		if err != nil && errors.As(err, &exitErr) {
-			os.Exit(exitErr.ExitCode())
+		if err := runOcMirrorV2(os.Args); err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				os.Exit(exitErr.ExitCode())
+			}
+			fmt.Printf("failed to run oc-mirror: %s\n", err.Error())
+			os.Exit(1)
 		}
 	} else {
 		rootCmd := cliV1.NewMirrorCmd()

--- a/cmd/oc-mirror/main.go
+++ b/cmd/oc-mirror/main.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"syscall"
 
 	"k8s.io/klog"
@@ -29,6 +30,13 @@ func main() {
 				os.Exit(exitErr.ExitCode())
 			}
 			fmt.Printf("failed to run oc-mirror: %s\n", err.Error())
+			if strings.Contains(err.Error(), "permission denied") {
+				tmpdir, ok := os.LookupEnv("TMPDIR")
+				if !ok {
+					tmpdir = "/tmp"
+				}
+				fmt.Printf("The tmp dir %q might be mounted as `noexec`. Please set TMPDIR to a filesystem with exec permissions.\n", tmpdir)
+			}
 			os.Exit(1)
 		}
 	} else {


### PR DESCRIPTION
# Description

It seems /home must also be mounted `noexec` [1]. So let's go back to extracting to /tmp since overriding it with the `TMPDIR` envvar is less disruptive than overriding `HOME`.
    
[1] https://stigviewer.com/stigs/red_hat_enterprise_linux_9/2025-02-27/finding/V-257852

Github / Jira issue: OCPBUGS-59646

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

```
$ podman run --rm -it --tmpfs /tmp:noexec docker.io/redhat/ubi9:latest
[root@68107d25fc95 /]# mount | grep '/tmp'
tmpfs on /tmp type tmpfs (rw,nosuid,nodev,noexec,relatime)

$ CGO_ENABLED=0 make build
$ podman cp bin/oc-mirror <container>:/root

[root@c8c6ec9d1700 /]# /root/oc-mirror --v2 --help
failed to run oc-mirror: fork/exec /tmp/oc-mirror-1960038340/oc-mirror: permission denied
The tmp dir "/tmp" might be mounted as `noexec`. Please set TMPDIR to a filesystem with exec permissions.

[root@c8c6ec9d1700 /]# TMPDIR=/root/ /root/oc-mirror --v2 --help
Mirror OCP Release, operator catalog and additional images using a declarative configuration file as an input.
[...]
```

## Expected Outcome
Warning message when TMPDIR is `noexec`.