### PR TITLE
NO-JIRA: Adding r4f4 as approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,8 @@
 reviewers:
-  - lmzuccarelli
-  - sherine-k
   - aguidirh
   - r4f4
 approvers:
-  - lmzuccarelli
-  - sherine-k
-  - jerpeter1
   - aguidirh
+  - r4f4
 component: oc
 subcomponent: oc-mirror


### PR DESCRIPTION
# Description

Adding @r4f4 as approvers and removing contributors who are not working with oc-mirror anymore.

## Type of change

- [x] Internal repo assets (diagrams / docs on github repo)