### PR TITLE
OCPBUGS-60929: generate the archive only after mirroring

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -578,16 +578,9 @@ func (o *ExecutorSchema) Complete(args []string) error {
 		if err := archive.RemovePastArchives(rootDir); err != nil {
 			return fmt.Errorf("unable to delete past archives from %s: %w", rootDir, err)
 		}
-		if o.Opts.Global.StrictArchiving {
-			o.MirrorArchiver, err = archive.NewMirrorArchive(o.Opts, rootDir, o.Opts.Global.ConfigPath, o.Opts.Global.WorkingDir, o.LocalStorageDisk, o.Config.ImageSetConfigurationSpec.ArchiveSize, o.Log)
-			if err != nil {
-				return err
-			}
-		} else {
-			o.MirrorArchiver, err = archive.NewPermissiveMirrorArchive(o.Opts, rootDir, o.Opts.Global.ConfigPath, o.Opts.Global.WorkingDir, o.LocalStorageDisk, o.Config.ImageSetConfigurationSpec.ArchiveSize, o.Log)
-			if err != nil {
-				return err
-			}
+		o.MirrorArchiver, err = archive.NewMirrorArchive(o.Opts, rootDir, o.Opts.Global.ConfigPath, o.Opts.Global.WorkingDir, o.LocalStorageDisk, o.Config.ImageSetConfigurationSpec.ArchiveSize, o.Log)
+		if err != nil {
+			return err
 		}
 	} else if o.Opts.IsDiskToMirror() { // if added so that the unArchiver is not instanciated for the prepare workflow
 		o.MirrorUnArchiver, err = archive.NewArchiveExtractor(rootDir, o.Opts.Global.WorkingDir, o.LocalStorageDisk)
@@ -894,9 +887,7 @@ func (o *ExecutorSchema) RunMirrorToDisk(cmd *cobra.Command, args []string) erro
 		return batchError
 	}
 
-	// prepare tar.gz when mirror to disk
 	o.Log.Info(emoji.Package + " Preparing the tarball archive...")
-	// next, generate the archive
 	return o.MirrorArchiver.BuildArchive(cmd.Context(), copiedSchema.AllImages)
 }
 


### PR DESCRIPTION
# Description

This fix is to avoid creating a tarball of 0kb in the beginning of the workflow. With this fix the archive will be generated only after the mirroring if there is NO batch errors.

Github / Jira issue: [OCPBUGS-60929](https://issues.redhat.com/browse/OCPBUGS-60929)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Scenario 1: Run m2d and let it finish with success.
Scenario 2: Run m2d and cut off the internet so it will finish with failures.

## Expected Outcome
Scenario 1: should generate a tarball
Scenario 2: should NOT generate a tarball (not even with 0kb).