### PR TITLE
OCPBUGS-66051: Remove empty status field from generated IDMS/ITMS files (manual 4.18 backport)

### DIFF
--- a/v2/internal/pkg/clusterresources/clusterresources.go
+++ b/v2/internal/pkg/clusterresources/clusterresources.go
@@ -156,6 +156,7 @@ func writeMirrorSet[T confv1.ImageDigestMirrorSet | confv1.ImageTagMirrorSet](mi
 			return fmt.Errorf("error while sanitizing the catalogSource object prior to marshalling: %v", err)
 		}
 		delete(unstructuredObj.Object["metadata"].(map[string]interface{}), "creationTimestamp")
+		delete(unstructuredObj.Object, "status")
 
 		msBytes, err := yaml.Marshal(unstructuredObj.Object)
 		if err != nil {


### PR DESCRIPTION
# Description

Manual cherrypick from the previous 4.18 backport: https://github.com/openshift/oc-mirror/pull/1319 

Changed to use manual yaml parsing instead of the yaml parser package, which does not exist in 4.18. This was favored over backporting the yaml parser package. 

Github / Jira issue: 

https://issues.redhat.com/browse/OCPBUGS-66051

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

make test, all tests passing

## Expected Outcome
Please describe the outcome expected from the tests.