### PR TITLE
ART-21727: Use v1.5.2 tag for openshift/origin instead of pseudo-version

### DIFF
--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -6,10 +6,8 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/openshift-eng/openshift-tests-extension v0.0.0-20260127124016-0fed2b824818
-	github.com/openshift/api v0.0.0-20260114133223-6ab113cb7368
-	github.com/openshift/origin v1.5.0-alpha.3.0.20260319150657-3318a72fb0d6
+	github.com/openshift/origin v1.5.2
 	github.com/spf13/cobra v1.10.1
-	github.com/tidwall/gjson v1.18.0
 	k8s.io/apimachinery v0.34.1
 	k8s.io/component-base v0.34.1
 	k8s.io/kubernetes v1.34.1
@@ -198,6 +196,7 @@ require (
 	github.com/opencontainers/runc v1.2.5 // indirect
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
 	github.com/opencontainers/selinux v1.11.1 // indirect
+	github.com/openshift/api v0.0.0-20260114133223-6ab113cb7368 // indirect
 	github.com/openshift/client-go v0.0.0-20260108185524-48f4ccfc4e13 // indirect
 	github.com/openshift/library-go v0.0.0-20251015151611-6fc7a74b67c5 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
@@ -221,6 +220,7 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/tecbiz-ch/nutanix-go-sdk v0.1.15 // indirect
+	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/vmware/govmomi v0.51.0 // indirect

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -539,8 +539,8 @@ github.com/openshift/library-go v0.0.0-20251015151611-6fc7a74b67c5 h1:bANtDc8Sge
 github.com/openshift/library-go v0.0.0-20251015151611-6fc7a74b67c5/go.mod h1:OlFFws1AO51uzfc48MsStGE4SFMWlMZD0+f5a/zCtKI=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1 h1:PMTgifBcBRLJJiM+LgSzPDTk9/Rx4qS09OUrfpY6GBQ=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
-github.com/openshift/origin v1.5.0-alpha.3.0.20260319150657-3318a72fb0d6 h1:mB/LRbJcrSZYPhz0iWHtYVy7f+l6c4+JpN9nYVKUPUw=
-github.com/openshift/origin v1.5.0-alpha.3.0.20260319150657-3318a72fb0d6/go.mod h1:UO9+n8VT/BLzLON2uHFxJhUei+j7va8R5f9Fpx+BtgE=
+github.com/openshift/origin v1.5.2 h1:2EnpqKBxSTdI4ONJoJy4NktcyWRZBU2oLxnGdMyCLqc=
+github.com/openshift/origin v1.5.2/go.mod h1:UO9+n8VT/BLzLON2uHFxJhUei+j7va8R5f9Fpx+BtgE=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=


### PR DESCRIPTION
The Go module proxy times out trying to resolve pseudo-versions for large OpenShift fork repos like openshift/origin, causing prefetch-dependencies failures in Konflux builds of oc-mirror-plugin ([ART-21727](https://redhat.atlassian.net/browse/ART-21727)).

Replace the pseudo-version with the v1.5.2 tag, which points to the same commit (3318a72fb0d6). Tagged versions are served directly by the Go proxy without needing to clone the full repository.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Github / Jira issue: 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the end-to-end testing setup to align with a newer OpenShift Origin release.
  * Refreshed dependency declarations to keep indirect packages consistent and maintain clean, up-to-date test tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->