### PR TITLE
[release-4.22] OCPBUGS-98716: Include index image sub-digests in dry run mapping.txt

### DIFF
--- a/internal/pkg/additional/local_stored_collector_test.go
+++ b/internal/pkg/additional/local_stored_collector_test.go
@@ -671,3 +671,7 @@ func (o MockManifest) ImageDigest(ctx context.Context, sourceCtx *types.SystemCo
 func (o MockManifest) ImageManifest(ctx context.Context, sourceCtx *types.SystemContext, imgRef string, instanceDigest *digest.Digest) ([]byte, string, error) {
 	return nil, "", nil
 }
+
+func (o MockManifest) GetManifestListDigests(ctx context.Context, sourceCtx *types.SystemContext, source string) ([]string, error) {
+	return nil, nil
+}

--- a/internal/pkg/cli/dryrun.go
+++ b/internal/pkg/cli/dryrun.go
@@ -6,24 +6,33 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
+
+	"go.podman.io/image/v5/types"
 
 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/consts"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/emoji"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/image"
 )
 
 func (o *ExecutorSchema) DryRun(ctx context.Context, allImages []v2alpha1.CopyImageSchema) error {
-	// set up location of logs dir
 	outDir := filepath.Join(o.Opts.Global.WorkingDir, dryRunOutDir)
-	// clean up logs directory
 	os.RemoveAll(outDir)
 
-	// create logs directory
 	err := o.MakeDir.makeDirAll(outDir, 0755)
 	if err != nil {
 		o.Log.Error(" %v ", err)
 		return err
 	}
-	// creating file for storing list of cached images
+
+	var manifestListDigests map[string][]string
+	if o.Opts.IsDryRunManifestLists {
+		o.Log.Info(emoji.LeftPointingMagnifyingGlass+" inspecting %d images for manifest lists...", len(allImages))
+		manifestListDigests = o.inspectManifestLists(ctx, allImages)
+	}
+
 	mappingTxtFilePath := filepath.Join(outDir, mappingFile)
 	mappingTxtFile, err := os.Create(mappingTxtFilePath)
 	if err != nil {
@@ -32,7 +41,7 @@ func (o *ExecutorSchema) DryRun(ctx context.Context, allImages []v2alpha1.CopyIm
 	defer mappingTxtFile.Close()
 	var buff bytes.Buffer
 	var missingImgsBuff bytes.Buffer
-	nbMissingImgs, nbAvailableImgs := o.processImages(ctx, allImages, &buff, &missingImgsBuff)
+	nbMissingImgs, nbAvailableImgs := o.processImages(ctx, allImages, manifestListDigests, &buff, &missingImgsBuff)
 
 	_, err = mappingTxtFile.Write(buff.Bytes())
 	if err != nil {
@@ -82,23 +91,134 @@ func (o *ExecutorSchema) writeMissingImagesFile(outDir string, missingImgsBuff *
 }
 
 // processImages processes all images and returns the count of missing and available images
-func (o *ExecutorSchema) processImages(ctx context.Context, allImages []v2alpha1.CopyImageSchema, buff, missingImgsBuff *bytes.Buffer) (int, int) {
+func (o *ExecutorSchema) processImages(ctx context.Context, allImages []v2alpha1.CopyImageSchema, manifestListDigests map[string][]string, buff, missingImgsBuff *bytes.Buffer) (int, int) {
 	nbMissingImgs := 0
 	nbAvailableImgs := 0
 	for _, img := range allImages {
-		buff.WriteString(img.Source + "=" + img.Destination + "\n")
-		if o.Opts.IsMirrorToDisk() {
-			exists, err := o.Mirror.Check(ctx, img.Destination, o.Opts, false)
-			if err != nil {
-				o.Log.Debug("unable to check existence of %s in local cache: %v", img.Destination, err)
-			}
-			if err != nil || !exists {
-				missingImgsBuff.WriteString(img.Source + "=" + img.Destination + "\n")
-				nbMissingImgs++
-			} else {
-				nbAvailableImgs++
-			}
+		missing := o.processImageForDryRun(ctx, img, manifestListDigests, buff, missingImgsBuff)
+		if missing {
+			nbMissingImgs++
+		} else if o.Opts.IsMirrorToDisk() {
+			nbAvailableImgs++
 		}
 	}
 	return nbMissingImgs, nbAvailableImgs
+}
+
+type subDigestEntry struct{ source, dest string }
+
+func (o *ExecutorSchema) processImageForDryRun(ctx context.Context, img v2alpha1.CopyImageSchema, manifestListDigests map[string][]string, buff, missingImgsBuff *bytes.Buffer) bool {
+	buff.WriteString(img.Source + "=" + img.Destination + "\n")
+
+	subDigestEntries := o.writeSubDigestEntries(img, manifestListDigests, buff)
+
+	if !o.Opts.IsMirrorToDisk() {
+		return false
+	}
+	exists, err := o.Mirror.Check(ctx, img.Destination, o.Opts, false)
+	if err != nil {
+		o.Log.Debug("unable to check existence of %s in local cache: %v", img.Destination, err)
+	}
+	if err != nil || !exists {
+		missingImgsBuff.WriteString(img.Source + "=" + img.Destination + "\n")
+		for _, sub := range subDigestEntries {
+			missingImgsBuff.WriteString(sub.source + "=" + sub.dest + "\n")
+		}
+		return true
+	}
+	return false
+}
+
+func (o *ExecutorSchema) writeSubDigestEntries(img v2alpha1.CopyImageSchema, manifestListDigests map[string][]string, buff *bytes.Buffer) []subDigestEntry {
+	manifestDigests := manifestListDigests[img.Origin]
+	if len(manifestDigests) == 0 {
+		manifestDigests = manifestListDigests[img.Source]
+	}
+	if len(manifestDigests) == 0 {
+		return nil
+	}
+	sourceBase, _, _ := strings.Cut(img.Source, "@")
+	entries := make([]subDigestEntry, 0, len(manifestDigests))
+	for _, digest := range manifestDigests {
+		subSource := sourceBase + "@" + digest
+		subDest := subDigestDestination(img.Destination, digest)
+		buff.WriteString(subSource + "=" + subDest + "\n")
+		entries = append(entries, subDigestEntry{source: subSource, dest: subDest})
+	}
+	return entries
+}
+
+// subDigestDestination returns a digest-pinned destination for a sub-digest entry.
+// For docker:// destinations, it strips the tag and appends the sub-digest to avoid
+// destination overwrites when multiple architectures map to the same tag.
+// For non-docker destinations (oci:, dir:, etc.), the destination is returned as-is.
+func subDigestDestination(dest string, digest string) string {
+	if !strings.HasPrefix(dest, consts.DockerProtocol) {
+		return dest
+	}
+	destSpec, err := image.ParseRef(dest)
+	if err != nil {
+		return dest
+	}
+	return destSpec.Transport + destSpec.Name + "@" + digest
+}
+
+// inspectManifestLists concurrently inspects all images to identify manifest lists
+// and returns a map of source references to their sub-manifest digests.
+// Concurrency is bounded via a semaphore to avoid overwhelming registries.
+func (o *ExecutorSchema) inspectManifestLists(ctx context.Context, images []v2alpha1.CopyImageSchema) map[string][]string {
+	manifestListDigests := make(map[string][]string)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	parallelism := o.Opts.ParallelImages
+	if parallelism == 0 {
+		parallelism = maxParallelImageDownloads
+	}
+	semaphore := make(chan struct{}, parallelism)
+
+	cancelCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for _, img := range images {
+		if cancelCtx.Err() != nil {
+			break
+		}
+
+		semaphore <- struct{}{}
+
+		wg.Add(1)
+		go func(source string) {
+			defer wg.Done()
+			defer func() { <-semaphore }()
+
+			var digests []string
+			sysCtx, err := o.newSystemContextForSource(source)
+			if err == nil {
+				digests, err = o.Manifest.GetManifestListDigests(cancelCtx, sysCtx, source)
+			}
+			if err != nil {
+				o.Log.Warn("unable to inspect manifest for %s: %v", source, err)
+				return
+			}
+			if len(digests) > 0 {
+				mu.Lock()
+				manifestListDigests[source] = digests
+				mu.Unlock()
+			}
+		}(img.Source)
+	}
+	wg.Wait()
+	return manifestListDigests
+}
+
+func (o *ExecutorSchema) newSystemContextForSource(source string) (*types.SystemContext, error) {
+	sysCtx, err := o.Opts.SrcImage.NewSystemContext()
+	if err != nil {
+		return nil, fmt.Errorf("error creating system context: %w", err)
+	}
+	if o.Opts.LocalStorageFQDN != "" && strings.Contains(source, o.Opts.LocalStorageFQDN) {
+		sysCtx.DockerInsecureSkipTLSVerify = types.OptionalBoolTrue
+	}
+	return sysCtx, nil
 }

--- a/internal/pkg/cli/dryrun_test.go
+++ b/internal/pkg/cli/dryrun_test.go
@@ -2,12 +2,15 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/distribution/distribution/v3/registry"
+	godigest "github.com/opencontainers/go-digest"
+	specv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/openshift/oc-mirror/v2/internal/pkg/api/v2alpha1"
@@ -15,6 +18,7 @@ import (
 	"github.com/openshift/oc-mirror/v2/internal/pkg/config"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/consts"
 	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/manifest"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
 )
 
@@ -608,5 +612,314 @@ func setupSignaturesDirectory(t *testing.T, testFolder string) {
 		sigFile := filepath.Join(signaturesDir, sig.name)
 		err := os.WriteFile(sigFile, []byte(sig.content), 0600)
 		assert.NoError(t, err)
+	}
+}
+
+// createTestOCILayout creates a minimal OCI image layout on disk with a manifest list
+// referencing three sub-manifests. It returns the OCI source string and the sub-digests.
+func createTestOCILayout(t *testing.T, testFolder string) (string, []godigest.Digest) {
+	t.Helper()
+
+	ociSourcePath := filepath.Join(testFolder, "test-oci-source")
+	err := os.MkdirAll(filepath.Join(ociSourcePath, specv1.ImageBlobsDir, "sha256"), 0o755)
+	if err != nil {
+		t.Fatalf("failed to create OCI directory structure: %v", err)
+	}
+
+	ociLayout, err := json.Marshal(specv1.ImageLayout{Version: specv1.ImageLayoutVersion})
+	if err != nil {
+		t.Fatalf("failed to marshal oci-layout: %v", err)
+	}
+	err = os.WriteFile(filepath.Join(ociSourcePath, specv1.ImageLayoutFile), ociLayout, 0o600)
+	if err != nil {
+		t.Fatalf("failed to write oci-layout: %v", err)
+	}
+
+	subDigests := []godigest.Digest{
+		godigest.Digest("sha256:aaa1111111111111111111111111111111111111111111111111111111111111"),
+		godigest.Digest("sha256:bbb2222222222222222222222222222222222222222222222222222222222222"),
+		godigest.Digest("sha256:ccc3333333333333333333333333333333333333333333333333333333333333"),
+	}
+
+	manifestList := specv1.Index{
+		MediaType: specv1.MediaTypeImageIndex,
+		Manifests: []specv1.Descriptor{
+			{MediaType: specv1.MediaTypeImageManifest, Digest: subDigests[0], Size: 1234, Platform: &specv1.Platform{Architecture: "amd64", OS: "linux"}},
+			{MediaType: specv1.MediaTypeImageManifest, Digest: subDigests[1], Size: 5678, Platform: &specv1.Platform{Architecture: "arm64", OS: "linux"}},
+			{MediaType: specv1.MediaTypeImageManifest, Digest: subDigests[2], Size: 9012, Platform: &specv1.Platform{Architecture: "ppc64le", OS: "linux"}},
+		},
+	}
+	manifestList.SchemaVersion = 2
+
+	manifestListBytes, err := json.Marshal(manifestList)
+	if err != nil {
+		t.Fatalf("failed to marshal manifest list: %v", err)
+	}
+
+	manifestListDigest := godigest.FromBytes(manifestListBytes)
+
+	err = os.WriteFile(
+		filepath.Join(ociSourcePath, specv1.ImageBlobsDir, "sha256", manifestListDigest.Encoded()),
+		manifestListBytes, 0o600)
+	if err != nil {
+		t.Fatalf("failed to write manifest list blob: %v", err)
+	}
+
+	indexJSON := specv1.Index{
+		MediaType: specv1.MediaTypeImageIndex,
+		Manifests: []specv1.Descriptor{
+			{
+				MediaType: specv1.MediaTypeImageIndex,
+				Digest:    manifestListDigest,
+				Size:      int64(len(manifestListBytes)),
+			},
+		},
+	}
+	indexJSON.SchemaVersion = 2
+
+	indexData, err := json.Marshal(indexJSON)
+	if err != nil {
+		t.Fatalf("failed to marshal index.json: %v", err)
+	}
+	err = os.WriteFile(filepath.Join(ociSourcePath, specv1.ImageIndexFile), indexData, 0o600)
+	if err != nil {
+		t.Fatalf("failed to write index.json: %v", err)
+	}
+
+	return consts.OciProtocolTrimmed + ociSourcePath, subDigests
+}
+
+// TestDryRunWithManifestList tests that manifest list sub-digests are included in mapping.txt.
+// It creates a proper OCI layout on disk as the source, with a manifest list blob
+// referencing sub-manifests, and verifies the dry-run output includes all sub-digests.
+func TestDryRunWithManifestList(t *testing.T) {
+	log := clog.New("trace")
+
+	global := &mirror.GlobalOptions{
+		SecurePolicy: false,
+	}
+
+	_, sharedOpts := mirror.SharedImageFlags()
+	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
+	_, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
+	_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
+	_, retryOpts := mirror.RetryFlags()
+
+	t.Run("Testing Executor : dryrun with manifest list should include sub-digests", func(t *testing.T) {
+		testFolder := t.TempDir()
+
+		global.WorkingDir = testFolder
+
+		ociSource, subDigests := createTestOCILayout(t, testFolder)
+
+		var imgs = []v2alpha1.CopyImageSchema{
+			{
+				Source:      ociSource,
+				Destination: consts.DockerProtocol + "registry.example.com/namespace/multiarch-image:latest",
+			},
+			{
+				Source:      consts.DockerProtocol + "registry.example.com/namespace/simple-image@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+				Destination: consts.OciProtocolTrimmed + "simple-image",
+			},
+		}
+
+		// storage cache for test
+		regCfg, err := setupRegForTest(testFolder)
+		if err != nil {
+			t.Errorf("storage cache error: %v ", err)
+		}
+		reg, err := registry.NewRegistry(context.Background(), regCfg)
+		if err != nil {
+			t.Errorf("storage cache error: %v ", err)
+		}
+
+		opts := &mirror.CopyOptions{
+			Global:                global,
+			DeprecatedTLSVerify:   deprecatedTLSVerifyOpt,
+			SrcImage:              srcOpts,
+			DestImage:             destOpts,
+			RetryOpts:             retryOpts,
+			IsDryRunManifestLists: true,
+			Mode:                  mirror.MirrorToDisk,
+			Dev:                   false,
+			LocalStorageFQDN:      regCfg.HTTP.Addr,
+		}
+
+		// read the ImageSetConfiguration
+		res, err := config.ReadConfig(opts.Global.ConfigPath, v2alpha1.ImageSetConfigurationKind)
+		if err != nil {
+			log.Error("imagesetconfig %v ", err)
+		}
+		var cfg v2alpha1.ImageSetConfiguration
+		if res == nil {
+			cfg = v2alpha1.ImageSetConfiguration{}
+		} else {
+			cfg = res.(v2alpha1.ImageSetConfiguration)
+		}
+
+		collector := &Collector{Log: log, Config: cfg, Opts: *opts, Fail: false}
+		mockMirror := Mirror{}
+
+		ex := &ExecutorSchema{
+			Log:                 log,
+			Opts:                opts,
+			Operator:            collector,
+			Release:             collector,
+			AdditionalImages:    collector,
+			Mirror:              mockMirror,
+			Manifest:            manifest.New(log),
+			LocalStorageService: *reg,
+			LogsDir:             testFolder,
+			MakeDir:             MakeDir{},
+		}
+
+		err = ex.DryRun(context.TODO(), imgs)
+		if err != nil {
+			t.Fatalf("should not fail: %v", err)
+		}
+
+		mappingPath := filepath.Join(testFolder, dryRunOutDir, mappingFile)
+		assert.FileExists(t, mappingPath)
+
+		mappingBytes, err := os.ReadFile(mappingPath)
+		if err != nil {
+			t.Fatalf("failed to read mapping file: %v", err)
+		}
+		mapping := string(mappingBytes)
+
+		expectedMapping := ociSource + "=" + imgs[0].Destination + "\n"
+		for _, d := range subDigests {
+			// Sub-digest destinations are digest-pinned for docker:// destinations
+			expectedMapping += ociSource + "@" + d.String() + "=" + consts.DockerProtocol + "registry.example.com/namespace/multiarch-image@" + d.String() + "\n"
+		}
+		expectedMapping += imgs[1].Source + "=" + imgs[1].Destination + "\n"
+
+		assert.Equal(t, expectedMapping, mapping)
+	})
+}
+
+// TestDryRunUnreachableImagesWarnButDontFail verifies that DryRun handles
+// unreachable images gracefully: manifest inspection warns but doesn't fail,
+// and base entries are still written to mapping.txt.
+func TestDryRunUnreachableImagesWarnButDontFail(t *testing.T) {
+	log := clog.New("trace")
+
+	global := &mirror.GlobalOptions{
+		SecurePolicy: false,
+	}
+
+	_, sharedOpts := mirror.SharedImageFlags()
+	_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
+	_, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
+	_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
+	_, retryOpts := mirror.RetryFlags()
+
+	testFolder := t.TempDir()
+	global.WorkingDir = testFolder
+
+	// These images point to a non-existent registry — manifest inspection will fail
+	var imgs = []v2alpha1.CopyImageSchema{
+		{Source: consts.DockerProtocol + "fake-registry.invalid/namespace/image1@sha256:aaa1111111111111111111111111111111111111111111111111111111111111", Destination: "oci:test1", Type: v2alpha1.TypeGeneric},
+		{Source: consts.DockerProtocol + "fake-registry.invalid/namespace/image2@sha256:bbb2222222222222222222222222222222222222222222222222222222222222", Destination: "oci:test2", Type: v2alpha1.TypeGeneric},
+	}
+
+	regCfg, err := setupRegForTest(testFolder)
+	if err != nil {
+		t.Fatalf("storage cache error: %v", err)
+	}
+	reg, err := registry.NewRegistry(context.Background(), regCfg)
+	if err != nil {
+		t.Fatalf("storage cache error: %v", err)
+	}
+
+	opts := &mirror.CopyOptions{
+		Global:                global,
+		DeprecatedTLSVerify:   deprecatedTLSVerifyOpt,
+		SrcImage:              srcOpts,
+		DestImage:             destOpts,
+		RetryOpts:             retryOpts,
+		IsDryRunManifestLists: true,
+		Mode:                  mirror.DiskToMirror,
+		Dev:                   false,
+		LocalStorageFQDN:      regCfg.HTTP.Addr,
+		ParallelImages:        4,
+	}
+
+	cfg := v2alpha1.ImageSetConfiguration{}
+	collector := &Collector{Log: log, Config: cfg, Opts: *opts, Fail: false}
+	mockMirror := Mirror{}
+
+	ex := &ExecutorSchema{
+		Log:                 log,
+		Opts:                opts,
+		Operator:            collector,
+		Release:             collector,
+		AdditionalImages:    collector,
+		Mirror:              mockMirror,
+		Manifest:            manifest.New(log),
+		LocalStorageService: *reg,
+		LogsDir:             testFolder,
+		MakeDir:             MakeDir{},
+	}
+
+	// Should not fail even though manifest inspection will warn for unreachable images
+	err = ex.DryRun(context.TODO(), imgs)
+	if err != nil {
+		t.Fatalf("should not fail: %v", err)
+	}
+
+	mappingPath := filepath.Join(testFolder, dryRunOutDir, mappingFile)
+	assert.FileExists(t, mappingPath)
+
+	mappingBytes, err := os.ReadFile(mappingPath)
+	if err != nil {
+		t.Fatalf("failed to read mapping file: %v", err)
+	}
+	mapping := string(mappingBytes)
+
+	// Base entries should still be written despite inspection failures
+	for _, img := range imgs {
+		assert.Contains(t, mapping, img.Source+"="+img.Destination)
+	}
+}
+
+func TestSubDigestDestination(t *testing.T) {
+	tests := []struct {
+		name     string
+		dest     string
+		digest   string
+		expected string
+	}{
+		{
+			name:     "docker destination with tag",
+			dest:     "docker://registry.example.com/namespace/image:latest",
+			digest:   "sha256:aaa1111111111111111111111111111111111111111111111111111111111111",
+			expected: "docker://registry.example.com/namespace/image@sha256:aaa1111111111111111111111111111111111111111111111111111111111111",
+		},
+		{
+			name:     "docker destination with port and tag",
+			dest:     "docker://localhost:9999/namespace/image:v1.0",
+			digest:   "sha256:bbb2222222222222222222222222222222222222222222222222222222222222",
+			expected: "docker://localhost:9999/namespace/image@sha256:bbb2222222222222222222222222222222222222222222222222222222222222",
+		},
+		{
+			name:     "docker destination with digest-as-tag",
+			dest:     "docker://localhost:55000/openshift4/ose-kube-rbac-proxy:sha256-ac54cb8ff880a935ea3b4b1efc96d35bbf973342c450400d6417d06e59050027",
+			digest:   "sha256:61d446b8b81cc1545ee805dbd46f921aecb1517c3478bdff654ab9a2a637845a",
+			expected: "docker://localhost:55000/openshift4/ose-kube-rbac-proxy@sha256:61d446b8b81cc1545ee805dbd46f921aecb1517c3478bdff654ab9a2a637845a",
+		},
+		{
+			name:     "oci destination kept as-is",
+			dest:     "oci:test-image",
+			digest:   "sha256:aaa1111111111111111111111111111111111111111111111111111111111111",
+			expected: "oci:test-image",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := subDigestDestination(tt.dest, tt.digest)
+			assert.Equal(t, tt.expected, result)
+		})
 	}
 }

--- a/internal/pkg/cli/executor.go
+++ b/internal/pkg/cli/executor.go
@@ -296,6 +296,7 @@ func NewMirrorCmd(log clog.PluggableLoggerInterface) *cobra.Command {
 	// copy-only options
 	cmd.Flags().StringVar(&opts.Global.From, "from", "", "Local storage directory for disk to mirror workflow")
 	cmd.Flags().BoolVarP(&opts.IsDryRun, "dry-run", "", false, "Print actions without mirroring images")
+	cmd.Flags().BoolVar(&opts.IsDryRunManifestLists, "dry-run-manifest-lists", false, "Like --dry-run, but also includes manifest list sub-digests in mapping.txt (implies --dry-run, cannot be combined with --dry-run)")
 	cmd.Flags().BoolVarP(&opts.Global.Quiet, "quiet", "q", false, "Enable detailed logging when copying images")
 	cmd.Flags().BoolVarP(&opts.Global.Force, "force", "f", false, "Force the copy and mirror functionality")
 	cmd.Flags().StringVar(&opts.Global.SinceString, "since", "", "Include all new content since specified date (format yyyy-MM-dd). When not provided, new content since previous mirroring is mirrored")
@@ -394,6 +395,12 @@ func (o ExecutorSchema) Validate(dest []string) error {
 		if _, err := time.Parse(time.DateOnly, o.Opts.Global.SinceString); err != nil {
 			return fmt.Errorf("--since flag needs to be in format yyyy-MM-dd")
 		}
+	}
+	if o.Opts.IsDryRunManifestLists && o.Opts.IsDryRun {
+		return fmt.Errorf("--dry-run and --dry-run-manifest-lists cannot be used together")
+	}
+	if o.Opts.IsDryRunManifestLists {
+		o.Opts.IsDryRun = true
 	}
 	// OCPBUGS-58467
 	if o.Opts.ParallelImages > 10 || o.Opts.ParallelImages < 1 {

--- a/internal/pkg/config/pin_catalogs_test.go
+++ b/internal/pkg/config/pin_catalogs_test.go
@@ -64,6 +64,9 @@ func (m *MockManifest) GetOperatorConfig(file string) (*v2alpha1.OperatorConfigS
 func (m *MockManifest) ImageManifest(ctx context.Context, srcCtx *types.SystemContext, ref string, instanceDigest *digest.Digest) ([]byte, string, error) {
 	return nil, "", nil
 }
+func (m *MockManifest) GetManifestListDigests(ctx context.Context, sourceCtx *types.SystemContext, source string) ([]string, error) {
+	return nil, nil
+}
 
 const (
 	// Valid SHA256 digests for testing (64 hex characters)

--- a/internal/pkg/delete/delete_images_test.go
+++ b/internal/pkg/delete/delete_images_test.go
@@ -562,6 +562,10 @@ func (o mockManifest) ImageManifest(ctx context.Context, sourceCtx *types.System
 	return nil, "", nil
 }
 
+func (o mockManifest) GetManifestListDigests(ctx context.Context, sourceCtx *types.SystemContext, source string) ([]string, error) {
+	return nil, nil
+}
+
 func (o mockManifest) GetOCIImageFromIndex(dir string) (gcrv1.Image, error) { //nolint:ireturn // as expected by go-containerregistry
 	return nil, nil
 }

--- a/internal/pkg/manifest/interface.go
+++ b/internal/pkg/manifest/interface.go
@@ -21,4 +21,5 @@ type ManifestInterface interface {
 	GetOperatorConfig(file string) (*v2alpha1.OperatorConfigSchema, error)
 	ImageDigest(ctx context.Context, sourceCtx *types.SystemContext, imgRef string) (string, error)
 	ImageManifest(ctx context.Context, sourceCtx *types.SystemContext, imgRef string, instanceDigest *digest.Digest) ([]byte, string, error)
+	GetManifestListDigests(ctx context.Context, sourceCtx *types.SystemContext, source string) ([]string, error)
 }

--- a/internal/pkg/manifest/manifest.go
+++ b/internal/pkg/manifest/manifest.go
@@ -32,6 +32,29 @@ func (o Manifest) ImageManifest(ctx context.Context, sourceCtx *types.SystemCont
 	return bytesManifest, mime, nil
 }
 
+func (o Manifest) GetManifestListDigests(ctx context.Context, sourceCtx *types.SystemContext, source string) ([]string, error) {
+	manifestBytes, manifestType, err := o.ImageManifest(ctx, sourceCtx, source, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if !manifest.MIMETypeIsMultiImage(manifestType) {
+		return nil, nil
+	}
+
+	list, err := manifest.ListFromBlob(manifestBytes, manifestType)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing manifest list for %s: %w", source, err)
+	}
+
+	instances := list.Instances()
+	digests := make([]string, 0, len(instances))
+	for _, instance := range instances {
+		digests = append(digests, instance.String())
+	}
+	return digests, nil
+}
+
 func (o Manifest) ImageDigest(ctx context.Context, sourceCtx *types.SystemContext, imgRef string) (string, error) {
 	if err := mirror.ReexecIfNecessaryForImages(imgRef); err != nil {
 		return "", fmt.Errorf("reexec mirror: %w", err)

--- a/internal/pkg/mirror/options.go
+++ b/internal/pkg/mirror/options.go
@@ -85,6 +85,7 @@ type CopyOptions struct {
 	DecryptionKeys           []string  // Keys needed to decrypt the image
 	Mode                     string    // possible values: mirrorToDisk, disktoMirror or mirrorToMirror
 	IsDryRun                 bool      // generates a mappings.txt without performing the mirroring
+	IsDryRunManifestLists    bool      // dry run that also inspects manifest lists and includes sub-digests
 	Dev                      bool      // developer mode - will be removed when completed
 	Destination              string    // what to target to
 	UUID                     uuid.UUID // set uuid

--- a/internal/pkg/operator/filtered_collector_test.go
+++ b/internal/pkg/operator/filtered_collector_test.go
@@ -1058,6 +1058,10 @@ func (o MockManifest) ImageManifest(ctx context.Context, srcCtx *types.SystemCon
 	return nil, "", errors.New("not implemented")
 }
 
+func (o MockManifest) GetManifestListDigests(ctx context.Context, sourceCtx *types.SystemContext, source string) ([]string, error) {
+	return nil, nil
+}
+
 func (o MockHandler) getRelatedImagesFromCatalog(dc *declcfg.DeclarativeConfig, copyImageSchemaMap *v2alpha1.CopyImageSchemaMap) (map[string][]v2alpha1.RelatedImage, error) {
 	relatedImages := make(map[string][]v2alpha1.RelatedImage)
 	relatedImages["abc"] = []v2alpha1.RelatedImage{

--- a/internal/pkg/release/cincinnati_test.go
+++ b/internal/pkg/release/cincinnati_test.go
@@ -256,3 +256,7 @@ func (o mockManifest) ConvertOCIIndexToSingleManifest(dir string, oci *specv1.In
 func (o mockManifest) ImageManifest(ctx context.Context, sourceCtx *types.SystemContext, imgRef string, instanceDigest *digest.Digest) ([]byte, string, error) {
 	return nil, "", nil
 }
+
+func (o mockManifest) GetManifestListDigests(ctx context.Context, sourceCtx *types.SystemContext, source string) ([]string, error) {
+	return nil, nil
+}

--- a/internal/pkg/release/local_stored_collector_test.go
+++ b/internal/pkg/release/local_stored_collector_test.go
@@ -769,6 +769,10 @@ func (o MockManifest) ImageManifest(ctx context.Context, sourceCtx *types.System
 	return nil, "", nil
 }
 
+func (o MockManifest) GetManifestListDigests(ctx context.Context, sourceCtx *types.SystemContext, source string) ([]string, error) {
+	return nil, nil
+}
+
 func (o MockCincinnati) GetReleaseReferenceImages(ctx context.Context) ([]v2alpha1.CopyImageSchema, error) {
 	var res []v2alpha1.CopyImageSchema
 	res = append(res, v2alpha1.CopyImageSchema{Type: v2alpha1.TypeOCPRelease, Source: "quay.io/openshift-release-dev/ocp-release:4.13.10-x86_64", Origin: "quay.io/openshift-release-dev/ocp-release:4.13.10-x86_64"})
@@ -840,4 +844,8 @@ func (o *ManifestMock) ImageDigest(ctx context.Context, sourceCtx *types.SystemC
 
 func (o *ManifestMock) ImageManifest(ctx context.Context, sourceCtx *types.SystemContext, imgRef string, instanceDigest *digest.Digest) ([]byte, string, error) {
 	return nil, "", nil
+}
+
+func (o *ManifestMock) GetManifestListDigests(ctx context.Context, sourceCtx *types.SystemContext, source string) ([]string, error) {
+	return nil, nil
 }

--- a/internal/pkg/signature/cosign_tag_based_signatures_test.go
+++ b/internal/pkg/signature/cosign_tag_based_signatures_test.go
@@ -107,6 +107,10 @@ func (m *mockManifest) ImageManifest(ctx context.Context, sourceCtx *types.Syste
 	}
 }
 
+func (m *mockManifest) GetManifestListDigests(ctx context.Context, sourceCtx *types.SystemContext, source string) ([]string, error) {
+	return nil, nil
+}
+
 func TestSigstoreAttachmentTag(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
# Description

Manual backport of https://github.com/openshift/oc-mirror/pull/1355

Github / Jira issue: https://redhat.atlassian.net/browse/OCPBUGS-66263

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to inspect manifest lists during dry runs and include sub-manifest digest mappings in `mapping.txt`.
  * Added digest-aware destination handling for Docker image references.
* **Bug Fixes**
  * Dry runs now continue successfully when registries are unreachable, while retaining available mappings and reporting warnings.
  * Improved handling of tag-and-digest image references in generated mirror configurations.
  * Catalog references are pinned more consistently before mirror execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->