### PR TITLE
build: Simplify Dockerfile.art by removing Cachito/remote sources setup

### DIFF
--- a/images/cli/Dockerfile.art
+++ b/images/cli/Dockerfile.art
@@ -1,37 +1,21 @@
 # This Dockerfile is used by CI to publish the oc-mirror image.
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.26-openshift-5.0 AS builder_rhel8
-COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
-WORKDIR $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app
-RUN cat $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/cachito.env
 RUN mkdir -p /go/src/github.com/openshift/oc-mirror
-RUN ln -s $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app /go/src/github.com/openshift/oc-mirror
 WORKDIR /go/src/github.com/openshift/oc-mirror
 COPY . .
-RUN source $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/cachito.env \
-    && make build
-
+RUN make build
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder_rhel9
-COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
-WORKDIR $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app
-RUN cat $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/cachito.env
 RUN mkdir -p /go/src/github.com/openshift/oc-mirror
-RUN ln -s $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app /go/src/github.com/openshift/oc-mirror
 WORKDIR /go/src/github.com/openshift/oc-mirror
 COPY . .
-RUN source $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/cachito.env \
-    && make build
+RUN make build
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS test-extension-builder
-COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
-WORKDIR $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app
-RUN cat $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/cachito.env
 RUN mkdir -p /go/src/github.com/openshift/oc-mirror
-RUN ln -s $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app /go/src/github.com/openshift/oc-mirror
 WORKDIR /go/src/github.com/openshift/oc-mirror
 COPY . .
-RUN source $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/cachito.env \
-    && cd tests/e2e \
+RUN cd tests/e2e \
     && GOTOOLCHAIN=auto go mod vendor \
     && CGO_ENABLED=0 GO_COMPLIANCE_POLICY="exempt_all" GOGC=20 GOTOOLCHAIN=auto go build -mod=vendor -p 1 -o bin/oc-mirror-tests-ext ./cmd \
     && gzip -c bin/oc-mirror-tests-ext > bin/oc-mirror-tests-ext.gz \


### PR DESCRIPTION
# Description

Removes the Cachito/remote sources build flow from `Dockerfile.art` and replaces it with a direct `COPY + make build` pattern across all three builder stages (rhel-8, rhel-9, and test-extension-builder).

Github / Jira issue: N/A

## Type of change

- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)

# How Has This Been Tested?

The Dockerfile was reviewed to confirm that the build steps are equivalent without the Cachito setup. The direct `COPY . .` + `make build` pattern is already used in the other Dockerfiles in this repo (`Dockerfile.ci`, `Dockerfile.konflux`).

## Expected Outcome

The image builds successfully using the simplified build flow without any Cachito/remote sources dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of oc-mirror builds across RHEL 8 and RHEL 9 environments.
  * Streamlined extension test build preparation for more consistent build execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->