### PR TITLE
OCPBUGS-86585: Fix --secure-policy bypass for operator images in mirrorToDisk

### DIFF
--- a/internal/pkg/operator/filtered_collector.go
+++ b/internal/pkg/operator/filtered_collector.go
@@ -388,7 +388,12 @@ func (o FilterCollector) ensureCatalogInOCIFormat(ctx context.Context, imgSpec i
 	catalogImageDir := filepath.Join(imageIndexDir, operatorCatalogImageDir)
 
 	if imgSpec.Transport != ociProtocol {
+		var localGlobal mirror.GlobalOptions
+		if o.Opts.Global != nil {
+			localGlobal = *o.Opts.Global
+		}
 		opts := o.Opts
+		opts.Global = &localGlobal
 		opts.Stdout = io.Discard
 		opts.RemoveSignatures = true
 		opts.Global.SecurePolicy = false

--- a/internal/pkg/operator/filtered_collector_test.go
+++ b/internal/pkg/operator/filtered_collector_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/common"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/image"
 	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/parser"
@@ -27,6 +28,11 @@ import (
 
 type MockMirror struct {
 	Fail bool
+}
+
+type SecurePolicyRecordingMirror struct {
+	SecurePolicyAtRun bool
+	RunCalled         bool
 }
 
 type MockManifest struct {
@@ -897,8 +903,63 @@ func (o MockMirror) Run(ctx context.Context, src, dest string, mode mirror.Mode,
 	return nil
 }
 
-func (o MockMirror) Check(ctx context.Context, image string, opts *mirror.CopyOptions, asCopySrc bool) (bool, error) {
+func (o MockMirror) Check(ctx context.Context, imageName string, opts *mirror.CopyOptions, asCopySrc bool) (bool, error) {
 	return true, nil
+}
+
+func (m *SecurePolicyRecordingMirror) Run(ctx context.Context, src, dest string, mode mirror.Mode, opts *mirror.CopyOptions) error {
+	m.RunCalled = true
+	if opts.Global != nil {
+		m.SecurePolicyAtRun = opts.Global.SecurePolicy
+	}
+	return nil
+}
+
+func (m *SecurePolicyRecordingMirror) Check(ctx context.Context, imageName string, opts *mirror.CopyOptions, asCopySrc bool) (bool, error) {
+	return true, nil
+}
+
+func TestEnsureCatalogInOCIFormatDoesNotMutateSharedSecurePolicy(t *testing.T) {
+	log := clog.New("trace")
+	tempDir := t.TempDir()
+
+	global := &mirror.GlobalOptions{
+		SecurePolicy: true,
+		WorkingDir:   filepath.Join(tempDir, "working-dir"),
+	}
+
+	_, sharedOpts := mirror.SharedImageFlags()
+	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
+	_, retryOpts := mirror.RetryFlags()
+	_, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
+	_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
+
+	recordingMirror := &SecurePolicyRecordingMirror{}
+	collector := FilterCollector{
+		OperatorCollector{
+			Log:    log,
+			Mirror: recordingMirror,
+			Opts: mirror.CopyOptions{
+				Global:              global,
+				DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
+				SrcImage:            srcOpts,
+				DestImage:           destOpts,
+				RetryOpts:           retryOpts,
+				Mode:                mirror.MirrorToDisk,
+				LocalStorageFQDN:    "localhost:9999",
+			},
+		},
+	}
+
+	imgSpec, err := image.ParseRef("docker://registry.example.com/catalog:v1.0")
+	assert.NoError(t, err)
+
+	imageIndexDir := filepath.Join(tempDir, "working-dir", operatorCatalogsDir, "catalog", "abc123")
+	err = collector.ensureCatalogInOCIFormat(context.Background(), imgSpec, "registry.example.com/catalog:v1.0", imageIndexDir)
+	assert.NoError(t, err)
+	assert.True(t, recordingMirror.RunCalled, "Mirror.Run should be called for docker:// catalog")
+	assert.False(t, recordingMirror.SecurePolicyAtRun, "local copy passed to Mirror.Run should have SecurePolicy=false")
+	assert.True(t, global.SecurePolicy, "shared GlobalOptions.SecurePolicy must remain true after ensureCatalogInOCIFormat")
 }
 
 func (o MockManifest) GetOperatorConfig(file string) (*v2alpha1.OperatorConfigSchema, error) {


### PR DESCRIPTION
# Description

Fix a security regression where `--secure-policy` does not enforce GPG signature verification for operator images (catalogs, bundles, related images) during `mirrorToDisk` and `mirrorToMirror` workflows.

The root cause is in `ensureCatalogInOCIFormat()` which performs a shallow copy of `CopyOptions`. Since `Global` is a pointer (`*GlobalOptions`), setting `opts.Global.SecurePolicy = false` mutates the shared object, permanently disabling signature verification for all subsequent image copies in the same process.

The fix clones `*GlobalOptions` into a local value before modification, keeping the `SecurePolicy = false` override scoped to the OCI format conversion only.

Github / Jira issue: [CLID-XXX](https://redhat.atlassian.net/browse/CLID-XXX)

Introduced by: #1151 (OCPBUGS-56378)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

### Unit test

Added `TestEnsureCatalogInOCIFormatDoesNotMutateSharedSecurePolicy` which:
1. Creates a `FilterCollector` with `SecurePolicy = true` on a shared `GlobalOptions`
2. Calls `ensureCatalogInOCIFormat()` with a `docker://` catalog reference
3. Asserts the `Mirror.Run()` call receives `SecurePolicy = false` (local override works)
4. Asserts the shared `GlobalOptions.SecurePolicy` remains `true` (no pointer mutation)

### Lab integration test (3-round)

Tested on RHEL 9 (x86_64) with stock oc-mirror `4.20.0-202511252120` and the patched binary.

**Catalogs:** redhat-operator-index:v4.18 (web-terminal), certified-operator-index:v4.18 (gpu-operator-certified), community-operator-index:v4.18 (argocd-operator)

| Round | Binary | Policy | Result |
|-------|--------|--------|--------|
| 1 | Stock | Correct GPG | All pass (baseline) |
| 2 | Stock | Wrong GPG | Operators pass (BUG: should fail) |
| 3 | **Patched** | Wrong GPG | All fail (fix validated) |

## Expected Outcome

- `--secure-policy` enforces GPG signature verification for **all** image types: operator catalogs, bundles, related images, and additionalImages
- `ensureCatalogInOCIFormat()` still correctly disables verification for its own internal OCI conversion copy (this is expected and intentional)
- No behavioral change when `--secure-policy` is not set

## Code Changes

### `v2/internal/pkg/operator/filtered_collector.go`

Before (buggy):
```go
opts := o.Opts                    // shallow copy, Global pointer shared
opts.Global.SecurePolicy = false  // mutates shared *GlobalOptions
```

After (fixed):
```go
var localGlobal mirror.GlobalOptions
if o.Opts.Global != nil {
    localGlobal = *o.Opts.Global
}
opts := o.Opts
opts.Global = &localGlobal         // local pointer, no shared mutation
opts.Stdout = io.Discard
opts.RemoveSignatures = true
opts.Global.SecurePolicy = false   // safe: only affects localGlobal
```

### `v2/internal/pkg/operator/filtered_collector_test.go`

Added `SecurePolicyRecordingMirror` mock and `TestEnsureCatalogInOCIFormatDoesNotMutateSharedSecurePolicy` test.
