### PR TITLE
OCPBUGS-59913: prevents panic when helm chart is nil

### DIFF
--- a/v2/internal/pkg/helm/local_stored_collector.go
+++ b/v2/internal/pkg/helm/local_stored_collector.go
@@ -354,7 +354,7 @@ func getImages(path string, imagePaths ...string) (images []v2alpha1.RelatedImag
 
 	var chart *helmchart.Chart
 	if chart, err = loader.Load(path); err != nil {
-		return nil, fmt.Errorf("failed to load %s: %w", chart.Name(), err)
+		return nil, fmt.Errorf("failed to load %s: %w", path, err)
 	}
 
 	var templates string


### PR DESCRIPTION
# Description

This PR prevents the panic to happen when the helm chart is nil (bug introduced on PR #1172).

Github / Jira issue: [OCPBUGS-59913](https://issues.redhat.com/browse/OCPBUGS-59913)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

With the following ImageSetConfig:

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  helm:
    local:
     - name: test-mirror-helm
       path: data/test-mirror-helm-0.3.0.tgz
       imagePaths:
        - "{.spec.template.spec.containers[*].env[*].value}"
```

I ran `m2d` without 3 times with the following scenarios:

* does not have data directory 
* does not have the data/test-mirror-helm-0.3.0.tgz file
* the data/test-mirror-helm-0.3.0.tgz file size is 0

## Expected Outcome

All the 3 `m2d` should not panic, it should show only an error message like below:

```
2025/08/01 11:03:43  [ERROR]  : [Executor] collection error: failed to load data/test-mirror-helm-0.3.0.tgz: stat data/test-mirror-helm-0.3.0.tgz: no such file or directory 
```