### PR TITLE
CLID-663: Split Dockerfile.konflux into RHEL8/RHEL9 to satistfy relea…

### DIFF
--- a/images/cli/Dockerfile.konflux.rhel8
+++ b/images/cli/Dockerfile.konflux.rhel8
@@ -1,0 +1,31 @@
+# Dockerfile for the Konflux CDN release pipeline: cross-compiles oc-mirror binaries
+# for all supported architectures on RHEL 8, packages them as compressed tarballs
+# in /releases/ for push-artifacts-to-cdn.
+
+# Stage 1: Cross-compile RHEL 8 binaries for all architectures
+FROM registry.access.redhat.com/ubi8/go-toolset:1.26 AS builder_rhel8
+USER root
+WORKDIR /go/src/github.com/openshift/oc-mirror
+COPY . .
+RUN git config --global --add safe.directory /go/src/github.com/openshift/oc-mirror && \
+    CGO_ENABLED=0 make cross-build && \
+    mkdir -p /output && \
+    for arch in amd64 arm64 ppc64le s390x; do \
+      tar -czf /output/oc-mirror-rhel8-linux-${arch}.tar.gz -C bin/linux-${arch} oc-mirror || exit 1; \
+    done
+
+# Stage 2: Final delivery image for push-artifacts-to-cdn
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+RUN mkdir -p /releases/
+COPY --from=builder_rhel8 /output/ /releases/
+
+# Required EC Metadata Labels
+LABEL vendor="Red Hat, Inc." \
+      name="oc-mirror" \
+      com.redhat.component="oc-mirror" \
+      version="1.0.0" \
+      release="1" \
+      summary="oc-mirror CLI tool transport container" \
+      description="OpenShift is a platform for developing, building, and deploying containerized applications." \
+      io.k8s.display-name="oc-mirror" \
+      io.openshift.tags="openshift,cli,mirror"

--- a/images/cli/Dockerfile.konflux.rhel9
+++ b/images/cli/Dockerfile.konflux.rhel9
@@ -1,20 +1,8 @@
 # Dockerfile for the Konflux CDN release pipeline: cross-compiles oc-mirror binaries
-# for all supported architectures on RHEL 8/9, packages them as compressed tarballs
+# for all supported architectures on RHEL 9, packages them as compressed tarballs
 # in /releases/ for push-artifacts-to-cdn.
 
-# Stage 1: Cross-compile RHEL 8 binaries for all architectures
-FROM registry.access.redhat.com/ubi8/go-toolset:1.26 AS builder_rhel8
-USER root
-WORKDIR /go/src/github.com/openshift/oc-mirror
-COPY . .
-RUN git config --global --add safe.directory /go/src/github.com/openshift/oc-mirror && \
-    CGO_ENABLED=0 make cross-build && \
-    mkdir -p /output && \
-    for arch in amd64 arm64 ppc64le s390x; do \
-      tar -czf /output/oc-mirror-rhel8-linux-${arch}.tar.gz -C bin/linux-${arch} oc-mirror || exit 1; \
-    done
-
-# Stage 2: Cross-compile RHEL 9 binaries for all architectures
+# Stage 1: Cross-compile RHEL 9 binaries for all architectures
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder_rhel9
 USER root
 WORKDIR /go/src/github.com/openshift/oc-mirror
@@ -26,10 +14,9 @@ RUN git config --global --add safe.directory /go/src/github.com/openshift/oc-mir
       tar -czf /output/oc-mirror-rhel9-linux-${arch}.tar.gz -C bin/linux-${arch} oc-mirror || exit 1; \
     done
 
-# Stage 3: Final delivery image for push-artifacts-to-cdn
+# Stage 2: Final delivery image for push-artifacts-to-cdn
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 RUN mkdir -p /releases/
-COPY --from=builder_rhel8 /output/ /releases/
 COPY --from=builder_rhel9 /output/ /releases/
 
 # Required EC Metadata Labels


### PR DESCRIPTION
…se pipeline requirements

# Description

See https://redhat.atlassian.net/browse/ART-20686 

Github / Jira issue: https://redhat.atlassian.net/browse/CLID-663

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Expected Outcome
Please describe the outcome expected from the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated RHEL 9 container builds for `oc-mirror` across amd64, arm64, ppc64le, and s390x architectures.
  * RHEL 9 release images now include compressed binary tarballs with required metadata.
* **Improvements**
  * Simplified RHEL 8 release packaging to focus on supported RHEL 8 artifacts.
  * RHEL 8 and RHEL 9 builds now provide clearly separated release outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->