### PR TITLE
CLID-459: changes the flag remove-signatures default to false

### DIFF
--- a/internal/pkg/cli/executor.go
+++ b/internal/pkg/cli/executor.go
@@ -296,7 +296,7 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 	cmd.Flags().IntVar(&opts.Global.MaxNestedPaths, "max-nested-paths", 0, "Number of nested paths, for destination registries that limit nested paths")
 	cmd.Flags().BoolVar(&opts.Global.StrictArchiving, "strict-archive", false, "If set, generates archives that are strictly less than archiveSize (set in the imageSetConfig). Mirroring will exit in error if a file being archived exceed archiveSize(GB)")
 	cmd.Flags().StringVar(&opts.RootlessStoragePath, "rootless-storage-path", "", "Override the default container rootless storage path (usually in etc/containers/storage.conf)")
-	cmd.Flags().BoolVar(&opts.RemoveSignatures, "remove-signatures", true, "Do not copy image signature")
+	cmd.Flags().BoolVar(&opts.RemoveSignatures, "remove-signatures", false, "Do not copy image signature")
 	cmd.Flags().BoolVar(&opts.Global.IgnoreReleaseSignature, "ignore-release-signature", false, "Ignore release signature")
 	HideFlags(cmd)
 


### PR DESCRIPTION
# Description

Having the flag --remove-signatures as false results to always mirroring the signature as default.

Github / Jira issue: [CLID-459](https://issues.redhat.com/browse/CLID-459)

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Run `m2d/d2m` or `m2m`.

## Expected Outcome
The target registry should have the signature of the container images mirrored (see one example below):

```
Fetching tags for repository: openshift/release-images
{
  "name": "openshift/release-images",
  "tags": [
    "4.15.58-x86_64",
    "sha256-427fc0b133cc2aa45a68c36b603403ab278c845c0232e1c59387c4abfff01b9a.sig"
  ]
}
```