### PR TITLE
OCPBUGS-86585: Add regression test for secure-policy catalog OCI conv…

### DIFF
--- a/internal/pkg/operator/catalog_handler_test.go
+++ b/internal/pkg/operator/catalog_handler_test.go
@@ -15,7 +15,9 @@ import (
 
 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/consts"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/image"
 	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
 )
 
 func TestRelatedImagesFromCatalog(t *testing.T) {
@@ -589,4 +591,63 @@ func TestFilterCatalog(t *testing.T) {
 			}
 		})
 	}
+}
+
+type securePolicyRecordingMirror struct {
+	SecurePolicyAtRun bool
+	RunCalled         bool
+}
+
+func (m *securePolicyRecordingMirror) Run(ctx context.Context, src, dest string, mode mirror.Mode, opts *mirror.CopyOptions) error {
+	m.RunCalled = true
+	if opts.Global != nil {
+		m.SecurePolicyAtRun = opts.Global.SecurePolicy
+	}
+	return nil
+}
+
+func (m *securePolicyRecordingMirror) Check(ctx context.Context, imageName string, opts *mirror.CopyOptions, asCopySrc bool) (bool, error) {
+	return true, nil
+}
+
+func TestEnsureCatalogInOCIFormatDoesNotMutateSharedSecurePolicy(t *testing.T) {
+	log := clog.New("trace")
+	tempDir := t.TempDir()
+
+	global := &mirror.GlobalOptions{
+		SecurePolicy: true,
+		WorkingDir:   filepath.Join(tempDir, "working-dir"),
+	}
+
+	_, sharedOpts := mirror.SharedImageFlags()
+	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
+	_, retryOpts := mirror.RetryFlags()
+	_, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
+	_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
+
+	recordingMirror := &securePolicyRecordingMirror{}
+	handler := CatalogHandler{
+		Log:    log,
+		Mirror: recordingMirror,
+	}
+
+	opts := mirror.CopyOptions{
+		Global:              global,
+		DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
+		SrcImage:            srcOpts,
+		DestImage:           destOpts,
+		RetryOpts:           retryOpts,
+		Mode:                mirror.MirrorToDisk,
+		LocalStorageFQDN:    "localhost:9999",
+	}
+
+	imgSpec, err := image.ParseRef("docker://registry.example.com/catalog:v1.0")
+	assert.NoError(t, err)
+
+	imageIndexDir := filepath.Join(tempDir, "working-dir", operatorCatalogsDir, "catalog", "abc123")
+	err = handler.EnsureCatalogInOCIFormat(context.Background(), imgSpec, "registry.example.com/catalog:v1.0", imageIndexDir, opts)
+	assert.NoError(t, err)
+	assert.True(t, recordingMirror.RunCalled, "Mirror.Run should be called for docker:// catalog")
+	assert.False(t, recordingMirror.SecurePolicyAtRun, "local copy passed to Mirror.Run should have SecurePolicy=false")
+	assert.True(t, global.SecurePolicy, "shared GlobalOptions.SecurePolicy must remain true after EnsureCatalogInOCIFormat")
 }


### PR DESCRIPTION
# Description

Add a regression test for OCPBUGS-86585 to ensure `EnsureCatalogInOCIFormat()` does not mutate shared `GlobalOptions` when it locally disables `--secure-policy` for the internal OCI catalog copy.

The fix is already present on `main` in `internal/pkg/operator/catalog_handler.go` (commit `99365b85`). This PR adds test coverage so the bypass cannot be reintroduced.

Github / Jira issue: [OCPBUGS-86585](https://issues.redhat.com/browse/OCPBUGS-86585)

Related: OCPBUGS-56378 / #1151

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added `TestEnsureCatalogInOCIFormatDoesNotMutateSharedSecurePolicy`.

Lab test on servermind with `main` binary:
- Wrong GPG: exit 12 (operators rejected)
- Correct GPG: exit 0 (all mirrored)

## Expected Outcome

- Test-only PR on `main`; no behavioral change
- Enables backport to `release-4.21` and `release-4.20`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage to verify that catalog operations maintain the integrity of shared configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->