### PR TITLE
OCPBUGS-60999: fix issue when using full true in m2m

### DIFF
--- a/v2/internal/pkg/api/v2alpha1/type_internal.go
+++ b/v2/internal/pkg/api/v2alpha1/type_internal.go
@@ -195,6 +195,8 @@ type RelatedImage struct {
 	//Used to identify if a related image is from an operator catalog on disk (oci:// on ImageSetConfiguration)
 	//TODO remove me when the migration from oc-mirror v1 to v2 ends
 	OriginFromOperatorCatalogOnDisk bool
+	// Used to identify if it is a full catalog (full: true && zero packages)
+	FullCatalog bool
 }
 
 type CollectorSchema struct {

--- a/v2/internal/pkg/operator/filtered_collector.go
+++ b/v2/internal/pkg/operator/filtered_collector.go
@@ -267,6 +267,7 @@ func (o FilterCollector) collectOperator( //nolint:cyclop // TODO: this needs fu
 			TargetTag:     targetTag,
 			TargetCatalog: op.TargetCatalog,
 			RebuiltTag:    rebuiltTag,
+			FullCatalog:   isFullCatalog(op),
 		},
 	}
 	return result, nil

--- a/v2/internal/pkg/operator/filtered_collector_test.go
+++ b/v2/internal/pkg/operator/filtered_collector_test.go
@@ -705,7 +705,7 @@ func TestFilterCollectorM2M(t *testing.T) {
 					Type:        v2alpha1.TypeOperatorCatalog,
 				},
 				{
-					Source:      "docker://localhost:9999/redhat/community-operator-index:v4.18",
+					Source:      "docker://registry.redhat.io/redhat/community-operator-index:v4.18",
 					Destination: "docker://localhost:5000/test/redhat/community-operator-index:v4.18",
 					Origin:      "docker://registry.redhat.io/redhat/community-operator-index:v4.18",
 					Type:        v2alpha1.TypeOperatorCatalog,


### PR DESCRIPTION
# Description

Before this fix during m2m when using full: true with no packages specified, the dispatch func was trying to retrieve a rebuilt catalog image from cache. This behavior was wrong since full: true with no packages specified does not rebuild the catalog.

This PR fixes this behavior, it gets the original catalog image in case it is a full catalog (`full: true` with no packages specified in the ImageSetConfiguration).

Github / Jira issue: [OCPBUGS-60999](https://issues.redhat.com/browse/OCPBUGS-60999)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

With the following ImageSetConfiguration: 

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
    targetCatalog: registry.test/operatorsredhat/redhat/catalog
    targetTag: v4.18_20250829
    full: true
```

Run `m2m`. 

## Expected Outcome
It should pass with the code from this PR and fail with the code from the main branch.