### PR TITLE
OCPBUGS-62478: Updating oc-mirror-plugin-container image to be consistent with ART for 4.21 (missing files of pr 1280)

### DIFF
--- a/images/cli/Dockerfile.ci
+++ b/images/cli/Dockerfile.ci
@@ -1,15 +1,15 @@
 # This Dockerfile is used by CI to publish the oc-mirror image.
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.24-openshift-4.20 AS builder_rhel8
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.24-openshift-4.21 AS builder_rhel8
 WORKDIR /go/src/github.com/openshift/oc-mirror
 COPY . .
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder_rhel9
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS builder_rhel9
 WORKDIR /go/src/github.com/openshift/oc-mirror
 COPY . .
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
 COPY --from=builder_rhel8 /go/src/github.com/openshift/oc-mirror/bin/oc-mirror /usr/bin/oc-mirror.rhel8
 COPY --from=builder_rhel9 /go/src/github.com/openshift/oc-mirror/bin/oc-mirror /usr/bin/oc-mirror
 COPY --from=builder_rhel9 /go/src/github.com/openshift/oc-mirror/bin/oc-mirror /usr/bin/oc-mirror.rhel9

--- a/images/cli/Dockerfile.test
+++ b/images/cli/Dockerfile.test
@@ -1,12 +1,12 @@
 FROM quay.io/oc-mirror/integration-tests-artifacts:v0.0.1 AS embed
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS builder
 WORKDIR /go/src/github.com/openshift/oc-mirror
 COPY . .
 # Statically link the binary so we can run it in any container base image
 RUN CGO_ENABLED=0 make build
 
-FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
 WORKDIR /artifacts
 RUN mkdir -p /artifacts/{scripts,isc,workdingdir} && chmod -R 777 /artifacts
 RUN mkdir -p /root/{.docker,.cache} /root/.oc-mirror/.cache && chmod -R 777 /root


### PR DESCRIPTION
# Description

These two files were missing in the ART PR #1280.

Github / Jira issue: 

- [OCPBUGS-62478](https://issues.redhat.com/browse/OCPBUGS-62478)