### PR TITLE
OCPBUGS-55489: removes unintended exec permissions

### DIFF
--- a/v2/internal/pkg/archive/unarchive.go
+++ b/v2/internal/pkg/archive/unarchive.go
@@ -178,7 +178,7 @@ func createFileWithProgress(parentDir string, header *tar.Header, reader *tar.Re
 	}
 	proxyReader := bar.ProxyReader(reader)
 	defer proxyReader.Close()
-	return writeFile(descriptor, proxyReader, header.FileInfo().Mode()|0755)
+	return writeFile(descriptor, proxyReader, header.FileInfo().Mode())
 }
 
 func writeFile(filePath string, reader io.Reader, perm os.FileMode) error {

--- a/v2/internal/pkg/delete/delete_images.go
+++ b/v2/internal/pkg/delete/delete_images.go
@@ -75,7 +75,7 @@ func (o DeleteImages) WriteDeleteMetaData(ctx context.Context, images []v2alpha1
 	if err != nil {
 		o.Log.Error(deleteImagesErrMsg, err)
 	}
-	err = os.WriteFile(filename, ymlData, 0755)
+	err = os.WriteFile(filename, ymlData, 0644)
 	if err != nil {
 		o.Log.Error(deleteImagesErrMsg, err)
 	}
@@ -98,7 +98,7 @@ func (o DeleteImages) WriteDeleteMetaData(ctx context.Context, images []v2alpha1
 	if err != nil {
 		o.Log.Error("%v ", err)
 	}
-	err = os.WriteFile(discYamlFile, discYamlData, 0755)
+	err = os.WriteFile(discYamlFile, discYamlData, 0644)
 	if err != nil {
 		o.Log.Error(deleteImagesErrMsg, err)
 	}

--- a/v2/internal/pkg/imagebuilder/catalog_builder.go
+++ b/v2/internal/pkg/imagebuilder/catalog_builder.go
@@ -15,11 +15,12 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/otiai10/copy"
+
 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/image"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/log"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
-	"github.com/otiai10/copy"
 )
 
 const (
@@ -125,7 +126,7 @@ func (c GCRCatalogBuilder) RebuildCatalog(ctx context.Context, catalogCopyRef v2
 	if err != nil {
 		return fmt.Errorf("error building catalog %s : %v", catalogCopyRef.Origin, err)
 	}
-	err = os.WriteFile(filepath.Join(filteredDir, "digest"), []byte(digest), 0755)
+	err = os.WriteFile(filepath.Join(filteredDir, "digest"), []byte(digest), 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

Some files (digest and delete files) created by oc-mirror had unintended exec permissions and also during the archive the exec permission was being added on some files, changing in this way the original permissions of the files.

Limitations of the PR: the artifacts generated by go-containerregistry (graph image and filtered catalog) are generated with exec permissions as shown below:

```
find ./alex-tests/ocpbugs-55489/ -type f -executable -exec ls {} +
./alex-tests/ocpbugs-55489/working-dir/graph-preparation/blobs/sha256/8d923108fe704ab06bd261497dad225138faea6ee75a111aea54b386694263e2
./alex-tests/ocpbugs-55489/working-dir/graph-preparation/index.json
./alex-tests/ocpbugs-55489/working-dir/graph-preparation/oci-layout
./alex-tests/ocpbugs-55489/working-dir/operator-catalogs/redhat-operator-index/f194f18577dac4c8952d8e3413e4677ff389e35cb281fa4573b0258a0f7c4daf/filtered-catalogs/710634675b9d5cc86a6fab0deb415b5f/filtered-catalog-image/blobs/sha256/06c3dcb16e59efcc413433291e0b60b38b9a42c400803bbf68715abad2c7c693
```

The limitation above is going to be covered in a separate PR.

Github / Jira issue: [OCPBUGS-55489](https://issues.redhat.com/browse/OCPBUGS-55489)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

With the following image set config:

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  platform:
    channels:
    - name: stable-4.17
      minVersion: 4.17.0
      maxVersion: 4.17.0
    graph: true
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20
      packages:
       - name: aws-load-balancer-operator
         channels:
           - name: stable-v1
  additionalImages: 
   - name: registry.redhat.io/ubi8/ubi:latest
  helm:
    repositories:
      - name: podinfo
        url: https://stefanprodan.github.io/podinfo
        charts:
          - name: podinfo
            version: 5.0.0
      - name: sbo
        url: https://redhat-developer.github.io/service-binding-operator-helm-chart/
      - name: cosigned
        url: https://sigstore.github.io/helm-charts
        charts:
          - name: cosigned
            version: 0.1.23
```

`m2d/d2m` and `m2m`

## Expected Outcome
The filtered catalog should run without issues:

```
podman pull localhost:5000/redhat/redhat-operator-index:v4.20 --tls-verify=false

Trying to pull localhost:5000/redhat/redhat-operator-index:v4.20...
Getting image source signatures
Copying blob 826fb35fe302 done   | 
Copying blob 38c7eb68cd95 skipped: already exists  
Copying blob 25c75c34b2e2 skipped: already exists  
Copying blob 04ef00d712bf done   | 
Copying blob 3357f22ae62e done   | 
Copying blob b767765d861c done   | 
Copying blob 8c14660ccaa0 done   | 
Copying config 6c07f79e3e done   | 
Writing manifest to image destination
6c07f79e3e6044f645864427a0c75230efd1e6692601c391aaf0bd491fa9337a

podman run 6c07f79e3e6044f645864427a0c75230efd1e6692601c391aaf0bd491fa9337a

time="2025-10-02T17:21:04Z" level=warning msg="unable to set termination log path" error="open /dev/termination-log: permission denied"
time="2025-10-02T17:21:04Z" level=info msg="starting pprof endpoint" address="localhost:6060"
time="2025-10-02T17:21:04Z" level=info msg="cache directory is empty, using preferred backend" backend=pogreb.v1 cache=/tmp/opm-serve-cache-3597748308 configs=/configs
time="2025-10-02T17:21:04Z" level=info msg="building cache" cache=/tmp/opm-serve-cache-3597748308 configs=/configs
time="2025-10-02T17:21:04Z" level=info msg="serving registry" cache=/tmp/opm-serve-cache-3597748308 configs=/configs port=50051
time="2025-10-02T17:21:04Z" level=info msg="stopped caching cpu profile data" address="localhost:6060"
^Ctime="2025-10-02T17:21:37Z" level=info msg="shutting down server" cache=/tmp/opm-serve-cache-3597748308 configs=/configs port=50051
```
