### PR TITLE
CLID-614: Test for Operator incremental mirroring

### DIFF
--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -954,3 +954,58 @@ func isOCMirrorVersionBefore(major int, minor int) bool {
 	}
 	return verMajor < major
 }
+
+// logTarSummary logs the size, total entry count, and blob count of a tar archive.
+func logTarSummary(label, tarPath string) {
+	info, err := os.Stat(tarPath)
+	Expect(err).NotTo(HaveOccurred())
+
+	entries := listTarEntries(tarPath)
+
+	blobCount := 0
+	repoSet := map[string]bool{}
+	for _, e := range entries {
+		if strings.Contains(e, "blobs/sha256/") {
+			blobCount++
+		}
+		if strings.HasPrefix(e, tarRepositoriesPath) {
+			parts := strings.SplitN(strings.TrimPrefix(e, tarRepositoriesPath), "/", 3)
+			if len(parts) >= 2 {
+				repoSet[parts[0]+"/"+parts[1]] = true
+			}
+		}
+	}
+
+	GinkgoWriter.Printf("[%s tar] path=%s size=%d bytes entries=%d blobs=%d repositories=%d\n",
+		label, tarPath, info.Size(), len(entries), blobCount, len(repoSet))
+	for repo := range repoSet {
+		GinkgoWriter.Printf("[%s tar]   repo: %s\n", label, repo)
+	}
+}
+
+// collectTarBlobPaths returns the sorted list of tar entry names that fall under
+// the given prefix. OCI blobs are content-addressed (the SHA-256 digest is part of
+// the path), so comparing blob paths is equivalent to comparing blob content.
+func collectTarBlobPaths(tarPath, prefix string) []string {
+	prefix = filepath.ToSlash(prefix)
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+
+	var paths []string
+	for _, entry := range listTarEntries(tarPath) {
+		e := filepath.ToSlash(entry)
+		if strings.HasPrefix(e, prefix) {
+			paths = append(paths, e)
+		}
+	}
+	return paths
+}
+
+// expectTarDoesNotContainPath verifies that no tar entry contains the given substring.
+func expectTarDoesNotContainPath(entries []string, substring string) {
+	for _, entry := range entries {
+		Expect(entry).NotTo(ContainSubstring(substring),
+			"tar archive should not contain path matching %q, but found: %s", substring, entry)
+	}
+}

--- a/tests/integration/incremental_mirroring_test.go
+++ b/tests/integration/incremental_mirroring_test.go
@@ -108,4 +108,83 @@ var _ = Describe("incremental mirroring", func() {
 			expectNoImageBlobsInArchives(incrementalArchives)
 		})
 	})
+
+	// CLID-614: Validate config-based incremental mirroring for operators.
+	// Runs mirrorToDisk twice with different ISCs against the same workspace:
+	//   Step 1: mirror foo pinned at 0.2.0
+	//   Step 2: expand foo to 0.2.0–0.3.1 and add bar (stable)
+	// The second archive should contain only the new blobs (expanded foo versions
+	// and bar) with no overlap from the first archive.
+	Describe("operator incremental mirrorToDisk", func() {
+		iscInitial := filepath.Join("operators", "isc-operator-incremental-initial.yaml")
+		iscUpdate := filepath.Join("operators", "isc-operator-incremental-update.yaml")
+
+		It("should produce a second tar with only incremental blob content", func() {
+			findSingleMirrorTar := func(dir, phase string) string {
+				matches, err := filepath.Glob(filepath.Join(dir, "mirror_*.tar"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(matches).To(HaveLen(1), "%s expected exactly one tar archive, got: %v", phase, matches)
+				return matches[0]
+			}
+
+			iscInitialPath := filepath.Join(iscDir, iscInitial)
+			iscUpdatePath := filepath.Join(iscDir, iscUpdate)
+
+			By("running mirrorToDisk with the initial ISC (foo pinned at 0.2.0)")
+			result, err := runner.MirrorToDisk(ctx, iscInitialPath, workDir, "--remove-signatures=true")
+			logOcMirrorResult("incremental step-1 mirrorToDisk", result)
+			expectOcMirrorCommandSuccess(result, err)
+
+			By("verifying the initial tar archive was created")
+			initialTar := findSingleMirrorTar(workDir, "initial")
+			Expect(initialTar).To(BeAnExistingFile(), "initial tar archive not found")
+			logTarSummary("initial", initialTar)
+
+			By("verifying the initial tar contains expected content")
+			expectCorrectTarArchiveContents(iscInitialPath, workDir)
+
+			By("moving the initial tar outside the working directory to preserve it")
+			preserveDir, err := os.MkdirTemp("", "oc-mirror-preserved-tar-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(preserveDir)
+			preservedTar := filepath.Join(preserveDir, "mirror_initial.tar")
+			err = os.Rename(initialTar, preservedTar)
+			Expect(err).NotTo(HaveOccurred(), "failed to move initial tar")
+
+			By("running mirrorToDisk with the updated ISC (foo 0.2.0-0.3.1 + bar stable)")
+			result, err = runner.MirrorToDisk(ctx, iscUpdatePath, workDir, "--remove-signatures=true")
+			logOcMirrorResult("incremental step-2 mirrorToDisk", result)
+			expectOcMirrorCommandSuccess(result, err)
+
+			By("verifying the incremental tar archive was created")
+			incrementalTar := findSingleMirrorTar(workDir, "incremental")
+			Expect(incrementalTar).To(BeAnExistingFile(), "incremental tar archive not found")
+			logTarSummary("incremental", incrementalTar)
+
+			By("comparing blob paths between the two tars")
+			const blobPrefix = "docker/registry/v2/blobs/sha256"
+			initialBlobs := collectTarBlobPaths(preservedTar, blobPrefix)
+			incrementalBlobs := collectTarBlobPaths(incrementalTar, blobPrefix)
+			GinkgoWriter.Printf("initial tar blob count:     %d\n", len(initialBlobs))
+			GinkgoWriter.Printf("incremental tar blob count: %d\n", len(incrementalBlobs))
+
+			Expect(incrementalBlobs).NotTo(BeEmpty(), "incremental tar should contain at least one blob")
+			initialBlobSet := make(map[string]struct{}, len(initialBlobs))
+			for _, b := range initialBlobs {
+				initialBlobSet[b] = struct{}{}
+			}
+			for _, b := range incrementalBlobs {
+				_, alreadyMirrored := initialBlobSet[b]
+				Expect(alreadyMirrored).To(BeFalse(),
+					"incremental tar re-included previously mirrored blob: %s", b)
+			}
+
+			By("verifying the initial tar does not contain the new operator package")
+			initialEntries := listTarEntries(preservedTar)
+			expectTarDoesNotContainPath(initialEntries, "/bar")
+
+			By("verifying the incremental tar contains the expected repositories")
+			expectCorrectTarArchiveContents(iscUpdatePath, workDir)
+		})
+	})
 })

--- a/tests/integration/testdata/imagesetconfigs/operators/isc-operator-incremental-initial.yaml
+++ b/tests/integration/testdata/imagesetconfigs/operators/isc-operator-incremental-initial.yaml
@@ -1,0 +1,12 @@
+# ImageSetConfig for incremental mirror test - Step 1: mirror a single pinned operator version
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v2alpha1
+mirror:
+  operators:
+    - catalog: quay.io/oc-mirror/oc-mirror-dev:test-catalog-latest
+      packages:
+      - name: foo
+        channels:
+        - name: beta
+          minVersion: '0.2.0'
+          maxVersion: '0.2.0'

--- a/tests/integration/testdata/imagesetconfigs/operators/isc-operator-incremental-update.yaml
+++ b/tests/integration/testdata/imagesetconfigs/operators/isc-operator-incremental-update.yaml
@@ -1,0 +1,15 @@
+# ImageSetConfig for incremental mirror test - Step 2: expand version range and add a new package
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v2alpha1
+mirror:
+  operators:
+    - catalog: quay.io/oc-mirror/oc-mirror-dev:test-catalog-latest
+      packages:
+      - name: foo
+        channels:
+        - name: beta
+          minVersion: '0.2.0'
+          maxVersion: '0.3.1'
+      - name: bar
+        channels:
+        - name: stable


### PR DESCRIPTION
# Description

Add an integration test for operator incremental mirroring (mirrorToDisk). The test verifies that oc-mirror produces archives containing only new content on subsequent runs when the ImageSetConfig changes.

The test runs mirrorToDisk twice against the same workspace with different ISCs:

- Step 1: mirrors operator foo pinned at version 0.2.0
- Step 2: expands foo to version range 0.2.0–0.3.1 and adds a new package bar (stable channel)

It then validates that the second archive contains only the incremental data,new blobs from the expanded version range and the newly added package with no overlap from the first archive.

Github / Jira issue: [CLID-614](https://redhat.atlassian.net/browse/CLID-614)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome

- Step 1 produces a tar archive containing blobs for foo at version 0.2.0
- Step 2 produces a tar archive containing only new blobs (additional foo versions and bar package)
- No blob from the initial archive appears in the incremental archive
- The initial archive does not contain any bar entries
- The incremental archive contains the expected repositories from the updated ISC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added new integration-test helper utilities to summarize tar archives and validate their contents (including blob and repository-level checks).
  * Added new ImageSetConfiguration fixtures for operator incremental mirroring step-based scenarios.
  * Introduced a new incremental mirroring integration test that runs mirror-to-disk twice and verifies blob non-overlap and expected archive contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->