### PR TITLE
OCPBUGS-100196: pkg/clusterresources: Use RFC3339 timestamp format

### DIFF
--- a/internal/pkg/clusterresources/clusterresources.go
+++ b/internal/pkg/clusterresources/clusterresources.go
@@ -856,7 +856,7 @@ func (o *ClusterResourcesGenerator) GenerateSignatureConfigMap(allRelatedImages 
 func generateOcMirrorAnnotations() map[string]string {
 	return map[string]string{
 		"createdBy":         "oc-mirror v2",
-		"createdAt":         time.Now().UTC().Format(time.RFC850),
+		"createdAt":         time.Now().UTC().Format(time.RFC3339),
 		"oc-mirror_version": version.Get().GitVersion,
 	}
 }


### PR DESCRIPTION
# Description

To be more in line with annotations from other cluster resources.

Github / Jira issue: OCPBUGS-100196

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Before:
```fish
❯ oc-mirror --v2 --config release-isc.yaml --workspace file://data/kube docker://localhost:5000 --dest-tls-verify=false --dry-run --log-level debug
❯ yq e data/kube/working-dir/cluster-resources/signature-configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  annotations:
    createdAt: Wednesday, 12-Aug-26 12:06:26 UTC
    createdBy: oc-mirror v2
    oc-mirror_version: v0.2.0-alpha.1-706-g315323f
```

After:
```fish
❯ oc-mirror --v2 --config release-isc.yaml --workspace file://data/iso docker://localhost:5000 --dest-tls-verify=false --dry-run --log-level debug
❯ yq e data/iso/working-dir/cluster-resources/signature-configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  annotations:
    createdAt: "2026-08-13T13:42:13Z"
    createdBy: oc-mirror v2
    oc-mirror_version: v0.2.0-alpha.1-703-gc00f07e
```

## Expected Outcome
`createdAt` date in ISO format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated timestamp formatting to use a standard UTC date-time format for generated metadata, improving consistency and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->