### PR TITLE
NO-JIRA: updates dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,24 @@
 version: 2
 updates:
+  # Configuration for the oc-mirror v1 go mod
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "daily"
-    allow:
-      - dependency-type: all
-    # Disable version updates
+    # Disable version updates, only allow security updates
     open-pull-requests-limit: 0
     groups:
-      golang:
+      oc-mirror-v1:
         applies-to: security-updates
+        patterns: [ "*" ]
+
+  # Configuration for the oc-mirror v2 go module
+  - package-ecosystem: "gomod"
+    directory: "/v2"
+    schedule:
+      interval: "daily"
+    # Allow all updates (version and security)
+    open-pull-requests-limit: 10
+    groups:
+      oc-mirror-v2:
         patterns: [ "*" ]


### PR DESCRIPTION
# Description

Updates the dependabot config to the following:
* Upgrade v1 dependencies only in case of CVEs
* Upgrade v2 dependencies when new versions are available and also in case of CVEs

## Type of change

- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)

# How Has This Been Tested?

It was tested on [my forked](https://github.com/aguidirh/oc-mirror/pulls) version of oc-mirror.

## Expected Outcome
v1 dependencies will be updated only in case of CVES and v2 dependencies will be updated in case of CVEs and new versions available.