### PR TITLE
OCPBUGS-85331: Include tag+digest images in both IDMS and ITMS

### DIFF
--- a/internal/pkg/clusterresources/clusterresources.go
+++ b/internal/pkg/clusterresources/clusterresources.go
@@ -557,7 +557,8 @@ func (o *ClusterResourcesGenerator) generateImageMirrors(allRelatedImages []v2al
 			// CLID-205: In order to achieve retrocompatibility with v1, and allow for the installer
 			// to have the correct mirror for the release images as well as for the release components in the IDMS
 			// we include the release image mirror in the IDMS, even though it is by tag
-			if !srcImgSpec.IsImageByDigestOnly() && relatedImage.Type != v2alpha1.TypeOCPRelease {
+			// OCPBUGS-85331: Also include images referenced by both tag and digest (they have a digest, so they can be in IDMS)
+			if !srcImgSpec.IsImageByDigestOnly() && !srcImgSpec.IsImageByTagAndDigest() && relatedImage.Type != v2alpha1.TypeOCPRelease {
 				toBeAdded = false
 			}
 		}

--- a/internal/pkg/clusterresources/clusterresources_test.go
+++ b/internal/pkg/clusterresources/clusterresources_test.go
@@ -197,6 +197,15 @@ var (
 			Type:        v2alpha1.TypeOCPRelease,
 		},
 	}
+	// OCPBUGS-85331: images with both tag and digest should appear in both IDMS and ITMS
+	imageListTagAndDigest = []v2alpha1.CopyImageSchema{
+		{
+			Source:      consts.DockerProtocol + "localhost:5000/nvidia/k8s/container-toolkit:v1.19.1",
+			Destination: consts.DockerProtocol + "myregistry/mynamespace/nvidia/k8s/container-toolkit:v1.19.1",
+			Origin:      consts.DockerProtocol + "nvcr.io/nvidia/k8s/container-toolkit:v1.19.1@sha256:c927adbc9b7755c5cb90022fdcc5c1295f5fe5fe1f38200a2dc65e85632b029c",
+			Type:        v2alpha1.TypeOperatorRelatedImage,
+		},
+	}
 )
 
 func TestIDMS_ITMSGenerator(t *testing.T) {
@@ -232,6 +241,14 @@ func TestIDMS_ITMSGenerator(t *testing.T) {
 			imgList:                      imageListDigestsOnly,
 			expectedNumberFilesGenerated: 1,
 			expectedItms:                 false,
+			expectedIdms:                 true,
+			expectedError:                false,
+		},
+		{
+			caseName:                     "Testing IDMS_ITMSGenerator - OCPBUGS-85331 tag and digest : should generate both idms and itms",
+			imgList:                      imageListTagAndDigest,
+			expectedNumberFilesGenerated: 2,
+			expectedItms:                 true,
 			expectedIdms:                 true,
 			expectedError:                false,
 		},


### PR DESCRIPTION
# Description

This PR fixes an issue where images referenced with both tag and digest (e.g., `nvcr.io/nvidia/k8s/container-toolkit:v1.19.1@sha256:c927...`) were only included in ImageTagMirrorSet (ITMS) files but not in ImageDigestMirrorSet (IDMS) files. This caused problems in disconnected environments where the IDMS is needed for digest-based image resolution.

The issue was discovered when mirroring the GPU operator, which references images with both tag and digest. The namespace `nvcr.io/nvidia/k8s` appeared in ITMS but was missing from IDMS, while other namespaces like `nvcr.io/nvidia/cloud-native` appeared in both.

This PR modifies the logic in `generateImageMirrors` to include images with both tag and digest in IDMS generation, ensuring they appear in both IDMS and ITMS files.

Github / Jira issue: OCPBUGS-85331

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

1. **Unit Tests**: Added a new test case `TestIDMS_ITMSGenerator/Testing_IDMS_ITMSGenerator_-_OCPBUGS-85331_tag_and_digest` that verifies images with both tag and digest appear in both IDMS and ITMS files.

2. **Test Data**: Created `imageListTagAndDigest` with a real-world example from the nvidia GPU operator:
   - Origin: `nvcr.io/nvidia/k8s/container-toolkit:v1.19.1@sha256:c927...` (tag+digest)
   
3. **Full Test Suite**: Ran `make test` to ensure no regressions in existing functionality. All tests pass.

4. **Manual Testing** (can be performed): 
   ```bash
   # Mirror GPU operator
   ./bin/oc-mirror -c config.yaml file://output --v2
   ./bin/oc-mirror -c config.yaml --from file://output docker://registry:5000 --v2
   
   # Verify both IDMS and ITMS contain nvcr.io/nvidia/k8s
   cat output/working-dir/cluster-resources/idms-oc-mirror.yaml
   cat output/working-dir/cluster-resources/itms-oc-mirror.yaml
   ```

## Expected Outcome

**Before this fix:**
- Images with tag+digest: ITMS only ❌
- Result: `nvcr.io/nvidia/k8s` missing from IDMS

**After this fix:**
- Images with tag+digest: Both IDMS and ITMS ✅
- Result: `nvcr.io/nvidia/k8s` appears in both IDMS and ITMS

**Behavior matrix:**

| Image Reference Type | IDMS | ITMS | Example |
|---------------------|------|------|---------|
| Tag only | ❌ | ✅ | `registry/image:v1.0` |
| Digest only | ✅ | ❌ | `registry/image@sha256:abc...` |
| **Tag + Digest** | **✅** | **✅** | `registry/image:v1.0@sha256:abc...` |
| OCP Release | ✅ | ✅ | (existing special case) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced image mirror configuration to properly handle images referenced with both tag and digest formats in generation output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->