### PR TITLE
NO-JIRA: Update README.md for Enclave Support link

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ The `delete` sub-command has its own set of flags:
 ```
 
 ### Other Features
-* [Enclave support](v2/docs/features/enclave_support.md)
+* [Enclave support](docs/features/enclave_support.md)
 
 #### Catalog Pinning
 


### PR DESCRIPTION
Correcting the Enclave support link in the README.md

# Description

Updated the enclave support link in README.md. Oneline change.

## Type of change

Please delete options that are not relevant.

- [x] Internal repo assets (diagrams / docs on github repo)

# How Has This Been Tested?

Have checked the link, and it now correctly resolves rather than 404ing. 

## Expected Outcome
The link should indeed resolve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Enclave support documentation link in README to reference the correct location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->