### PR TITLE
OCPBUGS-56398: Removes the clean up of logs directory

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -1060,8 +1060,6 @@ func (o *ExecutorSchema) setupLogsLevelAndDir() error {
 	o.Log.Level(o.Opts.Global.LogLevel)
 	// set up location of logs dir
 	o.LogsDir = filepath.Join(o.Opts.Global.WorkingDir, logsDir)
-	// clean up logs directory
-	os.RemoveAll(o.LogsDir)
 
 	// create logs directory
 	err := o.MakeDir.makeDirAll(o.LogsDir, 0755)


### PR DESCRIPTION
# Description

The logs directory was being cleaned at the beginning of each workflow, preventing in this way old logs to stay in the directory.

Github / Jira issue: [OCPBUGS-56398](https://issues.redhat.com/browse/OCPBUGS-56398)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran `m2m` more than once cutting the internet off during the mirroring process.

## Expected Outcome
```
ls -la ./alex-tests/ocpbugs-56398/working-dir/logs/
total 124
drwxr-xr-x. 1 aguidi aguidi   486 Oct  9 19:34 .
drwxr-xr-x. 1 aguidi aguidi   156 Oct  9 19:34 ..
-rw-r--r--. 1 aguidi aguidi   423 Oct  9 16:25 mirroring_errors_20251009_161324.txt
-rw-r--r--. 1 aguidi aguidi   423 Oct  9 16:29 mirroring_errors_20251009_162835.txt
-rw-r--r--. 1 aguidi aguidi  2224 Oct  9 16:25 oc-mirror-20251009_161324.log
-rw-r--r--. 1 aguidi aguidi  2223 Oct  9 16:29 oc-mirror-20251009_162835.log
-rw-r--r--. 1 aguidi aguidi   897 Oct  9 19:34 oc-mirror-20251009_193441.log
-rw-r--r--. 1 aguidi aguidi 96769 Oct  9 16:25 registry-20251009_161324.log
-rw-r--r--. 1 aguidi aguidi  3907 Oct  9 16:29 registry-20251009_162835.log
-rw-r--r--. 1 aguidi aguidi  1948 Oct  9 19:34 registry-20251009_193441.log
```