### PR TITLE
CLID-579: Validate BlockedImage regex

### DIFF
--- a/internal/pkg/config/validate.go
+++ b/internal/pkg/config/validate.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/Masterminds/semver/v3"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -16,7 +17,7 @@ type (
 )
 
 var (
-	validationChecks       = []validationFunc{validateOperatorOptions, validateReleaseChannels}
+	validationChecks       = []validationFunc{validateOperatorOptions, validateReleaseChannels, validateBlockedImages}
 	validationDeleteChecks = []validationDeleteFunc{validateOperatorOptionsDelete, validateReleaseChannelsDelete}
 )
 
@@ -150,6 +151,21 @@ func validateReleaseChannels(cfg *v2alpha1.ImageSetConfiguration) []error {
 			)}
 		}
 		channels.Insert(channel.Name)
+	}
+	return nil
+}
+
+func validateBlockedImages(cfg *v2alpha1.ImageSetConfiguration) []error {
+	var errs []error
+	for _, img := range cfg.Mirror.BlockedImages {
+		if _, err := regexp.Compile(img.Name); err != nil {
+			errs = append(errs, fmt.Errorf(
+				"blocked image %q: invalid regular expression: %w", img.Name, err,
+			))
+		}
+	}
+	if len(errs) > 0 {
+		return errs
 	}
 	return nil
 }

--- a/internal/pkg/config/validate_test.go
+++ b/internal/pkg/config/validate_test.go
@@ -305,6 +305,32 @@ func TestValidate(t *testing.T) {
 			expError: `invalid configuration: catalog "test-catalog1:latest": duplicate package entry "package1"`,
 		},
 		{
+			name: "Valid/BlockedImagesWithValidRegex",
+			config: &v2alpha1.ImageSetConfiguration{
+				ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+					Mirror: v2alpha1.Mirror{
+						BlockedImages: []v2alpha1.BlockedImage{
+							{Name: "registry/namespace/image@sha256:.*"},
+							{Name: "registry\\.example\\.com/.*"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Invalid/BlockedImageWithMalformedRegex",
+			config: &v2alpha1.ImageSetConfiguration{
+				ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+					Mirror: v2alpha1.Mirror{
+						BlockedImages: []v2alpha1.BlockedImage{
+							{Name: "[invalid"},
+						},
+					},
+				},
+			},
+			expError: `invalid configuration: blocked image "[invalid": invalid regular expression: error parsing regexp: missing closing ]: ` + "`[invalid`",
+		},
+		{
 			name: "Invalid/DuplicateOperatorPackageChannels",
 			config: &v2alpha1.ImageSetConfiguration{
 				ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{


### PR DESCRIPTION
# Description

During code review of https://github.com/openshift/oc-mirror/pull/1372, coderabbit flagged an issue surrounding validation of BlockedImage regexes: https://github.com/openshift/oc-mirror/pull/1372#discussion_r3065484807. This addresses the gap by providing validation through regex compilation on the BlockedImage names during config validation. 

Github / Jira issue: https://redhat.atlassian.net/browse/CLID-579

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

- ran unit tests
- quick manual test with test ISC:

```
apiVersion: mirror.openshift.io/v2alpha1
kind: ImageSetConfiguration
mirror:
  additionalimages:
    - name: registry.redhat.io/ubi8/ubi:latest
  blockedimages:
    - name: "registry\\.example\\.com/blocked/.*"
    - name: "[invalid-regex"
    - name: "valid-literal-name"
    - name: "(unclosed-group"
```

```
[dorzel@ppc64le-018: misc]$ oc-mirror --v2 --dest-tls-verify=false --authfile=/home/dorzel/oc-mirror/authfile.json -c blockedimages-test-isc.yaml file:///home/dorzel/oc-mirror/misc/test-mirror/ --dry-run
2026/05/06 17:01:26  [INFO]   : 👋 Hello, welcome to oc-mirror
2026/05/06 17:01:26  [INFO]   : ⚙️  setting up the environment for you...
2026/05/06 17:01:26  [WARN]   : ⚠️  Detected bad umask 002 (oc-mirror requires a umask of 0022)
2026/05/06 17:01:26  [INFO]   : ⚙️  environment version: v0.2.0-alpha.1-582-g0234a7f
2026/05/06 17:01:26  [ERROR]  : [Executor] invalid configuration: [blocked image "[invalid-regex": invalid regular expression: error parsing regexp: missing closing ]: `[invalid-regex`, blocked image "(unclosed-group": invalid regular expression: error parsing regexp: missing closing ): `(unclosed-group`] 
```

## Expected Outcome
- Invalid BlockedImage regexes throw errors.