### PR TITLE
OCPBUGS-61800: changes the warning message of 4.21

### DIFF
--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -83,8 +83,8 @@ const (
 )
 
 func NewMirrorCmd() *cobra.Command {
-	klog.Warning("\n\n⚠️  oc-mirror v1 is deprecated (starting in 4.18 release) and will be removed in a future release - please migrate to oc-mirror --v2\n\n")
-	klog.Warning("\n\n⚠️  starting with OCP release 4.21, oc-mirror v2 is going to be the default version, please migrate to oc-mirror v2 or start using --v1 in order to continue using the oc-mirror deprecated version\n\n")
+	klog.Warning("\n⚠️  oc-mirror v1 is deprecated (starting in 4.18 release) and will be removed in a future release - please migrate to oc-mirror --v2")
+	klog.Warning("\n⚠️  starting with oc-mirror 4.21, the use of --v1 or --v2 is mandatory, please use --v2 to use the supported oc-mirror version or --v1 to continue using the oc-mirror deprecated version\n\n")
 
 	o := MirrorOptions{
 		operatorCatalogToFullArtifactPath: map[string]string{},

--- a/pkg/cli/mirror/mirror.go
+++ b/pkg/cli/mirror/mirror.go
@@ -79,12 +79,15 @@ var (
 )
 
 const (
-	tagLatest string = "latest"
+	tagLatest    string = "latest"
+	BrightYellow string = "\033[93m"
+	DefaultColor string = "\033[0m"
 )
 
 func NewMirrorCmd() *cobra.Command {
-	klog.Warning("\n⚠️  oc-mirror v1 is deprecated (starting in 4.18 release) and will be removed in a future release - please migrate to oc-mirror --v2")
-	klog.Warning("\n⚠️  starting with oc-mirror 4.21, the use of --v1 or --v2 is mandatory, please use --v2 to use the supported oc-mirror version or --v1 to continue using the oc-mirror deprecated version\n\n")
+	klog.Warningln("⚠️  oc-mirror v1 is deprecated (started in 4.18 release) and will be removed in a future release - please migrate to oc-mirror --v2")
+	klog.Warningln(BrightYellow + "⚠️  starting with oc-mirror 4.21, the use of the flag --v1 or --v2 is mandatory, please use --v2 to use the supported oc-mirror version or --v1 to continue using the oc-mirror deprecated version" + DefaultColor)
+	klog.Warningln(BrightYellow + "⚠️  the sub-commands list, describe and init are only implemented in oc-mirror v1, so please use --v1 for these sub-commands until some replacement is provided\n" + DefaultColor)
 
 	o := MirrorOptions{
 		operatorCatalogToFullArtifactPath: map[string]string{},


### PR DESCRIPTION
# Description

The warning message was changed to let customers know that starting in 4.21 the use of --v1 or --v2 flag is mandatory..

Github / Jira issue: [OCPBUGS-61800](https://issues.redhat.com/browse/OCPBUGS-61800)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
./bin/oc-mirror --help
```

## Expected Outcome
Second and third message should be in yellow color.
```
W0919 11:49:26.494821  222595 mirror.go:88] ⚠️  oc-mirror v1 is deprecated (started in 4.18 release) and will be removed in a future release - please migrate to oc-mirror --v2
W0919 11:49:26.494843  222595 mirror.go:89] ⚠️  starting with oc-mirror 4.21, the use of the flag --v1 or --v2 is mandatory, please use --v2 to use the supported oc-mirror version or --v1 to continue using the oc-mirror deprecated version
W0919 11:49:26.494848  222595 mirror.go:90] ⚠️  the sub-commands list, describe and init are only implemented in oc-mirror v1, so please use --v1 for these sub-commands until some replacement is provided
```