### PR TITLE
OCPBUGS-61001: v2/clusterresources: add def namespace to UpdateService

### DIFF
--- a/internal/pkg/clusterresources/clusterresources.go
+++ b/internal/pkg/clusterresources/clusterresources.go
@@ -628,6 +628,7 @@ func (o *ClusterResourcesGenerator) UpdateServiceGenerator(graphImageRef, releas
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        updateServiceResourceName,
 			Annotations: generateOcMirrorAnnotations(),
+			Namespace:   updateServiceDefaultNamespace,
 		},
 		Spec: updateservicev1.UpdateServiceSpec{
 			Replicas:       2,

--- a/internal/pkg/clusterresources/clusterresources_test.go
+++ b/internal/pkg/clusterresources/clusterresources_test.go
@@ -1373,44 +1373,54 @@ func TestUpdateServiceGenerator(t *testing.T) {
 	tmpDir := t.TempDir()
 	workingDir := tmpDir + "/working-dir"
 
-	releaseImage := "quay.io/openshift-release-dev/ocp-release:4.13.10-x86_64"
-	graphImage := "localhost:5000/openshift/graph-image:latest"
+	const (
+		release    = "quay.io/openshift-release-dev/ocp-release"
+		graphImage = "localhost:5000/openshift/graph-image:latest"
+	)
+	releaseImage := fmt.Sprintf("%s:4.13.10-x86_64", release)
 
-	t.Run("Testing IDMSGenerator - Disk to Mirror : should pass", func(t *testing.T) {
+	t.Run("Testing UpdateServiceGenerator - Disk to Mirror : should pass", func(t *testing.T) {
 		cr := &ClusterResourcesGenerator{
 			Log:        log,
 			WorkingDir: workingDir,
 		}
 		err := cr.UpdateServiceGenerator(graphImage, releaseImage)
-		if err != nil {
-			t.Fatalf("should not fail")
-		}
+		assert.NoError(t, err)
 
 		_, err = os.Stat(filepath.Join(workingDir, clusterResourcesDir))
-		if err != nil {
-			t.Fatalf("output folder should exist")
-		}
+		assert.NoError(t, err, "output folder should exist")
 
 		resourceFiles, err := os.ReadDir(filepath.Join(workingDir, clusterResourcesDir))
-		if err != nil {
-			t.Fatalf("ls output folder should not fail")
-		}
+		assert.NoError(t, err, "ls output folder should not fail")
 
-		if len(resourceFiles) != 1 {
-			t.Fatalf("output folder should contain 1 updateservice.yaml file")
-		}
-
+		assert.Len(t, resourceFiles, 1, "output folder should contain 1 updateservice.yaml file")
 		assert.Equal(t, updateServiceFilename, resourceFiles[0].Name())
+
+		expectedOSUS := updateservicev1.UpdateService{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: updateservicev1.GroupVersion.String(),
+				Kind:       updateServiceResourceKind,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        updateServiceResourceName,
+				Annotations: generateOcMirrorAnnotations(),
+				Namespace:   updateServiceDefaultNamespace,
+			},
+			Spec: updateservicev1.UpdateServiceSpec{
+				Replicas:       2,
+				Releases:       release,
+				GraphDataImage: graphImage,
+			},
+		}
 
 		// Read the contents of resourceFiles[0]
 		filePath := filepath.Join(workingDir, clusterResourcesDir, resourceFiles[0].Name())
 		actualOSUS, err := parser.ParseYamlFile[updateservicev1.UpdateService](filePath)
-		if err != nil {
-			t.Fatalf("failed to unmarshall file: %v", err)
-		}
+		assert.NoErrorf(t, err, "failed to unmarshall UpdateService file %s", filePath)
 
 		assert.Equal(t, graphImage, actualOSUS.Spec.GraphDataImage)
 		assert.Equal(t, "quay.io/openshift-release-dev/ocp-release", actualOSUS.Spec.Releases)
+		assert.Equal(t, expectedOSUS, actualOSUS)
 
 		verifyNoStatusField(t, filePath)
 	})

--- a/internal/pkg/clusterresources/const.go
+++ b/internal/pkg/clusterresources/const.go
@@ -5,6 +5,7 @@ const (
 	updateServiceFilename          string = "updateService.yaml"
 	updateServiceResourceName      string = "update-service-oc-mirror"
 	updateServiceResourceKind      string = "UpdateService"
+	updateServiceDefaultNamespace  string = "openshift-update-service"
 	configMapApiVersion                   = "v1"
 	configMapKind                         = "ConfigMap"
 	configMapBinaryDataIndexFormat        = "sha256-%s-%d"


### PR DESCRIPTION
# Description

According to our docs, the default/recommended namespace is "openshift-update-service" [1]. If users want to use a custom namespace, they can edit the generated updateService.yaml file.

[1] https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html-single/disconnected_environments/index#update-service-install-web-console_updating-disconnected-cluster-osus

Github / Jira issue: OCPBUGS-61001

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

WIP

## Expected Outcome
`updateService.yaml` file contains the `"openshift-update-service"` namespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated UpdateService resource generation to properly set the default namespace, ensuring correct resource configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->