### PR TITLE
CLID-663: Create Dockerfile.konflux for konflux release pipeline

### DIFF
--- a/images/cli/Dockerfile.art
+++ b/images/cli/Dockerfile.art
@@ -45,7 +45,5 @@ COPY --from=test-extension-builder /go/src/github.com/openshift/oc-mirror/tests/
 
 LABEL io.k8s.display-name="oc-mirror" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
-      io.openshift.tags="openshift,cli,mirror" \
-      # We're not really an operator, we're just getting some data into the release image.
-      io.openshift.release.operator=true
+      io.openshift.tags="openshift,cli,mirror"
 ENTRYPOINT ["/usr/bin/oc-mirror"]

--- a/images/cli/Dockerfile.ci
+++ b/images/cli/Dockerfile.ci
@@ -33,7 +33,5 @@ COPY --from=test-extension-builder /go/src/github.com/openshift/oc-mirror/tests/
 
 LABEL io.k8s.display-name="oc-mirror" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
-      io.openshift.tags="openshift,cli,mirror" \
-      # We're not really an operator, we're just getting some data into the release image.
-      io.openshift.release.operator=true
+      io.openshift.tags="openshift,cli,mirror"
 ENTRYPOINT ["/usr/bin/oc-mirror"]

--- a/images/cli/Dockerfile.konflux
+++ b/images/cli/Dockerfile.konflux
@@ -1,0 +1,37 @@
+# Dockerfile for the Konflux CDN release pipeline: builds oc-mirror binaries for RHEL 8/9,
+# packages them as compressed tarballs in /releases/ for push-artifacts-to-cdn.
+
+# Stage 1: Build and compress RHEL 8 binary
+FROM registry.access.redhat.com/ubi8/go-toolset:1.24 AS builder_rhel8
+WORKDIR /go/src/github.com/openshift/oc-mirror
+COPY . .
+RUN make build && \
+    mkdir -p /output && \
+    GOARCH=$(go env GOARCH) && \
+    tar -czf /output/oc-mirror-rhel8-linux-${GOARCH}.tar.gz -C bin oc-mirror
+
+# Stage 2: Build and compress RHEL 9 binary
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder_rhel9
+WORKDIR /go/src/github.com/openshift/oc-mirror
+COPY . .
+RUN make build && \
+    mkdir -p /output && \
+    GOARCH=$(go env GOARCH) && \
+    tar -czf /output/oc-mirror-rhel9-linux-${GOARCH}.tar.gz -C bin oc-mirror
+
+# Stage 3: Final delivery image for push-artifacts-to-cdn
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN mkdir -p /releases/
+COPY --from=builder_rhel8 /output/ /releases/
+COPY --from=builder_rhel9 /output/ /releases/
+
+# Required EC Metadata Labels
+LABEL vendor="Red Hat, Inc." \
+      name="oc-mirror" \
+      com.redhat.component="oc-mirror" \
+      version="1.0.0" \
+      release="1" \
+      summary="oc-mirror CLI tool transport container" \
+      description="OpenShift is a platform for developing, building, and deploying containerized applications." \
+      io.k8s.display-name="oc-mirror" \
+      io.openshift.tags="openshift,cli,mirror"

--- a/images/cli/Dockerfile.konflux
+++ b/images/cli/Dockerfile.konflux
@@ -2,7 +2,7 @@
 # packages them as compressed tarballs in /releases/ for push-artifacts-to-cdn.
 
 # Stage 1: Build and compress RHEL 8 binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.24 AS builder_rhel8
+FROM registry.access.redhat.com/ubi8/go-toolset:1.26 AS builder_rhel8
 WORKDIR /go/src/github.com/openshift/oc-mirror
 COPY . .
 RUN make build && \


### PR DESCRIPTION
# Description

Creates Dockerfile.konflux for konflux release pipeline consumption as part of our transition out of the release payload. See the linked jira issue for more info. 

Also removes the `operator=true` from our .art Dockerfile. 

Github / Jira issue: https://redhat.atlassian.net/browse/CLID-663 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container image metadata labels to improve compatibility and standardize formatting, including clearer tag presentation and removal of operator-specific label/comment from the final image metadata.
* **New Features**
  * Added a Konflux CDN build pipeline for `oc-mirror` that generates release artifacts compatible with both UBI8 and UBI9, packaging the resulting binaries into final release-ready container outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->