### PR TITLE
OCPBUGS-59949: fixes the result output showing the wrong total

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -1050,6 +1050,7 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 	}
 	// exclude blocked images
 	releaseImgs = excludeImages(releaseImgs, o.Config.Mirror.BlockedImages)
+	releaseImgs = removeDuplicatedImages(releaseImgs, o.Opts.Function)
 
 	collectorSchema.TotalReleaseImages = len(releaseImgs)
 	o.Log.Debug(collecAllPrefix+"total release images to %s %d ", o.Opts.Function, collectorSchema.TotalReleaseImages)
@@ -1064,6 +1065,7 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 		oImgs := operatorImgs.AllImages
 		// exclude blocked images
 		oImgs = excludeImages(oImgs, o.Config.Mirror.BlockedImages)
+		oImgs = removeDuplicatedImages(oImgs, o.Opts.Function)
 		collectorSchema.TotalOperatorImages = len(oImgs)
 		o.Log.Debug(collecAllPrefix+"total operator images to %s %d ", o.Opts.Function, collectorSchema.TotalOperatorImages)
 		allRelatedImages = append(allRelatedImages, oImgs...)
@@ -1079,6 +1081,7 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 	} else {
 		// exclude blocked images
 		aImgs = excludeImages(aImgs, o.Config.Mirror.BlockedImages)
+		aImgs = removeDuplicatedImages(aImgs, o.Opts.Function)
 		collectorSchema.TotalAdditionalImages = len(aImgs)
 		o.Log.Debug(collecAllPrefix+"total additional images to %s %d ", o.Opts.Function, collectorSchema.TotalAdditionalImages)
 		allRelatedImages = append(allRelatedImages, aImgs...)
@@ -1091,19 +1094,11 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 	} else {
 		// exclude blocked images
 		hImgs = excludeImages(hImgs, o.Config.Mirror.BlockedImages)
+		hImgs = removeDuplicatedImages(hImgs, o.Opts.Function)
 		collectorSchema.TotalHelmImages = len(hImgs)
 		o.Log.Debug(collecAllPrefix+"total helm images to %s %d ", o.Opts.Function, collectorSchema.TotalHelmImages)
 		allRelatedImages = append(allRelatedImages, hImgs...)
 	}
-
-	// OCPBUGS-43731 - remove duplicates
-	allRelatedImages = slices.CompactFunc(allRelatedImages, func(a, b v2alpha1.CopyImageSchema) bool {
-		if o.Opts.Function == string(mirror.DeleteMode) {
-			return a.Destination == b.Destination
-		} else {
-			return a.Source == b.Source && a.Destination == b.Destination && a.Origin == b.Origin
-		}
-	})
 
 	sort.Sort(customsort.ByTypePriority(allRelatedImages))
 
@@ -1270,4 +1265,15 @@ func mandatoryRegistries(opts *mirror.CopyOptions) map[string]struct{} {
 	}
 
 	return regs
+}
+
+func removeDuplicatedImages(allRelatedImages []v2alpha1.CopyImageSchema, mode string) []v2alpha1.CopyImageSchema {
+	// OCPBUGS-43731 - remove duplicates
+	return slices.CompactFunc(allRelatedImages, func(a, b v2alpha1.CopyImageSchema) bool {
+		if mode == string(mirror.DeleteMode) {
+			return a.Destination == b.Destination
+		} else {
+			return a.Source == b.Source && a.Destination == b.Destination && a.Origin == b.Origin
+		}
+	})
 }


### PR DESCRIPTION
# Description

This PR fixes the bug where the total number of images in the Results after mirroring was wrong. 

This bug was introduced in PR #959 when the duplicated images func was implemented. This func was removing the images duplicated after the total was already assigned to the variable responsible to show the total number of images, showing in this way the wrong number.

In this PR the func responsible to remove the images duplicated was moved before the variable responsible for the total, in this way the total number of images is already going to take into account the images duplicated removed.

Github / Jira issue: [OCPBUGS-59949](https://issues.redhat.com/browse/OCPBUGS-59949)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

With the following ImageSetConfiguration:

```
apiVersion: mirror.openshift.io/v2alpha1
kind: ImageSetConfiguration
mirror: 
  helm: 
    repositories: 
      - name: openshift-charts
        url: https://charts.openshift.io
        charts: 
          - name: redhat-developer-hub
            version: "1.4.1"
```

I ran `m2d`, `d2m` and `m2m`. 

## Expected Outcome

The results should be the following with the code of this PR:

```
2025/08/01 15:03:17  [INFO]   : 📌 images to copy 2 
 ✓   (44s)  rhdh-hub-rhel9@sha256:d8268197ba0466643efb818fcad8f0fc29e32463f75b0f7f51d9ce75ec717572 ➡️  cache  
2 / 2 (48s) [==========================================================================================================================================] 100 %
 ✓   (48s)  postgresql-15@sha256:44a08b83a6c50714b52f4cf1c3476bc16b66faec21dd9a9bc07d1be5f97b8150 ➡️  cache  
2025/08/01 15:04:07  [INFO]   : === Results ===
2025/08/01 15:04:07  [INFO]   :  ✓  2 / 2 helm images mirrored successfully
```

While with the code from the main branch, it shows the wrong total in results:


```
2025/08/01 14:58:36  [INFO]   : 📌 images to copy 2 
 ✓   (28s)  rhdh-hub-rhel9@sha256:d8268197ba0466643efb818fcad8f0fc29e32463f75b0f7f51d9ce75ec717572 ➡️  cache  
2 / 2 (37s) [==========================================================================================================================================] 100 %
 ✓   (37s)  postgresql-15@sha256:44a08b83a6c50714b52f4cf1c3476bc16b66faec21dd9a9bc07d1be5f97b8150 ➡️  cache  
2025/08/01 14:59:14  [INFO]   : === Results ===
2025/08/01 14:59:14  [INFO]   :  ✗  2 / 3 helm images mirrored: Some helm images failed to be mirrored - please check the logs
```