### PR TITLE
CLID-512: claude: add slash command for ISC generation

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -1,0 +1,152 @@
+# Claude Commands for oc-mirror
+
+This directory contains custom Claude slash commands to help with oc-mirror development and configuration.
+
+## Available Commands
+
+### `/generate-imageset`
+
+Generate a v2alpha1 ImageSetConfiguration or DeleteImageSetConfiguration YAML file for oc-mirror.
+
+#### What it does
+
+This command provides an interactive workflow to create properly formatted configuration files for oc-mirror v2. It supports generating both mirroring configurations and deletion configurations with all available options.
+
+#### Usage
+
+Simply type `/generate-imageset` in your conversation with Claude Code and follow the prompts.
+
+Claude will ask you questions about:
+
+1. **Configuration type** - Choose between:
+   - `ImageSetConfiguration` - for mirroring container images
+   - `DeleteImageSetConfiguration` - for deleting mirrored images
+
+2. **Components to include** - Select from:
+   - **Platform** - OpenShift release versions and channels
+   - **Operators** - Red Hat or community operator catalogs
+   - **Additional Images** - Standalone container images
+   - **Helm** - Helm charts from repositories or local files
+
+3. **Specific details** - Depending on your selections:
+   - Channel names and version ranges
+   - Operator catalogs and package filters
+   - Image references with tags or digests
+   - Helm repository URLs and chart versions
+
+#### Examples
+
+**Example 1: Creating a simple platform mirror configuration**
+
+```
+User: /generate-imageset
+Claude: Which type of configuration do you want to generate?
+User: ImageSetConfiguration
+Claude: Which components do you want to configure?
+User: Just platform
+Claude: What channel name? (e.g., stable-4.18)
+User: stable-4.18
+Claude: Min version?
+User: 4.18.0
+Claude: Max version?
+User: 4.18.5
+...
+```
+
+This generates:
+```yaml
+---
+apiVersion: mirror.openshift.io/v2alpha1
+kind: ImageSetConfiguration
+mirror:
+  platform:
+    channels:
+      - name: stable-4.18
+        minVersion: 4.18.0
+        maxVersion: 4.18.5
+```
+
+**Example 2: Creating a comprehensive configuration**
+
+```
+User: /generate-imageset
+...
+User: Platform, Operators, and Additional Images
+...
+```
+
+This generates a complete configuration with multiple sections.
+
+**Example 3: Creating a delete configuration**
+
+```
+User: /generate-imageset
+Claude: Which type of configuration do you want to generate?
+User: DeleteImageSetConfiguration
+...
+```
+
+This generates a configuration for deleting previously mirrored content.
+
+#### What gets generated
+
+The command will:
+
+1. **Create the YAML file** with proper v2alpha1 structure
+2. **Write it to disk** (default names: `imageset-config.yaml` or `delete-imageset-config.yaml`)
+3. **Provide usage instructions** with example commands for:
+   - Mirror to Disk workflow
+   - Disk to Mirror workflow
+   - Mirror to Mirror workflow
+   - Delete workflows (Phase 1 and Phase 2)
+
+#### Common Workflows
+
+**Mirroring OpenShift releases to a disconnected registry:**
+```bash
+# Step 1: Generate config
+/generate-imageset
+# Select: ImageSetConfiguration, Platform
+# Specify channel and versions
+
+# Step 2: Use the generated config
+./bin/oc-mirror -c imageset-config.yaml --workspace file:///path/to/workspace docker://your-registry.com --v2
+```
+
+**Deleting old operator versions:**
+```bash
+# Step 1: Generate delete config
+/generate-imageset
+# Select: DeleteImageSetConfiguration, Operators
+# Specify catalogs and versions to delete
+
+# Step 2: Generate delete manifest
+./bin/oc-mirror delete -c delete-imageset-config.yaml --generate --workspace file:///path/to/workspace --delete-id cleanup-old docker://your-registry.com --v2
+
+# Step 3: Execute deletion
+./bin/oc-mirror delete --delete-yaml-file /path/to/workspace/working-dir/delete/delete-images-cleanup-old.yaml docker://your-registry.com --v2
+```
+
+#### Tips
+
+- You can include multiple components in a single configuration
+- All fields are optional - only specify what you need
+- The command generates v2alpha1 format only (oc-mirror v2)
+- Refer to `docs/image-set-examples/` for more configuration examples
+- For operators, you can specify entire catalogs (`full: true`) or individual packages
+- Use digests instead of tags for additional images when you need reproducible mirrors
+
+## Adding New Commands
+
+To add a new slash command:
+
+1. Create a new `.md` file in this directory (e.g., `my-command.md`)
+2. Write the command instructions following the pattern in `generate-imageset.md`
+3. The command name will be the filename without the `.md` extension
+4. Users can invoke it with `/my-command`
+
+## References
+
+- [oc-mirror README](../../README.md)
+- [oc-mirror Image Set Examples](../../docs/image-set-examples/)
+- [Delete Functionality Documentation](../../docs/features/delete-functionality.md)

--- a/.claude/commands/generate-imageset.md
+++ b/.claude/commands/generate-imageset.md
@@ -1,0 +1,129 @@
+# Generate ImageSet Configuration
+
+Generate a v2alpha1 ImageSetConfiguration or DeleteImageSetConfiguration YAML file for oc-mirror.
+
+## Instructions
+
+You are helping the user create an oc-mirror configuration file. Ask the user questions to gather requirements, then generate a complete YAML configuration.
+
+### Step 1: Configuration Type
+
+Ask the user which type of configuration they want to generate:
+- **ImageSetConfiguration** - for mirroring images (uses `mirror:` section)
+- **DeleteImageSetConfiguration** - for deleting images (uses `delete:` section)
+
+### Step 2: Components to Include
+
+Ask which components they want to configure (can select multiple):
+- **Platform** - OpenShift release versions
+- **Operators** - Operator catalogs and packages
+- **Additional Images** - Standalone container images
+- **Helm** - Helm charts from repositories or local files
+
+### Step 3: Gather Details for Each Component
+
+**For Platform (if selected):**
+- Channel name(s) (e.g., stable-4.18, stable-4.17, okd)
+- For each channel:
+  - Channel type (default: ocp, or specify okd)
+  - Min version (optional)
+  - Max version (optional)
+- Architecture(s) (optional, e.g., amd64, arm64, ppc64le, s390x)
+- Include graph data? (true/false, default: false)
+
+**For Operators (if selected):**
+- Catalog reference (e.g., registry.redhat.io/redhat/redhat-operator-index:v4.18)
+- Mirror entire catalog? (full: true)
+  - If no, ask for specific packages:
+    - Package name
+    - Min version (optional)
+    - Specific channel(s) (optional)
+- Repeat for additional catalogs
+
+**For Additional Images (if selected):**
+- List of image references (with tags or digests)
+  - Example: registry.redhat.io/ubi8/ubi:latest
+  - Example: quay.io/myorg/myimage@sha256:abc123...
+
+**For Helm (if selected):**
+- Remote repositories:
+  - Repository name
+  - Repository URL
+  - Charts to mirror (name and version)
+- Local charts:
+  - Chart name
+  - Local file path
+
+### Step 4: Generate Configuration
+
+Create a YAML file with this structure:
+
+```yaml
+---
+apiVersion: mirror.openshift.io/v2alpha1
+kind: <ImageSetConfiguration|DeleteImageSetConfiguration>
+<mirror|delete>:
+  platform:
+    architectures:
+      - "amd64"
+    channels:
+      - name: stable-4.18
+        minVersion: 4.18.0
+        maxVersion: 4.18.5
+    graph: true
+  operators:
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
+      packages:
+        - name: aws-load-balancer-operator
+          channels:
+            - name: stable-v1
+  additionalImages:
+    - name: registry.redhat.io/ubi8/ubi:latest
+  helm:
+    repositories:
+      - name: podinfo
+        url: https://stefanprodan.github.io/podinfo
+        charts:
+          - name: podinfo
+            version: 5.0.0
+    local:
+      - name: mychart
+        path: /path/to/chart.tgz
+```
+
+### Step 5: Write and Guide
+
+After generating the configuration:
+1. Write it to a file in the `isc/` folder (default: `isc/imageset-config.yaml` or `isc/delete-imageset-config.yaml`)
+2. Explain how to use it with oc-mirror
+3. Provide example commands based on the configuration type:
+
+**For ImageSetConfiguration:**
+```bash
+# Mirror to Disk
+./bin/oc-mirror -c isc/imageset-config.yaml file:///path/to/output --v2
+
+# Disk to Mirror
+./bin/oc-mirror -c isc/imageset-config.yaml --from file:///path/to/output docker://registry.example.com --v2
+
+# Mirror to Mirror
+./bin/oc-mirror -c isc/imageset-config.yaml --workspace file:///path/to/workspace docker://registry.example.com --v2
+```
+
+**For DeleteImageSetConfiguration:**
+```bash
+# Phase 1: Generate delete manifest
+./bin/oc-mirror delete -c isc/delete-imageset-config.yaml --generate --workspace file:///path/to/workspace --delete-id my-delete docker://registry.example.com --v2
+
+# Phase 2: Execute deletion
+./bin/oc-mirror delete --delete-yaml-file /path/to/workspace/working-dir/delete/delete-images-my-delete.yaml docker://registry.example.com --v2
+```
+
+## Important Notes
+
+- Always use `apiVersion: mirror.openshift.io/v2alpha1` (v2 only)
+- ImageSetConfiguration uses the `mirror:` top-level key
+- DeleteImageSetConfiguration uses the `delete:` top-level key
+- All fields are optional except the ones the user explicitly requests
+- Provide helpful comments in the generated YAML
+- Refer to oc-mirror examples in `docs/image-set-examples/` if needed

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ tags
 
 # Local imageset-config.yaml
 imageset-config.yaml
+./isc/*
 
 # Local integration test files
 __pycache__


### PR DESCRIPTION
# Description

Add a `/generate-imageset` claude command to guide the user to generate either an ImageSetConfiguration or DeleteImageSetConfiguration file.

Github / Jira issue: [CLID-512](https://issues.redhat.com//browse/CLID-512)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [x] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Run `/generate-imageset` when using `claude`.

## Expected Outcome
An `imageset-config.yaml` file is generated.