### PR TITLE
OCPBUGS-87496: update images to be consistent with ART

### DIFF
--- a/images/cli/Dockerfile.ci
+++ b/images/cli/Dockerfile.ci
@@ -1,10 +1,10 @@
 # This Dockerfile is used by CI to publish the oc-mirror image.
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.25-openshift-4.22 AS builder_rhel8
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.26-openshift-5.0 AS builder_rhel8
 WORKDIR /go/src/github.com/openshift/oc-mirror
 COPY . .
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder_rhel9
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder_rhel9
 WORKDIR /go/src/github.com/openshift/oc-mirror
 COPY . .
 RUN make build
@@ -25,7 +25,7 @@ RUN cd tests/e2e && \
     gzip -c bin/oc-mirror-tests-ext > bin/oc-mirror-tests-ext.gz && \
     rm -f bin/oc-mirror-tests-ext
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 COPY --from=builder_rhel8 /go/src/github.com/openshift/oc-mirror/bin/oc-mirror /usr/bin/oc-mirror.rhel8
 COPY --from=builder_rhel9 /go/src/github.com/openshift/oc-mirror/bin/oc-mirror /usr/bin/oc-mirror
 COPY --from=builder_rhel9 /go/src/github.com/openshift/oc-mirror/bin/oc-mirror /usr/bin/oc-mirror.rhel9

--- a/images/cli/Dockerfile.test
+++ b/images/cli/Dockerfile.test
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 WORKDIR /go/src/github.com/openshift/oc-mirror
 COPY . .
 RUN CGO_ENABLED=0 make build
 RUN cd tests/integration && CGO_ENABLED=0 go test -mod=mod -c -o /tmp/integration.test .
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 WORKDIR /artifacts
 RUN mkdir -p /artifacts && chmod -R 777 /artifacts
 RUN mkdir -p /root/{.docker,.cache} /root/.oc-mirror/.cache && chmod -R 777 /root


### PR DESCRIPTION
# Description

Follow-up to https://github.com/openshift/oc-mirror/pull/1432

Github / Jira issue: OCPBUGS-87496

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [x] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated builder and runtime base images in CI and test container configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->