### PR TITLE
CLID-663: Update Dockerfile.konflux to produce all arches via cross-c…

### DIFF
--- a/images/cli/Dockerfile.konflux
+++ b/images/cli/Dockerfile.konflux
@@ -1,23 +1,30 @@
-# Dockerfile for the Konflux CDN release pipeline: builds oc-mirror binaries for RHEL 8/9,
-# packages them as compressed tarballs in /releases/ for push-artifacts-to-cdn.
+# Dockerfile for the Konflux CDN release pipeline: cross-compiles oc-mirror binaries
+# for all supported architectures on RHEL 8/9, packages them as compressed tarballs
+# in /releases/ for push-artifacts-to-cdn.
 
-# Stage 1: Build and compress RHEL 8 binary
+# Stage 1: Cross-compile RHEL 8 binaries for all architectures
 FROM registry.access.redhat.com/ubi8/go-toolset:1.26 AS builder_rhel8
+USER root
 WORKDIR /go/src/github.com/openshift/oc-mirror
 COPY . .
-RUN make build && \
+RUN git config --global --add safe.directory /go/src/github.com/openshift/oc-mirror && \
+    CGO_ENABLED=0 make cross-build && \
     mkdir -p /output && \
-    GOARCH=$(go env GOARCH) && \
-    tar -czf /output/oc-mirror-rhel8-linux-${GOARCH}.tar.gz -C bin oc-mirror
+    for arch in amd64 arm64 ppc64le s390x; do \
+      tar -czf /output/oc-mirror-rhel8-linux-${arch}.tar.gz -C bin/linux-${arch} oc-mirror || exit 1; \
+    done
 
-# Stage 2: Build and compress RHEL 9 binary
+# Stage 2: Cross-compile RHEL 9 binaries for all architectures
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder_rhel9
+USER root
 WORKDIR /go/src/github.com/openshift/oc-mirror
 COPY . .
-RUN make build && \
+RUN git config --global --add safe.directory /go/src/github.com/openshift/oc-mirror && \
+    CGO_ENABLED=0 make cross-build && \
     mkdir -p /output && \
-    GOARCH=$(go env GOARCH) && \
-    tar -czf /output/oc-mirror-rhel9-linux-${GOARCH}.tar.gz -C bin oc-mirror
+    for arch in amd64 arm64 ppc64le s390x; do \
+      tar -czf /output/oc-mirror-rhel9-linux-${arch}.tar.gz -C bin/linux-${arch} oc-mirror || exit 1; \
+    done
 
 # Stage 3: Final delivery image for push-artifacts-to-cdn
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest


### PR DESCRIPTION
…ompile

# Description

This is required, as the way the konflux pipeline is setup, it does not use native-arch builders and requires cross-compilation and dumping of all 4 arch binaries into releases/. 

Github / Jira issue: 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-architecture release packages for `oc-mirror`, supporting `amd64`, `arm64`, `ppc64le`, and `s390x` on both RHEL 8 and RHEL 9.
  * Release artifacts are now built and delivered as separate compressed packages per architecture, improving consistency across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->