### PR TITLE
NO-JIRA: Add tests/results-integration to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ oc-mirror-workspace/
 working-dir/
 tests/hold-test-untar
 tests/results
+tests/results-integration
 build/
 cmd/mirror/logs/
 cmd/mirror/working-dir/


### PR DESCRIPTION
# Description

After running integration tests, `tests/results-integration` is not currently ignored. 

Github / Jira issue: 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

`make test-integration`

## Expected Outcome
`tests/results-integration` does not show up in git. 