### PR TITLE
Fix PreserveDigests for additionalImages in diskToMirror workflow

### DIFF
--- a/internal/pkg/batch/concurrent_chan_worker.go
+++ b/internal/pkg/batch/concurrent_chan_worker.go
@@ -143,6 +143,9 @@ func (o *ChannelConcurrentBatch) Worker(ctx context.Context, collectorSchema v2a
 								options.RemoveSignatures = true
 								options.PreserveDigests = false
 							}
+							if img.Type.IsAdditionalImage() && options.IsDiskToMirror() {
+								options.PreserveDigests = false
+							}
 
 							err = o.Mirror.Run(timeoutCtx, img.Source, img.Destination, mirror.Mode(opts.Function), &options) //nolint:contextcheck
 

--- a/internal/pkg/batch/concurrent_chan_worker_test.go
+++ b/internal/pkg/batch/concurrent_chan_worker_test.go
@@ -34,6 +34,7 @@ func TestOCPBUGS53455_RebuiltCatalogPreserveDigests(t *testing.T) {
 	tests := []struct {
 		name                     string
 		catalogImage             v2alpha1.CopyImageSchema
+		mode                     string
 		expectedPreserveDigests  bool
 		expectedRemoveSignatures bool
 		description              string
@@ -45,9 +46,10 @@ func TestOCPBUGS53455_RebuiltCatalogPreserveDigests(t *testing.T) {
 				Origin:      consts.DockerProtocol + "registry.redhat.io/redhat/redhat-operator-index:v4.17",
 				Destination: consts.DockerProtocol + "nexus:8082/redhat/redhat-operator-index:v4.17",
 				Type:        v2alpha1.TypeOperatorCatalog,
-				RebuiltTag:  "sha256-rebuilthash.tag", // This indicates a rebuilt catalog
+				RebuiltTag:  "sha256-rebuilthash.tag",
 			},
-			expectedPreserveDigests:  false, // CRITICAL: Must be false to allow format conversion
+			mode:                     mirror.MirrorToMirror,
+			expectedPreserveDigests:  false,
 			expectedRemoveSignatures: true,
 			description:              "Rebuilt catalogs need format conversion support for registries like Nexus",
 		},
@@ -58,9 +60,10 @@ func TestOCPBUGS53455_RebuiltCatalogPreserveDigests(t *testing.T) {
 				Origin:      consts.DockerProtocol + "registry.redhat.io/redhat/redhat-operator-index:v4.17",
 				Destination: consts.DockerProtocol + "nexus:8082/redhat/redhat-operator-index:v4.17",
 				Type:        v2alpha1.TypeOperatorCatalog,
-				RebuiltTag:  "", // Empty RebuiltTag means it's not rebuilt
+				RebuiltTag:  "",
 			},
-			expectedPreserveDigests:  true, // Default behavior
+			mode:                     mirror.MirrorToMirror,
+			expectedPreserveDigests:  true,
 			expectedRemoveSignatures: false,
 			description:              "Non-rebuilt catalogs should preserve digests",
 		},
@@ -73,6 +76,7 @@ func TestOCPBUGS53455_RebuiltCatalogPreserveDigests(t *testing.T) {
 				Type:        v2alpha1.TypeOperatorBundle,
 				RebuiltTag:  "",
 			},
+			mode:                     mirror.MirrorToMirror,
 			expectedPreserveDigests:  true,
 			expectedRemoveSignatures: false,
 			description:              "Operator bundles must preserve digests for signature verification",
@@ -86,9 +90,38 @@ func TestOCPBUGS53455_RebuiltCatalogPreserveDigests(t *testing.T) {
 				Type:        v2alpha1.TypeOperatorRelatedImage,
 				RebuiltTag:  "",
 			},
+			mode:                     mirror.MirrorToMirror,
 			expectedPreserveDigests:  true,
 			expectedRemoveSignatures: false,
 			description:              "Related images must preserve digests",
+		},
+		{
+			name: "Additional image in diskToMirror should have PreserveDigests=false",
+			catalogImage: v2alpha1.CopyImageSchema{
+				Source:      consts.DockerProtocol + "localhost:55000/prometheus/prometheus:latest",
+				Origin:      consts.DockerProtocol + "quay.io/prometheus/prometheus:latest",
+				Destination: consts.DockerProtocol + "nexus:8082/prometheus/prometheus:latest",
+				Type:        v2alpha1.TypeGeneric,
+				RebuiltTag:  "",
+			},
+			mode:                     mirror.DiskToMirror,
+			expectedPreserveDigests:  false,
+			expectedRemoveSignatures: false,
+			description:              "Additional images in diskToMirror need format conversion for multi-arch manifests",
+		},
+		{
+			name: "Additional image in mirrorToMirror should have PreserveDigests=true",
+			catalogImage: v2alpha1.CopyImageSchema{
+				Source:      consts.DockerProtocol + "quay.io/prometheus/prometheus:latest",
+				Origin:      consts.DockerProtocol + "quay.io/prometheus/prometheus:latest",
+				Destination: consts.DockerProtocol + "nexus:8082/prometheus/prometheus:latest",
+				Type:        v2alpha1.TypeGeneric,
+				RebuiltTag:  "",
+			},
+			mode:                     mirror.MirrorToMirror,
+			expectedPreserveDigests:  true,
+			expectedRemoveSignatures: false,
+			description:              "Additional images in mirrorToMirror should preserve digests",
 		},
 	}
 
@@ -112,7 +145,7 @@ func TestOCPBUGS53455_RebuiltCatalogPreserveDigests(t *testing.T) {
 				RetryOpts:           retryOpts,
 				Destination:         consts.DockerProtocol + "nexus:8082",
 				Dev:                 false,
-				Mode:                mirror.MirrorToMirror,
+				Mode:                tt.mode,
 				Function:            "copy",
 			}
 


### PR DESCRIPTION
# Description

Extends the `PreserveDigests=false` override to also apply to `additionalImages` (`TypeGeneric`) during the `diskToMirror` workflow.

During `mirrorToDisk`, the OCI layout write can change child manifest digests regardless of whether the source is Docker or OCI format — content normalization during the JSON round-trip (annotations, field ordering, whitespace) is enough to alter digests. The parent manifest list is rewritten with new digests, so the original digests no longer exist on disk. During `diskToMirror`, `containers/image`'s copy logic sees the manifest list format may need conversion, but `PreserveDigests=true` blocks any modification, causing the copy to fail.

This was partially fixed for operator catalogs in PR #1338 (OCPBUGS-73760) but the same fix was not applied to `additionalImages`.

Github / Jira issue: https://github.com/openshift/oc-mirror/issues/1466

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Added two new test cases to `TestOCPBUGS53455_RebuiltCatalogPreserveDigests` in `internal/pkg/batch/concurrent_chan_worker_test.go`:
  - `Additional image in diskToMirror should have PreserveDigests=false` — verifies the fix
  - `Additional image in mirrorToMirror should have PreserveDigests=true` — verifies no regression for direct mirror
- Added `mode` field to the test struct to allow per-case workflow mode testing
- All 6 test cases pass (4 existing + 2 new)
- `go vet` and `golangci-lint` pass with no new issues

## Expected Outcome

Multi-arch `additionalImages` mirror successfully through the `mirrorToDisk` → `diskToMirror` workflow without the `PreserveDigests` error.