### PR TITLE
[release-4.21] OCPBUGS-88030: Resolve catalog digests upfront in M2D/M2M workflows

### DIFF
--- a/internal/pkg/cli/executor.go
+++ b/internal/pkg/cli/executor.go
@@ -564,6 +564,14 @@ func (o *ExecutorSchema) Complete(args []string) error {
 
 	client, _ := release.NewOCPClient(uuid.New(), o.Log)
 
+	// OCPBUGS-81712: Pin all operator catalogs to digest before initializing collectors
+	// This prevents race conditions in M2D/M2M where catalog tags might change during execution
+	// Best-effort approach: failures are logged as warnings, invalid catalogs handled during collection
+	if len(o.Config.Mirror.Operators) > 0 && (o.Opts.IsMirrorToDisk() || o.Opts.IsMirrorToMirror()) {
+		o.Log.Debug("Resolving operator catalog digests for %d operators", len(o.Config.Mirror.Operators))
+		o.Config = config.PinCatalogDigests(context.Background(), o.Config, o.Manifest, o.Opts, o.Log)
+	}
+
 	o.ImageBuilder = imagebuilder.NewBuilder(o.Log, *o.Opts)
 	o.CatalogBuilder = imagebuilder.NewGCRCatalogBuilder(o.Log, *o.Opts)
 	signature := release.NewSignatureClient(o.Log, o.Config, *o.Opts)

--- a/internal/pkg/config/pin_catalogs.go
+++ b/internal/pkg/config/pin_catalogs.go
@@ -1,0 +1,155 @@
+package config
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/consts"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/image"
+	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/manifest"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
+)
+
+// PinCatalogDigests creates a copy of ImageSetConfiguration with catalog references
+// pinned to SHA256 digests instead of tags.
+//
+// OCPBUGS-81712: This function resolves all catalog tags to digests upfront (during Complete())
+// to prevent race conditions where catalog tags change between collection and mirroring.
+// Without this, a catalog tag could resolve to different digests at collection vs mirroring time,
+// causing the working-dir to be structured for one digest while the tarball contains another.
+//
+// For each operator catalog in cfg.Mirror.Operators:
+// - Parses the catalog reference
+// - Resolves the tag to a digest via network call (manifestAPI.ImageDigest)
+// - Replaces the catalog field with digest format: {registry}/{path}@sha256:{digest}
+// - Preserves original tag as TargetTag if user didn't provide one
+//
+// Best-effort approach: If catalog pinning fails (e.g., invalid registry, DNS errors, auth failures),
+// logs a warning and continues. This allows invalid catalogs to be caught by the operator collector
+// during collection phase, where proper exit codes (2, 4, 20) can be returned for integration tests.
+//
+// Returns a new ImageSetConfiguration with pinned catalogs. The original config is never mutated.
+// Never returns an error due to best-effort approach (errors are logged as warnings).
+func PinCatalogDigests(
+	ctx context.Context,
+	cfg v2alpha1.ImageSetConfiguration,
+	manifestAPI manifest.ManifestInterface,
+	opts *mirror.CopyOptions,
+	log clog.PluggableLoggerInterface,
+) v2alpha1.ImageSetConfiguration {
+	if len(cfg.Mirror.Operators) == 0 {
+		return cfg
+	}
+
+	// Create copy to avoid mutating original
+	pinnedCfg := copyISC(cfg)
+
+	// Iterate through operator catalogs by index to modify in place
+	for i := range pinnedCfg.Mirror.Operators {
+		op := &pinnedCfg.Mirror.Operators[i]
+
+		if err := pinSingleCatalogDigest(ctx, op, manifestAPI, opts, log); err != nil {
+			// Best-effort: log warning and continue instead of failing
+			// This allows the operator collector to handle the error with proper exit codes
+			log.Warn("failed to pin catalog at index %d (%s): %v - will be resolved during collection", i, op.Catalog, err)
+			continue
+		}
+	}
+
+	return pinnedCfg
+}
+
+// pinSingleCatalogDigest pins a single catalog reference to its SHA256 digest.
+//
+// The function modifies the op.Catalog field in-place and handles the following cases:
+// - OCI transport catalogs: skipped (already local, no network resolution needed)
+// - Already digest-pinned: skipped (no action needed)
+// - Tag-based reference: resolves digest via network call and updates op.Catalog
+// - Empty digest returned: skipped (catalog won't be pinned)
+//
+// When pinning a tag-based catalog:
+// 1. Preserves the original tag as TargetTag (if user didn't provide one)
+// 2. Resolves the tag to a digest via manifestAPI.ImageDigest (network call)
+// 3. Replaces op.Catalog with the digest-pinned reference
+// 4. Preserves transport prefix for non-docker transports
+//
+// Returns error only for fatal failures (parse errors, network errors).
+// Empty or missing digests result in skipping (no error) to maintain best-effort behavior.
+//
+//nolint:cyclop // Keeping function as-is to avoid diverging from release-4.22 and main branches
+func pinSingleCatalogDigest(
+	ctx context.Context,
+	op *v2alpha1.Operator,
+	manifestAPI manifest.ManifestInterface,
+	opts *mirror.CopyOptions,
+	log clog.PluggableLoggerInterface,
+) error {
+	// Parse catalog reference
+	imgSpec, err := image.ParseRef(op.Catalog)
+	if err != nil {
+		return fmt.Errorf("failed to parse catalog %s: %w", op.Catalog, err)
+	}
+
+	// Skip OCI catalogs - they're already local
+	if imgSpec.Transport == consts.OciProtocol {
+		log.Debug("Skipping OCI catalog %s (already local)", op.Catalog)
+		return nil
+	}
+
+	// Skip if the image is already pinned by digest
+	if imgSpec.IsImageByDigest() {
+		log.Debug("Catalog %s is already pinned by digest, skipping", op.Catalog)
+		return nil
+	}
+
+	// Preserve the original tag for the destination if user didn't provide targetTag
+	if op.TargetTag == "" && imgSpec.Tag != "" {
+		op.TargetTag = imgSpec.Tag
+		log.Debug("Preserving original tag %s as TargetTag for catalog %s", imgSpec.Tag, op.Catalog)
+	}
+
+	// Resolve tag to digest via network
+	srcCtx, err := opts.SrcImage.NewSystemContext()
+	if err != nil {
+		return fmt.Errorf("failed to create system context: %w", err)
+	}
+
+	catalogDigest, err := manifestAPI.ImageDigest(ctx, srcCtx, imgSpec.ReferenceWithTransport)
+	if err != nil {
+		return fmt.Errorf("failed to resolve digest for catalog %s: %w", op.Catalog, err)
+	}
+
+	// Skip pinning if digest is empty
+	if catalogDigest == "" {
+		log.Debug("Skipping catalog %s (empty digest)", op.Catalog)
+		return nil
+	}
+
+	// Build pinned reference: {registry}/{path}@sha256:{digest}
+	pinnedRef := image.WithDigest(imgSpec.Name, catalogDigest)
+
+	// Preserve transport prefix if non-docker
+	if imgSpec.Transport != "" && imgSpec.Transport != consts.DockerProtocol {
+		pinnedRef = imgSpec.Transport + pinnedRef
+	}
+
+	log.Debug("Resolved catalog %s to digest %s", op.Catalog, pinnedRef)
+	op.Catalog = pinnedRef
+	return nil
+}
+
+// copyISC creates a shallow copy of ImageSetConfiguration with a deep copy of the Operators slice.
+// This ensures we don't mutate the original configuration when pinning catalog digests.
+func copyISC(cfg v2alpha1.ImageSetConfiguration) v2alpha1.ImageSetConfiguration {
+	copied := cfg
+
+	// Deep copy operators slice (only part we modify)
+	if len(cfg.Mirror.Operators) > 0 {
+		copied.Mirror.Operators = make([]v2alpha1.Operator, len(cfg.Mirror.Operators))
+		copy(copied.Mirror.Operators, cfg.Mirror.Operators)
+	}
+
+	return copied
+}

--- a/internal/pkg/config/pin_catalogs_test.go
+++ b/internal/pkg/config/pin_catalogs_test.go
@@ -1,0 +1,436 @@
+package config
+
+import (
+	"context"
+	"testing"
+
+	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.podman.io/image/v5/types"
+
+	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/consts"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/image"
+	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
+)
+
+// MockManifest provides a test double for ManifestInterface
+// Based on the pattern from filtered_collector_test.go
+type MockManifest struct {
+	digestMap map[string]string // maps image reference to digest
+}
+
+func (m *MockManifest) ImageDigest(ctx context.Context, srcCtx *types.SystemContext, ref string) (string, error) {
+	if m.digestMap != nil {
+		if digest, ok := m.digestMap[ref]; ok {
+			return digest, nil
+		}
+	}
+	// Return empty string if not in map (catalog won't be pinned)
+	return "", nil
+}
+
+// Stub implementations for unused ManifestInterface methods
+func (m *MockManifest) GetOCIImageIndex(file string) (*v2alpha1.OCISchema, error) {
+	return nil, nil
+}
+func (m *MockManifest) GetOCIImageManifest(file string) (*v2alpha1.OCISchema, error) {
+	return nil, nil
+}
+func (m *MockManifest) GetOCIImageFromIndex(dir string) (gcrv1.Image, error) { //nolint:ireturn // as expected by go-containerregistry
+	return nil, nil
+}
+func (m *MockManifest) ExtractOCILayers(img gcrv1.Image, toPath, label string) error {
+	return nil
+}
+func (m *MockManifest) ConvertOCIIndexToSingleManifest(dir string, oci *v2alpha1.OCISchema) error {
+	return nil
+}
+func (m *MockManifest) GetReleaseSchema(filePath string) ([]v2alpha1.RelatedImage, error) {
+	return nil, nil
+}
+func (m *MockManifest) GetOperatorConfig(file string) (*v2alpha1.OperatorConfigSchema, error) {
+	return nil, nil
+}
+func (m *MockManifest) ImageManifest(ctx context.Context, srcCtx *types.SystemContext, ref string, instanceDigest *digest.Digest) ([]byte, string, error) {
+	return nil, "", nil
+}
+
+const (
+	// Valid SHA256 digests for testing (64 hex characters)
+	testDigest1 = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	testDigest2 = "fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321"
+
+	// Catalog references
+	redhatIndexTag          = "registry.redhat.io/redhat/redhat-operator-index:v4.12"
+	redhatIndexTagDocker    = consts.DockerProtocol + "registry.redhat.io/redhat/redhat-operator-index:v4.12"
+	certifiedIndexTag       = "registry.redhat.io/redhat/certified-operator-index:v4.12"
+	certifiedIndexTagDocker = consts.DockerProtocol + "registry.redhat.io/redhat/certified-operator-index:v4.12"
+	communityIndexBase      = "registry.redhat.io/redhat/community-operator-index"
+	redhatIndexBase         = "registry.redhat.io/redhat/redhat-operator-index"
+
+	// Test digests
+	testDigestShort1 = "abc123def456789"
+	testDigestShort2 = "digest1"
+	testDigestShort3 = "digest2"
+
+	// Error messages
+	errMsgParseCatalog = "failed to parse catalog"
+)
+
+// createM2DTestOpts creates a CopyOptions configured for MirrorToDisk mode
+// for testing catalog pinning (resolves digests via network calls via mock)
+func createM2DTestOpts(t *testing.T) *mirror.CopyOptions {
+	global := &mirror.GlobalOptions{
+		WorkingDir: t.TempDir(),
+	}
+	_, sharedOpts := mirror.SharedImageFlags()
+	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
+	_, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
+	_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
+
+	return &mirror.CopyOptions{
+		Mode:                mirror.MirrorToDisk,
+		Global:              global,
+		DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
+		SrcImage:            srcOpts,
+		DestImage:           destOpts,
+	}
+}
+
+func TestPinCatalogDigests_CopyBehavior(t *testing.T) {
+	logger := clog.New("trace")
+	ctx := context.Background()
+	opts := createM2DTestOpts(t)
+
+	cfg := v2alpha1.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+			Mirror: v2alpha1.Mirror{
+				Operators: []v2alpha1.Operator{
+					{
+						Catalog: redhatIndexTag,
+					},
+				},
+			},
+		},
+	}
+
+	manifest := &MockManifest{
+		digestMap: map[string]string{
+			redhatIndexTagDocker: testDigestShort1,
+		},
+	}
+
+	pinnedCfg := PinCatalogDigests(ctx, cfg, manifest, opts, logger)
+	assert.Equal(t,
+		image.WithDigest(redhatIndexBase, testDigestShort1),
+		pinnedCfg.Mirror.Operators[0].Catalog,
+	)
+
+	// Verify original config is unchanged (tests copy behavior)
+	assert.Equal(t,
+		redhatIndexTag,
+		cfg.Mirror.Operators[0].Catalog,
+	)
+}
+
+func TestPinCatalogDigests_NoOperators(t *testing.T) {
+	logger := clog.New("trace")
+	ctx := context.Background()
+	opts := createM2DTestOpts(t)
+
+	cfg := v2alpha1.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+			Mirror: v2alpha1.Mirror{
+				Operators: []v2alpha1.Operator{},
+			},
+		},
+	}
+
+	manifest := &MockManifest{}
+
+	pinnedCfg := PinCatalogDigests(ctx, cfg, manifest, opts, logger)
+	assert.Empty(t, pinnedCfg.Mirror.Operators)
+}
+
+func TestPinCatalogDigests_MultipleOperators(t *testing.T) {
+	logger := clog.New("trace")
+	ctx := context.Background()
+	opts := createM2DTestOpts(t)
+
+	cfg := v2alpha1.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+			Mirror: v2alpha1.Mirror{
+				Operators: []v2alpha1.Operator{
+					{
+						Catalog: redhatIndexTag,
+					},
+					{
+						Catalog: certifiedIndexTag,
+					},
+					{
+						Catalog: image.WithDigest(communityIndexBase, testDigest2),
+					},
+				},
+			},
+		},
+	}
+
+	manifest := &MockManifest{
+		digestMap: map[string]string{
+			redhatIndexTagDocker:    testDigestShort2,
+			certifiedIndexTagDocker: testDigestShort3,
+		},
+	}
+
+	pinnedCfg := PinCatalogDigests(ctx, cfg, manifest, opts, logger)
+
+	// First operator should be pinned
+	assert.Equal(t,
+		image.WithDigest(redhatIndexBase, testDigestShort2),
+		pinnedCfg.Mirror.Operators[0].Catalog,
+	)
+
+	// Second operator should be pinned
+	assert.Equal(t,
+		image.WithDigest("registry.redhat.io/redhat/certified-operator-index", testDigestShort3),
+		pinnedCfg.Mirror.Operators[1].Catalog,
+	)
+
+	// Third operator already pinned, should remain unchanged
+	assert.Equal(t,
+		image.WithDigest(communityIndexBase, testDigest2),
+		pinnedCfg.Mirror.Operators[2].Catalog,
+	)
+}
+
+func TestCopyISC(t *testing.T) {
+	original := v2alpha1.ImageSetConfiguration{
+		ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+			Mirror: v2alpha1.Mirror{
+				Operators: []v2alpha1.Operator{
+					{
+						Catalog: redhatIndexTag,
+					},
+				},
+			},
+		},
+	}
+
+	copied := copyISC(original)
+
+	// Modify the copied version
+	copied.Mirror.Operators[0].Catalog = "modified-catalog"
+
+	// Verify original is unchanged
+	assert.Equal(t,
+		redhatIndexTag,
+		original.Mirror.Operators[0].Catalog,
+	)
+
+	// Verify copied has the modification
+	assert.Equal(t,
+		"modified-catalog",
+		copied.Mirror.Operators[0].Catalog,
+	)
+}
+
+func TestPinSingleCatalog_Success(t *testing.T) {
+	logger := clog.New("trace")
+	ctx := context.Background()
+	opts := createM2DTestOpts(t)
+
+	op := &v2alpha1.Operator{
+		Catalog: redhatIndexTag,
+	}
+
+	manifest := &MockManifest{
+		digestMap: map[string]string{
+			redhatIndexTagDocker: testDigestShort1,
+		},
+	}
+
+	err := pinSingleCatalogDigest(ctx, op, manifest, opts, logger)
+	require.NoError(t, err)
+	assert.Equal(t, image.WithDigest(redhatIndexBase, testDigestShort1), op.Catalog)
+}
+
+func TestPinSingleCatalog_AlreadyPinned(t *testing.T) {
+	logger := clog.New("trace")
+	ctx := context.Background()
+	opts := createM2DTestOpts(t)
+
+	alreadyPinnedCatalog := image.WithDigest(redhatIndexBase, testDigest1)
+
+	op := &v2alpha1.Operator{
+		Catalog: alreadyPinnedCatalog,
+	}
+
+	manifest := &MockManifest{
+		digestMap: map[string]string{
+			consts.DockerProtocol + alreadyPinnedCatalog: "newdigest123",
+		},
+	}
+
+	err := pinSingleCatalogDigest(ctx, op, manifest, opts, logger)
+	require.NoError(t, err)
+	assert.Equal(t, alreadyPinnedCatalog, op.Catalog, "Should not modify already pinned catalog")
+}
+
+func TestPinSingleCatalog_NotInMap(t *testing.T) {
+	logger := clog.New("trace")
+	ctx := context.Background()
+	opts := createM2DTestOpts(t)
+
+	op := &v2alpha1.Operator{
+		Catalog: redhatIndexTag,
+	}
+
+	// Empty digest map - will use default digest
+	manifest := &MockManifest{
+		digestMap: map[string]string{},
+	}
+
+	err := pinSingleCatalogDigest(ctx, op, manifest, opts, logger)
+	require.NoError(t, err)
+	assert.Equal(t, redhatIndexTag, op.Catalog, "Should not modify catalog when not found in map")
+}
+
+func TestPinSingleCatalog_EmptyDigest(t *testing.T) {
+	logger := clog.New("trace")
+	ctx := context.Background()
+	opts := createM2DTestOpts(t)
+
+	op := &v2alpha1.Operator{
+		Catalog: redhatIndexTag,
+	}
+
+	manifest := &MockManifest{
+		digestMap: map[string]string{
+			redhatIndexTagDocker: "", // Empty digest
+		},
+	}
+
+	err := pinSingleCatalogDigest(ctx, op, manifest, opts, logger)
+	require.NoError(t, err)
+	assert.Equal(t, redhatIndexTag, op.Catalog, "Should not modify catalog for empty digest")
+}
+
+func TestPinSingleCatalog_InvalidCatalog(t *testing.T) {
+	logger := clog.New("trace")
+	ctx := context.Background()
+	opts := createM2DTestOpts(t)
+
+	op := &v2alpha1.Operator{
+		Catalog: "", // Empty catalog reference should fail parsing
+	}
+
+	manifest := &MockManifest{
+		digestMap: map[string]string{},
+	}
+
+	err := pinSingleCatalogDigest(ctx, op, manifest, opts, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), errMsgParseCatalog)
+}
+
+func TestPinSingleCatalog_OCITransport(t *testing.T) {
+	logger := clog.New("trace")
+	ctx := context.Background()
+	opts := createM2DTestOpts(t)
+
+	ociCatalog := "oci:///path/to/catalog"
+
+	op := &v2alpha1.Operator{
+		Catalog: ociCatalog,
+	}
+
+	manifest := &MockManifest{
+		digestMap: map[string]string{
+			ociCatalog: "ocidigests123",
+		},
+	}
+
+	err := pinSingleCatalogDigest(ctx, op, manifest, opts, logger)
+	require.NoError(t, err)
+	assert.Equal(t, ociCatalog, op.Catalog, "Should skip OCI catalog (already local)")
+}
+
+func TestPinSingleCatalog_DockerTransport(t *testing.T) {
+	logger := clog.New("trace")
+	ctx := context.Background()
+	opts := createM2DTestOpts(t)
+
+	dockerCatalog := consts.DockerProtocol + "registry.redhat.io/redhat/redhat-operator-index:v4.12"
+
+	op := &v2alpha1.Operator{
+		Catalog: dockerCatalog,
+	}
+
+	manifest := &MockManifest{
+		digestMap: map[string]string{
+			dockerCatalog: testDigestShort1,
+		},
+	}
+
+	err := pinSingleCatalogDigest(ctx, op, manifest, opts, logger)
+	require.NoError(t, err)
+	assert.Equal(t, image.WithDigest(redhatIndexBase, testDigestShort1), op.Catalog,
+		"Should omit docker:// transport prefix")
+}
+
+func TestPinSingleCatalog_NoTransport(t *testing.T) {
+	logger := clog.New("trace")
+	ctx := context.Background()
+	opts := createM2DTestOpts(t)
+
+	op := &v2alpha1.Operator{
+		Catalog: redhatIndexTag,
+	}
+
+	// Catalog without explicit transport (docker:// is implied)
+	manifest := &MockManifest{
+		digestMap: map[string]string{
+			redhatIndexTagDocker: testDigestShort1,
+		},
+	}
+
+	err := pinSingleCatalogDigest(ctx, op, manifest, opts, logger)
+	require.NoError(t, err)
+	assert.Equal(t, image.WithDigest(redhatIndexBase, testDigestShort1), op.Catalog,
+		"Should not add transport prefix when none specified")
+	assert.NotContains(t, op.Catalog, consts.DockerProtocol,
+		"Should not include docker:// prefix in pinned reference")
+}
+
+func TestPinSingleCatalog_MultipleCatalogs(t *testing.T) {
+	logger := clog.New("trace")
+	ctx := context.Background()
+	opts := createM2DTestOpts(t)
+
+	manifest := &MockManifest{
+		digestMap: map[string]string{
+			redhatIndexTagDocker:    testDigestShort1,
+			certifiedIndexTagDocker: testDigestShort2,
+		},
+	}
+
+	// Pin first catalog
+	op1 := &v2alpha1.Operator{
+		Catalog: redhatIndexTag,
+	}
+	err := pinSingleCatalogDigest(ctx, op1, manifest, opts, logger)
+	require.NoError(t, err)
+	assert.Equal(t, image.WithDigest(redhatIndexBase, testDigestShort1), op1.Catalog)
+
+	// Pin second catalog
+	op2 := &v2alpha1.Operator{
+		Catalog: certifiedIndexTag,
+	}
+	err = pinSingleCatalogDigest(ctx, op2, manifest, opts, logger)
+	require.NoError(t, err)
+	assert.Equal(t, image.WithDigest("registry.redhat.io/redhat/certified-operator-index", testDigestShort2), op2.Catalog)
+}

--- a/internal/pkg/image/image.go
+++ b/internal/pkg/image/image.go
@@ -167,3 +167,8 @@ func (i ImageSpec) SetTag(tag string) ImageSpec {
 	i.ReferenceWithTransport = strings.Replace(i.ReferenceWithTransport, oldTag, tag, 1)
 	return i
 }
+
+// WithDigest constructs an image reference with a SHA256 digest.
+func WithDigest(name, digest string) string {
+	return fmt.Sprintf("%s@sha256:%s", name, digest)
+}

--- a/internal/pkg/operator/filtered_collector.go
+++ b/internal/pkg/operator/filtered_collector.go
@@ -129,16 +129,56 @@ func createFolders(paths []string) error {
 	return errors.Join(errs...)
 }
 
-func digestOfFilter(catalog v2alpha1.Operator) (string, error) {
+// digestOfFilter computes a hash of the operator filter configuration.
+//
+// The catalogDigest parameter controls normalization behavior:
+//   - When non-empty: normalizes the catalog reference to "name@sha256:digest" form (CLID-513).
+//     This ensures consistent hashes whether catalog is specified by tag or digest in the ISC.
+//   - When empty: uses the catalog reference as-is.
+func digestOfFilter(catalog v2alpha1.Operator, catalogDigest string) (string, error) {
 	c := catalog
 	c.TargetCatalog = ""
 	c.TargetTag = ""
 	c.TargetCatalogSourceTemplate = ""
+	if c.Catalog != "" && catalogDigest != "" {
+		imgSpec, err := image.ParseRef(c.Catalog)
+		if err == nil {
+			c.Catalog = image.WithDigest(imgSpec.Name, catalogDigest)
+		}
+	}
 	pkgs, err := json.Marshal(c)
 	if err != nil {
 		return "", err
 	}
 	return fmt.Sprintf("%x", md5.Sum(pkgs))[0:32], nil
+}
+
+// findFilterDigest returns the filter digest to use, checking for an existing
+// filtered catalog on disk and falling back to the legacy digest if needed.
+func findFilterDigest(op v2alpha1.Operator, catalogDigest, filteredCatalogsDir string) (string, error) {
+	filterDigest, err := digestOfFilter(op, catalogDigest)
+	if err != nil {
+		return "", err
+	}
+
+	digestFile := filepath.Join(filteredCatalogsDir, filterDigest, "digest")
+	if _, err := os.Stat(digestFile); err == nil {
+		return filterDigest, nil
+	}
+
+	// Try legacy digest (without normalization) for backwards compatibility
+	// Error is intentionally ignored - if legacy digest fails, we use the normalized one
+	legacyDigest, _ := digestOfFilter(op, "")
+	if legacyDigest == filterDigest {
+		return filterDigest, nil
+	}
+
+	legacyDigestFile := filepath.Join(filteredCatalogsDir, legacyDigest, "digest")
+	if _, err := os.Stat(legacyDigestFile); err == nil {
+		return legacyDigest, nil
+	}
+
+	return filterDigest, nil
 }
 
 func (o FilterCollector) isAlreadyFiltered(ctx context.Context, srcImage, filteredImageDigest string) bool {
@@ -251,7 +291,10 @@ func (o FilterCollector) collectOperator( //nolint:cyclop // TODO: this needs fu
 
 	rebuiltTag := ""
 	if !isFullCatalog(op) {
-		tag, err := digestOfFilter(op)
+		imageIndexDir := filepath.Join(o.Opts.Global.WorkingDir, operatorCatalogsDir, imgSpec.ComponentName(), catalogDigest)
+		filteredCatalogsDir := filepath.Join(imageIndexDir, operatorCatalogFilteredDir)
+
+		tag, err := findFilterDigest(op, catalogDigest, filteredCatalogsDir)
 		if err != nil {
 			return v2alpha1.CatalogFilterResult{}, err
 		}
@@ -297,7 +340,7 @@ func (o FilterCollector) filterOperator(ctx context.Context, op v2alpha1.Operato
 	imageIndexDir := filepath.Join(o.Opts.Global.WorkingDir, operatorCatalogsDir, imgSpec.ComponentName(), catalogDigest)
 	filteredCatalogsDir := filepath.Join(imageIndexDir, operatorCatalogFilteredDir)
 
-	filterDigest, err := digestOfFilter(op)
+	filterDigest, err := findFilterDigest(op, catalogDigest, filteredCatalogsDir)
 	if err != nil {
 		return v2alpha1.CatalogFilterResult{}, err
 	}
@@ -328,7 +371,7 @@ func (o FilterCollector) filterOperator(ctx context.Context, op v2alpha1.Operato
 			FilteredConfigPath: filterConfigDir,
 			ToRebuild:          false,
 			DeclConfig:         filteredDC,
-			Digest:             string(filteredImageDigest),
+			Digest:             catalogDigest,
 		}, nil
 	}
 	o.Log.Debug("Catalog has not been filtered previously")

--- a/internal/pkg/operator/filtered_collector_test.go
+++ b/internal/pkg/operator/filtered_collector_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/common"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/config"
 	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/parser"
@@ -350,31 +351,31 @@ func TestFilterCollectorM2D(t *testing.T) {
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
-					Source:      "docker://redhat-operators:v4.7",
+					Source:      "docker://redhat-operators@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Destination: "docker://localhost:9999/redhat-operators:v4.7",
-					Origin:      "docker://redhat-operators:v4.7",
+					Origin:      "docker://redhat-operators@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeOperatorCatalog,
 				},
 				{
-					Source:      "docker://certified-operators:v4.7",
+					Source:      "docker://certified-operators@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Destination: "docker://localhost:9999/certified-operators:v4.7",
-					Origin:      "docker://certified-operators:v4.7",
+					Origin:      "docker://certified-operators@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "442c7ba64d56a85eea155325aa0c6537",
+					RebuiltTag:  "70eb0b2116707316c6130de415ceeb69",
 				},
 				{
-					Source:      "docker://community-operators:v4.7",
+					Source:      "docker://community-operators@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Destination: "docker://localhost:9999/community-operators:v4.7",
-					Origin:      "docker://community-operators:v4.7",
+					Origin:      "docker://community-operators@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "4dab2467f35b4d9c9ba7c2a7823de8bd",
+					RebuiltTag:  "ac8e314872a499f2c6edb0616489c628",
 				},
 				{
 					Source:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Destination: "docker://localhost:9999/simple-test-bundle:latest",
 					Origin:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
+					RebuiltTag:  "eaf28fd0a9f205e44fb52a8b0bd8e678",
 				},
 			},
 		},
@@ -406,7 +407,7 @@ func TestFilterCollectorM2D(t *testing.T) {
 					Destination: "docker://localhost:9999/simple-test-bundle:v4.14",
 					Origin:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
+					RebuiltTag:  "eaf28fd0a9f205e44fb52a8b0bd8e678",
 				},
 			},
 		},
@@ -444,7 +445,7 @@ func TestFilterCollectorM2D(t *testing.T) {
 					Destination: "docker://localhost:9999/test-catalog:v4.14",
 					Origin:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
+					RebuiltTag:  "eaf28fd0a9f205e44fb52a8b0bd8e678",
 				},
 			},
 		},
@@ -472,11 +473,11 @@ func TestFilterCollectorM2D(t *testing.T) {
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
-					Source:      "docker://certified-operators:v4.7",
+					Source:      "docker://certified-operators@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Destination: "docker://localhost:9999/test-namespace/test-catalog:v2.0",
-					Origin:      "docker://certified-operators:v4.7",
+					Origin:      "docker://certified-operators@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "442c7ba64d56a85eea155325aa0c6537",
+					RebuiltTag:  "70eb0b2116707316c6130de415ceeb69",
 				},
 			},
 		},
@@ -485,6 +486,10 @@ func TestFilterCollectorM2D(t *testing.T) {
 		t.Run(testCase.caseName, func(t *testing.T) {
 			ex := setupFilterCollector_MirrorToDisk(tempDir, log, manifest)
 			ex = ex.withConfig(testCase.config)
+
+			// OCPBUGS-81712: Pin catalogs to digest before collection (matches real M2D flow)
+			ex.Config = config.PinCatalogDigests(ctx, ex.Config, ex.Manifest, &ex.Opts, ex.Log)
+
 			res, err := ex.OperatorImageCollector(ctx)
 			if testCase.expectedError {
 				assert.Error(t, err)
@@ -555,18 +560,18 @@ func TestFilterCollectorD2M(t *testing.T) {
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
-					Source:      "docker://localhost:9999/simple-test-bundle:9fadc6c70adb4b2571f66f674a876279",
+					Source:      "docker://localhost:9999/simple-test-bundle:eaf28fd0a9f205e44fb52a8b0bd8e678",
 					Destination: "docker://localhost:5000/test/simple-test-bundle:latest",
 					Origin:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
+					RebuiltTag:  "eaf28fd0a9f205e44fb52a8b0bd8e678",
 				},
 				{
-					Source:      "docker://localhost:9999/redhat/redhat-operator-index:6566d78129230a2e107cb5aafcb7787b",
+					Source:      "docker://localhost:9999/redhat/redhat-operator-index:94563f14d54e0ea1d600fa8c002c204b",
 					Destination: "docker://localhost:5000/test/redhat/redhat-operator-index:v4.14",
 					Origin:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.14",
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "6566d78129230a2e107cb5aafcb7787b",
+					RebuiltTag:  "94563f14d54e0ea1d600fa8c002c204b",
 				},
 			},
 		},
@@ -599,11 +604,11 @@ func TestFilterCollectorD2M(t *testing.T) {
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
-					Source:      "docker://localhost:9999/test-catalog:9fadc6c70adb4b2571f66f674a876279",
+					Source:      "docker://localhost:9999/test-catalog:eaf28fd0a9f205e44fb52a8b0bd8e678",
 					Destination: "docker://localhost:5000/test/test-catalog:v4.14",
 					Origin:      "oci://" + filepath.Join(testDir, "simple-test-bundle"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "9fadc6c70adb4b2571f66f674a876279",
+					RebuiltTag:  "eaf28fd0a9f205e44fb52a8b0bd8e678",
 				},
 			},
 		},
@@ -701,87 +706,87 @@ func TestFilterCollectorM2M(t *testing.T) {
 					Type:        v2alpha1.TypeInvalid,
 				},
 				{
-					Source:      "docker://registry.redhat.io/redhat/community-operator-index:v4.18",
+					Source:      "docker://registry.redhat.io/redhat/community-operator-index@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Destination: "docker://localhost:9999/redhat/community-operator-index:v4.18",
-					Origin:      "docker://registry.redhat.io/redhat/community-operator-index:v4.18",
+					Origin:      "docker://registry.redhat.io/redhat/community-operator-index@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeOperatorCatalog,
 				},
 				{
-					Source:      "docker://registry.redhat.io/redhat/community-operator-index:v4.18",
+					Source:      "docker://registry.redhat.io/redhat/community-operator-index@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Destination: "docker://localhost:5000/test/redhat/community-operator-index:v4.18",
-					Origin:      "docker://registry.redhat.io/redhat/community-operator-index:v4.18",
+					Origin:      "docker://registry.redhat.io/redhat/community-operator-index@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeOperatorCatalog,
 				},
 				{
-					Source:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.17",
+					Source:      "docker://registry.redhat.io/redhat/redhat-operator-index@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Destination: "docker://localhost:9999/redhat/redhat-filtered-index:v4.17",
-					Origin:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.17",
+					Origin:      "docker://registry.redhat.io/redhat/redhat-operator-index@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "08a5610c0e6f72fd34b1c76d30788c66",
+					RebuiltTag:  "b6db5253b0a8b995840d4d6b5a8aefca",
 				},
 				{
-					Source:      "docker://registry.redhat.io/redhat/certified-operators:v4.17",
+					Source:      "docker://registry.redhat.io/redhat/certified-operators@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Destination: "docker://localhost:9999/redhat/certified-operators-pinned:v4.17.0-20241114",
-					Origin:      "docker://registry.redhat.io/redhat/certified-operators:v4.17",
+					Origin:      "docker://registry.redhat.io/redhat/certified-operators@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "65af60f894902a1758a30ae262c0e39e",
+					RebuiltTag:  "37e8b17cf0089fb1de93893cfb41dbfb",
 				},
 				{
 					Source:      "oci://" + filepath.Join(testDir, "catalog-on-disk1"),
 					Destination: "docker://localhost:9999/catalog-on-disk1:latest",
 					Origin:      "oci://" + filepath.Join(testDir, "catalog-on-disk1"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "fc2e113a1d6f0dbe89bd2bc5c83886e3",
+					RebuiltTag:  "bff06b6d6cc99438ad7a080e38025b52",
 				},
 				{
 					Source:      "oci://" + filepath.Join(testDir, "catalog-on-disk2"),
 					Destination: "docker://localhost:9999/coffee-shop-index:latest",
 					Origin:      "oci://" + filepath.Join(testDir, "catalog-on-disk2"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "421035ded2cb0e83f50ee6445b1466a5",
+					RebuiltTag:  "04a29cd46d562afadfa317467451756e",
 				},
 				{
 					Source:      "oci://" + filepath.Join(testDir, "catalog-on-disk3"),
 					Destination: "docker://localhost:9999/tea-shop-index:v3.14",
 					Origin:      "oci://" + filepath.Join(testDir, "catalog-on-disk3"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "d81a7ad49cabfc8aa050edaf56f25a3f",
+					RebuiltTag:  "4b3bae8f9360ced2d4a4473d5481cc9f",
 				},
 
 				{
-					Source:      "docker://localhost:9999/redhat/redhat-filtered-index:08a5610c0e6f72fd34b1c76d30788c66",
+					Source:      "docker://localhost:9999/redhat/redhat-filtered-index:b6db5253b0a8b995840d4d6b5a8aefca",
 					Destination: "docker://localhost:5000/test/redhat/redhat-filtered-index:v4.17",
-					Origin:      "docker://registry.redhat.io/redhat/redhat-operator-index:v4.17",
+					Origin:      "docker://registry.redhat.io/redhat/redhat-operator-index@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "08a5610c0e6f72fd34b1c76d30788c66",
+					RebuiltTag:  "b6db5253b0a8b995840d4d6b5a8aefca",
 				},
 				{
-					Source:      "docker://localhost:9999/redhat/certified-operators-pinned:65af60f894902a1758a30ae262c0e39e",
+					Source:      "docker://localhost:9999/redhat/certified-operators-pinned:37e8b17cf0089fb1de93893cfb41dbfb",
 					Destination: "docker://localhost:5000/test/redhat/certified-operators-pinned:v4.17.0-20241114",
-					Origin:      "docker://registry.redhat.io/redhat/certified-operators:v4.17",
+					Origin:      "docker://registry.redhat.io/redhat/certified-operators@sha256:f30638f60452062aba36a26ee6c036feead2f03b28f2c47f2b0a991e41baebea",
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "65af60f894902a1758a30ae262c0e39e",
+					RebuiltTag:  "37e8b17cf0089fb1de93893cfb41dbfb",
 				},
 				{
-					Source:      "docker://localhost:9999/catalog-on-disk1:fc2e113a1d6f0dbe89bd2bc5c83886e3",
+					Source:      "docker://localhost:9999/catalog-on-disk1:bff06b6d6cc99438ad7a080e38025b52",
 					Destination: "docker://localhost:5000/test/catalog-on-disk1:latest",
 					Origin:      "oci://" + filepath.Join(testDir, "catalog-on-disk1"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "fc2e113a1d6f0dbe89bd2bc5c83886e3",
+					RebuiltTag:  "bff06b6d6cc99438ad7a080e38025b52",
 				},
 				{
-					Source:      "docker://localhost:9999/coffee-shop-index:421035ded2cb0e83f50ee6445b1466a5",
+					Source:      "docker://localhost:9999/coffee-shop-index:04a29cd46d562afadfa317467451756e",
 					Destination: "docker://localhost:5000/test/coffee-shop-index:latest",
 					Origin:      "oci://" + filepath.Join(testDir, "catalog-on-disk2"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "421035ded2cb0e83f50ee6445b1466a5",
+					RebuiltTag:  "04a29cd46d562afadfa317467451756e",
 				},
 				{
-					Source:      "docker://localhost:9999/tea-shop-index:d81a7ad49cabfc8aa050edaf56f25a3f",
+					Source:      "docker://localhost:9999/tea-shop-index:4b3bae8f9360ced2d4a4473d5481cc9f",
 					Destination: "docker://localhost:5000/test/tea-shop-index:v3.14",
 					Origin:      "oci://" + filepath.Join(testDir, "catalog-on-disk3"),
 					Type:        v2alpha1.TypeOperatorCatalog,
-					RebuiltTag:  "d81a7ad49cabfc8aa050edaf56f25a3f",
+					RebuiltTag:  "4b3bae8f9360ced2d4a4473d5481cc9f",
 				},
 			},
 		},
@@ -792,6 +797,10 @@ func TestFilterCollectorM2M(t *testing.T) {
 			ex.Opts.Mode = mirror.MirrorToMirror
 			ex.Opts.Destination = "docker://localhost:5000/test"
 			ex = ex.withConfig(testCase.config)
+
+			// OCPBUGS-81712: Pin catalogs to digest before collection (matches real M2M flow)
+			ex.Config = config.PinCatalogDigests(ctx, ex.Config, ex.Manifest, &ex.Opts, ex.Log)
+
 			res, err := ex.OperatorImageCollector(ctx)
 			if testCase.expectedError {
 				assert.Error(t, err)


### PR DESCRIPTION
# Description

This PR fixes a race condition where operator catalog tags can resolve to different digests between collection and mirroring phases, causing diskToMirror failures in air-gapped environments.

**Root cause:** If Red Hat updates a catalog between collection (creates working-dir structure) and mirroring (creates tarball), the working-dir is structured for one digest but the tarball contains another. During D2M, oc-mirror cannot find the filtered catalog because the filter digest hash differs between M2D (created with one digest) and D2M (looking with another).

**Solution:** Pin all catalog digests during Complete() initialization, before collectors are created. This ensures consistent digest usage throughout collection and mirroring. For D2M, the findFilterDigest() fallback logic locates cached filtered catalogs even when the ISC has tags instead of digests.

Github / Jira issue: [OCPBUGS-88030](https://issues.redhat.com/browse/OCPBUGS-88030)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

## Unit Tests
- All existing operator tests pass (TestFilterCollectorM2D, TestFilterCollectorD2M, TestFilterCollectorM2M)
- Added 13 new tests in pin_catalogs_test.go covering:
  - PinCatalogDigests with various catalog types (docker, OCI, mixed)
  - pinSingleCatalogDigest with valid/invalid catalogs
  - copyISC for deep copy verification
- Updated filtered_collector_test.go expectations to match digest-based hashes

## Integration Testing
The fix enables the following workflow:
1. M2D with internet: Creates tar with filtered catalogs
2. D2M without internet: Successfully finds and uses cached filtered catalogs via findFilterDigest() fallback

## Key Changes Tested
- Catalog pinning converts tags to digests in M2D/M2M modes
- OCI catalogs are correctly skipped during pinning
- digestOfFilter() normalization works for docker-based catalogs
- findFilterDigest() fallback locates legacy (tag-based) filtered catalogs
- RebuiltTag values match release-4.22 expectations

## Expected Outcome

**Before fix:**
- D2M fails with "dial tcp: lookup registry.redhat.io: Temporary failure in name resolution"
- Cannot find filtered catalogs created during M2D

**After fix:**
- D2M successfully locates filtered catalogs via findFilterDigest() fallback
- Works in air-gapped environments without internet access
- Consistent behavior with release-4.22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Operator catalogs are now automatically pinned to immutable SHA256 digests during mirror operations, improving reproducibility and reliability when mirroring content.

* **Tests**
  * Added comprehensive test coverage for catalog digest pinning functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->