### PR TITLE
OCPBUGS-63480: Remove empty status field from generated IDMS/ITMS files

### DIFF
--- a/internal/pkg/clusterresources/clusterresources.go
+++ b/internal/pkg/clusterresources/clusterresources.go
@@ -163,6 +163,7 @@ func writeMirrorSet[T confv1.ImageDigestMirrorSet | confv1.ImageTagMirrorSet](mi
 			return fmt.Errorf("error while sanitizing the catalogSource object prior to marshalling: %v", err)
 		}
 		delete(unstructuredObj.Object["metadata"].(map[string]interface{}), "creationTimestamp")
+		delete(unstructuredObj.Object, "status")
 
 		msBytes, err := yaml.Marshal(unstructuredObj.Object)
 		if err != nil {

--- a/internal/pkg/clusterresources/clusterresources_test.go
+++ b/internal/pkg/clusterresources/clusterresources_test.go
@@ -291,6 +291,65 @@ func TestIDMS_ITMSGenerator(t *testing.T) {
 	}
 }
 
+// verifyNoStatusField checks that a YAML file (if it exists) does not contain a 'status' field.
+func verifyNoStatusField(t *testing.T, filePath string) {
+	t.Helper()
+	if _, err := os.Stat(filePath); err != nil {
+		return
+	}
+
+	yamlData, err := parser.ParseYamlFile[map[string]any](filePath)
+	assert.NoError(t, err)
+
+	assert.NotContains(t, yamlData, "status")
+}
+
+func TestIDMS_ITMS_NoStatusField(t *testing.T) {
+	log := clog.New("trace")
+
+	type testCase struct {
+		caseName string
+		imgList  []v2alpha1.CopyImageSchema
+	}
+	testCases := []testCase{
+		{
+			caseName: "Testing ITMS file does not contain status field - release use case",
+			imgList:  imageListRelease,
+		},
+		{
+			caseName: "Testing IDMS and ITMS files do not contain status field - mixed images",
+			imgList:  imageListMixed,
+		},
+		{
+			caseName: "Testing IDMS file does not contain status field - digests only",
+			imgList:  imageListDigestsOnly,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.caseName, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			workingDir := tmpDir + "/working-dir"
+
+			cr := &ClusterResourcesGenerator{
+				Log:              log,
+				WorkingDir:       workingDir,
+				LocalStorageFQDN: "localhost:55000",
+			}
+
+			err := cr.IDMS_ITMSGenerator(testCase.imgList, false)
+			assert.NoError(t, err)
+
+			// Check IDMS and ITMS files
+			idmsPath := filepath.Join(workingDir, clusterResourcesDir, "idms-oc-mirror.yaml")
+			itmsPath := filepath.Join(workingDir, clusterResourcesDir, "itms-oc-mirror.yaml")
+
+			verifyNoStatusField(t, idmsPath)
+			verifyNoStatusField(t, itmsPath)
+		})
+	}
+}
+
 func TestGenerateIDMS(t *testing.T) {
 	log := clog.New("trace")
 


### PR DESCRIPTION
# Description

This removes the empty status: {} field that was appended to generated IDMS/ITMS files and was causing errors with automated deployments via gitops. 

This line is generated from a blank unstructured k8s object, and does not pull in information from anywhere else, so can be completely removed. 

This seems to have been added in: https://github.com/openshift/oc-mirror/commit/7b1fb05ff33db335fcfc54ad036a258fd4607132. 

Github / Jira issue: https://issues.redhat.com/browse/OCPBUGS-63480

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

Re-ran a disk-to-mirror workflow as described in the bug. Status line no longer gets added to the file. 

## Expected Outcome
Please describe the outcome expected from the tests.

Status line no longer gets added to the file. 