### PR TITLE
no-jira: v2: add golangci-lint v2 config

### DIFF
--- a/v2/.golangci.v2.yaml
+++ b/v2/.golangci.v2.yaml
@@ -1,0 +1,98 @@
+version: "2"
+run:
+  build-tags:
+    - json1
+    - libdm_no_deferred_remove
+    - exclude_graphdriver_devicemapper
+    - exclude_graphdriver_btrfs
+    - containers_image_openpgp
+  modules-download-mode: readonly
+  issues-exit-code: 1
+  tests: true
+  allow-parallel-runners: false
+output:
+  formats:
+    text:
+      colors: true
+      path: stdout
+      print-linter-name: true
+      print-issued-lines: true
+  path-prefix: ""
+linters:
+  default: none
+  enable:
+    - bidichk
+    - bodyclose
+    - containedctx
+    - contextcheck
+    - copyloopvar
+    - cyclop
+    - depguard
+    - durationcheck
+    - errcheck
+    - errchkjson
+    - errname
+    - errorlint
+    - exhaustive
+    - exptostd
+    - fatcontext
+    - goconst
+    - gocritic
+    - gosec
+    - iface
+    - ineffassign
+    - intrange
+    - ireturn
+    - makezero
+    - mirror
+    - misspell
+    - nestif
+    - nilerr
+    - noctx
+    - nosprintfhostport
+    - prealloc
+    - recvcheck
+    - staticcheck
+    - unused
+    - wrapcheck
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: github.com/pkg/errors
+              desc: Should be replaced by stdlib errors package
+    wrapcheck:
+      ignore-package-globs:
+        - github.com/openshift/oc-mirror/v2/*
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - goconst
+        path: (.+)_test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  uniq-by-line: true
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/openshift/oc-mirror
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
# Description

Once we change CI to use golangci-lint v2, we can remove the old v1 config.

Github / Jira issue: 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.