### PR TITLE
CLID-655: Add test for incremental mirroring using archives by date

### DIFF
--- a/tests/integration/incremental_mirroring_test.go
+++ b/tests/integration/incremental_mirroring_test.go
@@ -1,0 +1,111 @@
+// incremental_mirroring_test.go validates the incremental mirroring workflow using the --since flag.
+// It verifies that oc-mirror produces a smaller archive (no image layer blobs) when the
+// --since date filters out previously mirrored content.
+package integration_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// findTarArchives returns the list of tar archives in workDir matching mirror_*.tar.
+func findTarArchives(workDir string) []string {
+	matches, err := filepath.Glob(filepath.Join(workDir, "mirror_*.tar"))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(matches).NotTo(BeEmpty(), "no tar archive found in %s", workDir)
+	return matches
+}
+
+// countBlobEntriesInArchives counts the number of blob entries (under docker/registry/v2/blobs/)
+// in the given tar archives. This represents actual image layer data stored in the archive.
+func countBlobEntriesInArchives(tarFiles []string) int {
+	blobCount := 0
+	for _, tarFile := range tarFiles {
+		entries := listTarEntries(tarFile)
+		for _, entry := range entries {
+			if strings.HasPrefix(entry, "docker/registry/v2/blobs/") {
+				blobCount++
+			}
+		}
+	}
+	return blobCount
+}
+
+// expectNoImageBlobsInArchives verifies that the given tar archives contain no image layer
+// blobs (entries under docker/registry/v2/blobs/). Only repository metadata links and
+// working-dir entries should be present.
+func expectNoImageBlobsInArchives(tarFiles []string) {
+	var blobEntries []string
+	for _, tarFile := range tarFiles {
+		entries := listTarEntries(tarFile)
+		for _, entry := range entries {
+			if strings.HasPrefix(entry, "docker/registry/v2/blobs/") {
+				blobEntries = append(blobEntries, entry)
+			}
+		}
+	}
+	Expect(blobEntries).To(BeEmpty(),
+		"expected no image blob entries in archive, but found %d:\n%s",
+		len(blobEntries), strings.Join(blobEntries, "\n"))
+}
+
+// CLID-655: Validate incremental mirroring using archives filtered by date.
+var _ = Describe("incremental mirroring", func() {
+	var workDir string
+
+	BeforeEach(func() {
+		workDir = setupWorkDir()
+	})
+
+	AfterEach(func() {
+		cleanupWorkDir(workDir)
+	})
+
+	// Verifies that --since flag produces an incremental archive with only new content.
+	// When --since is set to a future date (nothing cached after that date), the archive
+	// should contain no image layer blobs, only repository metadata links.
+	Describe("mirrorToDisk incremental with --since flag", func() {
+		iscFile := filepath.Join("happy_path", "isc-happy-path.yaml")
+
+		It("should produce a smaller archive on incremental run with --since", SpecTimeout(5*time.Minute), func(_ SpecContext) {
+			By("running initial mirrorToDisk")
+			result, err := runner.MirrorToDisk(ctx, filepath.Join(iscDir, iscFile), workDir, "--remove-signatures=true")
+			expectOcMirrorCommandSuccess(result, err)
+
+			By("verifying initial tar archive was produced")
+			initialArchives := findTarArchives(workDir)
+			initialBlobCount := countBlobEntriesInArchives(initialArchives)
+			GinkgoWriter.Printf("initial archive blob count: %d (files: %v)\n", initialBlobCount, initialArchives)
+			Expect(initialBlobCount).To(BeNumerically(">", 0), "initial archive should contain blobs")
+
+			By("removing initial tar archives to isolate incremental results")
+			for _, f := range initialArchives {
+				Expect(os.Remove(f)).To(Succeed())
+			}
+
+			By("running incremental mirrorToDisk with --since set to one year ahead (nothing new expected)")
+			sinceDate := time.Now().AddDate(1, 0, 0).Format("2006-01-02")
+			GinkgoWriter.Printf("using --since date: %s\n", sinceDate)
+			result, err = runner.MirrorToDisk(ctx, filepath.Join(iscDir, iscFile), workDir,
+				"--remove-signatures=true", "--since", sinceDate)
+			expectOcMirrorCommandSuccess(result, err)
+
+			By("verifying incremental archive has fewer blobs than initial")
+			incrementalArchives := findTarArchives(workDir)
+			incrementalBlobCount := countBlobEntriesInArchives(incrementalArchives)
+			GinkgoWriter.Printf("incremental archive blob count: %d (initial was %d, files: %v)\n",
+				incrementalBlobCount, initialBlobCount, incrementalArchives)
+			Expect(incrementalBlobCount).To(BeNumerically("<", initialBlobCount),
+				"incremental archive should have fewer blobs (%d) than initial (%d)",
+				incrementalBlobCount, initialBlobCount)
+
+			By("verifying incremental archive contains no image layer blobs")
+			expectNoImageBlobsInArchives(incrementalArchives)
+		})
+	})
+})


### PR DESCRIPTION
# Description

Adds a CLI integration test to validate that the --since flag correctly produces incremental archives during mirrorToDisk. The test verifies that when --since is set to a date after the initial mirror, the resulting archive excludes previously cached image layer blobs — containing only repository metadata links.

This ensures the incremental mirroring mechanism works as expected for disconnected environments where operators only need to transfer new content since the last sync.

Github / Jira issue: [CLID-655](https://redhat.atlassian.net/browse/CLID-655)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Test workflow:

1. Runs an initial mirrorToDisk and verifies the archive contains image layer blobs (89 entries under docker/registry/v2/blobs/)
2. Removes the initial tar archives to isolate incremental results
3. Runs mirrorToDisk again with --since set to one year ahead (no content is newer than that date)
4. Asserts the incremental archive contains strictly fewer blobs than the initial archive
5. Asserts the incremental archive contains zero image layer blobs

## Expected Outcome
1. Initial archive: 89 blob entries under docker/registry/v2/blobs/
2. Incremental archive: 0 blob entries (only repository metadata links and working-dir entries remain)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests for incremental mirroring using the `--since` flag. They exercise an initial mirror run and a subsequent incremental run, verifying the incremental archive is smaller and contains no image layer blobs compared to the initial archive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->