### PR TITLE
OCPBUGS-112078: pkg/cli/list: remove reference to marketplace catalog

### DIFF
--- a/internal/pkg/cli/list/operators.go
+++ b/internal/pkg/cli/list/operators.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/blang/semver/v4"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/model"
 	"github.com/operator-framework/operator-registry/alpha/property"
@@ -34,6 +35,9 @@ const (
 	certifiedCatalogRegistry   string = "registry.redhat.io/redhat/certified-operator-index"
 	marketplaceCatalogRegistry string = "registry.redhat.io/redhat/redhat-marketplace-index"
 )
+
+// See https://redhat.atlassian.net/browse/OPRUN-4417
+var marketplaceRemoveVersion semver.Version = semver.MustParse("4.22.0")
 
 type listOperatorsOptions struct {
 	catalogs   bool
@@ -264,8 +268,13 @@ func listCatalogsForVersion(ctx context.Context, log log.PluggableLoggerInterfac
 	fmt.Fprintln(w, "Available OpenShift OperatorHub catalogs:")
 	fmt.Fprintf(w, "OpenShift %s:\n", version)
 
+	defaultCatalogs := []string{redhatCatalogRegistry, certifiedCatalogRegistry, communityCatalogRegistry}
+	if sv, err := semver.ParseTolerant(version); err == nil && sv.LT(marketplaceRemoveVersion) {
+		defaultCatalogs = append(defaultCatalogs, marketplaceCatalogRegistry)
+	}
+
 	var errs []error
-	for _, catalog := range []string{redhatCatalogRegistry, certifiedCatalogRegistry, communityCatalogRegistry, marketplaceCatalogRegistry} {
+	for _, catalog := range defaultCatalogs {
 		ref := fmt.Sprintf("%s:v%s", catalog, version)
 		log.Debug("Checking whether catalog %q exists", ref)
 		exists, err := taggedCatalogExists(ctx, ref, opts)

--- a/internal/pkg/cli/list/operators_test.go
+++ b/internal/pkg/cli/list/operators_test.go
@@ -85,12 +85,40 @@ registry.redhat.io/redhat/certified-operator-index:v4.20
 registry.redhat.io/redhat/community-operator-index:v4.20
 registry.redhat.io/redhat/redhat-marketplace-index:v4.20
 `, w.String())
+
+		t.Run("but not include marketplace when version >= 4.22", func(t *testing.T) {
+			w := strings.Builder{}
+			err := listCatalogsForVersion(t.Context(), log, &w, "4.22", *opts)
+			assert.NoError(t, err)
+			assert.Equal(t, `Available OpenShift OperatorHub catalogs:
+OpenShift 4.22:
+registry.redhat.io/redhat/redhat-operator-index:v4.22
+registry.redhat.io/redhat/certified-operator-index:v4.22
+registry.redhat.io/redhat/community-operator-index:v4.22
+`, w.String())
+
+			w = strings.Builder{}
+			err = listCatalogsForVersion(t.Context(), log, &w, "5.0", *opts)
+			assert.NoError(t, err)
+			assert.Equal(t, `Available OpenShift OperatorHub catalogs:
+OpenShift 5.0:
+registry.redhat.io/redhat/redhat-operator-index:v5.0
+registry.redhat.io/redhat/certified-operator-index:v5.0
+registry.redhat.io/redhat/community-operator-index:v5.0
+`, w.String())
+		})
 	})
 
 	t.Run("should fail when OCP version is invalid", func(t *testing.T) {
 		w := strings.Builder{}
 		err := listCatalogsForVersion(t.Context(), log, &w, "foobar", *opts)
-		assert.ErrorContains(t, err, "failed to check catalog")
+		assert.NoError(t, err)
+		assert.Equal(t, `Available OpenShift OperatorHub catalogs:
+OpenShift foobar:
+Invalid catalog reference "registry.redhat.io/redhat/redhat-operator-index:vfoobar", please check version
+Invalid catalog reference "registry.redhat.io/redhat/certified-operator-index:vfoobar", please check version
+Invalid catalog reference "registry.redhat.io/redhat/community-operator-index:vfoobar", please check version
+`, w.String())
 	})
 }
 


### PR DESCRIPTION
# Description

Starting on 4.22, the catalog is not valid anymore.

Github / Jira issue: 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `list operators` to exclude the marketplace catalog for OpenShift 4.22 and later.
  * Improved handling of invalid OpenShift versions so catalog listings are returned without an unnecessary error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->