### PR TITLE
CLID-602: Test for enclave scenario

### DIFF
--- a/tests/integration/enclave_test.go
+++ b/tests/integration/enclave_test.go
@@ -1,0 +1,101 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/oc-mirror/tests/integration/pkg/ocmirror"
+	"github.com/openshift/oc-mirror/tests/integration/pkg/registry"
+)
+
+// A registries.conf redirect makes the enclave-side oc-mirror pull from the
+// intermediate registry instead of the original remote source.
+var _ = Describe("enclave", func() {
+	var workDir string
+
+	BeforeEach(func() {
+		workDir = setupWorkDir()
+	})
+
+	AfterEach(func() {
+		cleanupWorkDir(workDir)
+	})
+
+	Describe("mirror-to-mirror with registries.conf redirect", func() {
+		iscFile := filepath.Join("operators", "isc-operator-version-range.yaml")
+
+		// Workflow:
+		//  1. Mirror operators from the remote catalog into an intermediate registry.
+		//  2. Configure registries.conf to redirect quay.io pulls to the intermediate registry.
+		//  3. Mirror from the intermediate registry into a separate enclave registry.
+		//  4. Assert that the enclave catalog contains the correctly filtered bundles.
+		It("should forward operators from intermediate to enclave registry via registries.conf", func() {
+			iscPath := filepath.Join(iscDir, iscFile)
+			GinkgoWriter.Printf("ISC path: %s\n", iscPath)
+			GinkgoWriter.Printf("workDir: %s\n", workDir)
+
+			By("starting a second registry for the enclave destination")
+			enclaveRegistry, err := registry.Start(ctx, registryConfig, 0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(enclaveRegistry.WaitReady(ctx, 30*time.Second)).To(Succeed())
+			defer enclaveRegistry.Stop()
+			GinkgoWriter.Printf("intermediate registry: %s\n", testRegistry.Endpoint())
+			GinkgoWriter.Printf("enclave registry:      %s\n", enclaveRegistry.Endpoint())
+
+			By("mirroring from the remote catalog to the intermediate registry")
+			result, err := runner.MirrorToMirror(ctx, iscPath, workDir, testRegistry.Endpoint(),
+				"--remove-signatures=true", "--dest-tls-verify=false")
+			logOcMirrorResult("step-1 mirrorToMirror", result)
+			expectOcMirrorCommandSuccess(result, err)
+
+			By("verifying operator images exist in the intermediate registry")
+			logRegistryRepositories("intermediate", *testRegistry)
+			expectSuccessfulMirrorInRegistry(iscPath, *testRegistry)
+
+			By("mirroring from the intermediate registry to the enclave registry using registries.conf")
+			enclaveWorkDir := setupWorkDir()
+			defer cleanupWorkDir(enclaveWorkDir)
+
+			registriesConf := writeRegistriesConf(enclaveWorkDir, testRegistry.Endpoint())
+			GinkgoWriter.Printf("registries.conf: %s\n", registriesConf)
+			GinkgoWriter.Printf("enclave workDir: %s\n", enclaveWorkDir)
+
+			enclaveRunner := ocmirror.NewRunner(os.Getenv("OC_MIRROR_BINARY")).
+				WithEnv([]string{"CONTAINERS_REGISTRIES_CONF=" + registriesConf})
+
+			result, err = enclaveRunner.MirrorToMirror(ctx, iscPath, enclaveWorkDir, enclaveRegistry.Endpoint(),
+				"--remove-signatures=true", "--dest-tls-verify=false", "--src-tls-verify=false")
+			logOcMirrorResult("step-2 mirrorToMirror", result)
+			expectOcMirrorCommandSuccess(result, err)
+
+			By("verifying operator images exist in the enclave registry")
+			logRegistryRepositories("enclave", *enclaveRegistry)
+			expectSuccessfulMirrorInRegistry(iscPath, *enclaveRegistry)
+
+			By("verifying the enclave catalog contains the correctly filtered bundles")
+			expectCatalogBundlesMatchISC(ctx, *enclaveRegistry, iscPath, map[string][]string{
+				"foo": {"foo.v0.2.0", "foo.v0.3.0", "foo.v0.3.1"},
+			})
+		})
+	})
+})
+
+// writeRegistriesConf generates a containers registries.conf file that
+// redirects all quay.io pulls to the given mirror endpoint over plain HTTP.
+func writeRegistriesConf(dir, mirrorEndpoint string) string {
+	content := fmt.Sprintf(`[[registry]]
+  location = "quay.io"
+  [[registry.mirror]]
+    location = "%s"
+    insecure = true
+`, mirrorEndpoint)
+
+	p := filepath.Join(dir, "registries.conf")
+	Expect(os.WriteFile(p, []byte(content), 0o644)).To(Succeed())
+	return p
+}

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -759,12 +759,15 @@ func expectIDMSContainsExpectedContent(iscPath string, idmsSources []string) {
 	}
 }
 
+// referenceWithoutTagOrDigest strips the tag or digest from an image reference,
+// returning "domain/path" (e.g. "quay.io/ns/repo").
 func referenceWithoutTagOrDigest(imageRef string) string {
 	ref, err := reference.ParseNormalizedNamed(imageRef)
 	Expect(err).NotTo(HaveOccurred(), "failed to parse image ref: %s", imageRef)
 	return reference.Domain(ref) + "/" + reference.Path(ref)
 }
 
+// idmsSourceCoversRef returns true if any IDMS source is a prefix of the given image reference.
 func idmsSourceCoversRef(sources []string, ref string) bool {
 	for _, src := range sources {
 		if strings.HasPrefix(ref, src) {
@@ -774,6 +777,42 @@ func idmsSourceCoversRef(sources []string, ref string) bool {
 	return false
 }
 
+// logOcMirrorResult writes the oc-mirror command result to GinkgoWriter for diagnostics.
+func logOcMirrorResult(label string, result *ocmirror.Result) {
+	if result == nil {
+		GinkgoWriter.Printf("[%s] result is nil\n", label)
+		return
+	}
+	GinkgoWriter.Printf("[%s] exit_code=%d duration=%s\n", label, result.ExitCode, result.Duration)
+	if result.Stdout != "" {
+		GinkgoWriter.Printf("[%s] stdout:\n%s\n", label, result.Stdout)
+	}
+	if result.Stderr != "" {
+		GinkgoWriter.Printf("[%s] stderr:\n%s\n", label, result.Stderr)
+	}
+}
+
+// logRegistryRepositories lists all repositories in the registry and writes them to GinkgoWriter.
+func logRegistryRepositories(label string, reg registry.Registry) {
+	repos, err := reg.ListRepositories(ctx)
+	if err != nil {
+		GinkgoWriter.Printf("[%s registry] failed to list repositories: %v\n", label, err)
+		return
+	}
+	GinkgoWriter.Printf("[%s registry] %d repositories:\n", label, len(repos))
+	for _, repo := range repos {
+		tags, tagErr := reg.ListTags(ctx, repo)
+		if tagErr != nil {
+			GinkgoWriter.Printf("  %s (tags error: %v)\n", repo, tagErr)
+		} else {
+			GinkgoWriter.Printf("  %s  tags=%v\n", repo, tags)
+		}
+	}
+}
+
+// isOCMirrorVersionBefore returns true if the OC_MIRROR_VERSION environment variable
+// indicates a version strictly before major.minor. Returns false when the variable
+// is unset or set to "main".
 func isOCMirrorVersionBefore(major int, minor int) bool {
 	ver := os.Getenv("OC_MIRROR_VERSION")
 	if ver == "" || ver == "main" {

--- a/tests/integration/pkg/registry/registry.go
+++ b/tests/integration/pkg/registry/registry.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -30,7 +31,16 @@ type Registry struct {
 }
 
 // Start parses the config file, creates an in-process registry, and starts it in the background.
+// Pass port 0 to let the OS assign a free port automatically.
 func Start(ctx context.Context, configPath string, port int) (*Registry, error) {
+	if port == 0 {
+		p, err := freePort()
+		if err != nil {
+			return nil, fmt.Errorf("failed to allocate a free port: %w", err)
+		}
+		port = p
+	}
+
 	configData, err := os.ReadFile(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read registry config: %w", err)
@@ -166,4 +176,13 @@ func (r *Registry) IsCatalog(ctx context.Context, repo, tag string) (bool, error
 
 	_, ok := cf.Config.Labels["operators.operatorframework.io.index.configs.v1"]
 	return ok, nil
+}
+
+func freePort() (int, error) {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
 }


### PR DESCRIPTION
# Description

Add an integration test for the enclave mirroring scenario. This test validates the two-hop disconnected workflow where operator images are first mirrored from a remote catalog to an intermediate registry, then forwarded to a separate enclave registry using a `registries.conf` redirect. The test verifies that both registries end up with the same set of repositories.


Github / Jira issue: [CLID-602](https://redhat.atlassian.net/browse/CLID-602)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

## Expected Outcome
The test starts two local registries, mirrors operators into the first (intermediate), then uses registries.conf to redirect and mirror into the second (enclave). Both registries should contain the same repositories, and the test should pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration test covering mirror-to-mirror operator mirroring using a `registries.conf` redirect.
  * Added integration test helper utilities to validate mirrored catalog contents, log command diagnostics, and compare repository sets.
* **Bug Fixes**
  * Improved test registry startup to support automatic port selection when no port is specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->