### PR TITLE
CLID-592: pkg/cli: add unit tests for environment setup

### DIFF
--- a/internal/pkg/cli/executor.go
+++ b/internal/pkg/cli/executor.go
@@ -119,6 +119,12 @@ oc-mirror delete --delete-yaml-file /home/<user>/oc-mirror/delete1/working-dir/d
 `
 )
 
+var (
+	errWrongWorkingDirProtocol error = fmt.Errorf("when --workspace is used, it must have file:// prefix")
+	errConflictingCacheValues        = fmt.Errorf("either OC_MIRROR_CACHE or --cache-dir can be used but not both")
+	errInvalidLogLevel               = fmt.Errorf("invalid log-level, it should be one of (info,debug,trace,error)")
+)
+
 type ExecutorSchema struct {
 	Log                  clog.PluggableLoggerInterface
 	LogsDir              string
@@ -195,45 +201,7 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  false,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			// OCPBUGS-55374 (check current umask)
-			currentUmask := syscall.Umask(0)
-			syscall.Umask(currentUmask)
-			if currentUmask != 0o022 {
-				log.Warn(emoji.Warning+"  Detected bad umask 00%o (oc-mirror requires a umask of 0022)", currentUmask)
-			}
-
-			log.Info(emoji.WavingHandSign + " Hello, welcome to oc-mirror")
-			log.Info(emoji.Gear + "  setting up the environment for you...")
-
-			// Validate and set common flags
-			if len(opts.Global.WorkingDir) > 0 && !strings.Contains(opts.Global.WorkingDir, consts.FileProtocol) {
-				return fmt.Errorf("when --workspace is used, it must have file:// prefix")
-			}
-			if !slices.Contains([]string{"info", "debug", "trace", "error"}, opts.Global.LogLevel) {
-				return fmt.Errorf("log-level has an invalid value %s , it should be one of (info,debug,trace, error)", opts.Global.LogLevel)
-			}
-			// override log level
-			ex.Log.Level(ex.Opts.Global.LogLevel)
-
-			if os.Getenv(cacheEnvVar) != "" && opts.Global.CacheDir != "" {
-				return fmt.Errorf("either OC_MIRROR_CACHE or --cache-dir can be used but not both")
-			}
-
-			if opts.Global.CacheDir == "" {
-				// Default to the env var to keep previous behavior
-				opts.Global.CacheDir = os.Getenv(cacheEnvVar)
-			}
-			if opts.Global.CacheDir == "" {
-				homeDir, err := os.UserHomeDir()
-				if err != nil {
-					return fmt.Errorf("failed to setup default cache directory: %w", err)
-				}
-				// ensure cache dir exists
-				opts.Global.CacheDir = homeDir
-			}
-
-			log.Info(emoji.Gear+"  environment version: %s", version.Get().GitVersion)
-			return nil
+			return ex.setupEnvironment()
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.Function = string(mirror.CopyMode)
@@ -347,6 +315,49 @@ func HideFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().MarkHidden("cpu-prof")
 	cmd.PersistentFlags().MarkHidden("mem-prof")
 	cmd.PersistentFlags().MarkHidden("ignore-release-signature")
+}
+
+func (o *ExecutorSchema) setupEnvironment() error {
+	o.Log.Info(emoji.WavingHandSign + " Hello, welcome to oc-mirror")
+	o.Log.Info(emoji.Gear + "  setting up the environment for you...")
+
+	// OCPBUGS-55374 (check current umask)
+	currentUmask := syscall.Umask(0)
+	syscall.Umask(currentUmask)
+	if currentUmask != 0o022 {
+		o.Log.Warn(emoji.Warning+"  Detected bad umask 00%o (oc-mirror requires a umask of 0022)", currentUmask)
+	}
+
+	// Validate and set common flags
+	if len(o.Opts.Global.WorkingDir) > 0 && !strings.Contains(o.Opts.Global.WorkingDir, consts.FileProtocol) {
+		return errWrongWorkingDirProtocol
+	}
+
+	if !slices.Contains([]string{"info", "debug", "trace", "error"}, o.Opts.Global.LogLevel) {
+		return fmt.Errorf("%q: %w", o.Opts.Global.LogLevel, errInvalidLogLevel)
+	}
+	// override log level
+	o.Log.Level(o.Opts.Global.LogLevel)
+
+	if os.Getenv(cacheEnvVar) != "" && o.Opts.Global.CacheDir != "" {
+		return errConflictingCacheValues
+	}
+
+	if o.Opts.Global.CacheDir == "" {
+		// Default to the env var to keep previous behavior
+		o.Opts.Global.CacheDir = os.Getenv(cacheEnvVar)
+	}
+	if o.Opts.Global.CacheDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to setup default cache directory: %w", err)
+		}
+		// ensure cache dir exists
+		o.Opts.Global.CacheDir = homeDir
+	}
+
+	o.Log.Info(emoji.Gear+"  environment version: %s", version.Get().GitVersion)
+	return nil
 }
 
 // Validate - cobra validation

--- a/internal/pkg/cli/executor.go
+++ b/internal/pkg/cli/executor.go
@@ -329,7 +329,7 @@ func (o *ExecutorSchema) setupEnvironment() error {
 	}
 
 	// Validate and set common flags
-	if len(o.Opts.Global.WorkingDir) > 0 && !strings.Contains(o.Opts.Global.WorkingDir, consts.FileProtocol) {
+	if len(o.Opts.Global.WorkingDir) > 0 && !strings.HasPrefix(o.Opts.Global.WorkingDir, consts.FileProtocol) {
 		return errWrongWorkingDirProtocol
 	}
 

--- a/internal/pkg/cli/executor_test.go
+++ b/internal/pkg/cli/executor_test.go
@@ -703,6 +703,116 @@ func TestExecutorSetupLocalStorage(t *testing.T) {
 	})
 }
 
+func TestExecutorEnvironmentSetup(t *testing.T) {
+	const logLevel string = "debug"
+
+	// Save and later restore the cache env value.
+	oldValue, isEnvSet := os.LookupEnv(cacheEnvVar)
+	t.Cleanup(func() {
+		if !isEnvSet {
+			err := os.Unsetenv(cacheEnvVar)
+			assert.NoError(t, err)
+		} else {
+			err := os.Setenv(cacheEnvVar, oldValue)
+			assert.NoError(t, err)
+		}
+	})
+	// This allows us to assume that the cache env var is unset in the following test cases.
+	err := os.Unsetenv(cacheEnvVar)
+	assert.NoError(t, err)
+
+	t.Run("should fail when working dir does not start with file:// protocol", func(t *testing.T) {
+		global := &mirror.GlobalOptions{
+			SecurePolicy: false,
+			WorkingDir:   workingDir,
+			LogLevel:     logLevel,
+		}
+
+		ex := &ExecutorSchema{
+			Log:     clog.New("trace"),
+			Opts:    &mirror.CopyOptions{Global: global},
+			MakeDir: MockMakeDir{},
+		}
+		err := ex.setupEnvironment()
+		assert.ErrorIs(t, err, errWrongWorkingDirProtocol)
+	})
+
+	t.Run("should fail when both env var and command line arg are set", func(t *testing.T) {
+		global := &mirror.GlobalOptions{
+			SecurePolicy: false,
+			WorkingDir:   fmt.Sprintf("file://%s", workingDir),
+			CacheDir:     workingDir,
+			LogLevel:     logLevel,
+		}
+
+		ex := &ExecutorSchema{
+			Log:     clog.New("trace"),
+			Opts:    &mirror.CopyOptions{Global: global},
+			MakeDir: MockMakeDir{},
+		}
+		err := os.Setenv(cacheEnvVar, "working-dir")
+		assert.NoError(t, err, "should set cache env var")
+		t.Cleanup(func() { os.Unsetenv(cacheEnvVar) })
+		err = ex.setupEnvironment()
+		assert.ErrorIs(t, err, errConflictingCacheValues)
+	})
+
+	t.Run("should fail when log level is not valid", func(t *testing.T) {
+		global := &mirror.GlobalOptions{
+			SecurePolicy: false,
+			WorkingDir:   fmt.Sprintf("file://%s", workingDir),
+			LogLevel:     "quiet",
+		}
+
+		ex := &ExecutorSchema{
+			Log:     clog.New("trace"),
+			Opts:    &mirror.CopyOptions{Global: global},
+			MakeDir: MockMakeDir{},
+		}
+		err := ex.setupEnvironment()
+		assert.ErrorIs(t, err, errInvalidLogLevel)
+	})
+
+	t.Run("should set default cache dir value", func(t *testing.T) {
+		global := &mirror.GlobalOptions{
+			SecurePolicy: false,
+			WorkingDir:   fmt.Sprintf("file://%s", workingDir),
+			LogLevel:     logLevel,
+		}
+
+		ex := &ExecutorSchema{
+			Log:     clog.New("trace"),
+			Opts:    &mirror.CopyOptions{Global: global},
+			MakeDir: MockMakeDir{},
+		}
+		err := ex.setupEnvironment()
+		assert.NoError(t, err)
+		assert.Equal(t, ex.Log.GetLevel(), logLevel)
+		assert.NotEmpty(t, ex.Opts.Global.CacheDir, "default cache should be set")
+	})
+
+	t.Run("should use cache dir from env var when set", func(t *testing.T) {
+		global := &mirror.GlobalOptions{
+			SecurePolicy: false,
+			WorkingDir:   fmt.Sprintf("file://%s", workingDir),
+			LogLevel:     "debug",
+		}
+
+		ex := &ExecutorSchema{
+			Log:     clog.New("trace"),
+			Opts:    &mirror.CopyOptions{Global: global},
+			MakeDir: MockMakeDir{},
+		}
+		err := os.Setenv(cacheEnvVar, "working-dir")
+		assert.NoError(t, err, "should set cache env var")
+		t.Cleanup(func() { os.Unsetenv(cacheEnvVar) })
+		err = ex.setupEnvironment()
+		assert.NoError(t, err)
+		assert.Equal(t, ex.Log.GetLevel(), "debug")
+		assert.Equal(t, ex.Opts.Global.CacheDir, "working-dir")
+	})
+}
+
 // TestExecutorSetupWorkingDir
 func TestExecutorSetupWorkingDir(t *testing.T) {
 	workingDir := t.TempDir()


### PR DESCRIPTION
# Description

These tests should replace the cache-dir validation e2e test case OCP-79389 from QE.

Github / Jira issue: 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for environment configuration: enforces file:// working-directory prefix, detects cache-dir vs. env conflicts, validates log-level values, and verifies cache-defaulting behavior.

* **Refactor**
  * Centralized environment setup/validation into a single initializer; enforces stricter working-directory checks, clearer error signaling for misconfiguration, and consolidated log-level and cache-dir defaulting/override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->