### PR TITLE
CLID-513: operator catalogs pinned by digest in ISC

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,12 @@ The `delete` sub-command has its own set of flags:
 ### Other Features
 * [Enclave support](v2/docs/features/enclave_support.md)
 
+#### Catalog Pinning
+
+When running mirror-to-disk or mirror-to-mirror workflows, oc-mirror automatically generates pinned configuration files where operator catalogs are referenced by SHA256 digests instead of tags. This ensures reproducible mirroring operations since digest references always point to the exact same image content, while tag-based references can change over time.
+
+Two files are generated in the working directory: `isc_pinned_{timestamp}.yaml` contains a pinned ImageSetConfiguration with catalogs referenced by digest, and `disc_pinned_{timestamp}.yaml` contains a corresponding DeleteImageSetConfiguration. The pinned ISC can be used for reproducible mirrors of the exact same content, while the pinned DISC can be used later with the delete sub-command to remove precisely what was mirrored.
+
 ## Testing
 It is possible to run in this module unit tests.
 

--- a/internal/pkg/api/v2alpha1/type_config.go
+++ b/internal/pkg/api/v2alpha1/type_config.go
@@ -48,14 +48,14 @@ type DeleteImageSetConfigurationSpec struct {
 // Mirror defines the configuration for content types within the imageset.
 type Mirror struct {
 	// Platform defines the configuration for OpenShift and OKD platform types.
-	Platform Platform `json:"platform,omitempty"`
+	Platform Platform `json:"platform,omitempty,omitzero"`
 	// Operators defines the configuration for Operator content types.
 	Operators []Operator `json:"operators,omitempty"`
 	// AdditionalImages defines the configuration for a list
 	// of individual image content types.
 	AdditionalImages []Image `json:"additionalImages,omitempty"`
 	// Helm define the configuration for Helm content types.
-	Helm Helm `json:"helm,omitempty"`
+	Helm Helm `json:"helm,omitempty,omitzero"`
 	// BlockedImages define a list of images that will be blocked
 	// from the mirroring process if they exist in other content
 	// types in the configuration.
@@ -68,14 +68,14 @@ type Mirror struct {
 // Delete defines the configuration for content types within the imageset.
 type Delete struct {
 	// Platform defines the configuration for OpenShift and OKD platform types.
-	Platform Platform `json:"platform,omitempty"`
+	Platform Platform `json:"platform,omitempty,omitzero"`
 	// Operators defines the configuration for Operator content types.
 	Operators []Operator `json:"operators,omitempty"`
 	// AdditionalImages defines the configuration for a list
 	// of individual image content types.
 	AdditionalImages []Image `json:"additionalImages,omitempty"`
 	// Helm define the configuration for Helm content types.
-	Helm Helm `json:"helm,omitempty"`
+	Helm Helm `json:"helm,omitempty,omitzero"`
 	// Samples defines the configuration for Sample content types.
 	// This is currently not implemented.
 	Samples []SampleImages `json:"samples,omitempty"`

--- a/internal/pkg/config/pin_catalogs.go
+++ b/internal/pkg/config/pin_catalogs.go
@@ -1,0 +1,212 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/image"
+	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
+)
+
+// PinAndWriteISCAndDSC pins catalogs and writes both ISC and DISC files.
+// Returns paths to both written files (ISC path, DISC path).
+func PinAndWriteISCAndDSC(
+	cfg v2alpha1.ImageSetConfiguration,
+	catalogToFBCMap map[string]v2alpha1.CatalogFilterResult,
+	workingDir string,
+	log clog.PluggableLoggerInterface,
+) (string, string, error) {
+	// Pin catalog digests
+	pinnedISC, err := pinCatalogDigests(cfg, catalogToFBCMap, log)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to pin catalog digests: %w", err)
+	}
+
+	// Write pinned ISC
+	iscPath, err := writePinnedISC(pinnedISC, workingDir)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to write pinned ISC: %w", err)
+	}
+
+	// Write pinned DISC
+	discPath, err := createDISCFromISC(pinnedISC, workingDir)
+	if err != nil {
+		return iscPath, "", fmt.Errorf("failed to create pinned DISC: %w", err)
+	}
+
+	return iscPath, discPath, nil
+}
+
+// pinCatalogDigests creates a copy of ImageSetConfiguration with catalog references
+// pinned to SHA256 digests instead of tags.
+//
+// For each operator catalog in cfg.Mirror.Operators:
+// - Parses the catalog reference
+// - Looks up the digest in catalogToFBCMap
+// - Replaces the catalog field with digest format: {registry}/{path}@sha256:{digest}
+//
+// Returns a new ImageSetConfiguration with pinned catalogs and any errors encountered.
+func pinCatalogDigests(
+	cfg v2alpha1.ImageSetConfiguration,
+	catalogToFBCMap map[string]v2alpha1.CatalogFilterResult,
+	log clog.PluggableLoggerInterface,
+) (v2alpha1.ImageSetConfiguration, error) {
+	if len(cfg.Mirror.Operators) == 0 {
+		return cfg, nil
+	}
+
+	// Create copy to avoid mutating original
+	pinnedCfg := copyISC(cfg)
+
+	// Iterate through operator catalogs by index to modify in place
+	for i := range pinnedCfg.Mirror.Operators {
+		op := &pinnedCfg.Mirror.Operators[i]
+
+		pinnedRef, err := pinSingleCatalogDigest(op.Catalog, catalogToFBCMap, log)
+		if err != nil {
+			return v2alpha1.ImageSetConfiguration{}, err
+		}
+
+		if pinnedRef != "" {
+			op.Catalog = pinnedRef
+		}
+	}
+
+	return pinnedCfg, nil
+}
+
+// pinSingleCatalogDigest pins a single catalog reference to its SHA256 digest.
+//
+// Returns:
+// - pinnedRef: The pinned catalog reference (empty string if catalog should be skipped)
+// - error: Fatal error if parsing fails
+//
+// The function handles the following cases:
+// - Already digest-pinned: returns empty string (skip)
+// - Not found in catalogToFBCMap: returns empty string (skip)
+// - Empty digest: returns empty string (skip)
+// - Parse error: returns error
+// - Success: returns pinned reference
+func pinSingleCatalogDigest(
+	catalog string,
+	catalogToFBCMap map[string]v2alpha1.CatalogFilterResult,
+	log clog.PluggableLoggerInterface,
+) (string, error) {
+	// Parse catalog reference
+	imgSpec, err := image.ParseRef(catalog)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse catalog %s: %w", catalog, err)
+	}
+
+	// Skip if the image is already pinned by digest
+	if imgSpec.IsImageByDigest() {
+		log.Debug("Catalog %s is already pinned by digest, skipping", catalog)
+		return "", nil
+	}
+
+	// Look up digest in map
+	filterResult, ok := catalogToFBCMap[imgSpec.ReferenceWithTransport]
+	if !ok {
+		// Log warning but continue (non-fatal)
+		log.Warn("Catalog %s not found in CatalogToFBCMap, skipping pin", catalog)
+		return "", nil
+	}
+
+	// Check for empty digest
+	if filterResult.Digest == "" {
+		log.Warn("Empty digest for catalog %s, skipping pin", catalog)
+		return "", nil
+	}
+
+	// Build pinned reference: {registry}/{path}@sha256:{digest}
+	pinnedRef := image.WithDigest(imgSpec.Name, filterResult.Digest)
+
+	// Add transport prefix if non-docker (docker:// is default and can be omitted)
+	if imgSpec.Transport != "" && imgSpec.Transport != "docker://" {
+		pinnedRef = imgSpec.Transport + pinnedRef
+	}
+
+	log.Debug("Pinning catalog %s to %s", catalog, pinnedRef)
+	return pinnedRef, nil
+}
+
+// writeConfigToFile writes a config object (ISC or DISC) to a YAML file with timestamp naming.
+// Returns the absolute path to the written file.
+func writeConfigToFile(obj interface{}, configType, workingDir string) (string, error) {
+	filename := fmt.Sprintf("%s_pinned_%s.yaml", configType, time.Now().UTC().Format(time.RFC3339))
+	filePath := filepath.Join(workingDir, filename)
+
+	yamlData, err := yaml.Marshal(obj)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal %s to YAML: %w", strings.ToUpper(configType), err)
+	}
+
+	// #nosec G306 -- config files need to be readable by other users
+	if err := os.WriteFile(filePath, yamlData, 0o644); err != nil {
+		return "", fmt.Errorf("failed to write pinned %s to %s: %w", strings.ToUpper(configType), filePath, err)
+	}
+
+	return filePath, nil
+}
+
+// writePinnedISC writes an ImageSetConfiguration to a YAML file with timestamp naming.
+//
+// The file is written to: {workingDir}/isc_pinned_{timestamp}.yaml
+// e.g., isc_pinned_2025-12-31T11:37:17Z.yaml
+//
+// Returns the absolute path to the written file.
+func writePinnedISC(
+	cfg v2alpha1.ImageSetConfiguration,
+	workingDir string,
+) (string, error) {
+	cfg.SetGroupVersionKind(v2alpha1.GroupVersion.WithKind(v2alpha1.ImageSetConfigurationKind))
+	return writeConfigToFile(cfg, "isc", workingDir)
+}
+
+// createDISCFromISC creates a DeleteImageSetConfiguration from an already-pinned ImageSetConfiguration.
+// It simply converts the Mirror section to a Delete section.
+//
+// The file is written to: {workingDir}/disc_pinned_{timestamp}.yaml
+// e.g., disc_pinned_2025-12-31T11:37:17Z.yaml
+//
+// Returns the absolute path to the written pinned DISC file.
+func createDISCFromISC(
+	pinnedISC v2alpha1.ImageSetConfiguration,
+	workingDir string,
+) (string, error) {
+	disc := v2alpha1.DeleteImageSetConfiguration{
+		DeleteImageSetConfigurationSpec: v2alpha1.DeleteImageSetConfigurationSpec{
+			Delete: v2alpha1.Delete{
+				Platform:         pinnedISC.Mirror.Platform,
+				Operators:        pinnedISC.Mirror.Operators,
+				AdditionalImages: pinnedISC.Mirror.AdditionalImages,
+				Helm:             pinnedISC.Mirror.Helm,
+			},
+		},
+	}
+
+	// Set TypeMeta for DeleteImageSetConfiguration
+	disc.SetGroupVersionKind(v2alpha1.GroupVersion.WithKind(v2alpha1.DeleteImageSetConfigurationKind))
+
+	return writeConfigToFile(disc, "disc", workingDir)
+}
+
+// copyISC creates a shallow copy of ImageSetConfiguration with a deep copy of the Operators slice.
+// This ensures we don't mutate the original configuration when pinning catalog digests.
+func copyISC(cfg v2alpha1.ImageSetConfiguration) v2alpha1.ImageSetConfiguration {
+	copied := cfg
+
+	// Deep copy operators slice (only part we modify)
+	if len(cfg.Mirror.Operators) > 0 {
+		copied.Mirror.Operators = make([]v2alpha1.Operator, len(cfg.Mirror.Operators))
+		copy(copied.Mirror.Operators, cfg.Mirror.Operators)
+	}
+
+	return copied
+}

--- a/internal/pkg/config/pin_catalogs_test.go
+++ b/internal/pkg/config/pin_catalogs_test.go
@@ -1,0 +1,607 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+
+	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/image"
+	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
+)
+
+const (
+	// Valid SHA256 digests for testing (64 hex characters)
+	testDigest1 = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	testDigest2 = "fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321"
+
+	// Catalog references
+	redhatIndexTag          = "registry.redhat.io/redhat/redhat-operator-index:v4.12"
+	redhatIndexTagDocker    = "docker://registry.redhat.io/redhat/redhat-operator-index:v4.12"
+	certifiedIndexTag       = "registry.redhat.io/redhat/certified-operator-index:v4.12"
+	certifiedIndexTagDocker = "docker://registry.redhat.io/redhat/certified-operator-index:v4.12"
+	communityIndexBase      = "registry.redhat.io/redhat/community-operator-index"
+	redhatIndexBase         = "registry.redhat.io/redhat/redhat-operator-index"
+
+	// Test digests
+	testDigestShort1 = "abc123def456789"
+	testDigestShort2 = "digest1"
+	testDigestShort3 = "digest2"
+	testDigestShort4 = "abc123"
+
+	// Kind constants
+	kindISC  = "ImageSetConfiguration"
+	kindDISC = "DeleteImageSetConfiguration"
+
+	// API version
+	apiVersion = "mirror.openshift.io/v2alpha1"
+
+	// Filename patterns
+	filenamePrefixISC  = "isc_pinned_"
+	filenamePrefixDISC = "disc_pinned_"
+
+	// Error messages
+	errMsgParseCatalog   = "failed to parse catalog"
+	errMsgWriteISC       = "failed to write pinned ISC"
+	errMsgWriteDISC      = "failed to write pinned DISC"
+	nonexistentDirectory = "/nonexistent/directory/path"
+)
+
+func TestPinCatalogDigests_CopyBehavior(t *testing.T) {
+	logger := clog.New("trace")
+
+	cfg := v2alpha1.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+			Mirror: v2alpha1.Mirror{
+				Operators: []v2alpha1.Operator{
+					{
+						Catalog: redhatIndexTag,
+					},
+				},
+			},
+		},
+	}
+
+	catalogMap := map[string]v2alpha1.CatalogFilterResult{
+		redhatIndexTagDocker: {
+			Digest: testDigestShort1,
+		},
+	}
+
+	pinnedCfg, err := pinCatalogDigests(cfg, catalogMap, logger)
+	require.NoError(t, err)
+	assert.Equal(t,
+		image.WithDigest(redhatIndexBase, testDigestShort1),
+		pinnedCfg.Mirror.Operators[0].Catalog,
+	)
+
+	// Verify original config is unchanged (tests copy behavior)
+	assert.Equal(t,
+		redhatIndexTag,
+		cfg.Mirror.Operators[0].Catalog,
+	)
+}
+
+func TestPinCatalogDigests_NoOperators(t *testing.T) {
+	logger := clog.New("trace")
+
+	cfg := v2alpha1.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+			Mirror: v2alpha1.Mirror{
+				Operators: []v2alpha1.Operator{},
+			},
+		},
+	}
+
+	catalogMap := map[string]v2alpha1.CatalogFilterResult{}
+
+	pinnedCfg, err := pinCatalogDigests(cfg, catalogMap, logger)
+	require.NoError(t, err)
+	assert.Empty(t, pinnedCfg.Mirror.Operators)
+}
+
+func TestPinCatalogDigests_MultipleOperators(t *testing.T) {
+	logger := clog.New("trace")
+
+	cfg := v2alpha1.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+			Mirror: v2alpha1.Mirror{
+				Operators: []v2alpha1.Operator{
+					{
+						Catalog: redhatIndexTag,
+					},
+					{
+						Catalog: certifiedIndexTag,
+					},
+					{
+						Catalog: image.WithDigest(communityIndexBase, testDigest2),
+					},
+				},
+			},
+		},
+	}
+
+	catalogMap := map[string]v2alpha1.CatalogFilterResult{
+		redhatIndexTagDocker: {
+			Digest: testDigestShort2,
+		},
+		certifiedIndexTagDocker: {
+			Digest: testDigestShort3,
+		},
+	}
+
+	pinnedCfg, err := pinCatalogDigests(cfg, catalogMap, logger)
+	require.NoError(t, err)
+
+	// First operator should be pinned
+	assert.Equal(t,
+		image.WithDigest(redhatIndexBase, testDigestShort2),
+		pinnedCfg.Mirror.Operators[0].Catalog,
+	)
+
+	// Second operator should be pinned
+	assert.Equal(t,
+		image.WithDigest("registry.redhat.io/redhat/certified-operator-index", testDigestShort3),
+		pinnedCfg.Mirror.Operators[1].Catalog,
+	)
+
+	// Third operator already pinned, should remain unchanged
+	assert.Equal(t,
+		image.WithDigest(communityIndexBase, testDigest2),
+		pinnedCfg.Mirror.Operators[2].Catalog,
+	)
+}
+
+func TestWritePinnedISC_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := v2alpha1.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+			Mirror: v2alpha1.Mirror{
+				Operators: []v2alpha1.Operator{
+					{
+						Catalog: image.WithDigest(redhatIndexBase, testDigest1),
+					},
+				},
+			},
+		},
+	}
+
+	filePath, err := writePinnedISC(cfg, tmpDir)
+	require.NoError(t, err)
+
+	// Verify file was created
+	assert.FileExists(t, filePath)
+
+	// Verify file is in the correct directory
+	assert.Equal(t, tmpDir, filepath.Dir(filePath))
+
+	// Verify filename format
+	filename := filepath.Base(filePath)
+	assert.True(t, strings.HasPrefix(filename, filenamePrefixISC))
+	assert.True(t, strings.HasSuffix(filename, ".yaml"))
+
+	// Verify file contents can be read back
+	data, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+
+	var loadedCfg v2alpha1.ImageSetConfiguration
+	err = yaml.Unmarshal(data, &loadedCfg)
+	require.NoError(t, err)
+
+	// Verify TypeMeta is set
+	assert.Equal(t, kindISC, loadedCfg.Kind)
+	assert.Equal(t, apiVersion, loadedCfg.APIVersion)
+
+	// Verify operator catalog is preserved
+	assert.Equal(t,
+		image.WithDigest(redhatIndexBase, testDigest1),
+		loadedCfg.Mirror.Operators[0].Catalog,
+	)
+}
+
+func TestWritePinnedISC_InvalidDirectory(t *testing.T) {
+	cfg := v2alpha1.ImageSetConfiguration{}
+
+	// Use a non-existent directory
+	_, err := writePinnedISC(cfg, nonexistentDirectory)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), errMsgWriteISC)
+}
+
+func TestPinAndWriteConfigs(t *testing.T) {
+	tmpDir := t.TempDir()
+	logger := clog.New("trace")
+
+	cfg := v2alpha1.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+			Mirror: v2alpha1.Mirror{
+				Operators: []v2alpha1.Operator{
+					{
+						Catalog: redhatIndexTag,
+					},
+				},
+			},
+		},
+	}
+
+	catalogMap := map[string]v2alpha1.CatalogFilterResult{
+		redhatIndexTagDocker: {
+			Digest: testDigestShort1,
+		},
+	}
+
+	iscPath, discPath, err := PinAndWriteISCAndDSC(cfg, catalogMap, tmpDir, logger)
+	require.NoError(t, err)
+	assert.FileExists(t, iscPath)
+	assert.FileExists(t, discPath)
+
+	// Verify ISC file
+	iscData, err := os.ReadFile(iscPath)
+	require.NoError(t, err)
+	var loadedISC v2alpha1.ImageSetConfiguration
+	err = yaml.Unmarshal(iscData, &loadedISC)
+	require.NoError(t, err)
+	assert.Equal(t, kindISC, loadedISC.Kind)
+	assert.Equal(t,
+		image.WithDigest(redhatIndexBase, testDigestShort1),
+		loadedISC.Mirror.Operators[0].Catalog,
+	)
+
+	// Verify DISC file
+	discData, err := os.ReadFile(discPath)
+	require.NoError(t, err)
+	var loadedDISC v2alpha1.DeleteImageSetConfiguration
+	err = yaml.Unmarshal(discData, &loadedDISC)
+	require.NoError(t, err)
+	assert.Equal(t, kindDISC, loadedDISC.Kind)
+	assert.Equal(t,
+		image.WithDigest(redhatIndexBase, testDigestShort1),
+		loadedDISC.Delete.Operators[0].Catalog,
+	)
+}
+
+func TestCopyISC(t *testing.T) {
+	original := v2alpha1.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+			Mirror: v2alpha1.Mirror{
+				Operators: []v2alpha1.Operator{
+					{
+						Catalog: redhatIndexTag,
+					},
+				},
+			},
+		},
+	}
+
+	copied := copyISC(original)
+
+	// Modify the copied version
+	copied.Mirror.Operators[0].Catalog = "modified-catalog"
+
+	// Verify original is unchanged
+	assert.Equal(t,
+		redhatIndexTag,
+		original.Mirror.Operators[0].Catalog,
+	)
+
+	// Verify copied has the modification
+	assert.Equal(t,
+		"modified-catalog",
+		copied.Mirror.Operators[0].Catalog,
+	)
+}
+
+func TestCreateDISCFromISC_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a pinned ISC (catalogs already have digests)
+	pinnedISC := v2alpha1.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+			Mirror: v2alpha1.Mirror{
+				Operators: []v2alpha1.Operator{
+					{
+						Catalog: image.WithDigest(redhatIndexBase, testDigestShort1),
+					},
+				},
+			},
+		},
+	}
+
+	filePath, err := createDISCFromISC(pinnedISC, tmpDir)
+	require.NoError(t, err)
+	assert.FileExists(t, filePath)
+
+	// Verify filename format
+	filename := filepath.Base(filePath)
+	assert.True(t, strings.HasPrefix(filename, filenamePrefixDISC))
+	assert.True(t, strings.HasSuffix(filename, ".yaml"))
+
+	// Read back and verify
+	data, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+
+	var loadedDISC v2alpha1.DeleteImageSetConfiguration
+	err = yaml.Unmarshal(data, &loadedDISC)
+	require.NoError(t, err)
+
+	// Verify TypeMeta
+	assert.Equal(t, kindDISC, loadedDISC.Kind)
+	assert.Equal(t, apiVersion, loadedDISC.APIVersion)
+
+	// Verify operator catalog is pinned (copied from pinnedISC)
+	assert.Equal(t,
+		image.WithDigest(redhatIndexBase, testDigestShort1),
+		loadedDISC.Delete.Operators[0].Catalog,
+	)
+}
+
+func TestCreateDISCFromISC_MultipleOperators(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a pinned ISC (all catalogs already have digests)
+	pinnedISC := v2alpha1.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+			Mirror: v2alpha1.Mirror{
+				Operators: []v2alpha1.Operator{
+					{
+						Catalog: image.WithDigest(redhatIndexBase, testDigestShort2),
+					},
+					{
+						Catalog: image.WithDigest("registry.redhat.io/redhat/certified-operator-index", testDigestShort3),
+					},
+					{
+						Catalog: image.WithDigest(communityIndexBase, testDigest2),
+					},
+				},
+			},
+		},
+	}
+
+	filePath, err := createDISCFromISC(pinnedISC, tmpDir)
+	require.NoError(t, err)
+
+	// Read back and verify
+	data, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+
+	var loadedDISC v2alpha1.DeleteImageSetConfiguration
+	err = yaml.Unmarshal(data, &loadedDISC)
+	require.NoError(t, err)
+
+	// All operators should be pinned (copied from pinnedISC)
+	assert.Equal(t,
+		image.WithDigest(redhatIndexBase, testDigestShort2),
+		loadedDISC.Delete.Operators[0].Catalog,
+	)
+	assert.Equal(t,
+		image.WithDigest("registry.redhat.io/redhat/certified-operator-index", testDigestShort3),
+		loadedDISC.Delete.Operators[1].Catalog,
+	)
+	assert.Equal(t,
+		image.WithDigest(communityIndexBase, testDigest2),
+		loadedDISC.Delete.Operators[2].Catalog,
+	)
+}
+
+func TestCreateDISCFromISC_AllSections(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a pinned ISC with all sections
+	pinnedISC := v2alpha1.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+			Mirror: v2alpha1.Mirror{
+				Platform: v2alpha1.Platform{
+					Channels: []v2alpha1.ReleaseChannel{
+						{
+							Name: "stable-4.12",
+						},
+					},
+				},
+				Operators: []v2alpha1.Operator{
+					{
+						Catalog: image.WithDigest(redhatIndexBase, testDigestShort4),
+					},
+				},
+				AdditionalImages: []v2alpha1.Image{
+					{
+						Name: "quay.io/example/image:latest",
+					},
+				},
+				Helm: v2alpha1.Helm{
+					Repositories: []v2alpha1.Repository{
+						{
+							Name: "my-repo",
+							URL:  "https://example.com/charts",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	filePath, err := createDISCFromISC(pinnedISC, tmpDir)
+	require.NoError(t, err)
+
+	// Read back and verify
+	data, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+
+	var loadedDISC v2alpha1.DeleteImageSetConfiguration
+	err = yaml.Unmarshal(data, &loadedDISC)
+	require.NoError(t, err)
+
+	// Verify all sections are copied
+	assert.Equal(t, "stable-4.12", loadedDISC.Delete.Platform.Channels[0].Name)
+	assert.Equal(t, image.WithDigest(redhatIndexBase, testDigestShort4), loadedDISC.Delete.Operators[0].Catalog)
+	assert.Equal(t, "quay.io/example/image:latest", loadedDISC.Delete.AdditionalImages[0].Name)
+	assert.Equal(t, "my-repo", loadedDISC.Delete.Helm.Repositories[0].Name)
+}
+
+func TestCreateDISCFromISC_InvalidDirectory(t *testing.T) {
+	pinnedISC := v2alpha1.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+			Mirror: v2alpha1.Mirror{
+				Operators: []v2alpha1.Operator{
+					{
+						Catalog: image.WithDigest(redhatIndexBase, testDigestShort4),
+					},
+				},
+			},
+		},
+	}
+
+	// Use a non-existent directory
+	_, err := createDISCFromISC(pinnedISC, nonexistentDirectory)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), errMsgWriteDISC)
+}
+
+// Tests for pinSingleCatalogDigest function
+
+func TestPinSingleCatalog_Success(t *testing.T) {
+	logger := clog.New("trace")
+
+	catalogMap := map[string]v2alpha1.CatalogFilterResult{
+		redhatIndexTagDocker: {
+			Digest: testDigestShort1,
+		},
+	}
+
+	pinnedRef, err := pinSingleCatalogDigest(redhatIndexTag, catalogMap, logger)
+	require.NoError(t, err)
+	assert.Equal(t, image.WithDigest(redhatIndexBase, testDigestShort1), pinnedRef)
+}
+
+func TestPinSingleCatalog_AlreadyPinned(t *testing.T) {
+	logger := clog.New("trace")
+
+	alreadyPinnedCatalog := image.WithDigest(redhatIndexBase, testDigest1)
+
+	catalogMap := map[string]v2alpha1.CatalogFilterResult{
+		"docker://" + alreadyPinnedCatalog: {
+			Digest: "newdigest123",
+		},
+	}
+
+	pinnedRef, err := pinSingleCatalogDigest(alreadyPinnedCatalog, catalogMap, logger)
+	require.NoError(t, err)
+	assert.Empty(t, pinnedRef, "Should return empty string for already pinned catalog")
+}
+
+func TestPinSingleCatalog_NotInMap(t *testing.T) {
+	logger := clog.New("trace")
+
+	// Empty catalog map
+	catalogMap := map[string]v2alpha1.CatalogFilterResult{}
+
+	pinnedRef, err := pinSingleCatalogDigest(redhatIndexTag, catalogMap, logger)
+	require.NoError(t, err)
+	assert.Empty(t, pinnedRef, "Should return empty string when catalog not found in map")
+}
+
+func TestPinSingleCatalog_EmptyDigest(t *testing.T) {
+	logger := clog.New("trace")
+
+	catalogMap := map[string]v2alpha1.CatalogFilterResult{
+		redhatIndexTagDocker: {
+			Digest: "", // Empty digest
+		},
+	}
+
+	pinnedRef, err := pinSingleCatalogDigest(redhatIndexTag, catalogMap, logger)
+	require.NoError(t, err)
+	assert.Empty(t, pinnedRef, "Should return empty string for empty digest")
+}
+
+func TestPinSingleCatalog_InvalidCatalog(t *testing.T) {
+	logger := clog.New("trace")
+
+	catalogMap := map[string]v2alpha1.CatalogFilterResult{}
+
+	// Empty catalog reference should fail parsing
+	pinnedRef, err := pinSingleCatalogDigest("", catalogMap, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), errMsgParseCatalog)
+	assert.Empty(t, pinnedRef)
+}
+
+func TestPinSingleCatalog_OCITransport(t *testing.T) {
+	logger := clog.New("trace")
+
+	ociCatalog := "oci:///path/to/catalog"
+
+	catalogMap := map[string]v2alpha1.CatalogFilterResult{
+		ociCatalog: {
+			Digest: "ocidigests123",
+		},
+	}
+
+	pinnedRef, err := pinSingleCatalogDigest(ociCatalog, catalogMap, logger)
+	require.NoError(t, err)
+	assert.Equal(t, "oci://"+image.WithDigest("/path/to/catalog", "ocidigests123"), pinnedRef,
+		"Should preserve OCI transport prefix")
+}
+
+func TestPinSingleCatalog_DockerTransport(t *testing.T) {
+	logger := clog.New("trace")
+
+	dockerCatalog := "docker://registry.redhat.io/redhat/redhat-operator-index:v4.12"
+
+	catalogMap := map[string]v2alpha1.CatalogFilterResult{
+		dockerCatalog: {
+			Digest: testDigestShort1,
+		},
+	}
+
+	pinnedRef, err := pinSingleCatalogDigest(dockerCatalog, catalogMap, logger)
+	require.NoError(t, err)
+	assert.Equal(t, image.WithDigest(redhatIndexBase, testDigestShort1), pinnedRef,
+		"Should omit docker:// transport prefix")
+}
+
+func TestPinSingleCatalog_NoTransport(t *testing.T) {
+	logger := clog.New("trace")
+
+	// Catalog without explicit transport (docker:// is implied)
+	catalogMap := map[string]v2alpha1.CatalogFilterResult{
+		redhatIndexTagDocker: {
+			Digest: testDigestShort1,
+		},
+	}
+
+	pinnedRef, err := pinSingleCatalogDigest(redhatIndexTag, catalogMap, logger)
+	require.NoError(t, err)
+	assert.Equal(t, image.WithDigest(redhatIndexBase, testDigestShort1), pinnedRef,
+		"Should not add transport prefix when none specified")
+	assert.NotContains(t, pinnedRef, "docker://",
+		"Should not include docker:// prefix in pinned reference")
+}
+
+func TestPinSingleCatalog_MultipleCatalogs(t *testing.T) {
+	logger := clog.New("trace")
+
+	catalogMap := map[string]v2alpha1.CatalogFilterResult{
+		redhatIndexTagDocker: {
+			Digest: testDigestShort1,
+		},
+		certifiedIndexTagDocker: {
+			Digest: testDigestShort2,
+		},
+	}
+
+	// Pin first catalog
+	pinnedRef1, err := pinSingleCatalogDigest(redhatIndexTag, catalogMap, logger)
+	require.NoError(t, err)
+	assert.Equal(t, image.WithDigest(redhatIndexBase, testDigestShort1), pinnedRef1)
+
+	// Pin second catalog
+	pinnedRef2, err := pinSingleCatalogDigest(certifiedIndexTag, catalogMap, logger)
+	require.NoError(t, err)
+	assert.Equal(t, image.WithDigest("registry.redhat.io/redhat/certified-operator-index", testDigestShort2), pinnedRef2)
+}

--- a/internal/pkg/image/image.go
+++ b/internal/pkg/image/image.go
@@ -167,3 +167,8 @@ func (i ImageSpec) SetTag(tag string) ImageSpec {
 	i.ReferenceWithTransport = strings.Replace(i.ReferenceWithTransport, oldTag, tag, 1)
 	return i
 }
+
+// WithDigest constructs an image reference with a SHA256 digest.
+func WithDigest(name, digest string) string {
+	return fmt.Sprintf("%s@sha256:%s", name, digest)
+}

--- a/internal/pkg/operator/common.go
+++ b/internal/pkg/operator/common.go
@@ -88,12 +88,16 @@ func (o OperatorCollector) catalogDigest(ctx context.Context, catalog v2alpha1.O
 		return "", fmt.Errorf("unable to determine cached reference for catalog: %w", err)
 	}
 
+	// If the catalog is specified by digest, return it directly.
+	// No need to query the cache - the digest is already known from the ISC.
+	if srcImgSpec.IsImageByDigestOnly() {
+		return srcImgSpec.Digest, nil
+	}
+
 	var tag string
 	switch {
 	case len(catalog.TargetTag) > 0: // applies only to catalogs
 		tag = catalog.TargetTag
-	case srcImgSpec.Tag == "" && srcImgSpec.Digest != "":
-		tag = fmt.Sprintf("%s-%s", srcImgSpec.Algorithm, srcImgSpec.Digest)
 	case srcImgSpec.Tag == "" && srcImgSpec.Digest == "" && srcImgSpec.Transport == ociProtocol:
 		tag = latestTag
 	default:

--- a/internal/pkg/operator/filtered_collector_test.go
+++ b/internal/pkg/operator/filtered_collector_test.go
@@ -358,21 +358,21 @@ func TestFilterCollectorM2D(t *testing.T) {
 					Destination: "docker://localhost:9999/certified-operators:v4.7",
 					Origin:      "docker://certified-operators:v4.7",
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "442c7ba64d56a85eea155325aa0c6537",
+					RebuiltTag:  "70eb0b2116707316c6130de415ceeb69",
 				},
 				{
 					Source:      "docker://community-operators:v4.7",
 					Destination: "docker://localhost:9999/community-operators:v4.7",
 					Origin:      "docker://community-operators:v4.7",
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "4dab2467f35b4d9c9ba7c2a7823de8bd",
+					RebuiltTag:  "ac8e314872a499f2c6edb0616489c628",
 				},
 				{
 					Source:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Destination: "docker://localhost:9999/simple-test-bundle:latest",
 					Origin:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
+					RebuiltTag:  "eaf28fd0a9f205e44fb52a8b0bd8e678",
 				},
 			},
 		},
@@ -404,7 +404,7 @@ func TestFilterCollectorM2D(t *testing.T) {
 					Destination: "docker://localhost:9999/simple-test-bundle:v4.14",
 					Origin:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
+					RebuiltTag:  "eaf28fd0a9f205e44fb52a8b0bd8e678",
 				},
 			},
 		},
@@ -442,7 +442,7 @@ func TestFilterCollectorM2D(t *testing.T) {
 					Destination: "docker://localhost:9999/test-catalog:v4.14",
 					Origin:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
+					RebuiltTag:  "eaf28fd0a9f205e44fb52a8b0bd8e678",
 				},
 			},
 		},
@@ -474,7 +474,7 @@ func TestFilterCollectorM2D(t *testing.T) {
 					Destination: "docker://localhost:9999/test-namespace/test-catalog:v2.0",
 					Origin:      "docker://certified-operators:v4.7",
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "442c7ba64d56a85eea155325aa0c6537",
+					RebuiltTag:  "70eb0b2116707316c6130de415ceeb69",
 				},
 			},
 		},
@@ -553,18 +553,18 @@ func TestFilterCollectorD2M(t *testing.T) {
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
-					Source:      "docker://localhost:9999/simple-test-bundle:9fadc6c70adb4b2571f66f674a876279",
+					Source:      "docker://localhost:9999/simple-test-bundle:eaf28fd0a9f205e44fb52a8b0bd8e678",
 					Destination: "docker://localhost:5000/test/simple-test-bundle:latest",
 					Origin:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
+					RebuiltTag:  "eaf28fd0a9f205e44fb52a8b0bd8e678",
 				},
 				{
-					Source:      "docker://localhost:9999/redhat/redhat-operator-index:6566d78129230a2e107cb5aafcb7787b",
+					Source:      "docker://localhost:9999/redhat/redhat-operator-index:94563f14d54e0ea1d600fa8c002c204b",
 					Destination: "docker://localhost:5000/test/redhat/redhat-operator-index:v4.14",
 					Origin:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.14",
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "6566d78129230a2e107cb5aafcb7787b",
+					RebuiltTag:  "94563f14d54e0ea1d600fa8c002c204b",
 				},
 			},
 		},
@@ -597,11 +597,11 @@ func TestFilterCollectorD2M(t *testing.T) {
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
-					Source:      "docker://localhost:9999/test-catalog:9fadc6c70adb4b2571f66f674a876279",
+					Source:      "docker://localhost:9999/test-catalog:eaf28fd0a9f205e44fb52a8b0bd8e678",
 					Destination: "docker://localhost:5000/test/test-catalog:v4.14",
 					Origin:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
+					RebuiltTag:  "eaf28fd0a9f205e44fb52a8b0bd8e678",
 				},
 			},
 		},
@@ -715,71 +715,71 @@ func TestFilterCollectorM2M(t *testing.T) {
 					Destination: "docker://localhost:9999/redhat/redhat-filtered-index:v4.17",
 					Origin:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.17",
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "08a5610c0e6f72fd34b1c76d30788c66",
+					RebuiltTag:  "b6db5253b0a8b995840d4d6b5a8aefca",
 				},
 				{
 					Source:      "docker://registry.redhat.io/redhat/certified-operators:v4.17",
 					Destination: "docker://localhost:9999/redhat/certified-operators-pinned:v4.17.0-20241114",
 					Origin:      "docker://registry.redhat.io/redhat/certified-operators:v4.17",
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "65af60f894902a1758a30ae262c0e39e",
+					RebuiltTag:  "37e8b17cf0089fb1de93893cfb41dbfb",
 				},
 				{
 					Source:      "oci://" + filepath.Join(testDir, "catalog-on-disk1"),
 					Destination: "docker://localhost:9999/catalog-on-disk1:latest",
 					Origin:      "oci://" + filepath.Join(testDir, "catalog-on-disk1"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "fc2e113a1d6f0dbe89bd2bc5c83886e3",
+					RebuiltTag:  "bff06b6d6cc99438ad7a080e38025b52",
 				},
 				{
 					Source:      "oci://" + filepath.Join(testDir, "catalog-on-disk2"),
 					Destination: "docker://localhost:9999/coffee-shop-index:latest",
 					Origin:      "oci://" + filepath.Join(testDir, "catalog-on-disk2"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "421035ded2cb0e83f50ee6445b1466a5",
+					RebuiltTag:  "04a29cd46d562afadfa317467451756e",
 				},
 				{
 					Source:      "oci://" + filepath.Join(testDir, "catalog-on-disk3"),
 					Destination: "docker://localhost:9999/tea-shop-index:v3.14",
 					Origin:      "oci://" + filepath.Join(testDir, "catalog-on-disk3"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "d81a7ad49cabfc8aa050edaf56f25a3f",
+					RebuiltTag:  "4b3bae8f9360ced2d4a4473d5481cc9f",
 				},
 
 				{
-					Source:      "docker://localhost:9999/redhat/redhat-filtered-index:08a5610c0e6f72fd34b1c76d30788c66",
+					Source:      "docker://localhost:9999/redhat/redhat-filtered-index:b6db5253b0a8b995840d4d6b5a8aefca",
 					Destination: "docker://localhost:5000/test/redhat/redhat-filtered-index:v4.17",
 					Origin:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.17",
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "08a5610c0e6f72fd34b1c76d30788c66",
+					RebuiltTag:  "b6db5253b0a8b995840d4d6b5a8aefca",
 				},
 				{
-					Source:      "docker://localhost:9999/redhat/certified-operators-pinned:65af60f894902a1758a30ae262c0e39e",
+					Source:      "docker://localhost:9999/redhat/certified-operators-pinned:37e8b17cf0089fb1de93893cfb41dbfb",
 					Destination: "docker://localhost:5000/test/redhat/certified-operators-pinned:v4.17.0-20241114",
 					Origin:      "docker://registry.redhat.io/redhat/certified-operators:v4.17",
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "65af60f894902a1758a30ae262c0e39e",
+					RebuiltTag:  "37e8b17cf0089fb1de93893cfb41dbfb",
 				},
 				{
-					Source:      "docker://localhost:9999/catalog-on-disk1:fc2e113a1d6f0dbe89bd2bc5c83886e3",
+					Source:      "docker://localhost:9999/catalog-on-disk1:bff06b6d6cc99438ad7a080e38025b52",
 					Destination: "docker://localhost:5000/test/catalog-on-disk1:latest",
 					Origin:      "oci://" + filepath.Join(testDir, "catalog-on-disk1"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "fc2e113a1d6f0dbe89bd2bc5c83886e3",
+					RebuiltTag:  "bff06b6d6cc99438ad7a080e38025b52",
 				},
 				{
-					Source:      "docker://localhost:9999/coffee-shop-index:421035ded2cb0e83f50ee6445b1466a5",
+					Source:      "docker://localhost:9999/coffee-shop-index:04a29cd46d562afadfa317467451756e",
 					Destination: "docker://localhost:5000/test/coffee-shop-index:latest",
 					Origin:      "oci://" + filepath.Join(testDir, "catalog-on-disk2"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "421035ded2cb0e83f50ee6445b1466a5",
+					RebuiltTag:  "04a29cd46d562afadfa317467451756e",
 				},
 				{
-					Source:      "docker://localhost:9999/tea-shop-index:d81a7ad49cabfc8aa050edaf56f25a3f",
+					Source:      "docker://localhost:9999/tea-shop-index:4b3bae8f9360ced2d4a4473d5481cc9f",
 					Destination: "docker://localhost:5000/test/tea-shop-index:v3.14",
 					Origin:      "oci://" + filepath.Join(testDir, "catalog-on-disk3"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "d81a7ad49cabfc8aa050edaf56f25a3f",
+					RebuiltTag:  "4b3bae8f9360ced2d4a4473d5481cc9f",
 				},
 			},
 		},
@@ -1071,4 +1071,102 @@ func (o MockHandler) getDeclarativeConfig(filePath string) (*declcfg.Declarative
 			},
 		},
 	}, nil
+}
+
+func TestFindFilterDigest(t *testing.T) {
+	t.Run("returns normalized digest when it exists", func(t *testing.T) {
+		tempDir := t.TempDir()
+		op := v2alpha1.Operator{
+			Catalog: "registry.redhat.io/redhat/redhat-operator-index:v4.14",
+			IncludeConfig: v2alpha1.IncludeConfig{
+				Packages: []v2alpha1.IncludePackage{{Name: "op1"}},
+			},
+		}
+		catalogDigest := "abc123"
+
+		normalizedDigest, err := digestOfFilter(op, catalogDigest)
+		assert.NoError(t, err)
+
+		// Create the normalized digest folder
+		normalizedDir := filepath.Join(tempDir, normalizedDigest)
+		err = os.MkdirAll(normalizedDir, 0755)
+		assert.NoError(t, err)
+		err = os.WriteFile(filepath.Join(normalizedDir, "digest"), []byte("somefilteredimagedigest"), 0644) // #nosec G306
+		assert.NoError(t, err)
+
+		result, err := findFilterDigest(op, catalogDigest, tempDir)
+		assert.NoError(t, err)
+		assert.Equal(t, normalizedDigest, result)
+	})
+
+	t.Run("returns legacy digest when only legacy folder exists", func(t *testing.T) {
+		tempDir := t.TempDir()
+		op := v2alpha1.Operator{
+			Catalog: "registry.redhat.io/redhat/redhat-operator-index:v4.14",
+			IncludeConfig: v2alpha1.IncludeConfig{
+				Packages: []v2alpha1.IncludePackage{{Name: "op1"}},
+			},
+		}
+		catalogDigest := "abc123"
+
+		normalizedDigest, err := digestOfFilter(op, catalogDigest)
+		assert.NoError(t, err)
+		legacyDigest, err := digestOfFilter(op, "")
+		assert.NoError(t, err)
+		assert.NotEqual(t, normalizedDigest, legacyDigest, "digests should differ for this test")
+
+		// Create the legacy digest folder (not the normalized one)
+		legacyDir := filepath.Join(tempDir, legacyDigest)
+		err = os.MkdirAll(legacyDir, 0755)
+		assert.NoError(t, err)
+		err = os.WriteFile(filepath.Join(legacyDir, "digest"), []byte("somefilteredimagedigest"), 0644) // #nosec G306
+		assert.NoError(t, err)
+
+		result, err := findFilterDigest(op, catalogDigest, tempDir)
+		assert.NoError(t, err)
+		assert.Equal(t, legacyDigest, result, "should return the legacy digest for backwards compatibility")
+
+		_, err = os.Stat(legacyDir)
+		assert.NoError(t, err, "legacy folder should still exist")
+	})
+
+	t.Run("returns normalized digest when neither exists", func(t *testing.T) {
+		tempDir := t.TempDir()
+		op := v2alpha1.Operator{
+			Catalog: "registry.redhat.io/redhat/redhat-operator-index:v4.14",
+			IncludeConfig: v2alpha1.IncludeConfig{
+				Packages: []v2alpha1.IncludePackage{{Name: "op1"}},
+			},
+		}
+		catalogDigest := "abc123"
+
+		normalizedDigest, err := digestOfFilter(op, catalogDigest)
+		assert.NoError(t, err)
+
+		result, err := findFilterDigest(op, catalogDigest, tempDir)
+		assert.NoError(t, err)
+		assert.Equal(t, normalizedDigest, result)
+	})
+
+	t.Run("returns same digest when legacy equals normalized", func(t *testing.T) {
+		tempDir := t.TempDir()
+		// When catalogDigest is empty, legacy and normalized should be the same
+		op := v2alpha1.Operator{
+			Catalog: "registry.redhat.io/redhat/redhat-operator-index:v4.14",
+			IncludeConfig: v2alpha1.IncludeConfig{
+				Packages: []v2alpha1.IncludePackage{{Name: "op1"}},
+			},
+		}
+		catalogDigest := "" // empty catalog digest means no normalization
+
+		normalizedDigest, err := digestOfFilter(op, catalogDigest)
+		assert.NoError(t, err)
+		legacyDigest, err := digestOfFilter(op, "")
+		assert.NoError(t, err)
+		assert.Equal(t, normalizedDigest, legacyDigest, "should be equal when catalogDigest is empty")
+
+		result, err := findFilterDigest(op, catalogDigest, tempDir)
+		assert.NoError(t, err)
+		assert.Equal(t, normalizedDigest, result)
+	})
 }


### PR DESCRIPTION
# Description

Add a feature to pin operator catalogs by digest, even if the original ImageSetConfig operator catalogs are referenced by tag.

When running the m2d or m2m workflows, a pinned ISC and the corresponding DISC are created in the working directory.

Github / Jira issue: 
N/A

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update on openshift docs

# How Has This Been Tested?
- Adding unit tests
- Relevant scenarios:
  - m2d using an isc with a catalog by tag, then verify that the pinned isc and disc are created
  - m2d by tag, then d2m using the newly created isc pinned by digest, then delete using the pinned disc
  - m2d using an older oc-mirror version without these changes, delete cache and working dir (everything except tar) then d2m using the code of this PR
  - m2m

## Expected Outcome
Please describe the outcome expected from the tests.