### PR TITLE
OCPBUGS-62603: Fix printing collection messages with 0 collection items

### DIFF
--- a/internal/pkg/cli/executor.go
+++ b/internal/pkg/cli/executor.go
@@ -1107,7 +1107,9 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 	)
 
 	o.Log.Info(emoji.SleuthOrSpy + "  going to discover the necessary images...")
-	o.Log.Info(emoji.LeftPointingMagnifyingGlass + " collecting release images...")
+	if len(o.Config.Mirror.Platform.Channels) > 0 || o.Config.Mirror.Platform.Release != "" || o.Config.Mirror.Platform.Graph {
+		o.Log.Info(emoji.LeftPointingMagnifyingGlass + " collecting release images...")
+	}
 	// collect releases
 	releaseImgs, err := o.Release.ReleaseImageCollector(ctx)
 	if err != nil {
@@ -1125,7 +1127,9 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 	o.Log.Debug(collecAllPrefix+"total release images to %s %d ", o.Opts.Function, collectorSchema.TotalReleaseImages)
 	allRelatedImages = append(allRelatedImages, releaseImgs...)
 
-	o.Log.Info(emoji.LeftPointingMagnifyingGlass + " collecting operator images...")
+	if len(o.Config.Mirror.Operators) > 0 {
+		o.Log.Info(emoji.LeftPointingMagnifyingGlass + " collecting operator images...")
+	}
 	// collect operators
 	operatorImgs, err := o.Operator.OperatorImageCollector(ctx)
 	if err != nil {
@@ -1142,7 +1146,9 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 		collectorSchema.CatalogToFBCMap = operatorImgs.CatalogToFBCMap
 	}
 
-	o.Log.Info(emoji.LeftPointingMagnifyingGlass + " collecting additional images...")
+	if len(o.Config.Mirror.AdditionalImages) > 0 {
+		o.Log.Info(emoji.LeftPointingMagnifyingGlass + " collecting additional images...")
+	}
 	// collect additionalImages
 	aImgs, err := o.AdditionalImages.AdditionalImagesCollector(ctx)
 	if err != nil {
@@ -1156,7 +1162,9 @@ func (o *ExecutorSchema) CollectAll(ctx context.Context) (v2alpha1.CollectorSche
 		allRelatedImages = append(allRelatedImages, aImgs...)
 	}
 
-	o.Log.Info(emoji.LeftPointingMagnifyingGlass + " collecting helm images...")
+	if len(o.Config.Mirror.Helm.Repositories) > 0 || len(o.Config.Mirror.Helm.Local) > 0 {
+		o.Log.Info(emoji.LeftPointingMagnifyingGlass + " collecting helm images...")
+	}
 	hImgs, err := o.HelmCollector.HelmImageCollector(ctx)
 	if err != nil {
 		helmErr = err


### PR DESCRIPTION
# Description

Only prints the collection messages if there are items collected for those categories. 

Another option would be to treat these messages as informational for listing the steps taken by oc-mirror regardless, and then adding a message specifically to say none were collected, but due to the nature of the bug I took the simpler route of not printing them. 

Github / Jira issue: https://redhat.atlassian.net/browse/OCPBUGS-62603 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Ran various m2d with items specified/omitted in each category. 

## Expected Outcome

Print output is correctly omitted when there are no collection items for a category. 