### PR TITLE
OCPBUGS-61136: Only print catalog rebuild message if there are catalo…

### DIFF
--- a/internal/pkg/cli/executor.go
+++ b/internal/pkg/cli/executor.go
@@ -1196,6 +1196,16 @@ func (o *ExecutorSchema) RebuildCatalogs(ctx context.Context, operatorImgs v2alp
 	// CLID-230 rebuild-catalogs
 	oImgs := operatorImgs.AllImages
 	if o.Opts.IsMirrorToDisk() || o.Opts.IsMirrorToMirror() {
+		needsRebuild := false
+		for _, result := range operatorImgs.CatalogToFBCMap {
+			if result.ToRebuild {
+				needsRebuild = true
+				break
+			}
+		}
+		if !needsRebuild {
+			return nil
+		}
 		o.Log.Info(emoji.RepeatSingleButton + " rebuilding catalogs")
 
 		for _, copyImage := range oImgs {


### PR DESCRIPTION
…gs to rebuild

# Description

Currently we unconditionally print the rebuilding catalogs message before looping through the collected list to see if they need rebuilding. This adds a pre-scan check that aborts before the loop if none are found, and prints the message if at least one exists that needs to be rebuilt.

Github / Jira issue: https://redhat.atlassian.net/browse/OCPBUGS-61136 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

- Ran various m2d with the ISC specified in the bug

## Expected Outcome

- output no longer exists