### PR TITLE
OCPBUGS-64640: remove environment setup output

### DIFF
--- a/internal/pkg/cli/executor.go
+++ b/internal/pkg/cli/executor.go
@@ -195,6 +195,24 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  false,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			log.Info(emoji.WavingHandSign + " Hello, welcome to oc-mirror")
+
+			// Validate and set log level for all subcommands
+			if !slices.Contains([]string{"info", "debug", "trace", "error"}, opts.Global.LogLevel) {
+				return fmt.Errorf("log-level has an invalid value %s , it should be one of (info,debug,trace, error)", opts.Global.LogLevel)
+			}
+			// override log level
+			ex.Log.Level(ex.Opts.Global.LogLevel)
+
+			log.Info(emoji.Gear+"  environment version: %s", version.Get().GitVersion)
+
+			// Skip environment setup for subcommands that don't need it
+			if cmd.Name() == "version" || (cmd.Parent() != nil && cmd.Parent().Name() == "list") {
+				return nil
+			}
+
+			log.Info(emoji.Gear + "  setting up the environment for you...")
+
 			// OCPBUGS-55374 (check current umask)
 			currentUmask := syscall.Umask(0)
 			syscall.Umask(currentUmask)
@@ -202,18 +220,10 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 				log.Warn(emoji.Warning+"  Detected bad umask 00%o (oc-mirror requires a umask of 0022)", currentUmask)
 			}
 
-			log.Info(emoji.WavingHandSign + " Hello, welcome to oc-mirror")
-			log.Info(emoji.Gear + "  setting up the environment for you...")
-
 			// Validate and set common flags
 			if len(opts.Global.WorkingDir) > 0 && !strings.Contains(opts.Global.WorkingDir, consts.FileProtocol) {
 				return fmt.Errorf("when --workspace is used, it must have file:// prefix")
 			}
-			if !slices.Contains([]string{"info", "debug", "trace", "error"}, opts.Global.LogLevel) {
-				return fmt.Errorf("log-level has an invalid value %s , it should be one of (info,debug,trace, error)", opts.Global.LogLevel)
-			}
-			// override log level
-			ex.Log.Level(ex.Opts.Global.LogLevel)
 
 			if os.Getenv(cacheEnvVar) != "" && opts.Global.CacheDir != "" {
 				return fmt.Errorf("either OC_MIRROR_CACHE or --cache-dir can be used but not both")
@@ -232,7 +242,6 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 				opts.Global.CacheDir = homeDir
 			}
 
-			log.Info(emoji.Gear+"  environment version: %s", version.Get().GitVersion)
 			return nil
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/cli/executor.go
+++ b/internal/pkg/cli/executor.go
@@ -319,7 +319,6 @@ func HideFlags(cmd *cobra.Command) {
 
 func (o *ExecutorSchema) setupEnvironment() error {
 	o.Log.Info(emoji.WavingHandSign + " Hello, welcome to oc-mirror")
-	o.Log.Info(emoji.Gear + "  setting up the environment for you...")
 
 	// OCPBUGS-55374 (check current umask)
 	currentUmask := syscall.Umask(0)


### PR DESCRIPTION
# Description

Remove unneeded environment setup output. This isn't providing much useful information, and the time between this message and the next is near-instant.

Github / Jira issue: https://redhat.atlassian.net/browse/OCPBUGS-64640 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

- ran `oc-mirror version --v2`
- ran `oc-mirror --v2 list releases`
- ran `oc-mirror --v2 list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.21`
- ran a small m2d, d2m

## Expected Outcome

Output in question is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter validation for log levels to ensure only valid options (info, debug, trace, error) are accepted.

* **Chores**
  * Optimized performance by streamlining command initialization.
  * Improved logging output clarity and sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->