### PR TITLE
WIP: OCPBUGS-60903: v2/version: output ocp release version

### DIFF
--- a/v2/internal/pkg/version/version.go
+++ b/v2/internal/pkg/version/version.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
 	"github.com/spf13/cobra"
@@ -28,7 +29,36 @@ var (
 	buildDate string
 	// state of git tree, either "clean" or "dirty"
 	gitTreeState string
+
+	// releaseVersionPadded may be replaced in the binary with Release
+	// Metadata: Version that overrides defaultVersion as a null-terminated
+	// string within the allowed character length. This allows a distributor to
+	// override the version without having to rebuild the source.
+	releaseVersionPadded = "\x00_RELEASE_VERSION_LOCATION_\x00XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\x00"
+	releaseVersionPrefix = "\x00_RELEASE_VERSION_LOCATION_\x00"
+	releaseVersionLength = len(releaseVersionPadded)
 )
+
+func Version() (string, error) {
+	if strings.HasPrefix(releaseVersionPadded, releaseVersionPrefix) {
+		return fmt.Sprintf("unreleased-%s", commitFromGit), nil
+	}
+	nullTerminator := strings.IndexByte(releaseVersionPadded, '\x00')
+	if nullTerminator == -1 {
+		// the binary has been altered, but we didn't find a null terminator within the release name constant which is an error
+		return commitFromGit, fmt.Errorf("release name location was replaced but without a null terminator before %d bytes", releaseVersionLength)
+	} else if nullTerminator > releaseVersionLength {
+		// the binary has been altered, but the null terminator is *longer* than the constant encoded in the library
+		return commitFromGit, fmt.Errorf("release name location contains no null-terminator and constant is corrupted")
+	}
+	releaseName := releaseVersionPadded[:nullTerminator]
+	if len(releaseName) == 0 {
+		// the binary has been altered, but the replaced release name is empty which is incorrect
+		// the oc binary will not be pinned to Release Metadata: Version
+		return commitFromGit, fmt.Errorf("release name was incorrectly replaced during extract")
+	}
+	return releaseName, nil
+}
 
 type Info struct {
 	Major        string `json:"major"`
@@ -48,8 +78,8 @@ type VersionOptions struct {
 	V2     bool
 }
 
-// Version is a struct for version information
-type Version struct {
+// VersionInfo is a struct for version information
+type VersionInfo struct {
 	ClientVersion *Info `json:"clientVersion,omitempty" yaml:"clientVersion,omitempty"`
 }
 
@@ -98,7 +128,7 @@ func (o *VersionOptions) Validate() error {
 }
 
 func (o *VersionOptions) Run() error {
-	var versionInfo Version
+	var versionInfo VersionInfo
 
 	clientVersion := Get()
 	versionInfo.ClientVersion = &clientVersion
@@ -106,7 +136,7 @@ func (o *VersionOptions) Run() error {
 	switch o.Output {
 	case "":
 		if o.Short {
-			fmt.Fprintf(os.Stdout, "Client Version: %s\n", clientVersion.GitVersion)
+			fmt.Fprintf(os.Stdout, "Client Version: %s\n", clientVersion.Major)
 		} else {
 			fmt.Fprintf(os.Stderr, "WARNING: This version information is deprecated and will be replaced with the output from --short. Use --output=yaml|json to get the full version.\n")
 			fmt.Fprintf(os.Stdout, "Client Version: %#v\n", clientVersion)
@@ -131,9 +161,13 @@ func (o *VersionOptions) Run() error {
 }
 
 func Get() Info {
+	version, err := Version()
+	if err != nil {
+		panic(fmt.Errorf("could not assembler binary version: %w", err))
+	}
 	return Info{
-		Major:        majorFromGit,
-		Minor:        minorFromGit,
+		Major:        version,
+		Minor:        version,
 		GitCommit:    commitFromGit,
 		GitVersion:   versionFromGit,
 		GitTreeState: gitTreeState,


### PR DESCRIPTION
# Description

A commit hash cannot be easily related to an ocp release version.

Github / Jira issue: OCPBUGS-60903

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.