### PR TITLE
CLID-625, CLID-626: Tests for --parallel-images and --parallel-layers flags

### DIFF
--- a/internal/pkg/mirror/mirror.go
+++ b/internal/pkg/mirror/mirror.go
@@ -237,9 +237,9 @@ func isErrorRetryable(err error) bool {
 	case errors.Is(err, context.Canceled):
 		return false
 	case errors.As(err, &httpError):
-		// Retry on 502, 503, and 504 server errors, they appear to be quite common in the field
+		// Retry on 500-504 server errors, they appear to be quite common in the field
 		// We duplicate this here because older versions of oc-mirror cannot bump containers/common given Golang version restrictions
-		if httpError.StatusCode >= http.StatusBadGateway && httpError.StatusCode <= http.StatusGatewayTimeout {
+		if httpError.StatusCode >= http.StatusInternalServerError && httpError.StatusCode <= http.StatusGatewayTimeout {
 			return true
 		}
 		return false

--- a/tests/integration/image-builders/additional_images/README.md
+++ b/tests/integration/image-builders/additional_images/README.md
@@ -1,0 +1,5 @@
+# additional_images
+
+Builders for additional images referenced in integration test ImageSetConfigurations.
+
+Each image lives in its own subdirectory (for example `multilayers/`).

--- a/tests/integration/image-builders/additional_images/multilayers/Dockerfile
+++ b/tests/integration/image-builders/additional_images/multilayers/Dockerfile
@@ -1,0 +1,31 @@
+FROM quay.io/openshifttest/registry
+
+# Layer 1
+RUN touch /layer1 && echo "Layer 1" > /layer1
+
+# Layer 2
+RUN touch /layer2 && echo "Layer 2" > /layer2
+
+# Layer 3
+RUN touch /layer3 && echo "Layer 3" > /layer3
+
+# Layer 4
+RUN touch /layer4 && echo "Layer 4" > /layer4
+
+# Layer 5
+RUN touch /layer5 && echo "Layer 5" > /layer5
+
+# Layer 6
+RUN touch /layer6 && echo "Layer 6" > /layer6
+
+# Layer 7
+RUN touch /layer7 && echo "Layer 7" > /layer7
+
+# Layer 8
+RUN touch /layer8 && echo "Layer 8" > /layer8
+
+# Layer 9
+RUN touch /layer9 && echo "Layer 9" > /layer9
+
+# Layer 10
+RUN touch /layer10 && echo "Layer 10" > /layer10

--- a/tests/integration/image-builders/additional_images/multilayers/Makefile
+++ b/tests/integration/image-builders/additional_images/multilayers/Makefile
@@ -1,0 +1,19 @@
+REGISTRY ?= quay.io/oc-mirror/oc-mirror-dev
+TAG ?= multilayers-latest
+RUNTIME ?= podman
+
+IMAGE_REF = $(REGISTRY):$(TAG)
+
+.PHONY: all build push digest
+
+all: build
+
+build:
+	$(RUNTIME) build -f Dockerfile -t $(IMAGE_REF) .
+
+# Maintainer-only: run manually after build.
+push: build
+	$(RUNTIME) push $(IMAGE_REF)
+
+digest:
+	@$(RUNTIME) inspect $(IMAGE_REF) --format '{{index .Digest}}'

--- a/tests/integration/image-builders/additional_images/multilayers/README.md
+++ b/tests/integration/image-builders/additional_images/multilayers/README.md
@@ -1,0 +1,19 @@
+# multilayers
+
+OCI image with more than 10 layers, used by integration tests for `--parallel-layers` behavior.
+
+## Build
+
+```bash
+make build
+```
+
+## Publish (maintainer only)
+
+Push to `quay.io/oc-mirror/oc-mirror-dev` (not `openshifttest`):
+
+```bash
+make push
+```
+
+The integration test ISC references `quay.io/oc-mirror/oc-mirror-dev:multilayers-latest`.

--- a/tests/integration/parallel_copy_test.go
+++ b/tests/integration/parallel_copy_test.go
@@ -1,0 +1,197 @@
+package integration_test
+
+import (
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/oc-mirror/tests/integration/pkg/ocmirror"
+)
+
+var _ = Describe("parallel copy", func() {
+	var workDir string
+
+	BeforeEach(func() {
+		workDir = setupWorkDir()
+	})
+
+	AfterEach(func() {
+		cleanupWorkDir(workDir)
+	})
+
+	Describe("parallel-layers", func() {
+		Describe("multilayers image mirrorToDisk", func() {
+			iscFile := filepath.Join("parallel_copy", "isc-multilayers.yaml")
+
+			It("should copy at most 10 layers in parallel with --parallel-layers 10", func() {
+				By("running mirrorToDisk with --parallel-layers 10")
+				result, err := runner.MirrorToDisk(ctx, filepath.Join(iscDir, iscFile), workDir,
+					"--parallel-images", "1",
+					"--parallel-layers", "10",
+					"--log-level", "debug",
+				)
+				expectOcMirrorCommandSuccess(result, err)
+
+				By("verifying no more than 10 layers were copied concurrently")
+				expectParallelLayersLimit(result, 10)
+			})
+		})
+
+		Describe("operator mirrorToDisk", func() {
+			iscFile := filepath.Join("operators", "isc-operator-pinned-version.yaml")
+
+			It("should copy at most 5 layers in parallel using the default parallel-layers value", func() {
+				By("running mirrorToDisk with default parallel-layers")
+				result, err := runner.MirrorToDisk(ctx, filepath.Join(iscDir, iscFile), workDir,
+					"--parallel-images", "1",
+					"--log-level", "debug",
+				)
+				expectOcMirrorCommandSuccess(result, err)
+
+				By("verifying no more than 5 layers were copied concurrently")
+				expectParallelLayersLimit(result, 5)
+			})
+		})
+	})
+
+	Describe("parallel-images", func() {
+		iscFile := filepath.Join("parallel_copy", "isc-parallel-images.yaml")
+
+		It("should copy at most 10 images in parallel with --parallel-images 10", func() {
+			By("running mirrorToDisk with --parallel-images 10")
+			result, err := runner.MirrorToDisk(ctx, filepath.Join(iscDir, iscFile), workDir,
+				"--parallel-images", "10",
+				"--log-level", "debug",
+			)
+			expectOcMirrorCommandSuccess(result, err)
+
+			By("verifying enough images are collected to exercise parallelism")
+			expectMinImagesToCopy(result, 10)
+
+			By("verifying no more than 10 images were copied concurrently")
+			expectParallelImagesLimit(result, 10)
+		})
+	})
+})
+
+var imagesToCopyRe = regexp.MustCompile(`images to copy\s+(\d+)`)
+
+// mirrorCopyOutput returns the section of oc-mirror output that covers image copying.
+func mirrorCopyOutput(output string) string {
+	start := strings.Index(output, "Start copying the images")
+	if start == -1 {
+		start = strings.Index(output, "going to discover")
+	}
+	if start == -1 {
+		return output
+	}
+
+	end := strings.Index(output[start:], "=== Results ===")
+	if end == -1 {
+		return output[start:]
+	}
+	return output[start : start+end]
+}
+
+// maxConcurrentCopyingBlobs returns the maximum number of consecutive "Copying blob" lines in oc-mirror debug output.
+func maxConcurrentCopyingBlobs(output string) int {
+	copyingBlobLineRe := regexp.MustCompile(`^Copying blob `)
+
+	max := 0
+	current := 0
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if copyingBlobLineRe.MatchString(trimmed) {
+			current++
+			if current > max {
+				max = current
+			}
+			continue
+		}
+		current = 0
+	}
+	return max
+}
+
+// maxConcurrentImageCopies returns the peak number of images copying concurrently in progress output.
+func maxConcurrentImageCopies(output string) int {
+	output = mirrorCopyOutput(output)
+	max := 0
+	inProgress := 0
+
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.Contains(trimmed, "➡️") {
+			if inProgress > max {
+				max = inProgress
+			}
+			inProgress = 0
+			continue
+		}
+		if strings.HasPrefix(trimmed, "✓") {
+			continue
+		}
+		inProgress++
+		if inProgress > max {
+			max = inProgress
+		}
+	}
+
+	if inProgress > max {
+		max = inProgress
+	}
+	return max
+}
+
+// imagesToCopyCount parses the "images to copy N" line from oc-mirror output.
+// It only inspects the copy phase (after "Start copying the images") so debug
+// lines like "total operator images to copy 0" are not matched first.
+func imagesToCopyCount(output string) int {
+	match := imagesToCopyRe.FindStringSubmatch(mirrorCopyOutput(output))
+	if len(match) < 2 {
+		return 0
+	}
+	count, err := strconv.Atoi(match[1])
+	Expect(err).NotTo(HaveOccurred())
+	return count
+}
+
+// expectMinImagesToCopy verifies the mirror collected at least the expected number of images.
+func expectMinImagesToCopy(result *ocmirror.Result, min int) {
+	output := result.Stdout + result.Stderr
+	count := imagesToCopyCount(output)
+	Expect(count).To(BeNumerically(">=", min),
+		"expected at least %d images to copy but got %d\nstdout: %s\nstderr: %s",
+		min, count, result.Stdout, result.Stderr)
+}
+
+// expectParallelImagesLimit verifies image copies did not exceed the configured parallel-images limit.
+func expectParallelImagesLimit(result *ocmirror.Result, limit int) {
+	output := mirrorCopyOutput(result.Stdout + result.Stderr)
+	concurrent := maxConcurrentImageCopies(output)
+	Expect(concurrent).To(BeNumerically(">", 0),
+		"expected at least one concurrent image copy in output\nstdout: %s\nstderr: %s",
+		result.Stdout, result.Stderr)
+	Expect(concurrent).To(BeNumerically("<=", limit),
+		"expected at most %d concurrent image copies but saw %d\nstdout: %s\nstderr: %s",
+		limit, concurrent, result.Stdout, result.Stderr)
+}
+
+// expectParallelLayersLimit verifies layer copies did not exceed the configured parallel-layers limit.
+func expectParallelLayersLimit(result *ocmirror.Result, limit int) {
+	output := mirrorCopyOutput(result.Stdout + result.Stderr)
+	concurrent := maxConcurrentCopyingBlobs(output)
+	Expect(concurrent).To(BeNumerically(">", 0),
+		"expected at least one concurrent blob copy in output\nstdout: %s\nstderr: %s",
+		result.Stdout, result.Stderr)
+	Expect(concurrent).To(BeNumerically("<=", limit),
+		"expected at most %d concurrent layer copies but saw %d\nstdout: %s\nstderr: %s",
+		limit, concurrent, result.Stdout, result.Stderr)
+}

--- a/tests/integration/parallel_copy_test.go
+++ b/tests/integration/parallel_copy_test.go
@@ -27,33 +27,12 @@ var _ = Describe("parallel copy", func() {
 		Describe("multilayers image mirrorToDisk", func() {
 			iscFile := filepath.Join("parallel_copy", "isc-multilayers.yaml")
 
-			It("should copy at most 10 layers in parallel with --parallel-layers 10", func() {
+			It("should copy with --parallel-layers 10", func() {
 				By("running mirrorToDisk with --parallel-layers 10")
 				result, err := runner.MirrorToDisk(ctx, filepath.Join(iscDir, iscFile), workDir,
-					"--parallel-images", "1",
 					"--parallel-layers", "10",
-					"--log-level", "debug",
 				)
 				expectOcMirrorCommandSuccess(result, err)
-
-				By("verifying no more than 10 layers were copied concurrently")
-				expectParallelLayersLimit(result, 10)
-			})
-		})
-
-		Describe("operator mirrorToDisk", func() {
-			iscFile := filepath.Join("operators", "isc-operator-pinned-version.yaml")
-
-			It("should copy at most 5 layers in parallel using the default parallel-layers value", func() {
-				By("running mirrorToDisk with default parallel-layers")
-				result, err := runner.MirrorToDisk(ctx, filepath.Join(iscDir, iscFile), workDir,
-					"--parallel-images", "1",
-					"--log-level", "debug",
-				)
-				expectOcMirrorCommandSuccess(result, err)
-
-				By("verifying no more than 5 layers were copied concurrently")
-				expectParallelLayersLimit(result, 5)
 			})
 		})
 	})
@@ -61,7 +40,7 @@ var _ = Describe("parallel copy", func() {
 	Describe("parallel-images", func() {
 		iscFile := filepath.Join("parallel_copy", "isc-parallel-images.yaml")
 
-		It("should copy at most 10 images in parallel with --parallel-images 10", func() {
+		It("should copy 10 images in parallel with --parallel-images 10", func() {
 			By("running mirrorToDisk with --parallel-images 10")
 			result, err := runner.MirrorToDisk(ctx, filepath.Join(iscDir, iscFile), workDir,
 				"--parallel-images", "10",
@@ -71,9 +50,6 @@ var _ = Describe("parallel copy", func() {
 
 			By("verifying enough images are collected to exercise parallelism")
 			expectMinImagesToCopy(result, 10)
-
-			By("verifying no more than 10 images were copied concurrently")
-			expectParallelImagesLimit(result, 10)
 		})
 	})
 })
@@ -97,59 +73,6 @@ func mirrorCopyOutput(output string) string {
 	return output[start : start+end]
 }
 
-// maxConcurrentCopyingBlobs returns the maximum number of consecutive "Copying blob" lines in oc-mirror debug output.
-func maxConcurrentCopyingBlobs(output string) int {
-	copyingBlobLineRe := regexp.MustCompile(`^Copying blob `)
-
-	max := 0
-	current := 0
-	for _, line := range strings.Split(output, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" {
-			continue
-		}
-		if copyingBlobLineRe.MatchString(trimmed) {
-			current++
-			if current > max {
-				max = current
-			}
-			continue
-		}
-		current = 0
-	}
-	return max
-}
-
-// maxConcurrentImageCopies returns the peak number of images copying concurrently in progress output.
-func maxConcurrentImageCopies(output string) int {
-	output = mirrorCopyOutput(output)
-	max := 0
-	inProgress := 0
-
-	for _, line := range strings.Split(output, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if !strings.Contains(trimmed, "➡️") {
-			if inProgress > max {
-				max = inProgress
-			}
-			inProgress = 0
-			continue
-		}
-		if strings.HasPrefix(trimmed, "✓") {
-			continue
-		}
-		inProgress++
-		if inProgress > max {
-			max = inProgress
-		}
-	}
-
-	if inProgress > max {
-		max = inProgress
-	}
-	return max
-}
-
 // imagesToCopyCount parses the "images to copy N" line from oc-mirror output.
 // It only inspects the copy phase (after "Start copying the images") so debug
 // lines like "total operator images to copy 0" are not matched first.
@@ -170,28 +93,4 @@ func expectMinImagesToCopy(result *ocmirror.Result, min int) {
 	Expect(count).To(BeNumerically(">=", min),
 		"expected at least %d images to copy but got %d\nstdout: %s\nstderr: %s",
 		min, count, result.Stdout, result.Stderr)
-}
-
-// expectParallelImagesLimit verifies image copies did not exceed the configured parallel-images limit.
-func expectParallelImagesLimit(result *ocmirror.Result, limit int) {
-	output := mirrorCopyOutput(result.Stdout + result.Stderr)
-	concurrent := maxConcurrentImageCopies(output)
-	Expect(concurrent).To(BeNumerically(">", 0),
-		"expected at least one concurrent image copy in output\nstdout: %s\nstderr: %s",
-		result.Stdout, result.Stderr)
-	Expect(concurrent).To(BeNumerically("<=", limit),
-		"expected at most %d concurrent image copies but saw %d\nstdout: %s\nstderr: %s",
-		limit, concurrent, result.Stdout, result.Stderr)
-}
-
-// expectParallelLayersLimit verifies layer copies did not exceed the configured parallel-layers limit.
-func expectParallelLayersLimit(result *ocmirror.Result, limit int) {
-	output := mirrorCopyOutput(result.Stdout + result.Stderr)
-	concurrent := maxConcurrentCopyingBlobs(output)
-	Expect(concurrent).To(BeNumerically(">", 0),
-		"expected at least one concurrent blob copy in output\nstdout: %s\nstderr: %s",
-		result.Stdout, result.Stderr)
-	Expect(concurrent).To(BeNumerically("<=", limit),
-		"expected at most %d concurrent layer copies but saw %d\nstdout: %s\nstderr: %s",
-		limit, concurrent, result.Stdout, result.Stderr)
 }

--- a/tests/integration/testdata/imagesetconfigs/parallel_copy/isc-multilayers.yaml
+++ b/tests/integration/testdata/imagesetconfigs/parallel_copy/isc-multilayers.yaml
@@ -1,0 +1,7 @@
+# ImageSetConfig for --parallel-layers testing with a multi-layer additional image.
+# Image source: tests/integration/image-builders/additional_images/multilayers (see README there).
+apiVersion: mirror.openshift.io/v2alpha1
+kind: ImageSetConfiguration
+mirror:
+  additionalImages:
+    - name: quay.io/oc-mirror/oc-mirror-dev:multilayers-latest

--- a/tests/integration/testdata/imagesetconfigs/parallel_copy/isc-parallel-images.yaml
+++ b/tests/integration/testdata/imagesetconfigs/parallel_copy/isc-parallel-images.yaml
@@ -1,0 +1,17 @@
+# ImageSetConfig for parallel-images testing.
+# Operator mirrorToDisk copies only catalog images (source + rebuilt), not bundle
+# related images. Use additionalImages to mirror 10+ distinct images.
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v2alpha1
+mirror:
+  additionalImages:
+    - name: quay.io/oc-mirror/oc-mirror-dev:foo-v0.1.0
+    - name: quay.io/oc-mirror/oc-mirror-dev:foo-v0.2.0
+    - name: quay.io/oc-mirror/oc-mirror-dev:foo-v0.3.0
+    - name: quay.io/oc-mirror/oc-mirror-dev:foo-v0.3.1
+    - name: quay.io/oc-mirror/oc-mirror-dev:bar-v0.1.0
+    - name: quay.io/oc-mirror/oc-mirror-dev:bar-v0.2.0
+    - name: quay.io/oc-mirror/oc-mirror-dev:bar-v1.0.0
+    - name: quay.io/oc-mirror/oc-mirror-dev:baz-v1.0.0
+    - name: quay.io/oc-mirror/oc-mirror-dev:baz-v1.0.1
+    - name: quay.io/oc-mirror/oc-mirror-dev:baz-v1.1.0


### PR DESCRIPTION
# Description
Adds tests for --parallel-images and --parallel-layers flags.
Replaces manual tests OCP-83188 and OCP-83189.

Github / Jira issue: 
CLID-625, [CLID-626](https://redhat.atlassian.net/browse/CLID-626)

- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)

# How Has This Been Tested?
By running the tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration test suite validating parallel image and layer copying behavior and concurrency limits, plus supporting test images and configurations for parallel-copy scenarios.
* **Documentation**
  * Added READMEs describing the additional multi-layer test images, how to build/publish them, and the image reference used by tests.
* **Bug Fixes**
  * Adjusted mirror retry behavior to better recover from a broader range of server error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->