### PR TITLE
OCPBUGS-90096: Make dry-run also generate cluster-resources

### DIFF
--- a/internal/pkg/cli/dryrun.go
+++ b/internal/pkg/cli/dryrun.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -26,13 +27,64 @@ func (o *ExecutorSchema) DryRun(ctx context.Context, allImages []v2alpha1.CopyIm
 	mappingTxtFilePath := filepath.Join(outDir, mappingFile)
 	mappingTxtFile, err := os.Create(mappingTxtFilePath)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create mapping file: %w", err)
 	}
 	defer mappingTxtFile.Close()
-	imagesAvailable := map[string]bool{}
-	nbMissingImgs := 0
 	var buff bytes.Buffer
 	var missingImgsBuff bytes.Buffer
+	nbMissingImgs, nbAvailableImgs := o.processImages(ctx, allImages, &buff, &missingImgsBuff)
+
+	_, err = mappingTxtFile.Write(buff.Bytes())
+	if err != nil {
+		return fmt.Errorf("failed to write mapping file: %w", err)
+	}
+	if err := o.writeMissingImagesFile(outDir, &missingImgsBuff, nbMissingImgs, len(allImages)); err != nil {
+		return err
+	}
+
+	if nbAvailableImgs > 0 {
+		o.Log.Info("all %d images required for mirroring are available in local cache. You may proceed with mirroring from disk to disconnected registry", nbAvailableImgs)
+	}
+	o.Log.Info(emoji.PageFacingUp+" list of all images for mirroring in : %s", mappingTxtFilePath)
+
+	// Generate cluster resources in dry-run mode (skip for mirror-to-disk since target registry is unknown)
+	if !o.Opts.IsMirrorToDisk() {
+		if err := o.generateClusterResources(ctx, allImages); err != nil {
+			// In dry-run mode, log cluster resource generation errors as warnings instead of failing
+			o.Log.Warn("Cluster resources generation failed (dry-run mode): %v", err)
+		}
+	}
+
+	return nil
+}
+
+// writeMissingImagesFile creates the missing.txt file if there are missing images
+func (o *ExecutorSchema) writeMissingImagesFile(outDir string, missingImgsBuff *bytes.Buffer, nbMissingImgs, totalImgs int) error {
+	if nbMissingImgs == 0 {
+		return nil
+	}
+
+	missingImgsFilePath := filepath.Join(outDir, missingImgsFile)
+	missingImgsTxtFile, err := os.Create(missingImgsFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to create missing images file: %w", err)
+	}
+	defer missingImgsTxtFile.Close()
+
+	_, err = missingImgsTxtFile.Write(missingImgsBuff.Bytes())
+	if err != nil {
+		return fmt.Errorf("failed to write missing images file: %w", err)
+	}
+
+	o.Log.Warn(emoji.Warning+"  %d/%d images necessary for mirroring are not available in the cache.", nbMissingImgs, totalImgs)
+	o.Log.Warn("List of missing images in : %s.\nplease re-run the mirror to disk process", missingImgsFilePath)
+	return nil
+}
+
+// processImages processes all images and returns the count of missing and available images
+func (o *ExecutorSchema) processImages(ctx context.Context, allImages []v2alpha1.CopyImageSchema, buff, missingImgsBuff *bytes.Buffer) (int, int) {
+	nbMissingImgs := 0
+	nbAvailableImgs := 0
 	for _, img := range allImages {
 		buff.WriteString(img.Source + "=" + img.Destination + "\n")
 		if o.Opts.IsMirrorToDisk() {
@@ -43,33 +95,10 @@ func (o *ExecutorSchema) DryRun(ctx context.Context, allImages []v2alpha1.CopyIm
 			if err != nil || !exists {
 				missingImgsBuff.WriteString(img.Source + "=" + img.Destination + "\n")
 				nbMissingImgs++
+			} else {
+				nbAvailableImgs++
 			}
 		}
 	}
-
-	_, err = mappingTxtFile.Write(buff.Bytes())
-	if err != nil {
-		return err
-	}
-	if nbMissingImgs > 0 {
-		// creating file for storing list of cached images
-		missingImgsFilePath := filepath.Join(outDir, missingImgsFile)
-		missingImgsTxtFile, err := os.Create(missingImgsFilePath)
-		if err != nil {
-			return err
-		}
-		defer missingImgsTxtFile.Close()
-		_, err = missingImgsTxtFile.Write(missingImgsBuff.Bytes())
-		if err != nil {
-			return err
-		}
-		o.Log.Warn(emoji.Warning+"  %d/%d images necessary for mirroring are not available in the cache.", nbMissingImgs, len(allImages))
-		o.Log.Warn("List of missing images in : %s.\nplease re-run the mirror to disk process", missingImgsFilePath)
-	}
-
-	if len(imagesAvailable) > 0 {
-		o.Log.Info("all %d images required for mirroring are available in local cache. You may proceed with mirroring from disk to disconnected registry", len(imagesAvailable))
-	}
-	o.Log.Info(emoji.PageFacingUp+" list of all images for mirroring in : %s", mappingTxtFilePath)
-	return nil
+	return nbMissingImgs, nbAvailableImgs
 }

--- a/internal/pkg/cli/dryrun_test.go
+++ b/internal/pkg/cli/dryrun_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,15 +11,15 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/clusterresources"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/config"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/consts"
 	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
 )
 
-// TestExecutorRunPrepare
-func TestDryRun(t *testing.T) {
-	imgs := []v2alpha1.CopyImageSchema{
+func getTestImages() []v2alpha1.CopyImageSchema {
+	return []v2alpha1.CopyImageSchema{
 		{Source: consts.DockerProtocol + "registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:test"},
 		{Source: consts.DockerProtocol + "registry/name/namespace/sometestimage-b@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:test"},
 		{Source: consts.DockerProtocol + "registry/name/namespace/sometestimage-c@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:test"},
@@ -29,10 +30,362 @@ func TestDryRun(t *testing.T) {
 		{Source: consts.DockerProtocol + "registry/name/namespace/sometestimage-h@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:test"},
 		{Source: consts.DockerProtocol + "registry/name/namespace/sometestimage-i@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea", Destination: "oci:test"},
 	}
-	log := clog.New("trace")
+}
 
+func TestDryRun(t *testing.T) {
+	imgs := getTestImages()
+
+	tests := []struct {
+		name                           string
+		mode                           string
+		mockMirrorFail                 bool
+		shouldGenerateClusterResources bool
+		enableClusterResourcesGen      bool
+		enableGraphGeneration          bool
+		expectMissingFile              bool
+		expectCatalogs                 bool
+		expectSignatures               bool
+		description                    string
+	}{
+		{
+			name:                           "M2D should pass without cluster resources",
+			mode:                           mirror.MirrorToDisk,
+			mockMirrorFail:                 false,
+			shouldGenerateClusterResources: false,
+			enableClusterResourcesGen:      false,
+			enableGraphGeneration:          false,
+			expectMissingFile:              false,
+			expectCatalogs:                 false,
+			expectSignatures:               false,
+			description:                    "Mirror-to-disk mode should not generate cluster resources since target registry is unknown",
+		},
+		{
+			name:                           "M2D with missing images",
+			mode:                           mirror.MirrorToDisk,
+			mockMirrorFail:                 true,
+			shouldGenerateClusterResources: false,
+			enableClusterResourcesGen:      false,
+			enableGraphGeneration:          false,
+			expectMissingFile:              true,
+			expectCatalogs:                 false,
+			expectSignatures:               false,
+			description:                    "Mirror-to-disk mode with missing images should create missing.txt but no cluster resources",
+		},
+		{
+			name:                           "M2M should generate cluster resources",
+			mode:                           mirror.MirrorToMirror,
+			mockMirrorFail:                 false,
+			shouldGenerateClusterResources: true,
+			enableClusterResourcesGen:      true,
+			enableGraphGeneration:          true,
+			expectMissingFile:              false,
+			expectCatalogs:                 false,
+			expectSignatures:               false,
+			description:                    "Mirror-to-mirror mode should generate all cluster resources when properly configured",
+		},
+		{
+			name:                           "D2M should generate cluster resources",
+			mode:                           mirror.DiskToMirror,
+			mockMirrorFail:                 false,
+			shouldGenerateClusterResources: true,
+			enableClusterResourcesGen:      true,
+			enableGraphGeneration:          false,
+			expectMissingFile:              false,
+			expectCatalogs:                 false,
+			expectSignatures:               false,
+			description:                    "Disk-to-mirror mode should generate cluster resources when properly configured",
+		},
+		{
+			name:                           "M2M with catalogs should generate catalog resources",
+			mode:                           mirror.MirrorToMirror,
+			mockMirrorFail:                 false,
+			shouldGenerateClusterResources: true,
+			enableClusterResourcesGen:      true,
+			enableGraphGeneration:          true,
+			expectMissingFile:              false,
+			expectCatalogs:                 true,
+			expectSignatures:               false,
+			description:                    "Mirror-to-mirror mode with operators should generate CatalogSource and ClusterCatalog files",
+		},
+		{
+			name:                           "M2M with signatures should generate signature ConfigMap",
+			mode:                           mirror.MirrorToMirror,
+			mockMirrorFail:                 false,
+			shouldGenerateClusterResources: true,
+			enableClusterResourcesGen:      true,
+			enableGraphGeneration:          true,
+			expectMissingFile:              false,
+			expectCatalogs:                 false,
+			expectSignatures:               true,
+			description:                    "Mirror-to-mirror mode with signatures should generate signature ConfigMap files",
+		},
+		{
+			name:                           "M2M with catalogs and signatures should generate all resources",
+			mode:                           mirror.MirrorToMirror,
+			mockMirrorFail:                 false,
+			shouldGenerateClusterResources: true,
+			enableClusterResourcesGen:      true,
+			enableGraphGeneration:          true,
+			expectMissingFile:              false,
+			expectCatalogs:                 true,
+			expectSignatures:               true,
+			description:                    "Mirror-to-mirror mode with operators and signatures should generate all cluster resources",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runDryRunTestCase(t, tt, imgs)
+		})
+	}
+}
+
+// runDryRunTestCase executes a single test case for the DryRun functionality
+func runDryRunTestCase(t *testing.T, tt struct {
+	name                           string
+	mode                           string
+	mockMirrorFail                 bool
+	shouldGenerateClusterResources bool
+	enableClusterResourcesGen      bool
+	enableGraphGeneration          bool
+	expectMissingFile              bool
+	expectCatalogs                 bool
+	expectSignatures               bool
+	description                    string
+}, imgs []v2alpha1.CopyImageSchema) {
+	log := clog.New("trace")
+	testFolder := t.TempDir()
+
+	ex, testImages, err := setupDryRunTest(t, testFolder, tt, imgs, log)
+	assert.NoError(t, err)
+
+	err = ex.DryRun(context.TODO(), testImages)
+	assert.NoError(t, err)
+
+	verifyDryRunResults(t, testFolder, tt, testImages)
+}
+
+// setupDryRunTest prepares the test environment and executor for a dry run test
+func setupDryRunTest(t *testing.T, testFolder string, tt struct {
+	name                           string
+	mode                           string
+	mockMirrorFail                 bool
+	shouldGenerateClusterResources bool
+	enableClusterResourcesGen      bool
+	enableGraphGeneration          bool
+	expectMissingFile              bool
+	expectCatalogs                 bool
+	expectSignatures               bool
+	description                    string
+}, imgs []v2alpha1.CopyImageSchema, log clog.PluggableLoggerInterface) (*ExecutorSchema, []v2alpha1.CopyImageSchema, error) {
+	opts, reg, err := setupTestEnvironment(t, testFolder, tt.mode)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ex := createExecutorForTest(testFolder, opts, reg, log, tt)
+	testImages := selectTestImages(imgs, tt.shouldGenerateClusterResources, tt.expectCatalogs)
+
+	// Set up test environment based on expectations
+	if tt.expectSignatures {
+		setupSignaturesDirectory(t, testFolder)
+	}
+
+	return ex, testImages, nil
+}
+
+// createExecutorForTest creates the appropriate executor based on test configuration
+func createExecutorForTest(testFolder string, opts *mirror.CopyOptions, reg *registry.Registry, log clog.PluggableLoggerInterface, tt struct {
+	name                           string
+	mode                           string
+	mockMirrorFail                 bool
+	shouldGenerateClusterResources bool
+	enableClusterResourcesGen      bool
+	enableGraphGeneration          bool
+	expectMissingFile              bool
+	expectCatalogs                 bool
+	expectSignatures               bool
+	description                    string
+}) *ExecutorSchema {
+	if tt.enableClusterResourcesGen {
+		return createTestExecutorWithClusterResources(testFolder, opts, reg, log, tt.enableGraphGeneration, tt.expectCatalogs)
+	}
+
+	ex := createTestExecutor(testFolder, opts, reg, log)
+	if tt.mockMirrorFail {
+		ex.Mirror = Mirror{Fail: true}
+	}
+	return ex
+}
+
+// selectTestImages returns the appropriate test images based on test configuration
+func selectTestImages(imgs []v2alpha1.CopyImageSchema, shouldGenerateClusterResources bool, expectCatalogs bool) []v2alpha1.CopyImageSchema {
+	if shouldGenerateClusterResources {
+		testImages := []v2alpha1.CopyImageSchema{
+			{
+				Source:      consts.DockerProtocol + "registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+				Destination: "registry.example.com/test/image-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+				Origin:      consts.DockerProtocol + "registry/name/namespace/sometestimage-a@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
+				Type:        v2alpha1.TypeGeneric,
+			},
+			{
+				Source:      consts.DockerProtocol + "quay.io/openshift-release-dev/ocp-release:4.14.0-x86_64",
+				Destination: "registry.example.com/test/ocp-release:4.14.0-x86_64",
+				Origin:      consts.DockerProtocol + "quay.io/openshift-release-dev/ocp-release:4.14.0-x86_64",
+				Type:        v2alpha1.TypeOCPRelease,
+			},
+		}
+
+		// Add catalog images if catalogs are expected to be tested
+		// IMPORTANT: Destination must NOT contain LocalStorageFQDN (localhost:5000) for CatalogSource generation
+		if expectCatalogs {
+			catalogImages := []v2alpha1.CopyImageSchema{
+				{
+					Source:      consts.DockerProtocol + "registry.redhat.io/redhat/redhat-operator-index:v4.14@sha256:a1b2c3d4e5f67890123456789012345678901234567890123456789012345678",
+					Destination: "registry.example.com/test/redhat-operator-index:v4.14@sha256:a1b2c3d4e5f67890123456789012345678901234567890123456789012345678",
+					Origin:      consts.DockerProtocol + "registry.redhat.io/redhat/redhat-operator-index:v4.14@sha256:a1b2c3d4e5f67890123456789012345678901234567890123456789012345678",
+					Type:        v2alpha1.TypeOperatorCatalog,
+				},
+			}
+			testImages = append(testImages, catalogImages...)
+		}
+
+		return testImages
+	}
+	return imgs
+}
+
+// verifyDryRunResults validates the output files and directories created by DryRun
+func verifyDryRunResults(t *testing.T, testFolder string, tt struct {
+	name                           string
+	mode                           string
+	mockMirrorFail                 bool
+	shouldGenerateClusterResources bool
+	enableClusterResourcesGen      bool
+	enableGraphGeneration          bool
+	expectMissingFile              bool
+	expectCatalogs                 bool
+	expectSignatures               bool
+	description                    string
+}, testImages []v2alpha1.CopyImageSchema) {
+	verifyMappingFile(t, testFolder, testImages)
+	verifyClusterResources(t, testFolder, tt)
+	verifyMissingImagesFile(t, testFolder, tt, testImages)
+}
+
+// verifyMappingFile validates the mapping.txt file contents
+func verifyMappingFile(t *testing.T, testFolder string, testImages []v2alpha1.CopyImageSchema) {
+	mappingPath := filepath.Join(testFolder, dryRunOutDir, "mapping.txt")
+	assert.FileExists(t, mappingPath, "mapping.txt should always be created")
+
+	mappingBytes, err := os.ReadFile(mappingPath)
+	assert.NoError(t, err)
+	mapping := string(mappingBytes)
+
+	for _, img := range testImages {
+		assert.Contains(t, mapping, img.Source+"="+img.Destination, "mapping should contain all images")
+	}
+}
+
+// verifyClusterResources validates cluster resources generation based on test configuration
+func verifyClusterResources(t *testing.T, testFolder string, tt struct {
+	name                           string
+	mode                           string
+	mockMirrorFail                 bool
+	shouldGenerateClusterResources bool
+	enableClusterResourcesGen      bool
+	enableGraphGeneration          bool
+	expectMissingFile              bool
+	expectCatalogs                 bool
+	expectSignatures               bool
+	description                    string
+}) {
+	clusterResourcesPath := filepath.Join(testFolder, clusterResourcesDir)
+
+	if tt.shouldGenerateClusterResources {
+		verifyClusterResourcesExist(t, clusterResourcesPath, tt.enableGraphGeneration, tt.expectCatalogs, tt.expectSignatures)
+	} else {
+		assert.NoDirExists(t, clusterResourcesPath, "cluster-resources directory should NOT exist for %s mode", tt.mode)
+	}
+}
+
+// verifyClusterResourcesExist validates that expected cluster resource files exist
+func verifyClusterResourcesExist(t *testing.T, clusterResourcesPath string, enableGraphGeneration bool, expectCatalogs bool, expectSignatures bool) {
+	assert.DirExists(t, clusterResourcesPath, "cluster-resources directory should exist for modes that generate cluster resources")
+
+	idmsFile := filepath.Join(clusterResourcesPath, "idms-oc-mirror.yaml")
+	assert.FileExists(t, idmsFile, "IDMS file should be generated")
+
+	itmsFile := filepath.Join(clusterResourcesPath, "itms-oc-mirror.yaml")
+	assert.FileExists(t, itmsFile, "ITMS file should be generated")
+
+	// Check for signature ConfigMap files (strict validation based on expectations)
+	verifySignatureConfigMapFiles(t, clusterResourcesPath, expectSignatures)
+
+	// Check for CatalogSource files (strict validation based on expectations)
+	verifyCatalogSourceFiles(t, clusterResourcesPath, expectCatalogs)
+
+	// Check for ClusterCatalog files (strict validation based on expectations)
+	verifyClusterCatalogFiles(t, clusterResourcesPath, expectCatalogs)
+
+	if enableGraphGeneration {
+		verifyUpdateServiceFile(t, clusterResourcesPath)
+	}
+}
+
+// verifyUpdateServiceFile validates the UpdateService file when graph generation is enabled
+func verifyUpdateServiceFile(t *testing.T, clusterResourcesPath string) {
+	updateServiceFile := filepath.Join(clusterResourcesPath, "updateService.yaml")
+	assert.FileExists(t, updateServiceFile, "UpdateService manifest should be generated when platform.graph=true")
+
+	updateServiceContent, err := os.ReadFile(updateServiceFile)
+	assert.NoError(t, err)
+	updateServiceStr := string(updateServiceContent)
+	assert.Contains(t, updateServiceStr, "graphDataImage:", "UpdateService should contain graphDataImage field")
+	assert.NotContains(t, updateServiceStr, "localhost:5000/openshift/graph-data", "UpdateService should not contain hardcoded localhost reference")
+}
+
+// verifyMissingImagesFile validates the missing.txt file based on test expectations
+func verifyMissingImagesFile(t *testing.T, testFolder string, tt struct {
+	name                           string
+	mode                           string
+	mockMirrorFail                 bool
+	shouldGenerateClusterResources bool
+	enableClusterResourcesGen      bool
+	enableGraphGeneration          bool
+	expectMissingFile              bool
+	expectCatalogs                 bool
+	expectSignatures               bool
+	description                    string
+}, testImages []v2alpha1.CopyImageSchema) {
+	missingImgsPath := filepath.Join(testFolder, dryRunOutDir, missingImgsFile)
+
+	if tt.expectMissingFile {
+		verifyMissingImagesFileExists(t, missingImgsPath, testImages)
+	} else {
+		assert.NoFileExists(t, missingImgsPath, "missing.txt should not exist when no images are missing")
+	}
+}
+
+// verifyMissingImagesFileExists validates that the missing images file contains expected content
+func verifyMissingImagesFileExists(t *testing.T, missingImgsPath string, testImages []v2alpha1.CopyImageSchema) {
+	assert.FileExists(t, missingImgsPath, "missing.txt should exist when there are missing images")
+
+	missingBytes, err := os.ReadFile(missingImgsPath)
+	assert.NoError(t, err)
+	missing := string(missingBytes)
+
+	for _, img := range testImages {
+		assert.Contains(t, missing, img.Source+"="+img.Destination, "missing images should contain all images when mirror fails")
+	}
+}
+
+// setupTestEnvironment creates common test setup for dry run tests
+func setupTestEnvironment(t *testing.T, testFolder string, mode string) (*mirror.CopyOptions, *registry.Registry, error) {
+	// Create fresh GlobalOptions for this test
 	global := &mirror.GlobalOptions{
 		SecurePolicy: false,
+		WorkingDir:   testFolder,
 	}
 
 	_, sharedOpts := mirror.SharedImageFlags()
@@ -41,157 +394,219 @@ func TestDryRun(t *testing.T) {
 	_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
 	_, retryOpts := mirror.RetryFlags()
 
-	t.Run("Testing Executor : dryrun M2D should pass", func(t *testing.T) {
-		testFolder := t.TempDir()
+	// storage cache for test
+	regCfg, err := setupRegForTest(testFolder)
+	if err != nil {
+		return nil, nil, err
+	}
+	reg, err := registry.NewRegistry(context.Background(), regCfg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create registry: %w", err)
+	}
 
-		global.WorkingDir = testFolder
+	opts := &mirror.CopyOptions{
+		Global:              global,
+		DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
+		SrcImage:            srcOpts,
+		DestImage:           destOpts,
+		RetryOpts:           retryOpts,
+		IsDryRun:            true,
+		Mode:                mode,
+		Dev:                 false,
+		LocalStorageFQDN:    regCfg.HTTP.Addr,
+	}
 
-		// storage cache for test
-		regCfg, err := setupRegForTest(testFolder)
-		if err != nil {
-			t.Errorf("storage cache error: %v ", err)
-		}
-		reg, err := registry.NewRegistry(context.Background(), regCfg)
-		if err != nil {
-			t.Errorf("storage cache error: %v ", err)
-		}
+	return opts, reg, nil
+}
 
-		opts := &mirror.CopyOptions{
-			Global:              global,
-			DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
-			SrcImage:            srcOpts,
-			DestImage:           destOpts,
-			RetryOpts:           retryOpts,
-			IsDryRun:            true,
-			Mode:                mirror.MirrorToDisk,
-			Dev:                 false,
-			LocalStorageFQDN:    regCfg.HTTP.Addr,
+// createTestExecutor creates a test ExecutorSchema
+func createTestExecutor(testFolder string, opts *mirror.CopyOptions, reg *registry.Registry, log clog.PluggableLoggerInterface) *ExecutorSchema {
+	// read the ImageSetConfiguration
+	res, err := config.ReadConfig(opts.Global.ConfigPath, v2alpha1.ImageSetConfigurationKind)
+	if err != nil {
+		log.Error("imagesetconfig %v ", err)
+	}
+	var cfg v2alpha1.ImageSetConfiguration
+	if res == nil {
+		cfg = v2alpha1.ImageSetConfiguration{}
+	} else {
+		cfg = res.(v2alpha1.ImageSetConfiguration)
+	}
+	collector := &Collector{Log: log, Config: cfg, Opts: *opts, Fail: false}
+	mockMirror := Mirror{}
+
+	return &ExecutorSchema{
+		Log:                 log,
+		Opts:                opts,
+		Operator:            collector,
+		Release:             collector,
+		AdditionalImages:    collector,
+		Mirror:              mockMirror,
+		LocalStorageService: *reg,
+		LogsDir:             testFolder,
+		MakeDir:             MakeDir{},
+	}
+}
+
+// createTestExecutorWithClusterResources creates a test ExecutorSchema with cluster resources generation enabled
+func createTestExecutorWithClusterResources(testFolder string, opts *mirror.CopyOptions, reg *registry.Registry, log clog.PluggableLoggerInterface, enableGraphGeneration bool, expectCatalogs bool) *ExecutorSchema {
+	// Create a minimal ImageSetConfiguration for testing
+	cfg := v2alpha1.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+			Mirror: v2alpha1.Mirror{
+				Platform: v2alpha1.Platform{
+					Channels: []v2alpha1.ReleaseChannel{
+						{
+							Name: "stable-4.14",
+						},
+					},
+					Graph: enableGraphGeneration, // Enable/disable UpdateService generation based on test needs
+				},
+			},
+		},
+	}
+
+	// Add operators configuration when catalogs are expected
+	if expectCatalogs {
+		cfg.Mirror.Operators = []v2alpha1.Operator{
+			{
+				Catalog: "registry.redhat.io/redhat/redhat-operator-index:v4.14",
+				IncludeConfig: v2alpha1.IncludeConfig{
+					Packages: []v2alpha1.IncludePackage{
+						{
+							Name: "test-operator",
+						},
+					},
+				},
+			},
 		}
-		// read the ImageSetConfiguration
-		res, err := config.ReadConfig(opts.Global.ConfigPath, v2alpha1.ImageSetConfigurationKind)
-		if err != nil {
-			log.Error("imagesetconfig %v ", err)
+	}
+
+	collector := &Collector{Log: log, Config: cfg, Opts: *opts, Fail: false}
+	mockMirror := Mirror{}
+
+	// Initialize ClusterResources generator (this is what enables cluster resource generation)
+	clusterResourcesGenerator := clusterresources.New(log, testFolder, cfg, opts.LocalStorageFQDN)
+
+	return &ExecutorSchema{
+		Log:                 log,
+		Opts:                opts,
+		Config:              cfg,
+		Operator:            collector,
+		Release:             collector,
+		AdditionalImages:    collector,
+		Mirror:              mockMirror,
+		LocalStorageService: *reg,
+		LogsDir:             testFolder,
+		MakeDir:             MakeDir{},
+		ClusterResources:    clusterResourcesGenerator, // This is the key difference from other tests
+	}
+}
+
+// verifySignatureConfigMapFiles validates signature ConfigMap files based on expectations
+func verifySignatureConfigMapFiles(t *testing.T, clusterResourcesPath string, expectSignatures bool) {
+	signatureYamlFile := filepath.Join(clusterResourcesPath, "signature-configmap.yaml")
+	signatureJsonFile := filepath.Join(clusterResourcesPath, "signature-configmap.json")
+
+	yamlExists := false
+	jsonExists := false
+
+	if _, err := os.Stat(signatureYamlFile); err == nil {
+		yamlExists = true
+	}
+	if _, err := os.Stat(signatureJsonFile); err == nil {
+		jsonExists = true
+	}
+
+	if expectSignatures {
+		// Strict validation: files MUST exist
+		assert.FileExists(t, signatureYamlFile, "signature-configmap.yaml MUST exist when signatures are expected")
+		assert.FileExists(t, signatureJsonFile, "signature-configmap.json MUST exist when signatures are expected")
+	} else {
+		// Conditional validation: if files exist, both should exist
+		if yamlExists {
+			assert.FileExists(t, signatureYamlFile, "signature-configmap.yaml should exist when signatures are present")
 		}
-		var cfg v2alpha1.ImageSetConfiguration
-		if res == nil {
-			cfg = v2alpha1.ImageSetConfiguration{}
+		if jsonExists {
+			assert.FileExists(t, signatureJsonFile, "signature-configmap.json should exist when signatures are present")
+		}
+	}
+}
+
+// verifyCatalogSourceFiles validates CatalogSource files based on expectations
+func verifyCatalogSourceFiles(t *testing.T, clusterResourcesPath string, expectCatalogs bool) {
+	catalogSourceFiles, err := filepath.Glob(filepath.Join(clusterResourcesPath, "cs-*.yaml"))
+	assert.NoError(t, err)
+
+	if expectCatalogs {
+		// Strict validation: files MUST exist
+		assert.True(t, len(catalogSourceFiles) > 0, "CatalogSource files MUST be generated when catalogs are expected")
+		// Validate that each file actually exists and is readable
+		for _, file := range catalogSourceFiles {
+			assert.FileExists(t, file, "CatalogSource file should be readable")
+		}
+	} else {
+		// Conditional validation: just log what we found
+		if len(catalogSourceFiles) > 0 {
+			t.Logf("✅ Found %d unexpected CatalogSource files: %v", len(catalogSourceFiles), catalogSourceFiles)
+			// Still validate that they are correct if they exist
+			for _, file := range catalogSourceFiles {
+				assert.FileExists(t, file, "CatalogSource file should be readable")
+			}
 		} else {
-			cfg = res.(v2alpha1.ImageSetConfiguration)
+			t.Logf("ℹ️  No CatalogSource files found (expected when no operators are configured)")
 		}
-		collector := &Collector{Log: log, Config: cfg, Opts: *opts, Fail: false}
-		mockMirror := Mirror{}
+	}
+}
 
-		ex := &ExecutorSchema{
-			Log:                 log,
-			Opts:                opts,
-			Operator:            collector,
-			Release:             collector,
-			AdditionalImages:    collector,
-			Mirror:              mockMirror,
-			LocalStorageService: *reg,
-			LogsDir:             testFolder,
-			MakeDir:             MakeDir{},
-		}
+// verifyClusterCatalogFiles validates ClusterCatalog files based on expectations
+func verifyClusterCatalogFiles(t *testing.T, clusterResourcesPath string, expectCatalogs bool) {
+	clusterCatalogFiles, err := filepath.Glob(filepath.Join(clusterResourcesPath, "cc-*.yaml"))
+	assert.NoError(t, err)
 
-		err = ex.DryRun(context.TODO(), imgs)
-		if err != nil {
-			t.Fatalf("should not fail")
+	if expectCatalogs {
+		// Strict validation: files MUST exist
+		assert.True(t, len(clusterCatalogFiles) > 0, "ClusterCatalog files MUST be generated when catalogs are expected")
+		// Validate that each file actually exists and is readable
+		for _, file := range clusterCatalogFiles {
+			assert.FileExists(t, file, "ClusterCatalog file should be readable")
 		}
-		mappingPath := filepath.Join(testFolder, dryRunOutDir, "mapping.txt")
-		assert.FileExists(t, mappingPath)
-
-		mappingBytes, err := os.ReadFile(mappingPath)
-		if err != nil {
-			t.Fatalf("failed to read mapping file: %v", err)
-		}
-		mapping := string(mappingBytes)
-
-		for _, img := range imgs {
-			assert.Contains(t, mapping, img.Source+"="+img.Destination)
-		}
-	})
-
-	t.Run("Testing Executor : dryrun M2D - errors finding images in cache - should generate missing.txt", func(t *testing.T) {
-		testFolder := t.TempDir()
-
-		global.WorkingDir = testFolder
-
-		// storage cache for test
-		regCfg, err := setupRegForTest(testFolder)
-		if err != nil {
-			t.Errorf("storage cache error: %v ", err)
-		}
-		reg, err := registry.NewRegistry(context.Background(), regCfg)
-		if err != nil {
-			t.Errorf("storage cache error: %v ", err)
-		}
-
-		opts := &mirror.CopyOptions{
-			Global:              global,
-			DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
-			SrcImage:            srcOpts,
-			DestImage:           destOpts,
-			RetryOpts:           retryOpts,
-			IsDryRun:            true,
-			Mode:                mirror.MirrorToDisk,
-			Dev:                 false,
-			LocalStorageFQDN:    regCfg.HTTP.Addr,
-		}
-		// read the ImageSetConfiguration
-		res, err := config.ReadConfig(opts.Global.ConfigPath, v2alpha1.ImageSetConfigurationKind)
-		if err != nil {
-			log.Error("imagesetconfig %v ", err)
-		}
-		var cfg v2alpha1.ImageSetConfiguration
-		if res == nil {
-			cfg = v2alpha1.ImageSetConfiguration{}
+	} else {
+		// Conditional validation: just log what we found
+		if len(clusterCatalogFiles) > 0 {
+			t.Logf("✅ Found %d unexpected ClusterCatalog files: %v", len(clusterCatalogFiles), clusterCatalogFiles)
+			// Still validate that they are correct if they exist
+			for _, file := range clusterCatalogFiles {
+				assert.FileExists(t, file, "ClusterCatalog file should be readable")
+			}
 		} else {
-			cfg = res.(v2alpha1.ImageSetConfiguration)
-			log.Debug("imagesetconfig : %v", cfg)
+			t.Logf("ℹ️  No ClusterCatalog files found (expected when no operators are configured)")
 		}
-		collector := &Collector{Log: log, Config: cfg, Opts: *opts, Fail: false}
-		mockMirror := Mirror{Fail: true}
+	}
+}
 
-		ex := &ExecutorSchema{
-			Log:                 log,
-			Opts:                opts,
-			Operator:            collector,
-			Release:             collector,
-			AdditionalImages:    collector,
-			Mirror:              mockMirror,
-			LocalStorageService: *reg,
-			LogsDir:             "/tmp/",
-			MakeDir:             MakeDir{},
-		}
+// setupSignaturesDirectory creates a test signatures directory with sample signature files
+func setupSignaturesDirectory(t *testing.T, testFolder string) {
+	signaturesDir := filepath.Join(testFolder, "signatures")
+	err := os.MkdirAll(signaturesDir, 0755)
+	assert.NoError(t, err)
 
-		err = ex.DryRun(context.TODO(), imgs)
-		if err != nil {
-			t.Fatalf("should not fail")
-		}
-		mappingPath := filepath.Join(testFolder, dryRunOutDir, mappingFile)
-		assert.FileExists(t, mappingPath)
+	// Create sample signature files that match the expected naming pattern
+	// Signature files are named as: {imageTag}-sha256-{digest}.sig
+	// The logic matches signatureFiles[imageTag] against the actual image tags
+	sampleSignatures := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "4.14.0-x86_64-sha256-f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea.sig",
+			content: "sample signature content for release image with tag 4.14.0-x86_64",
+		},
+	}
 
-		mappingBytes, err := os.ReadFile(mappingPath)
-		if err != nil {
-			t.Fatalf("failed to read mapping file: %v", err)
-		}
-		mapping := string(mappingBytes)
-
-		for _, img := range imgs {
-			assert.Contains(t, mapping, img.Source+"="+img.Destination)
-		}
-
-		missingImgsPath := filepath.Join(testFolder, dryRunOutDir, missingImgsFile)
-		assert.FileExists(t, mappingPath)
-
-		missingBytes, err := os.ReadFile(missingImgsPath)
-		if err != nil {
-			t.Fatalf("failed to read mapping file: %v", err)
-		}
-		missing := string(missingBytes)
-
-		for _, img := range imgs {
-			assert.Contains(t, missing, img.Source+"="+img.Destination)
-		}
-	})
+	for _, sig := range sampleSignatures {
+		sigFile := filepath.Join(signaturesDir, sig.name)
+		err := os.WriteFile(sigFile, []byte(sig.content), 0600)
+		assert.NoError(t, err)
+	}
 }

--- a/internal/pkg/cli/executor.go
+++ b/internal/pkg/cli/executor.go
@@ -956,39 +956,8 @@ func (o *ExecutorSchema) RunMirrorToMirror(cmd *cobra.Command, args []string) er
 
 	o.createConfigsWithPinnedCatalogs(collectorSchema)
 
-	// create IDMS/ITMS
-	forceRepositoryScope := o.Opts.Global.MaxNestedPaths > 0
-	if err := o.ClusterResources.IDMS_ITMSGenerator(copiedSchema.AllImages, forceRepositoryScope); err != nil {
+	if err := o.generateClusterResources(cmd.Context(), copiedSchema.AllImages); err != nil {
 		return err
-	}
-
-	if err := o.ClusterResources.CatalogSourceGenerator(copiedSchema.AllImages); err != nil {
-		return err
-	}
-
-	if err := o.ClusterResources.ClusterCatalogGenerator(copiedSchema.AllImages); err != nil {
-		return err
-	}
-
-	// generate signature config map
-	if err := o.ClusterResources.GenerateSignatureConfigMap(copiedSchema.AllImages); err != nil {
-		// as this is not a seriously fatal error we just log the error
-		o.Log.Warn("%s", err)
-	}
-
-	// create updateService
-	if o.Config.Mirror.Platform.Graph {
-		graphImage, err := o.Release.GraphImage()
-		if err != nil {
-			return err
-		}
-		releaseImage, err := o.Release.ReleaseImage(cmd.Context())
-		if err != nil {
-			return err
-		}
-		if err := o.ClusterResources.UpdateServiceGenerator(graphImage, releaseImage); err != nil {
-			return err
-		}
 	}
 
 	return batchError
@@ -1036,43 +1005,80 @@ func (o *ExecutorSchema) RunDiskToMirror(cmd *cobra.Command, args []string) erro
 	// NOTE: we will check for batch errors at the end
 	copiedSchema, batchError := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts)
 
-	// create IDMS/ITMS
-	forceRepositoryScope := o.Opts.Global.MaxNestedPaths > 0
-	if err := o.ClusterResources.IDMS_ITMSGenerator(copiedSchema.AllImages, forceRepositoryScope); err != nil {
+	if err := o.generateClusterResources(cmd.Context(), copiedSchema.AllImages); err != nil {
 		return err
-	}
-
-	// create catalog source
-	if err := o.ClusterResources.CatalogSourceGenerator(copiedSchema.AllImages); err != nil {
-		return err
-	}
-
-	if err := o.ClusterResources.ClusterCatalogGenerator(copiedSchema.AllImages); err != nil {
-		return err
-	}
-
-	// generate signature config map
-	if err := o.ClusterResources.GenerateSignatureConfigMap(copiedSchema.AllImages); err != nil {
-		// as this is not a seriously fatal error we just log the error
-		o.Log.Warn("%s", err)
-	}
-
-	// create updateService
-	if o.Config.Mirror.Platform.Graph {
-		graphImage, err := o.Release.GraphImage()
-		if err != nil {
-			return err
-		}
-		releaseImage, err := o.Release.ReleaseImage(cmd.Context())
-		if err != nil {
-			return err
-		}
-		if err := o.ClusterResources.UpdateServiceGenerator(graphImage, releaseImage); err != nil {
-			return err
-		}
 	}
 
 	return batchError
+}
+
+// generateClusterResources generates the following cluster resources:
+// IDMS/ITMS, CatalogSource, ClusterCatalog, UpdateService and SignatureConfigMap.
+func (o *ExecutorSchema) generateClusterResources(ctx context.Context, images []v2alpha1.CopyImageSchema) error {
+	if o.ClusterResources == nil {
+		return fmt.Errorf("cluster resources generator is not initialized")
+	}
+	o.Log.Info(emoji.PageFacingUp + " Generating cluster resources...")
+
+	if err := o.generateImageMirrorSet(images); err != nil {
+		return err
+	}
+
+	if err := o.generateCatalogResources(images); err != nil {
+		return err
+	}
+
+	if err := o.ClusterResources.GenerateSignatureConfigMap(images); err != nil {
+		o.Log.Warn("Failed to generate signature ConfigMap: %v", err)
+	}
+
+	if err := o.generateUpdateServiceResource(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// generateImageMirrorSet generates IDMS/ITMS resources
+func (o *ExecutorSchema) generateImageMirrorSet(images []v2alpha1.CopyImageSchema) error {
+	forceRepositoryScope := o.Opts.Global.MaxNestedPaths > 0
+	if err := o.ClusterResources.IDMS_ITMSGenerator(images, forceRepositoryScope); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *ExecutorSchema) generateCatalogResources(images []v2alpha1.CopyImageSchema) error {
+	if err := o.ClusterResources.CatalogSourceGenerator(images); err != nil {
+		return err
+	}
+
+	if err := o.ClusterResources.ClusterCatalogGenerator(images); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *ExecutorSchema) generateUpdateServiceResource(ctx context.Context) error {
+	if !o.Config.Mirror.Platform.Graph {
+		return nil
+	}
+
+	graphImage, err := o.Release.GraphImage()
+	if err != nil {
+		return err
+	}
+
+	releaseImage, err := o.Release.ReleaseImage(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := o.ClusterResources.UpdateServiceGenerator(graphImage, releaseImage); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // setupLogsLevelAndDir - private utility to setup log


### PR DESCRIPTION
# Description

Create cluster-resource manifests while running with `--dry-run` flag

Github / Jira issue: 

https://redhat.atlassian.net/browse/RFE-4107

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Run `oc-mirror` with `--dry-run` and manifests should apear in working-dir/cluster-resources
It was tested manually

## Expected Outcome
Manifests should be present in `cluster-resources` directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dry-run now writes image mapping output immediately, always logs its path, and creates a missing-image report only when missing images are detected. Cluster resource generation is skipped when mirroring to disk; otherwise IDMS/ITMS, catalog manifests and signature ConfigMap are produced. UpdateService is generated when graph/release images are resolvable.

* **Tests**
  * Refactored/expanded dry-run tests into table-driven cases validating mapping output, missing-image handling, conditional cluster-resources, catalog manifests, and UpdateService content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->