### PR TITLE
CLID-524: additionalImages collector error handling

### DIFF
--- a/internal/pkg/additional/local_stored_collector.go
+++ b/internal/pkg/additional/local_stored_collector.go
@@ -2,6 +2,7 @@ package additional
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -49,6 +50,7 @@ func (o LocalStorageCollector) destinationRegistry() string {
 func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([]v2alpha1.CopyImageSchema, error) {
 
 	var allImages []v2alpha1.CopyImageSchema
+	var allErrs []error
 
 	o.Log.Debug(collectorPrefix+"setting copy option o.Opts.MultiArch=%s when collecting releases image", o.Opts.MultiArch)
 	for _, img := range o.Config.ImageSetConfigurationSpec.Mirror.AdditionalImages {
@@ -60,11 +62,13 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 		if err != nil {
 			// OCPBUGS-33081 - skip if parse error (i.e semver and other)
 			o.Log.Warn("%v : SKIPPING", err)
+			allErrs = append(allErrs, fmt.Errorf("parse image %q: %w", img.Name, err))
 			continue
 		}
 
 		if img.TargetRepo != "" && !v2alpha1.IsValidPathComponent(img.TargetRepo) {
 			o.Log.Warn("invalid targetRepo %s for image %s : SKIPPING", img.TargetRepo, img.Name)
+			allErrs = append(allErrs, fmt.Errorf("invalid targetRepo %s for image %s", img.TargetRepo, img.Name))
 			continue
 		}
 
@@ -84,21 +88,26 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 		case o.Opts.IsDiskToMirror(), o.Opts.IsDelete():
 			tmpSrc, tmpDest = o.buildDiskToMirrorPaths(img, imgSpec, targetRepo, targetTag)
 		}
+
 		if tmpSrc == "" || tmpDest == "" {
 			o.Log.Error(collectorPrefix+"unable to determine src %s or dst %s for %s", tmpSrc, tmpDest, img.Name)
-			return allImages, fmt.Errorf("unable to determine src %s or dst %s for %s", tmpSrc, tmpDest, img.Name)
+			allErrs = append(allErrs, fmt.Errorf("unable to determine src %s or dst %s for %s", tmpSrc, tmpDest, img.Name))
+			continue
 		}
+
 		srcSpec, err := image.ParseRef(tmpSrc) // makes sure this ref is valid, and adds transport if needed
 		if err != nil {
 			o.Log.Error(errMsg, err.Error())
-			return nil, err
+			allErrs = append(allErrs, fmt.Errorf("parse source %q: %w", tmpSrc, err))
+			continue
 		}
 		src = srcSpec.ReferenceWithTransport
 
 		destSpec, err := image.ParseRef(tmpDest) // makes sure this ref is valid, and adds transport if needed
 		if err != nil {
 			o.Log.Error(errMsg, err.Error())
-			return nil, err
+			allErrs = append(allErrs, fmt.Errorf("parse destination %q: %w", tmpDest, err))
+			continue
 		}
 		dest = destSpec.ReferenceWithTransport
 
@@ -107,7 +116,7 @@ func (o LocalStorageCollector) AdditionalImagesCollector(ctx context.Context) ([
 
 		allImages = append(allImages, v2alpha1.CopyImageSchema{Source: src, Destination: dest, Origin: origin, Type: v2alpha1.TypeGeneric})
 	}
-	return allImages, nil
+	return allImages, errors.Join(allErrs...)
 }
 
 // buildMirrorToDiskPaths constructs source and destination paths for mirror-to-disk and mirror-to-mirror operations

--- a/internal/pkg/additional/local_stored_collector_test.go
+++ b/internal/pkg/additional/local_stored_collector_test.go
@@ -7,6 +7,7 @@ import (
 	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.podman.io/image/v5/types"
 
 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
@@ -189,7 +190,7 @@ func TestAdditionalImageCollector(t *testing.T) {
 	opts.Mode = mirror.MirrorToDisk
 	ex = New(log, cfg, opts, mockmirror, manifest)
 
-	t.Run("Testing AdditionalImagesCollector : mirrorToDisk should not fail (skipped)", func(t *testing.T) {
+	t.Run("Testing AdditionalImagesCollector : mirrorToDisk should collect valid images and return parse errors", func(t *testing.T) {
 		expected := []v2alpha1.CopyImageSchema{
 			{
 				Source:      consts.DockerProtocol + "registry.redhat.io/ubi8/ubi:latest",
@@ -211,14 +212,12 @@ func TestAdditionalImageCollector(t *testing.T) {
 			},
 		}
 		res, err := ex.AdditionalImagesCollector(ctx)
-		if err != nil {
-			log.Error(" %v ", err)
-			t.Fatalf("should not fail")
-		}
+		// Should return error for images that failed to parse
+		require.Error(t, err)
 		assert.ElementsMatch(t, expected, res)
 	})
 
-	t.Run("Testing AdditionalImagesCollector : diskToMirror should skip failing image with warning", func(t *testing.T) {
+	t.Run("Testing AdditionalImagesCollector : diskToMirror should collect valid images and return parse errors", func(t *testing.T) {
 		// should error diskToMirror
 		cfg.Mirror.AdditionalImages[1].Name = "sometest.registry.com/testns/test@shaf30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea"
 		opts.Mode = mirror.DiskToMirror
@@ -244,10 +243,8 @@ func TestAdditionalImageCollector(t *testing.T) {
 			},
 		}
 		res, err := ex.AdditionalImagesCollector(ctx)
-		if err != nil {
-			log.Error(" %v ", err)
-			t.Fatalf("should not fail")
-		}
+		// Should return error for images that failed to parse
+		require.Error(t, err)
 		assert.ElementsMatch(t, expected, res)
 	})
 }
@@ -260,6 +257,8 @@ func TestAdditionalImageCollectorWithTargetRepoAndTag(t *testing.T) {
 		additionalImages []v2alpha1.Image
 		useV1Tags        bool
 		expected         []v2alpha1.CopyImageSchema
+		expectError      bool
+		errContains      []string
 	}
 
 	cases := []spec{
@@ -361,7 +360,7 @@ func TestAdditionalImageCollectorWithTargetRepoAndTag(t *testing.T) {
 			},
 		},
 		{
-			name:        "invalid TargetRepo should skip image with warning",
+			name:        "invalid TargetRepo should skip image with warning and return error",
 			mode:        mirror.MirrorToDisk,
 			destination: "oci://test",
 			additionalImages: []v2alpha1.Image{
@@ -380,6 +379,38 @@ func TestAdditionalImageCollectorWithTargetRepoAndTag(t *testing.T) {
 					Destination: "docker://test.registry.com/ubi9/ubi:latest",
 					Type:        v2alpha1.TypeGeneric,
 				},
+			},
+			expectError: true,
+			errContains: []string{"invalid targetRepo"},
+		},
+		{
+			name:        "multiple invalid images should return joined errors",
+			mode:        mirror.MirrorToDisk,
+			destination: "oci://test",
+			additionalImages: []v2alpha1.Image{
+				{
+					Name: "sometest.registry.com/testns/test@shainvaliddigest1",
+				},
+				{
+					Name: "registry.redhat.io/ubi9/ubi:latest",
+				},
+				{
+					Name:       "registry.redhat.io/ubi8/ubi:latest",
+					TargetRepo: "invalid:tag",
+				},
+			},
+			expected: []v2alpha1.CopyImageSchema{
+				{
+					Source:      "docker://registry.redhat.io/ubi9/ubi:latest",
+					Origin:      "registry.redhat.io/ubi9/ubi:latest",
+					Destination: "docker://test.registry.com/ubi9/ubi:latest",
+					Type:        v2alpha1.TypeGeneric,
+				},
+			},
+			expectError: true,
+			errContains: []string{
+				"shainvaliddigest1",
+				"invalid targetRepo",
 			},
 		},
 		{
@@ -542,7 +573,14 @@ func TestAdditionalImageCollectorWithTargetRepoAndTag(t *testing.T) {
 			}
 
 			res, err := ex.AdditionalImagesCollector(ctx)
-			assert.NoError(t, err)
+			if c.expectError {
+				require.Error(t, err)
+				for _, substr := range c.errContains {
+					assert.Contains(t, err.Error(), substr)
+				}
+			} else {
+				require.NoError(t, err)
+			}
 			assert.ElementsMatch(t, c.expected, res)
 		})
 	}

--- a/internal/pkg/cli/executor.go
+++ b/internal/pkg/cli/executor.go
@@ -1143,14 +1143,13 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 	aImgs, err := o.AdditionalImages.AdditionalImagesCollector(ctx)
 	if err != nil {
 		additionalImgErr = err
-	} else {
-		// exclude blocked images
-		aImgs = excludeImages(aImgs, o.Config.Mirror.BlockedImages)
-		aImgs = removeDuplicatedImages(aImgs, o.Opts.Function)
-		collectorSchema.TotalAdditionalImages = len(aImgs)
-		o.Log.Debug(collecAllPrefix+"total additional images to %s %d ", o.Opts.Function, collectorSchema.TotalAdditionalImages)
-		allRelatedImages = append(allRelatedImages, aImgs...)
 	}
+	// exclude blocked images
+	aImgs = excludeImages(aImgs, o.Config.Mirror.BlockedImages)
+	aImgs = removeDuplicatedImages(aImgs, o.Opts.Function)
+	collectorSchema.TotalAdditionalImages = len(aImgs)
+	o.Log.Debug(collecAllPrefix+"total additional images to %s %d ", o.Opts.Function, collectorSchema.TotalAdditionalImages)
+	allRelatedImages = append(allRelatedImages, aImgs...)
 
 	o.Log.Info(emoji.LeftPointingMagnifyingGlass + " collecting helm images...")
 	hImgs, err := o.HelmCollector.HelmImageCollector(ctx)


### PR DESCRIPTION
# Description

To be merged after #1327. 

Github / Jira issue: 

https://issues.redhat.com/browse/CLID-524

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Aggregated validation errors for image collection so users receive a combined report of all issues instead of a single early error.
  * Additional images are now processed, counted, and included even when collection yields non-fatal errors.

* **Tests**
  * Test cases updated to assert expected error outcomes for image parsing/validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->