### PR TITLE
CLID-415: adds a warn message to v1 about change behavior on OCP release 4.21

### DIFF
--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -84,6 +84,7 @@ const (
 
 func NewMirrorCmd() *cobra.Command {
 	klog.Warning("\n\n⚠️  oc-mirror v1 is deprecated (starting in 4.18 release) and will be removed in a future release - please migrate to oc-mirror --v2\n\n")
+	klog.Warning("\n\n⚠️  starting with OCP release 4.21, oc-mirror v2 is going to be the default version, please migrate to oc-mirror v2 or start using --v1 in order to continue using the oc-mirror deprecated version\n\n")
 
 	o := MirrorOptions{
 		operatorCatalogToFullArtifactPath: map[string]string{},


### PR DESCRIPTION
# Description

This PR adds a warn message to let customers know that starting in `OCP release 4.21`, they need to use `--v1` in case they want to continue using the oc-mirror deprecated version.

Github / Jira issue: [CLID-415](https://issues.redhat.com/browse/CLID-415)

## Type of change

- [x] Code Change on log output
- [x] This change requires a documentation update on openshift docs

# How Has This Been Tested?

I ran the following command:

```
./bin/oc-mirror -c /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/alex-isc/clid-28.yaml file:///home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/clid-28
```

## Expected Outcome
```
⚠️  starting in OCP release 4.21, oc-mirror v2 is going to be the default version, please migrate to oc-mirror v2 or start using --v1 in order to continue using the oc-mirror deprecated version
```