### PR TITLE
CLID-701, CLID-702: mirror through proxy integration tests

### DIFF
--- a/tests/integration/pkg/proxy/proxy.go
+++ b/tests/integration/pkg/proxy/proxy.go
@@ -8,6 +8,8 @@
 package proxy
 
 import (
+	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -21,8 +23,9 @@ type Proxy struct {
 	listener net.Listener
 	server   *http.Server
 
-	mu    sync.Mutex
-	hosts map[string]struct{}
+	mu       sync.Mutex
+	hosts    map[string]struct{}
+	serveErr error
 }
 
 // Start starts a forward proxy listening on an OS-assigned local port.
@@ -34,9 +37,23 @@ func Start() (*Proxy, error) {
 
 	p := &Proxy{listener: ln, hosts: make(map[string]struct{})}
 	p.server = &http.Server{Handler: http.HandlerFunc(p.handleConnect)}
-	go func() { _ = p.server.Serve(ln) }()
+	go func() {
+		// Save any error other than the expected one from Stop closing the server.
+		if err := p.server.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			p.mu.Lock()
+			p.serveErr = err
+			p.mu.Unlock()
+		}
+	}()
 
 	return p, nil
+}
+
+// Err returns any unexpected error from serving proxy connections, or nil.
+func (p *Proxy) Err() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.serveErr
 }
 
 // URL returns the proxy's base URL, suitable for HTTP_PROXY/HTTPS_PROXY.
@@ -93,12 +110,16 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 
 	p.recordHost(r.Host)
 
-	destConn, err := net.DialTimeout("tcp", r.Host, 10*time.Second)
+	dialCtx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	var dialer net.Dialer
+	destConn, err := dialer.DialContext(dialCtx, "tcp", r.Host)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
-	defer destConn.Close()
+	closeDest := func() { _ = destConn.Close() }
+	defer closeDest()
 
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
@@ -109,17 +130,29 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
-	defer clientConn.Close()
+	closeClient := func() { _ = clientConn.Close() }
+	defer closeClient()
 
 	if _, err := clientConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
 		return
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() { defer wg.Done(); _, _ = io.Copy(destConn, clientConn) }()
-	go func() { defer wg.Done(); _, _ = io.Copy(clientConn, destConn) }()
-	wg.Wait()
+	// Close both connections once either side finishes, so a stuck peer
+	// transfer can't block the handler indefinitely.
+	done := make(chan struct{}, 2)
+	go func() {
+		_, _ = io.Copy(destConn, clientConn)
+		done <- struct{}{}
+	}()
+	go func() {
+		_, _ = io.Copy(clientConn, destConn)
+		done <- struct{}{}
+	}()
+
+	<-done
+	closeDest()
+	closeClient()
+	<-done
 }
 
 // UnusedAddr returns a local "host:port" address that is not currently being

--- a/tests/integration/pkg/proxy/proxy.go
+++ b/tests/integration/pkg/proxy/proxy.go
@@ -1,0 +1,137 @@
+// Package proxy provides a minimal HTTPS forward proxy used by integration
+// tests to verify that oc-mirror routes its network traffic through
+// HTTP_PROXY/HTTPS_PROXY. It only supports CONNECT tunneling: oc-mirror's
+// only plain-HTTP traffic targets its own local cache on localhost, which
+// Go's net/http never routes through a configured proxy, so there is no
+// plain-HTTP destination for this proxy to ever handle. It records every
+// host it has been asked to tunnel traffic to.
+package proxy
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Proxy is a minimal forward proxy for testing purposes.
+type Proxy struct {
+	listener net.Listener
+	server   *http.Server
+
+	mu    sync.Mutex
+	hosts map[string]struct{}
+}
+
+// Start starts a forward proxy listening on an OS-assigned local port.
+func Start() (*Proxy, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+
+	p := &Proxy{listener: ln, hosts: make(map[string]struct{})}
+	p.server = &http.Server{Handler: http.HandlerFunc(p.handleConnect)}
+	go func() { _ = p.server.Serve(ln) }()
+
+	return p, nil
+}
+
+// URL returns the proxy's base URL, suitable for HTTP_PROXY/HTTPS_PROXY.
+func (p *Proxy) URL() string {
+	return "http://" + p.listener.Addr().String()
+}
+
+// Stop closes the proxy listener and any open connections.
+func (p *Proxy) Stop() error {
+	return p.server.Close()
+}
+
+// SawHost reports whether any host the proxy forwarded traffic to contains substr.
+func (p *Proxy) SawHost(substr string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for h := range p.hosts {
+		if strings.Contains(h, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// Hosts returns every distinct host the proxy has forwarded traffic to, for
+// diagnostics when an assertion fails.
+func (p *Proxy) Hosts() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	hosts := make([]string, 0, len(p.hosts))
+	for h := range p.hosts {
+		hosts = append(hosts, h)
+	}
+	return hosts
+}
+
+func (p *Proxy) recordHost(hostport string) {
+	host := hostport
+	if h, _, err := net.SplitHostPort(hostport); err == nil {
+		host = h
+	}
+	p.mu.Lock()
+	p.hosts[host] = struct{}{}
+	p.mu.Unlock()
+}
+
+// handleConnect handles HTTPS tunneling: it dials the requested host and
+// pipes bytes between the client and destination once the tunnel is established.
+func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodConnect {
+		http.Error(w, "only CONNECT is supported", http.StatusMethodNotAllowed)
+		return
+	}
+
+	p.recordHost(r.Host)
+
+	destConn, err := net.DialTimeout("tcp", r.Host, 10*time.Second)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer destConn.Close()
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+	clientConn, _, err := hijacker.Hijack()
+	if err != nil {
+		return
+	}
+	defer clientConn.Close()
+
+	if _, err := clientConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
+		return
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); _, _ = io.Copy(destConn, clientConn) }()
+	go func() { defer wg.Done(); _, _ = io.Copy(clientConn, destConn) }()
+	wg.Wait()
+}
+
+// UnusedAddr returns a local "host:port" address that is not currently being
+// listened on, useful for simulating an unreachable proxy in negative-path tests.
+func UnusedAddr() (string, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", err
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		return "", err
+	}
+	return addr, nil
+}

--- a/tests/integration/proxy_test.go
+++ b/tests/integration/proxy_test.go
@@ -1,0 +1,105 @@
+package integration_test
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/oc-mirror/tests/integration/pkg/ocmirror"
+	"github.com/openshift/oc-mirror/tests/integration/pkg/proxy"
+)
+
+var _ = Describe("mirroring through an HTTP(S) proxy", func() {
+	var workDir string
+	iscHappyPath := filepath.Join("happy_path", "isc-happy-path.yaml")
+
+	BeforeEach(func() {
+		workDir = setupWorkDir()
+	})
+
+	AfterEach(func() {
+		cleanupWorkDir(workDir)
+	})
+
+	It("should route all mirroring traffic through the configured proxy and succeed", func() {
+		fwdProxy, err := proxy.Start()
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(fwdProxy.Stop)
+
+		// Custom runner so we don't mutate the shared global runner's env.
+		proxyRunner := ocmirror.NewRunner(os.Getenv("OC_MIRROR_BINARY")).WithEnv([]string{
+			"HTTP_PROXY=" + fwdProxy.URL(),
+			"HTTPS_PROXY=" + fwdProxy.URL(),
+			"http_proxy=" + fwdProxy.URL(),
+			"https_proxy=" + fwdProxy.URL(),
+		})
+
+		By("running mirrorToDisk with HTTP_PROXY/HTTPS_PROXY set")
+		result, err := proxyRunner.MirrorToDisk(ctx, filepath.Join(iscDir, iscHappyPath), workDir)
+		expectOcMirrorCommandSuccess(result, err)
+
+		By("verifying images are mirrored in the local cache")
+		expectSuccessfulMirrorInLocalCache(filepath.Join(iscDir, iscHappyPath), cacheDir)
+
+		By("verifying the proxy observed connections to the expected external hosts")
+		GinkgoWriter.Printf("hosts seen by proxy: %v\n", fwdProxy.Hosts())
+		Expect(fwdProxy.SawHost("quay.io")).To(BeTrue(),
+			"expected the proxy to observe a connection to quay.io (release/catalog/additional images); hosts seen: %v", fwdProxy.Hosts())
+		Expect(fwdProxy.SawHost("stefanprodan.github.io")).To(BeTrue(),
+			"expected the proxy to observe a connection to stefanprodan.github.io (helm repository index/chart); hosts seen: %v", fwdProxy.Hosts())
+		Expect(fwdProxy.SawHost("ghcr.io")).To(BeTrue(),
+			"expected the proxy to observe a connection to ghcr.io (image referenced by the helm chart); hosts seen: %v", fwdProxy.Hosts())
+	})
+
+	It("should fail when the configured proxy is unreachable", func() {
+		unreachableAddr, err := proxy.UnusedAddr()
+		Expect(err).NotTo(HaveOccurred())
+
+		proxyRunner := ocmirror.NewRunner(os.Getenv("OC_MIRROR_BINARY")).WithEnv([]string{
+			"HTTP_PROXY=http://" + unreachableAddr,
+			"HTTPS_PROXY=http://" + unreachableAddr,
+			"http_proxy=http://" + unreachableAddr,
+			"https_proxy=http://" + unreachableAddr,
+		})
+
+		By("running mirrorToDisk with an unreachable proxy configured")
+		result, err := proxyRunner.MirrorToDisk(ctx, filepath.Join(iscDir, iscHappyPath), workDir, "--retry-times=1")
+		expectOcMirrorCommandFailure(result, err)
+
+		output := result.Stdout + result.Stderr
+		Expect(output).To(SatisfyAny(
+			ContainSubstring("proxyconnect"),
+			ContainSubstring("connection refused"),
+		), "expected failure to be related to the unreachable proxy, got:\nstdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+	})
+
+	It("should exit promptly instead of hanging when release channel resolution can't reach an unreachable proxy", func() {
+		// Channel resolution has a 60-minute timeout and no retries, so this
+		// checks oc-mirror fails fast instead of hanging on a dead proxy.
+		iscProxyChannels := filepath.Join("proxy", "isc-proxy-channels.yaml")
+
+		unreachableAddr, err := proxy.UnusedAddr()
+		Expect(err).NotTo(HaveOccurred())
+
+		proxyRunner := ocmirror.NewRunner(os.Getenv("OC_MIRROR_BINARY")).WithEnv([]string{
+			"HTTP_PROXY=http://" + unreachableAddr,
+			"HTTPS_PROXY=http://" + unreachableAddr,
+			"http_proxy=http://" + unreachableAddr,
+			"https_proxy=http://" + unreachableAddr,
+		})
+
+		By("running mirrorToDisk with graph+channels and an unreachable proxy configured")
+		result, err := proxyRunner.MirrorToDisk(ctx, filepath.Join(iscDir, iscProxyChannels), workDir)
+		expectOcMirrorCommandFailure(result, err)
+
+		By("verifying oc-mirror exits promptly instead of hanging until the Cincinnati request times out")
+		Expect(result.Duration).To(BeNumerically("<", 30*time.Second),
+			"oc-mirror took %s to fail; expected it to exit promptly instead of hanging", result.Duration)
+
+		Expect(result.Stdout+result.Stderr).To(ContainSubstring("no release images found"),
+			"expected a clear release-collection error, got:\nstdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+	})
+})

--- a/tests/integration/proxy_test.go
+++ b/tests/integration/proxy_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"time"
@@ -30,11 +31,14 @@ var _ = Describe("mirroring through an HTTP(S) proxy", func() {
 		DeferCleanup(fwdProxy.Stop)
 
 		// Custom runner so we don't mutate the shared global runner's env.
+		// Clear NO_PROXY/no_proxy so an inherited value can't bypass the proxy.
 		proxyRunner := ocmirror.NewRunner(os.Getenv("OC_MIRROR_BINARY")).WithEnv([]string{
 			"HTTP_PROXY=" + fwdProxy.URL(),
 			"HTTPS_PROXY=" + fwdProxy.URL(),
 			"http_proxy=" + fwdProxy.URL(),
 			"https_proxy=" + fwdProxy.URL(),
+			"NO_PROXY=",
+			"no_proxy=",
 		})
 
 		By("running mirrorToDisk with HTTP_PROXY/HTTPS_PROXY set")
@@ -52,6 +56,9 @@ var _ = Describe("mirroring through an HTTP(S) proxy", func() {
 			"expected the proxy to observe a connection to stefanprodan.github.io (helm repository index/chart); hosts seen: %v", fwdProxy.Hosts())
 		Expect(fwdProxy.SawHost("ghcr.io")).To(BeTrue(),
 			"expected the proxy to observe a connection to ghcr.io (image referenced by the helm chart); hosts seen: %v", fwdProxy.Hosts())
+
+		By("verifying the proxy itself did not fail unexpectedly while serving connections")
+		Expect(fwdProxy.Err()).NotTo(HaveOccurred())
 	})
 
 	It("should fail when the configured proxy is unreachable", func() {
@@ -63,6 +70,8 @@ var _ = Describe("mirroring through an HTTP(S) proxy", func() {
 			"HTTPS_PROXY=http://" + unreachableAddr,
 			"http_proxy=http://" + unreachableAddr,
 			"https_proxy=http://" + unreachableAddr,
+			"NO_PROXY=",
+			"no_proxy=",
 		})
 
 		By("running mirrorToDisk with an unreachable proxy configured")
@@ -89,10 +98,17 @@ var _ = Describe("mirroring through an HTTP(S) proxy", func() {
 			"HTTPS_PROXY=http://" + unreachableAddr,
 			"http_proxy=http://" + unreachableAddr,
 			"https_proxy=http://" + unreachableAddr,
+			"NO_PROXY=",
+			"no_proxy=",
 		})
 
+		// Bound this command so a regression of the 60-minute timeout fails
+		// fast instead of burning the suite's time budget.
+		commandCtx, cancel := context.WithTimeout(ctx, 25*time.Second)
+		DeferCleanup(cancel)
+
 		By("running mirrorToDisk with graph+channels and an unreachable proxy configured")
-		result, err := proxyRunner.MirrorToDisk(ctx, filepath.Join(iscDir, iscProxyChannels), workDir)
+		result, err := proxyRunner.MirrorToDisk(commandCtx, filepath.Join(iscDir, iscProxyChannels), workDir)
 		expectOcMirrorCommandFailure(result, err)
 
 		By("verifying oc-mirror exits promptly instead of hanging until the Cincinnati request times out")

--- a/tests/integration/testdata/imagesetconfigs/proxy/isc-proxy-channels.yaml
+++ b/tests/integration/testdata/imagesetconfigs/proxy/isc-proxy-channels.yaml
@@ -1,0 +1,12 @@
+# ImageSetConfig used to verify that oc-mirror exits promptly instead of
+# hanging until the Cincinnati request timeout when HTTP_PROXY/HTTPS_PROXY
+# point at an unreachable proxy. platform.graph is never actually reached in
+# this scenario: channel resolution fails first (see local_stored_collector.go),
+# so this is safe to run without a real proxy or network access.
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v2alpha1
+mirror:
+  platform:
+    graph: true
+    channels:
+    - name: stable-4.15


### PR DESCRIPTION
# Description

Add integration coverage for oc-mirror's HTTP(S) proxy support:

* New minimal forward proxy test helper (tests/integration/pkg/proxy) that records which hosts traffic was routed to.
* Positive test: mirrorToDisk succeeds through the proxy, which observes connections to quay.io, the helm repo, and images referenced by the helm chart.
* Negative test: mirrorToDisk fails when the configured proxy is unreachable.
* Negative test: release channel resolution (graph + channels) fails fast instead of hanging on the 60-minute Cincinnati timeout when the proxy is unreachable.

Github / Jira issue: 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

Running tests locally

## Expected Outcome
Please describe the outcome expected from the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for successful HTTPS proxy routing.
  * Added tests for unreachable proxies, including prompt failure during release-channel resolution.
  * Added validation of routed hosts, command results, error messages, and execution timing.
* **Test Infrastructure**
  * Added a local HTTPS CONNECT proxy for integration testing.
  * Added test configuration for platform graph generation through a proxy.
  * Added support for reserving unreachable local proxy addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->