### PR TITLE
OCPBUGS-62106: v2/cli: show binary version in output

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -533,6 +533,7 @@ func (o *ExecutorSchema) Complete(args []string) error {
 		return err
 	}
 
+	o.Log.Info(emoji.Gear+"  environment version: %s", version.Get().GitVersion)
 	o.Log.Info(emoji.TwistedRighwardsArrows+" workflow mode: %s ", o.Opts.Mode)
 
 	if o.Opts.Global.SinceString != "" {


### PR DESCRIPTION
# Description

This should avoid a round-trip of asking a user which oc-mirror version they are executing.

Github / Jira issue: OCPBUGS-62106

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

```
❯ ~/prjs/github.com/openshift/oc-mirror/v2/build/oc-mirror --config multi-channels-isc-bad.yaml --v2 file://data/multi-channels-bad --dry-run
2025/09/23 15:13:11  [INFO]   : 👋 Hello, welcome to oc-mirror
2025/09/23 15:13:11  [INFO]   : ⚙️  setting up the environment for you...
2025/09/23 15:13:11  [INFO]   : ⚙️  environment version: v0.2.0-alpha.1-456-gdfcc18b
2025/09/23 15:13:11  [INFO]   : 🔀 workflow mode: mirrorToDisk 
2025/09/23 15:13:11  [INFO]   : 🕵  going to discover the necessary images...
2025/09/23 15:13:11  [INFO]   : 🔍 collecting release images...
2025/09/23 15:13:11  [INFO]   : 🔍 collecting operator images...
 ⠙   (16s) Collecting catalog registry.redhat.io/redhat/redhat-operator-index:v4.16 
^C⏎

 ❯ head data/multi-channels-bad/working-dir/logs/oc-mirror-20250923_151311.log 
2025/09/23 15:13:11  [INFO]   : ⚙️  environment version: v0.2.0-alpha.1-456-gdfcc18b
2025/09/23 15:13:11  [INFO]   : 🔀 workflow mode: mirrorToDisk 
2025/09/23 15:13:11  [INFO]   : 🕵  going to discover the necessary images...
2025/09/23 15:13:11  [INFO]   : 🔍 collecting release images...
2025/09/23 15:13:11  [INFO]   : 🔍 collecting operator images...                                                                               
```

## Expected Outcome
Git version is shown in the standard output and log file.