### PR TITLE
CLID-480: v2: do not invoke v1 make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,10 @@ verify:
 
 vet:
 	$(GO) vet $(GO_MOD_FLAGS) $(GO_BUILD_FLAGS) ./...
-	make -C v1 vet
 
 test-unit:
 	mkdir -p tests/results
 	$(GO) test $(GO_MOD_FLAGS) $(GO_BUILD_FLAGS) -short -coverprofile=tests/results/cover.out -race -count=1 ./internal/pkg/...
-	make -C v1 test-unit
 
 test-integration:
 	mkdir -p tests/results-integration
@@ -56,19 +54,15 @@ test-integration:
 	$(GO) test $(GO_MOD_FLAGS) $(GO_BUILD_FLAGS) -coverprofile=tests/results-integration/cover-release.out -race -count=1 ./internal/pkg/... -run TestIntegrationRelease
 	$(GO) test $(GO_MOD_FLAGS) $(GO_BUILD_FLAGS) -coverprofile=tests/results-integration/cover-additional.out -race -count=1 ./internal/pkg/... -run TestIntegrationAdditionalM2M
 	$(GO) test $(GO_MOD_FLAGS) $(GO_BUILD_FLAGS) -coverprofile=tests/results-integration/cover-release.out -race -count=1 ./internal/pkg/... -run TestIntegrationReleaseM2M
-	make -C v1 test-integration
 
 tidy:
 	$(GO) mod tidy
-	make -C v1 tidy
 
 sanity: tidy format vet
-	make -C v1 sanity
 	git diff --exit-code
 .PHONY: sanity
 
 format: verify-gofmt
-	make -C v1 verify-gofmt
 
 cover:
 	$(GO) tool cover -html=tests/results/cover.out -o tests/results/cover.html


### PR DESCRIPTION
# Description

Now that we've separated v1 and v2 CI tests in [1], we do not need to invoke v1 `make` commands in the v2 Makefile anymore.

[1] https://github.com/openshift/release/pull/70966

Github / Jira issue: 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [x] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.