### PR TITLE
NO-JIRA: Dockerfile.art: package oc-mirror binaries as tar.gz archives

### DIFF
--- a/images/cli/Dockerfile.art
+++ b/images/cli/Dockerfile.art
@@ -43,6 +43,10 @@ COPY --from=builder_rhel9 /go/src/github.com/openshift/oc-mirror/bin/oc-mirror /
 COPY --from=builder_rhel9 /go/src/github.com/openshift/oc-mirror/bin/oc-mirror /usr/bin/oc-mirror.rhel9
 COPY --from=test-extension-builder /go/src/github.com/openshift/oc-mirror/tests/e2e/bin/oc-mirror-tests-ext.gz /usr/bin/oc-mirror-tests-ext.gz
 
+RUN mkdir -p /releases/
+RUN tar czf /releases/oc-mirror-rhel9-linux-amd64.tar.gz -C /usr/bin oc-mirror
+RUN tar czf /releases/oc-mirror-rhel8-linux-amd64.tar.gz -C /usr/bin oc-mirror.rhel8
+
 LABEL io.k8s.display-name="oc-mirror" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
       io.openshift.tags="openshift,cli,mirror" \


### PR DESCRIPTION
## Summary
- Create `/releases/` directory in the ART Dockerfile
- Package the rhel9 `oc-mirror` binary as `oc-mirror-rhel9-linux-amd64.tar.gz`
- Package the rhel8 `oc-mirror.rhel8` binary as `oc-mirror-rhel8-linux-amd64.tar.gz`

## Test plan
- [ ] Verify the image builds successfully with the new `RUN` steps
- [ ] Confirm `/releases/` directory contains the expected tar archives after build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release tarballs for the RHEL 8 and RHEL 9 Linux AMD64 versions of the `oc-mirror` tool.
  * The tarballs are generated automatically during the container image build and include the corresponding executable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->