### PR TITLE
CLID-632: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,94 +1,94 @@
-# oc-mirror v2
+# oc-mirror
 
-oc-mirror v2 is a command line tool to mirror Openshift Container Platform (OCP) Release, operator catalog and additional images.
+`oc-mirror` is an OpenShift CLI tool for mirroring container images to disconnected and partially disconnected environments.
 
-The command line uses a declarative configuration file as the input to discover from where to get the container images and copy them to a container registry.
+It reads a declarative `ImageSetConfiguration` to discover OpenShift release payloads, operator catalogs, Helm charts, and additional container images, then copies them to a target mirror registry or local archive.
 
-There are three workflows available in oc-mirror currently:
+- [oc-mirror](#oc-mirror)
+  - [Overview](#overview)
+    - [Destination prefixes](#destination-prefixes)
+    - [Authentication](#authentication)
+  - [Quick Start](#quick-start)
+    - [Prerequisites](#prerequisites)
+    - [Build](#build)
+  - [Usage](#usage)
+    - [Image Set Configuration](#image-set-configuration)
+    - [Mirror to Disk](#mirror-to-disk)
+    - [Disk to Mirror](#disk-to-mirror)
+    - [Mirror to Mirror](#mirror-to-mirror)
+    - [Delete Subcommand](#delete-subcommand)
+      - [Delete Image Set Configuration](#delete-image-set-configuration)
+      - [Delete Phase 1](#delete-phase-1)
+      - [Delete Phase 2](#delete-phase-2)
+    - [List Subcommand](#list-subcommand)
+      - [List releases](#list-releases)
+      - [List operators](#list-operators)
+  - [Flags Reference](#flags-reference)
+    - [Global flags](#global-flags)
+    - [Mirror command flags](#mirror-command-flags)
+    - [Delete subcommand flags](#delete-subcommand-flags)
+    - [List subcommand flags](#list-subcommand-flags)
+      - [`list releases`](#list-releases-1)
+      - [`list operators`](#list-operators-1)
+  - [Features](#features)
+    - [Cluster Resources](#cluster-resources)
+    - [Catalog Pinning](#catalog-pinning)
+    - [Additional Feature Documentation](#additional-feature-documentation)
+  - [Repository Guidance](#repository-guidance)
+  - [Security](#security)
+  - [License](#license)
 
-- `mirrorToDisk` (`m2d` for shorter) - pulls the container images from a source specified in the image set configuration and packs them into a tar archive on disk (local directory).
-- `diskToMirror` (`d2m` for shorter) - copy the containers images from the tar archive to a container registry.
-- `mirrorToMirror` (`m2m` for shorter) - copy the container images from the source specified in the image set configuration to the destination (container registry).
+## Overview
 
-The workflows `m2d` and `d2m` are used together for fully disconnected scenarios, where `m2d` requires internet access to pull the images and `d2m` runs without internet access (Note: for enclave scenario `m2d` does not need internet access by changing registries.conf file).
+Three mirroring workflows are available:
 
-The workflow `m2m` is used for partially disconnected scenario, the machine running the workflow has internet access and also access to the disconnected environment (target container registry).
+| Workflow | Short name | Description |
+|----------|-----------|-------------|
+| Mirror to Disk | `m2d` | Pull images from source registries and pack them into a tar archive on disk. |
+| Disk to Mirror | `d2m` | Unpack a tar archive and push images to a target container registry. |
+| Mirror to Mirror | `m2m` | Copy images directly from source registries to a target container registry. |
 
-When specifying the destination on the command line, there are two prefixes available:
+**Mirror to Disk** and **Disk to Mirror** are used together for fully air-gapped environments. `m2d` runs on a machine with internet access to create the archive, then `d2m` runs in the disconnected environment to push images to the local registry. For enclave scenarios, `m2d` can also pull from an internal registry using a `registries.conf` file.
 
-- `file://<destination location>` - used in `m2d`: destination is a local directory where the tar archive will be stored.
-- `docker://<destination location>` - used in `d2m` and `m2m`: destination is a container registry.
+**Mirror to Mirror** is used for partially disconnected environments where the machine running the tool has access to both the internet and the target registry.
 
-The default podman credentials location (`$XDG_RUNTIME_DIR/containers/auth.json`) is used for authenticating to the container registries. The docker location `~/.docker/config.json` for credentials is also supported as a secondary location.
+### Destination prefixes
 
-**IMPORTANT**: The oc-mirror v1 was deprecated in OCP 4.18 (v1 README [here](v1/README_v1.md)) and will be removed in a future release.
+When specifying the destination on the command line:
 
-## Table of contents
-* [Getting Started](#getting-started)
-    * [Prerequisites](#prerequisites)
-    * [Clone the repository](#clone-the-repository)
-    * [Building](#building)
-* [Using the application](#using-the-application)
-    * [oc-mirror command](#oc-mirror-command)
-        * [Creating the Image Set Configuration](#creating-the-image-set-configuration)
-        * [Mirror To Disk](#mirror-to-disk)
-        * [Disk To Mirror](#disk-to-mirror)
-        * [Mirror To Mirror](#mirror-to-mirror)
-        * [Cluster Resources](#cluster-resources)
-    * [Delete sub command](#delete-sub-command)
-        * [Creating the Delete Image Set Configuration](#creating-the-delete-image-set-configuration)
-        * [Delete Phase 1 (--generate)](#delete-phase-1)
-        * [Delete Phase 2 ](#delete-phase-2)
-    * [Other Features](#other-features)
-* [Testing](#testing)
-* [Development](#development)
-  * [Architecture](#architecture)
-  * [Code Source Documentation - Only for oc-mirror v2 developers](#code-source-documentation-only-for-oc-mirror-v2-developers)
-* [Built with](#built-with)
+- `file://<path>` — local directory for the tar archive (used with `m2d`)
+- `docker://<registry>` — container registry (used with `d2m` and `m2m`)
 
-## Getting Started
-These instructions will provide a copy of the source code. After following these steps it will be possible to start using the command line tool.
+### Authentication
+
+The default podman credentials location (`$XDG_RUNTIME_DIR/containers/auth.json`) is used for authenticating to container registries. The Docker location (`~/.docker/config.json`) is also supported as a fallback.
+
+> **Note:** oc-mirror v1 was deprecated in OCP 4.18 and will be removed in a future release. The v1 README is available [here](v1/README_v1.md).
+
+## Quick Start
 
 ### Prerequisites
 
-```
 - Git
-- Golang
-```
+- Go (see `go.mod` for minimum version)
 
-### Clone the repository
+### Build
 
-```
+```bash
 git clone https://github.com/openshift/oc-mirror.git
-```
-
-### Building
-Building the `oc-mirror` binary is the first step and it is possible to build it with the following command from this (`oc-mirror/`) directory:
-
-```
-make clean
-make tidy
+cd oc-mirror
 make build
 ```
 
-After performing the steps above a new file (`oc-mirror`) will appear in the `bin/` folder.
+The binary is created at `bin/oc-mirror`. You can use oc-mirror as an `oc` plugin by placing the binary in a directory on your `$PATH`.
 
-NOTE: it is possible to use oc-mirror as a plugin of Openshift Client (oc) by placing the oc-mirror binary in a directory specified in $PATH.
+## Usage
 
-## Using the application
-After building the binary in the previous step, it is possible to run the `oc-mirror` command and the `oc-mirror delete` sub command.
+### Image Set Configuration
 
-### oc-mirror command
-The oc-mirror command copies container images specified in the Image Set Configuration from source to destination.
+The Image Set Configuration (`ImageSetConfiguration`) is the declarative input that tells oc-mirror what to mirror. Pass it with the `-c` or `--config` flag.
 
-Three workflows are available with this command: `m2d`, `d2m` and `m2m`.
-
-### Creating the Image Set Configuration
-The Image Set Configuration is the input file for the oc-mirror command (using the flag `-c` or `--config`).
-
-Here is an example of the Image Set Configuration for reference. More examples can be found [here](docs/image-set-examples/).
-
-```
+```yaml
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
 mirror:
@@ -105,8 +105,7 @@ mirror:
        - name: 3scale-operator
        - name: node-observability-operator
   additionalImages:
-   - name: quay.io/rh_ee_aguidi/multi-platform-container:latest
-   - name: quay.io/rh_ee_aguidi/empty-image:latest
+   - name: registry.redhat.io/ubi9/ubi:latest
   helm:
     repositories:
       - name: cosigned
@@ -115,76 +114,42 @@ mirror:
           - name: cosigned
             version: 0.1.23
     local:
-     - name: helm-empty-image
-       path: /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/helm-empty-image
+     - name: my-local-chart
+       path: /path/to/local/chart
 ```
 
-#### Mirror To Disk
-```
-./bin/oc-mirror -c ./isc.yaml file:///home/<user>/oc-mirror/mirror1 --v2
-```
- 
-#### Disk To Mirror
-```
-./bin/oc-mirror -c ./isc.yaml --from file:///home/<user>/oc-mirror/mirror1 docker://localhost:6000 --v2
-```
- 
-#### Mirror To Mirror
-```
-./bin/oc-mirror -c ./isc.yaml --workspace file:///home/<user>/oc-mirror/mirror1 docker://localhost:6000 --v2
+More examples can be found in the [image set examples](docs/image-set-examples/) directory.
+
+### Mirror to Disk
+
+```bash
+oc-mirror -c ./isc.yaml file:///home/<user>/oc-mirror/mirror1 --v2
 ```
 
-`oc-mirror` has a set of flags to control its behavior.
+### Disk to Mirror
 
-```
-      --authfile string                path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json
-      --cache-dir string               oc-mirror cache directory location. Default is $HOME
-  -c, --config string                  Path to imageset configuration file
-      --dest-tls-verify                require HTTPS and verify certificates when talking to the container registry or daemon (default true)
-      --dry-run                        Print actions without mirroring images
-      --from string                    Local storage directory for disk to mirror workflow
-  -h, --help                           help for oc-mirror
-      --image-timeout duration         Timeout for mirroring an image (default 10m0s)
-      --log-level string               Log level one of (info, debug, trace, error) (default "info")
-      --max-nested-paths int           Number of nested paths, for destination registries that limit nested paths
-      --parallel-images uint           Indicates the number of images mirrored in parallel (default 8)
-      --parallel-layers uint           Indicates the number of image layers mirrored in parallel (default 10)
-      --policy string                  Path to a trust policy file
-  -p, --port uint16                    HTTP port used by oc-mirror's local storage instance (default 55000)
-      --registries.d DIR               use registry configuration files in DIR (e.g. for container signature storage)
-      --remove-signatures              Do not copy image signature (default false)
-      --retry-delay duration           delay between 2 retries (default 1s)
-      --retry-times int                the number of times to possibly retry (default 2)
-      --rootless-storage-path string   Override the default container rootless storage path (usually in etc/containers/storage.conf)
-      --secure-policy                  If set, will enable signature verification (secure policy for signature verification)
-      --since string                   Include all new content since specified date (format yyyy-MM-dd). When not provided, new content since previous mirroring is mirrored
-      --src-tls-verify                 require HTTPS and verify certificates when talking to the container registry or daemon (default true)
-      --strict-archive                 If set, generates archives that are strictly less than archiveSize (set in the imageSetConfig). Mirroring will exit in error if a file being archived exceed archiveSize(GB)
-  -v, --version                        version for oc-mirror
-      --workspace string               oc-mirror workspace where resources and internal artifacts are generated
+```bash
+oc-mirror -c ./isc.yaml --from file:///home/<user>/oc-mirror/mirror1 docker://localhost:6000 --v2
 ```
 
-#### Cluster Resources
-In the end of a successful `d2m` or `m2m` workflow, cluster resources will be generated under `/home/<user>/oc-mirror/mirror1/working-dir/cluster-resources`. It is needed to apply these cluster resources on the openshift cluster so the cluster can pull the container images from the right container registry. The cluster resources generated by oc-mirror are:
+### Mirror to Mirror
 
-* ImageDigestMirrorSet (IDMS)
-* ImageTagMirrorSet (ITMS)
-* CatalogSource
-* ClusterCatalog
-* UpdateService (Used by OpenShift Update Service - OSUS)
-
-### Delete sub command
-
-There is also a `delete` sub command to delete images specified in the Delete Image Set Configuration from a remote registry. This command is split in two phases:
-
-- Phase 1: using a delete image set configuration as an input, oc-mirror discovers all images that needed to be deleted. These images are included in a delete-images file to be consumed as input in the second phase.
-- Phase 2: using the file generated in first phase, oc-mirror will delete all container image manifests specified on this file on the destination specified in the command line. It is up to the container registry to run the garbage collector to clean up all the blobs which are not referenced by a manifest. Deleting only manifests is safer since blobs shared between more than one image are not going to be deleted.
-
-For more details about the delete feature can be found [here](docs/features/delete-functionality.md).
-
-### Creating the Delete Image Set Configuration
-
+```bash
+oc-mirror -c ./isc.yaml --workspace file:///home/<user>/oc-mirror/mirror1 docker://localhost:6000 --v2
 ```
+
+### Delete Subcommand
+
+The `delete` subcommand removes images from a remote registry. It operates in two phases:
+
+1. **Phase 1 (`--generate`):** Discovers all images to delete based on a `DeleteImageSetConfiguration` and writes them to a YAML file.
+2. **Phase 2:** Reads the generated YAML file and deletes the image manifests from the target registry. The registry's garbage collector is responsible for cleaning up unreferenced blobs.
+
+For full details, see [Delete Functionality](docs/features/delete-functionality.md).
+
+#### Delete Image Set Configuration
+
+```yaml
 kind: DeleteImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
 delete:
@@ -201,91 +166,168 @@ delete:
        - name: 3scale-operator
        - name: node-observability-operator
   additionalImages:
-   - name: quay.io/rh_ee_aguidi/multi-platform-container:latest
-   - name: quay.io/rh_ee_aguidi/empty-image:latest
-  helm:
-    repositories:
-      - name: cosigned
-        url: https://sigstore.github.io/helm-charts
-        charts:
-          - name: cosigned
-            version: 0.1.23
-    local:
-     - name: helm-empty-image
-       path: /home/aguidi/go/src/github.com/aguidirh/oc-mirror/alex-tests/helm-empty-image
+   - name: registry.redhat.io/ubi9/ubi:latest
 ```
-
 
 #### Delete Phase 1
-```
-./bin/oc-mirror delete -c ./delete-isc.yaml --generate --workspace file:///home/<user>/oc-mirror/delete1 --delete-id delete1-test docker://localhost:6000 --v2
+
+```bash
+oc-mirror delete -c ./delete-isc.yaml --generate --workspace file:///home/<user>/oc-mirror/delete1 --delete-id delete1-test docker://localhost:6000 --v2
 ```
 
 #### Delete Phase 2
-```
-./bin/oc-mirror delete --delete-yaml-file /home/<user>/oc-mirror/delete1/working-dir/delete/delete-images-delete1-test.yaml docker://localhost:6000 --v2
-```
 
-The `delete` sub-command has its own set of flags:
-
-```
-      --delete-id string          Used to differentiate between versions for files created by the delete functionality
-      --delete-signatures         Used to delete the container image signatures, for multi arch images, it deletes only the manifest list signature
-      --delete-v1-images          Used during the migration, along with --generate, in order to target images previously mirrored with oc-mirror v1
-      --delete-yaml-file string   If set will use the generated or updated yaml file to delete contents
-      --force-cache-delete        Used to force delete  the local cache manifests and blobs
-      --generate                  Used to generate the delete yaml for the list of manifests and blobs , used in the step to actually delete from local cache and remote registry
-  -h, --help                      help for delete
+```bash
+oc-mirror delete --delete-yaml-file /home/<user>/oc-mirror/delete1/working-dir/delete/delete-images-delete1-test.yaml docker://localhost:6000 --v2
 ```
 
-### Other Features
-* [Enclave support](docs/features/enclave_support.md)
+### List Subcommand
 
-#### Catalog Pinning
+The `list` subcommand queries available platform releases and operator content without mirroring anything.
 
-When running mirror-to-disk or mirror-to-mirror workflows, oc-mirror automatically generates pinned configuration files where operator catalogs are referenced by SHA256 digests instead of tags. This ensures reproducible mirroring operations since digest references always point to the exact same image content, while tag-based references can change over time.
+#### List releases
 
-Two files are generated in the working directory: `isc_pinned_{timestamp}.yaml` contains a pinned ImageSetConfiguration with catalogs referenced by digest, and `disc_pinned_{timestamp}.yaml` contains a corresponding DeleteImageSetConfiguration. The pinned ISC can be used for reproducible mirrors of the exact same content, while the pinned DISC can be used later with the delete sub-command to remove precisely what was mirrored.
+```bash
+# List all available OpenShift release versions
+oc-mirror --v2 list releases
 
-## Testing
-It is possible to run in this module unit tests.
+# List releases for a specific version
+oc-mirror --v2 list releases --version=4.18
 
-To run the unit tests run the following command from this directory:
+# List releases in a specific channel
+oc-mirror --v2 list releases --channel=stable-4.18
 
-```
-make test-unit
-```
+# List releases filtered by architecture (valid: amd64, arm64, ppc64le, s390x, multi)
+oc-mirror --v2 list releases --channel=fast-4.18 --version=4.18 --filter-by-archs amd64,arm64
 
-It is also possible to see all the lines coverage by the unit tests generating an HTML using the following command (it will create a file called `cover.html` in the `v2/tests/results` folder):
-
-```
-make v2cover
-```
-
-## Development
-This section will give an overview about oc-mirror v2 architecture and how to generate docs from oc-mirror source code.
-
-### Architecture
-![Alt text](assets/architecture.png)
-
-### Code Source Documentation Only for oc-mirror v2 developers
-
-The module contains the documentation generated from the code. It means that all comments in packages, types, funcs, variables and constants will generate documentation in HTML.
-
-**Install the godoc**
-```
-go install golang.org/x/tools/cmd/godoc
+# List all channels for a specific version
+oc-mirror --v2 list releases --channels --version=4.18
 ```
 
-**Run the command below **
+#### List operators
+
+```bash
+# List available catalogs for an OpenShift version
+oc-mirror --v2 list operators --catalogs --version=4.18
+
+# List all packages in a catalog
+oc-mirror --v2 list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18
+
+# List all channels for a package
+oc-mirror --v2 list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --package=aws-load-balancer-operator
+
+# List versions in a specific channel
+oc-mirror --v2 list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --package=aws-load-balancer-operator --channel=stable-v1
 ```
-godoc -http=:6060
+
+## Flags Reference
+
+### Global flags
+
+```
+      --authfile string                path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json
+      --cache-dir string               oc-mirror cache directory location. Default is $HOME
+  -c, --config string                  Path to imageset configuration file
+      --dest-tls-verify                require HTTPS and verify certificates when talking to the container registry or daemon (default true)
+      --log-level string               Log level one of (info, debug, trace, error) (default "info")
+      --parallel-images uint           Number of images mirrored in parallel (default 4)
+      --parallel-layers uint           Number of image layers mirrored in parallel (default 5)
+      --policy string                  Path to a trust policy file
+  -p, --port uint16                    HTTP port used by oc-mirror's local storage instance (default 55000)
+      --registries.d DIR               use registry configuration files in DIR (e.g. for container signature storage)
+      --retry-delay duration           delay between retries (default 0 uses exponential backoff, set value uses constant delay)
+      --retry-times int                the number of times to possibly retry (default 5)
+      --src-tls-verify                 require HTTPS and verify certificates when talking to the container registry or daemon (default true)
+      --workspace string               oc-mirror workspace where resources and internal artifacts are generated
+  -v, --version                        version for oc-mirror
+  -h, --help                           help for oc-mirror
 ```
 
-**View docs**
+### Mirror command flags
 
-Open godocs [here](http://localhost:6060/pkg/github.com/openshift/oc-mirror/?m=all) while the command above is still running.
+```
+      --dry-run                        Print actions without mirroring images
+      --dry-run-manifest-lists         Like --dry-run, but also includes manifest list sub-digests in mapping.txt (implies --dry-run)
+      --from string                    Local storage directory for disk to mirror workflow
+      --ignore-release-signature       Ignore release signature
+      --image-timeout duration         Timeout for mirroring an image (default 10m0s)
+      --max-nested-paths int           Number of nested paths, for destination registries that limit nested paths
+      --remove-signatures              Do not copy image signatures
+      --rootless-storage-path string   Override the default container rootless storage path
+      --secure-policy                  Enable signature verification (secure policy for signature verification)
+      --since string                   Include all new content since specified date (format yyyy-MM-dd)
+      --strict-archive                 Generate archives strictly less than archiveSize (set in the ImageSetConfiguration)
+```
 
+### Delete subcommand flags
 
-## Built with
-* [Golang](https://go.dev) - Programming Language
+```
+      --delete-id string          Identifier to differentiate between versions of delete output files
+      --delete-signatures         Delete container image signatures (for multi-arch, deletes only the manifest list signature)
+      --delete-v1-images          Target images previously mirrored with oc-mirror v1 (used with --generate)
+      --delete-yaml-file string   Path to the generated or updated YAML file for deleting contents
+      --force-cache-delete        Force delete local cache manifests and blobs
+      --generate                  Generate the delete YAML listing manifests and blobs to delete
+```
+
+### List subcommand flags
+
+#### `list releases`
+
+```
+      --channel string            List information for a specific channel (defaults to stable)
+      --channels                  List all channel information (requires --version)
+      --filter-by-archs strings   Architecture filter for release images (default [amd64])
+      --version string            OpenShift release version
+```
+
+#### `list operators`
+
+```
+      --catalog string   List information for a specified catalog
+      --catalogs         List available catalogs for an OpenShift release version (requires --version)
+      --channel string   List information for a specified channel (requires --catalog and --package)
+      --package string   List information for a specified package (requires --catalog)
+      --version string   OpenShift release version
+```
+
+## Features
+
+### Cluster Resources
+
+After a successful `d2m` or `m2m` workflow, oc-mirror generates cluster resources that must be applied to the OpenShift cluster so it can pull images from the mirror registry:
+
+- **ImageDigestMirrorSet (IDMS)** — maps image digests to the mirror registry
+- **ImageTagMirrorSet (ITMS)** — maps image tags to the mirror registry
+- **CatalogSource** — registers mirrored operator catalogs with OLM
+- **ClusterCatalog** — registers mirrored catalogs for the cluster catalog framework
+- **UpdateService** — configures OpenShift Update Service (OSUS) for disconnected updates
+
+These resources are generated under `<workspace>/working-dir/cluster-resources`.
+
+### Catalog Pinning
+
+When running `m2d` or `m2m` workflows, oc-mirror automatically generates pinned configuration files where operator catalogs are referenced by SHA256 digest instead of tag. This ensures reproducible mirroring since digest references always resolve to the exact same image content.
+
+Two files are generated in the working directory:
+- `isc_pinned_{timestamp}.yaml` — pinned `ImageSetConfiguration` for reproducible re-mirrors
+- `disc_pinned_{timestamp}.yaml` — corresponding `DeleteImageSetConfiguration` for precise cleanup
+
+### Additional Feature Documentation
+
+- [Enclave Support](docs/features/enclave_support.md) — multi-stage mirroring through intermediate disconnected networks
+- [Signature Verification](docs/features/signature-verification.md) — verifying image signatures during mirroring
+- [Delete Functionality](docs/features/delete-functionality.md) — removing mirrored images from a registry
+
+## Repository Guidance
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — contributor workflow, development setup, testing, and PR guidelines
+- [ARCHITECTURE.md](ARCHITECTURE.md) — system design, component relationships, and data flow
+
+## Security
+
+If you find a security issue in this project, do **not** file it as a public GitHub issue. Instead, report it confidentially at https://access.redhat.com/security/team/contact.
+
+## License
+
+oc-mirror is licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
# Description

Update README.md, unifying the style and updating stale info.

Github / Jira issue: https://redhat.atlassian.net/browse/CLID-632

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [x] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

## Expected Outcome


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the main documentation to match the latest `oc-mirror` v2 structure and examples.
  * Refreshed quick start, authentication, destination prefix, and build/prerequisite guidance.
  * Revised configuration examples, including image set, disk/mirror workflows, delete flow, and list command usage.
  * Updated flag references and feature documentation for clearer command options and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->