### PR TITLE
[release-4.19] OCPBUGS-59760: warn if tmp is `noexec`

### DIFF
--- a/cmd/oc-mirror/main.go
+++ b/cmd/oc-mirror/main.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"syscall"
 
 	"k8s.io/klog"
@@ -29,6 +30,13 @@ func main() {
 				os.Exit(exitErr.ExitCode())
 			}
 			fmt.Printf("failed to run oc-mirror: %s\n", err.Error())
+			if strings.Contains(err.Error(), "permission denied") {
+				tmpdir, ok := os.LookupEnv("TMPDIR")
+				if !ok {
+					tmpdir = "/tmp"
+				}
+				fmt.Printf("The tmp dir %q might be mounted as `noexec`. Please set TMPDIR to a filesystem with exec permissions.\n", tmpdir)
+			}
 			os.Exit(1)
 		}
 	} else {

--- a/cmd/oc-mirror/main.go
+++ b/cmd/oc-mirror/main.go
@@ -23,10 +23,13 @@ var mirrorV2 embed.FS
 
 func main() {
 	if slices.Contains(os.Args, "--v2") {
-		err := runOcMirrorV2(os.Args)
-		var exitErr *exec.ExitError
-		if err != nil && errors.As(err, &exitErr) {
-			os.Exit(exitErr.ExitCode())
+		if err := runOcMirrorV2(os.Args); err != nil {
+			var exitErr *exec.ExitError
+			if err != nil && errors.As(err, &exitErr) {
+				os.Exit(exitErr.ExitCode())
+			}
+			fmt.Printf("failed to run oc-mirror: %s\n", err.Error())
+			os.Exit(1)
 		}
 	} else {
 		rootCmd := cliV1.NewMirrorCmd()


### PR DESCRIPTION
# Description

Manual cherry-pick of https://github.com/openshift/oc-mirror/pull/1228

Github / Jira issue: OCPBUGS-59760

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.