### PR TITLE
OCPBUGS-61497: fix: return only requested version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/openshift/api v0.0.0-20240529192326-16d44e6d3e7d
 	github.com/operator-framework/operator-registry v1.50.0
 	github.com/otiai10/copy v1.14.1
-	github.com/sherine-k/catalog-filter v0.0.4
+	github.com/sherine-k/catalog-filter v0.0.5
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.9

--- a/go.sum
+++ b/go.sum
@@ -361,8 +361,8 @@ github.com/secure-systems-lab/go-securesystemslib v0.9.1 h1:nZZaNz4DiERIQguNy0cL
 github.com/secure-systems-lab/go-securesystemslib v0.9.1/go.mod h1:np53YzT0zXGMv6x4iEWc9Z59uR+x+ndLwCLqPYpLXVU=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
-github.com/sherine-k/catalog-filter v0.0.4 h1:UWM3XaktjbvKw5ktC2NoxQLP+6KNbvaplwiAaVV411g=
-github.com/sherine-k/catalog-filter v0.0.4/go.mod h1:NQ667IgdlOYYHeLwppvrtm5TtYIn7b3CCyYKGT2e3rI=
+github.com/sherine-k/catalog-filter v0.0.5 h1:RExES+TRnkIcK6GwMBXGbku1X5C11Wr03FHQj38f060=
+github.com/sherine-k/catalog-filter v0.0.5/go.mod h1:NQ667IgdlOYYHeLwppvrtm5TtYIn7b3CCyYKGT2e3rI=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sigstore/fulcio v1.6.6 h1:XaMYX6TNT+8n7Npe8D94nyZ7/ERjEsNGFC+REdi/wzw=

--- a/internal/pkg/operator/catalog_handler_test.go
+++ b/internal/pkg/operator/catalog_handler_test.go
@@ -10,11 +10,12 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/common"
 	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
-	"github.com/operator-framework/operator-registry/alpha/declcfg"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFilterRelatedImagesFromCatalog(t *testing.T) {
@@ -1144,7 +1145,7 @@ func TestFilterCatalog(t *testing.T) {
 			},
 
 			expectedBundles: []string{},
-			expectedError:   errors.New("package \"3scale-operator\" channel \"threescale-mas\" has version range \">=77.77.77 <=77.77.77\" that results in an empty channel"),
+			expectedError:   errors.New("error finding specific bundle: specific version 77.77.77 not found in bundles"),
 			expectedWarning: ""},
 	}
 


### PR DESCRIPTION
# Description

This PR updates the `catalog-filter` dependency from v0.0.4 to v0.0.5 to fix an issue where `oc-mirror` was unable to properly mirror specific versions of operators (e.g., `redis-enterprise-operator-cert`) when using `minVersion` and `maxVersion` fields in the ImageSetConfiguration.

The updated `catalog-filter` library provides improved error handling and validation for version range filtering, resulting in more accurate error messages when specific versions cannot be found in operator catalogs.

Github / Jira issue: [OCPBUGS-61497](https://issues.redhat.com/browse/OCPBUGS-61497)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

With the following ImageSetConfig:

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v1alpha2
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.16
      packages:
      - name: rhbk-operator
        defaultChannel: stable-v26
        channels:
        - name: 'stable-v26'
          maxVersion: '26.0.8-opr.1'
          minVersion: '26.0.8-opr.1'
```

Run `m2m`

## Expected Outcome

- Only the version `26.0.8-opr.1` should be inside of the custom catalog. 

