### PR TITLE
OCPBUGS-75013: Fix reg config detection for explicit false values

### DIFF
--- a/internal/pkg/registriesd/registriesd.go
+++ b/internal/pkg/registriesd/registriesd.go
@@ -129,14 +129,14 @@ func createRegistryConfigFile(registryFileAbsPath, registryHost string) error {
 		registryConfigStruct = registryConfiguration{
 			Docker: map[string]registryNamespace{
 				registryHost: {
-					UseSigstoreAttachments: true,
+					UseSigstoreAttachments: boolPtr(true),
 				},
 			},
 			DefaultDocker: nil,
 		}
 	} else {
 		registryConfigStruct = registryConfiguration{
-			DefaultDocker: &registryNamespace{UseSigstoreAttachments: true},
+			DefaultDocker: &registryNamespace{UseSigstoreAttachments: boolPtr(true)},
 		}
 	}
 

--- a/internal/pkg/registriesd/registriesd_test.go
+++ b/internal/pkg/registriesd/registriesd_test.go
@@ -27,13 +27,13 @@ func TestPrepareRegistrydCustomDir(t *testing.T) {
 	cfg, err := parser.ParseYamlFile[registryConfiguration](expectedCacheRegistryFile)
 	assert.NoError(t, err)
 	assert.Contains(t, cfg.Docker, "localhost:55000")
-	assert.True(t, cfg.Docker["localhost:55000"].UseSigstoreAttachments)
+	assert.Equal(t, boolPtr(true), cfg.Docker["localhost:55000"].UseSigstoreAttachments)
 
 	assert.FileExists(t, expectedDestRegistryFile)
 	cfg, err = parser.ParseYamlFile[registryConfiguration](expectedDestRegistryFile)
 	assert.NoError(t, err)
 	assert.Contains(t, cfg.Docker, "mymirror.com")
-	assert.True(t, cfg.Docker["mymirror.com"].UseSigstoreAttachments)
+	assert.Equal(t, boolPtr(true), cfg.Docker["mymirror.com"].UseSigstoreAttachments)
 }
 
 func TestGetCustomRegistrydConfigPath(t *testing.T) {

--- a/internal/pkg/registriesd/types.go
+++ b/internal/pkg/registriesd/types.go
@@ -8,9 +8,13 @@ type registryConfiguration struct {
 
 // registryNamespace defines lookaside locations for a single namespace.
 type registryNamespace struct {
-	Lookaside              string `json:"lookaside,omitempty"`         // For reading, and if LookasideStaging is not present, for writing.
-	LookasideStaging       string `json:"lookaside-staging,omitempty"` // For writing only.
-	SigStore               string `json:"sigstore,omitempty"`          // For compatibility, deprecated in favor of Lookaside.
-	SigStoreStaging        string `json:"sigstore-staging,omitempty"`  // For compatibility, deprecated in favor of LookasideStaging.
-	UseSigstoreAttachments bool   `json:"use-sigstore-attachments"`    // originally , this had omitempty, so the type was *bool
+	Lookaside              string `json:"lookaside,omitempty"`                // For reading, and if LookasideStaging is not present, for writing.
+	LookasideStaging       string `json:"lookaside-staging,omitempty"`        // For writing only.
+	SigStore               string `json:"sigstore,omitempty"`                 // For compatibility, deprecated in favor of Lookaside.
+	SigStoreStaging        string `json:"sigstore-staging,omitempty"`         // For compatibility, deprecated in favor of LookasideStaging.
+	UseSigstoreAttachments *bool  `json:"use-sigstore-attachments,omitempty"` // Since the zero-value of bool is false, it is needed to have a pointer to identify when a field was not set.
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }


### PR DESCRIPTION
# Description

This PR fixes an issue where registry configuration files with explicitly set `use-sigstore-attachments: false` were being incorrectly treated as unconfigured, causing oc-mirror to generate a new configuration file instead of respecting the user's existing configuration.

The root cause was that the `UseSigstoreAttachments` field in `registryNamespace` struct used a plain `bool` type. In Go, when unmarshaling YAML/JSON, omitted boolean fields default to `false`, making it impossible to distinguish between:
- A field that was omitted (should be treated as "not configured")
- A field explicitly set to `false` (should be treated as "configured")

This caused the `mandatoryRegistriesWithoutConfig` function to incorrectly identify explicitly-configured registries as unconfigured, leading to new configuration files being generated that override the user's existing settings.

**Solution:** Changed `UseSigstoreAttachments` from `bool` to `*bool`, allowing three distinct states:
- `nil` = field omitted (not configured)
- `&false` = explicitly set to false (configured)
- `&true` = explicitly set to true (configured)

Github / Jira issue: [OCPBUGS-75013](https://issues.redhat.com/browse/OCPBUGS-75013)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Test with a custom registry configuration file that has `use-sigstore-attachments: false` explicitly set:

1. Create a registry config file in `~/.config/containers/registries.d/default.yaml`:
   ```yaml
   default-docker:
     use-sigstore-attachments: false
   ```

2. Run oc-mirror with a configuration that requires the default registry

3. Verify that the `default.yaml` file generated in the working directory's registries.d folder contains the user's existing configuration (`use-sigstore-attachments: false`) rather than a newly generated configuration with different values

## Expected Outcome

- When a registry config file exists with any field explicitly set (including `use-sigstore-attachments: false`), the `mandatoryRegistriesWithoutConfig` function should recognize it as configured and skip generating a new config file
- oc-mirror should copy/respect the user's existing registry configuration instead of overriding it with auto-generated values
- The comparison `*configFile.DefaultDocker != zeroStruct` at [registriesd.go:183](internal/pkg/registriesd/registriesd.go#L183) should correctly evaluate to `true` when `UseSigstoreAttachments` is explicitly set to `false`
