### PR TITLE
OCPBUGS-104448: mirror s390x kubevirt container when appropriate

### DIFF
--- a/internal/pkg/api/v2alpha1/type_kubevirt.go
+++ b/internal/pkg/api/v2alpha1/type_kubevirt.go
@@ -33,13 +33,23 @@ type Images struct {
 	Kubevirt Kubevirt `json:"kubevirt"`
 }
 
-type X86_64 struct {
+// ArchImages holds the bootable image data for a single CPU architecture.
+// The JSON key names (x86_64, aarch64, etc.) come directly from the
+// 0000_50_installer_coreos-bootimages ConfigMap embedded in each release payload.
+type ArchImages struct {
 	Artifacts Artifacts `json:"artifacts"`
 	Images    Images    `json:"images"`
 }
 
+// X86_64 is kept as a type alias for ArchImages to preserve backward
+// compatibility with code that was written before multi-arch support.
+type X86_64 = ArchImages
+
 type Architectures struct {
-	X86_64 X86_64 `json:"x86_64"`
+	X86_64  ArchImages `json:"x86_64"`
+	Aarch64 ArchImages `json:"aarch64"`
+	Ppc64le ArchImages `json:"ppc64le"`
+	S390x   ArchImages `json:"s390x"`
 }
 
 // InstallerConfigMap - this is the yaml structure

--- a/internal/pkg/release/local_stored_collector.go
+++ b/internal/pkg/release/local_stored_collector.go
@@ -604,9 +604,18 @@ func (o LocalStorageCollector) getKubeVirtImages(releaseArtifactsDir string) ([]
 			continue
 		}
 		o.Log.Info("kubeVirtContainer set to true [ including : %v (arch: %v) ]", digestRef, archKey)
+
+		// For backward compatibility, only append the architecture suffix when
+		// mirroring multiple architectures. Single-arch mirrors retain the legacy
+		// tag name "kube-virt-container".
+		imageName := "kube-virt-container"
+		if len(archKeys) > 1 {
+			imageName += "-" + archKey
+		}
+
 		images = append(images, v2alpha1.RelatedImage{
 			Image: digestRef,
-			Name:  "kube-virt-container",
+			Name:  imageName,
 			Type:  v2alpha1.TypeOCPReleaseContent,
 		})
 	}

--- a/internal/pkg/release/local_stored_collector.go
+++ b/internal/pkg/release/local_stored_collector.go
@@ -208,11 +208,11 @@ func (o *LocalStorageCollector) collectReleaseImages(ctx context.Context, releas
 	}
 
 	if o.Config.Mirror.Platform.KubeVirtContainer {
-		ki, err := o.getKubeVirtImage(cacheDir)
+		kvImages, err := o.getKubeVirtImages(cacheDir)
 		if err != nil {
 			return []v2alpha1.RelatedImage{}, err
 		}
-		allRelatedImages = append(allRelatedImages, ki)
+		allRelatedImages = append(allRelatedImages, kvImages...)
 	}
 
 	return allRelatedImages, nil
@@ -318,11 +318,11 @@ func (o *LocalStorageCollector) prepareReleaseBatchFromDir(releaseDir string) ([
 	}
 
 	if o.Config.Mirror.Platform.KubeVirtContainer {
-		ki, err := o.getKubeVirtImage(releaseDir)
+		kvImages, err := o.getKubeVirtImages(releaseDir)
 		if err != nil {
 			return []v2alpha1.CopyImageSchema{}, err
 		}
-		releaseRelatedImages = append(releaseRelatedImages, ki)
+		releaseRelatedImages = append(releaseRelatedImages, kvImages...)
 	}
 
 	return o.prepareD2MCopyBatch(releaseRelatedImages, releaseTag)
@@ -537,16 +537,34 @@ func (o *LocalStorageCollector) ReleaseImage(ctx context.Context) (string, error
 	}
 }
 
-// getKubeVirtImage - CLID-179 : include coreos-bootable container image
-// if set it will be across the board for all releases
-func (o LocalStorageCollector) getKubeVirtImage(releaseArtifactsDir string) (v2alpha1.RelatedImage, error) {
+// kubeVirtArchName maps the Go/OCP architecture names used in the
+// ImageSetConfiguration to the keys used in the
+// 0000_50_installer_coreos-bootimages ConfigMap JSON (architectures.*).
+// Only architectures that actually ship a kubevirt container image are listed;
+// as of RHCOS 4.15+ those are x86_64 and s390x.
+// aarch64 and ppc64le are present in the bootimages JSON but carry no
+// kubevirt image entry, so they are intentionally omitted here.
+var kubeVirtArchName = map[string]string{
+	"amd64": "x86_64",
+	"s390x": "s390x",
+}
+
+// allKubeVirtArchKeys lists the bootimages JSON architecture keys that carry a
+// kubevirt image. Used when the user selects the "multi" sparse-manifest-list
+// workflow (platform.platforms) so that every supported arch is mirrored.
+var allKubeVirtArchKeys = []string{"x86_64", "s390x"}
+
+// getKubeVirtImages - CLID-179 : include coreos-bootable container images
+// for all requested architectures. Returns one RelatedImage per architecture
+// whose kubevirt digest-ref is non-empty in the bootimages ConfigMap.
+func (o LocalStorageCollector) getKubeVirtImages(releaseArtifactsDir string) ([]v2alpha1.RelatedImage, error) {
 	// parse the main yaml file
 	biFile := strings.Join([]string{releaseArtifactsDir, releaseBootableImagesFullPath}, "/")
 	icm, err := parser.ParseYamlFile[v2alpha1.InstallerConfigMap](biFile)
 	if err != nil {
 		// this should not break the release process
 		// we just report the error and continue
-		return v2alpha1.RelatedImage{}, fmt.Errorf("marshalling kubevirt yaml file %w", err)
+		return nil, fmt.Errorf("marshalling kubevirt yaml file %w", err)
 	}
 
 	o.Log.Trace("data %v", icm.Data.Stream)
@@ -555,20 +573,99 @@ func (o LocalStorageCollector) getKubeVirtImage(releaseArtifactsDir string) (v2a
 	if err != nil {
 		// this should not break the release process
 		// we just report the error and continue
-		return v2alpha1.RelatedImage{}, fmt.Errorf("parsing json from kubevirt configmap data %w", err)
+		return nil, fmt.Errorf("parsing json from kubevirt configmap data %w", err)
 	}
 
-	image := ibi.Architectures.X86_64.Images.Kubevirt.DigestRef
-	if image == "" {
-		return v2alpha1.RelatedImage{}, fmt.Errorf("could not find kubevirt image in this release")
+	// Build the set of bootimages JSON architecture keys to collect.
+	// When the user chose platform.platforms (the "multi" payload path) we
+	// collect every architecture present in the ConfigMap. When the user
+	// chose the older platform.architectures field we map each entry to its
+	// JSON key. Defaults to x86_64 for backward compatibility.
+	archKeys := o.requestedKubeVirtArchKeys()
+
+	// archImages maps a bootimages JSON key to its ArchImages struct.
+	archImages := map[string]v2alpha1.ArchImages{
+		"x86_64":  ibi.Architectures.X86_64,
+		"aarch64": ibi.Architectures.Aarch64,
+		"ppc64le": ibi.Architectures.Ppc64le,
+		"s390x":   ibi.Architectures.S390x,
 	}
-	o.Log.Info("kubeVirtContainer set to true [ including : %v ]", image)
-	kubeVirtImage := v2alpha1.RelatedImage{
-		Image: image,
-		Name:  "kube-virt-container",
-		Type:  v2alpha1.TypeOCPReleaseContent,
+
+	var images []v2alpha1.RelatedImage
+	for _, archKey := range archKeys {
+		ai, ok := archImages[archKey]
+		if !ok {
+			o.Log.Warn("kubevirt: unknown architecture key %q — skipping", archKey)
+			continue
+		}
+		digestRef := ai.Images.Kubevirt.DigestRef
+		if digestRef == "" {
+			o.Log.Debug("kubevirt: no digest-ref for architecture %q in this release — skipping", archKey)
+			continue
+		}
+		o.Log.Info("kubeVirtContainer set to true [ including : %v (arch: %v) ]", digestRef, archKey)
+		images = append(images, v2alpha1.RelatedImage{
+			Image: digestRef,
+			Name:  "kube-virt-container",
+			Type:  v2alpha1.TypeOCPReleaseContent,
+		})
 	}
-	return kubeVirtImage, nil
+
+	if len(images) == 0 {
+		return nil, fmt.Errorf("could not find kubevirt image in this release")
+	}
+	return images, nil
+}
+
+// requestedKubeVirtArchKeys returns the bootimages JSON architecture keys
+// that correspond to the architectures requested in the ImageSetConfiguration.
+// When platform.platforms is set (the "multi" sparse-manifest-list workflow)
+// all known architecture keys are returned. When platform.architectures is
+// set each entry is mapped from its Go name (e.g. "amd64") to its JSON key
+// (e.g. "x86_64"). Defaults to ["x86_64"] for backward compatibility.
+func (o LocalStorageCollector) requestedKubeVirtArchKeys() []string {
+	cfg := o.Config.Mirror.Platform
+
+	// New path: platform.platforms was set — the release payload is the "multi"
+	// manifest list and we want kubevirt images for every architecture.
+	if len(cfg.Platforms) > 0 {
+		var keys []string
+		for _, pf := range cfg.Platforms {
+			if jsonKey, ok := kubeVirtArchName[pf.Architecture]; ok {
+				keys = append(keys, jsonKey)
+			} else {
+				o.Log.Warn("kubevirt: no bootimages key for platform architecture %q — skipping", pf.Architecture)
+			}
+		}
+		if len(keys) > 0 {
+			return keys
+		}
+		// Fall through: none of the requested architectures had a known mapping;
+		// return all keys so we still attempt to collect something.
+		return allKubeVirtArchKeys
+	}
+
+	// Deprecated path: platform.architectures was set.
+	//nolint:staticcheck // SA1019: Architectures is deprecated but we maintain backward compatibility
+	if len(cfg.Architectures) > 0 {
+		var keys []string
+		for _, arch := range cfg.Architectures {
+			if arch == "multi" {
+				return allKubeVirtArchKeys
+			}
+			if jsonKey, ok := kubeVirtArchName[arch]; ok {
+				keys = append(keys, jsonKey)
+			} else {
+				o.Log.Warn("kubevirt: no bootimages key for architecture %q — skipping", arch)
+			}
+		}
+		if len(keys) > 0 {
+			return keys
+		}
+	}
+
+	// Default: backward-compatible single-arch (x86_64).
+	return []string{"x86_64"}
 }
 
 func (o LocalStorageCollector) handleGraphImage(ctx context.Context) (v2alpha1.CopyImageSchema, error) {

--- a/internal/pkg/release/local_stored_collector_test.go
+++ b/internal/pkg/release/local_stored_collector_test.go
@@ -850,6 +850,206 @@ func (o *ManifestMock) GetManifestListDigests(ctx context.Context, sourceCtx *ty
 	return nil, nil
 }
 
+// TestRequestedKubeVirtArchKeys verifies that the architecture-key resolution
+// logic correctly maps user-facing architecture names to bootimages JSON keys
+// and handles all three configuration paths (Platforms, Architectures, default).
+// Only x86_64 (amd64) and s390x carry kubevirt images in the bootimages JSON.
+func TestRequestedKubeVirtArchKeys(t *testing.T) {
+	log := clog.New("trace")
+
+	makeCollector := func(cfg v2alpha1.ImageSetConfiguration) LocalStorageCollector {
+		return LocalStorageCollector{
+			Log:    log,
+			Config: cfg,
+		}
+	}
+
+	t.Run("platform.platforms amd64+s390x maps to x86_64+s390x", func(t *testing.T) {
+		cfg := v2alpha1.ImageSetConfiguration{
+			ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+				Mirror: v2alpha1.Mirror{
+					Platform: v2alpha1.Platform{
+						Platforms: []v2alpha1.InstancePlatformFilter{
+							{OS: "linux", Architecture: "amd64"},
+							{OS: "linux", Architecture: "s390x"},
+						},
+						KubeVirtContainer: true,
+					},
+				},
+			},
+		}
+		keys := makeCollector(cfg).requestedKubeVirtArchKeys()
+		assert.ElementsMatch(t, []string{"x86_64", "s390x"}, keys)
+	})
+
+	t.Run("platform.platforms with unsupported arch (arm64) is skipped", func(t *testing.T) {
+		cfg := v2alpha1.ImageSetConfiguration{
+			ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+				Mirror: v2alpha1.Mirror{
+					Platform: v2alpha1.Platform{
+						Platforms: []v2alpha1.InstancePlatformFilter{
+							{OS: "linux", Architecture: "arm64"},
+						},
+						KubeVirtContainer: true,
+					},
+				},
+			},
+		}
+		// arm64 has no kubevirt entry; falls back to all known keys
+		keys := makeCollector(cfg).requestedKubeVirtArchKeys()
+		assert.ElementsMatch(t, allKubeVirtArchKeys, keys)
+	})
+
+	t.Run("deprecated platform.architectures amd64 maps to x86_64", func(t *testing.T) {
+		cfg := v2alpha1.ImageSetConfiguration{
+			ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+				Mirror: v2alpha1.Mirror{
+					Platform: v2alpha1.Platform{
+						Architectures:     []string{"amd64"},
+						KubeVirtContainer: true,
+					},
+				},
+			},
+		}
+		keys := makeCollector(cfg).requestedKubeVirtArchKeys()
+		assert.Equal(t, []string{"x86_64"}, keys)
+	})
+
+	t.Run("deprecated platform.architectures multi returns all kubevirt arch keys", func(t *testing.T) {
+		cfg := v2alpha1.ImageSetConfiguration{
+			ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+				Mirror: v2alpha1.Mirror{
+					Platform: v2alpha1.Platform{
+						Architectures:     []string{"multi"},
+						KubeVirtContainer: true,
+					},
+				},
+			},
+		}
+		keys := makeCollector(cfg).requestedKubeVirtArchKeys()
+		assert.ElementsMatch(t, allKubeVirtArchKeys, keys)
+	})
+
+	t.Run("no architecture config defaults to x86_64", func(t *testing.T) {
+		cfg := v2alpha1.ImageSetConfiguration{
+			ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+				Mirror: v2alpha1.Mirror{
+					Platform: v2alpha1.Platform{
+						KubeVirtContainer: true,
+					},
+				},
+			},
+		}
+		keys := makeCollector(cfg).requestedKubeVirtArchKeys()
+		assert.Equal(t, []string{"x86_64"}, keys)
+	})
+}
+
+// TestGetKubeVirtImages verifies that getKubeVirtImages returns one image per
+// architecture that carries a kubevirt digest-ref in the bootimages ConfigMap.
+// Per the upstream coreos-rhel-9.json, only x86_64 and s390x have kubevirt images.
+func TestGetKubeVirtImages(t *testing.T) {
+	log := clog.New("trace")
+
+	// The testdata bootimages file mirrors the upstream shape:
+	// x86_64 and s390x have kubevirt images; aarch64 and ppc64le do not.
+	testdataDir := filepath.Join(consts.TestFolder, "working-dir-fake", "hold-release", "ocp-release", "4.14.1-x86_64")
+
+	t.Run("default (no arch config) returns only x86_64 kubevirt image", func(t *testing.T) {
+		cfg := v2alpha1.ImageSetConfiguration{
+			ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+				Mirror: v2alpha1.Mirror{
+					Platform: v2alpha1.Platform{KubeVirtContainer: true},
+				},
+			},
+		}
+		col := LocalStorageCollector{Log: log, Config: cfg}
+		images, err := col.getKubeVirtImages(testdataDir)
+		assert.NoError(t, err)
+		assert.Len(t, images, 1)
+		assert.Contains(t, images[0].Image, "sha256:729265d5ef6ed6a45bcd55c46877e3acb9eae3f49c78cd795d5b53aa85e3775b")
+	})
+
+	t.Run("platform.platforms amd64+s390x returns two kubevirt images", func(t *testing.T) {
+		cfg := v2alpha1.ImageSetConfiguration{
+			ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+				Mirror: v2alpha1.Mirror{
+					Platform: v2alpha1.Platform{
+						Platforms: []v2alpha1.InstancePlatformFilter{
+							{OS: "linux", Architecture: "amd64"},
+							{OS: "linux", Architecture: "s390x"},
+						},
+						KubeVirtContainer: true,
+					},
+				},
+			},
+		}
+		col := LocalStorageCollector{Log: log, Config: cfg}
+		images, err := col.getKubeVirtImages(testdataDir)
+		assert.NoError(t, err)
+		assert.Len(t, images, 2)
+
+		refs := make([]string, len(images))
+		for i, img := range images {
+			refs[i] = img.Image
+		}
+		assert.Contains(t, refs, "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:729265d5ef6ed6a45bcd55c46877e3acb9eae3f49c78cd795d5b53aa85e3775b")
+		assert.Contains(t, refs, "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:s390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390")
+	})
+
+	t.Run("platform.platforms with all arches returns only x86_64+s390x kubevirt images", func(t *testing.T) {
+		// aarch64 and ppc64le have no kubevirt entry in the bootimages JSON; they are skipped.
+		cfg := v2alpha1.ImageSetConfiguration{
+			ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+				Mirror: v2alpha1.Mirror{
+					Platform: v2alpha1.Platform{
+						Platforms: []v2alpha1.InstancePlatformFilter{
+							{OS: "linux", Architecture: "amd64"},
+							{OS: "linux", Architecture: "arm64"},
+							{OS: "linux", Architecture: "ppc64le"},
+							{OS: "linux", Architecture: "s390x"},
+						},
+						KubeVirtContainer: true,
+					},
+				},
+			},
+		}
+		col := LocalStorageCollector{Log: log, Config: cfg}
+		images, err := col.getKubeVirtImages(testdataDir)
+		assert.NoError(t, err)
+		// arm64 and ppc64le have no kubevirt mapping, so only x86_64 and s390x images are returned.
+		assert.Len(t, images, 2)
+		for _, img := range images {
+			assert.Equal(t, v2alpha1.TypeOCPReleaseContent, img.Type)
+			assert.Equal(t, "kube-virt-container", img.Name)
+			assert.NotEmpty(t, img.Image)
+		}
+	})
+
+	t.Run("deprecated platform.architectures multi returns x86_64+s390x kubevirt images", func(t *testing.T) {
+		cfg := v2alpha1.ImageSetConfiguration{
+			ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
+				Mirror: v2alpha1.Mirror{
+					Platform: v2alpha1.Platform{
+						Architectures:     []string{"multi"},
+						KubeVirtContainer: true,
+					},
+				},
+			},
+		}
+		col := LocalStorageCollector{Log: log, Config: cfg}
+		images, err := col.getKubeVirtImages(testdataDir)
+		assert.NoError(t, err)
+		assert.Len(t, images, 2)
+		refs := make([]string, len(images))
+		for i, img := range images {
+			refs[i] = img.Image
+		}
+		assert.Contains(t, refs, "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:729265d5ef6ed6a45bcd55c46877e3acb9eae3f49c78cd795d5b53aa85e3775b")
+		assert.Contains(t, refs, "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:s390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390")
+	})
+}
+
 func TestBuildReleasePlatformFilters(t *testing.T) {
 	platforms := []v2alpha1.InstancePlatformFilter{
 		{OS: "linux", Architecture: "amd64"},

--- a/internal/pkg/release/local_stored_collector_test.go
+++ b/internal/pkg/release/local_stored_collector_test.go
@@ -955,7 +955,7 @@ func TestGetKubeVirtImages(t *testing.T) {
 	// x86_64 and s390x have kubevirt images; aarch64 and ppc64le do not.
 	testdataDir := filepath.Join(consts.TestFolder, "working-dir-fake", "hold-release", "ocp-release", "4.14.1-x86_64")
 
-	t.Run("default (no arch config) returns only x86_64 kubevirt image", func(t *testing.T) {
+	t.Run("default (no arch config) returns only x86_64 kubevirt image with legacy name", func(t *testing.T) {
 		cfg := v2alpha1.ImageSetConfiguration{
 			ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
 				Mirror: v2alpha1.Mirror{
@@ -968,9 +968,11 @@ func TestGetKubeVirtImages(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, images, 1)
 		assert.Contains(t, images[0].Image, "sha256:729265d5ef6ed6a45bcd55c46877e3acb9eae3f49c78cd795d5b53aa85e3775b")
+		// Backward compatibility: single-arch mirrors use the legacy name without suffix
+		assert.Equal(t, "kube-virt-container", images[0].Name)
 	})
 
-	t.Run("platform.platforms amd64+s390x returns two kubevirt images", func(t *testing.T) {
+	t.Run("platform.platforms amd64+s390x returns two kubevirt images with arch suffix", func(t *testing.T) {
 		cfg := v2alpha1.ImageSetConfiguration{
 			ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
 				Mirror: v2alpha1.Mirror{
@@ -989,15 +991,20 @@ func TestGetKubeVirtImages(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, images, 2)
 
-		refs := make([]string, len(images))
-		for i, img := range images {
-			refs[i] = img.Image
+		// Multi-arch: names include architecture suffix to avoid tag collision
+		for _, img := range images {
+			switch img.Name {
+			case "kube-virt-container-x86_64":
+				assert.Contains(t, img.Image, "sha256:729265d5ef6ed6a45bcd55c46877e3acb9eae3f49c78cd795d5b53aa85e3775b")
+			case "kube-virt-container-s390x":
+				assert.Contains(t, img.Image, "sha256:s390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390")
+			default:
+				t.Fatalf("unknown kubevirt image: %s", img.Name)
+			}
 		}
-		assert.Contains(t, refs, "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:729265d5ef6ed6a45bcd55c46877e3acb9eae3f49c78cd795d5b53aa85e3775b")
-		assert.Contains(t, refs, "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:s390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390")
 	})
 
-	t.Run("platform.platforms with all arches returns only x86_64+s390x kubevirt images", func(t *testing.T) {
+	t.Run("platform.platforms with all arches returns only x86_64+s390x kubevirt images with arch suffix", func(t *testing.T) {
 		// aarch64 and ppc64le have no kubevirt entry in the bootimages JSON; they are skipped.
 		cfg := v2alpha1.ImageSetConfiguration{
 			ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
@@ -1019,14 +1026,17 @@ func TestGetKubeVirtImages(t *testing.T) {
 		assert.NoError(t, err)
 		// arm64 and ppc64le have no kubevirt mapping, so only x86_64 and s390x images are returned.
 		assert.Len(t, images, 2)
-		for _, img := range images {
+		names := make([]string, len(images))
+		for i, img := range images {
 			assert.Equal(t, v2alpha1.TypeOCPReleaseContent, img.Type)
-			assert.Equal(t, "kube-virt-container", img.Name)
 			assert.NotEmpty(t, img.Image)
+			names[i] = img.Name
 		}
+		// Multi-arch: names include architecture suffix
+		assert.ElementsMatch(t, []string{"kube-virt-container-x86_64", "kube-virt-container-s390x"}, names)
 	})
 
-	t.Run("deprecated platform.architectures multi returns x86_64+s390x kubevirt images", func(t *testing.T) {
+	t.Run("deprecated platform.architectures multi returns x86_64+s390x kubevirt images with arch suffix", func(t *testing.T) {
 		cfg := v2alpha1.ImageSetConfiguration{
 			ImageSetConfigurationSpec: v2alpha1.ImageSetConfigurationSpec{
 				Mirror: v2alpha1.Mirror{
@@ -1041,12 +1051,16 @@ func TestGetKubeVirtImages(t *testing.T) {
 		images, err := col.getKubeVirtImages(testdataDir)
 		assert.NoError(t, err)
 		assert.Len(t, images, 2)
-		refs := make([]string, len(images))
-		for i, img := range images {
-			refs[i] = img.Image
+		for _, img := range images {
+			switch img.Name {
+			case "kube-virt-container-x86_64":
+				assert.Contains(t, img.Image, "sha256:729265d5ef6ed6a45bcd55c46877e3acb9eae3f49c78cd795d5b53aa85e3775b")
+			case "kube-virt-container-s390x":
+				assert.Contains(t, img.Image, "sha256:s390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390")
+			default:
+				t.Fatalf("unknown kubevirt image %s", img.Name)
+			}
 		}
-		assert.Contains(t, refs, "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:729265d5ef6ed6a45bcd55c46877e3acb9eae3f49c78cd795d5b53aa85e3775b")
-		assert.Contains(t, refs, "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:s390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390")
 	})
 }
 

--- a/tests/unit/testdata/working-dir-fake/hold-release/ocp-release/4.14.1-x86_64/release-manifests/0000_50_installer_coreos-bootimages.yaml
+++ b/tests/unit/testdata/working-dir-fake/hold-release/ocp-release/4.14.1-x86_64/release-manifests/0000_50_installer_coreos-bootimages.yaml
@@ -23,6 +23,21 @@ data:
               "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-415.92.202402201450-0-azure.x86_64.vhd"
             }
           }
+        },
+        "aarch64": {
+          "rhel-coreos-extensions": {}
+        },
+        "ppc64le": {
+          "rhel-coreos-extensions": {}
+        },
+        "s390x": {
+          "images": {
+            "kubevirt": {
+              "release": "415.92.202402201450-0",
+              "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.15-9.2-kubevirt-s390x",
+              "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:s390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390xs390"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
# Description

If `s390x` or `multi` architectures are requested, we should include the s390x kubevirt container in the mirroring.

Github / Jira issue: OCPBUGS-104448

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

```yaml
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  platform:
    architectures: ["multi"]
    channels:
      - name: stable-4.22
        minVersion: 4.22.1
        maxVersion: 4.22.1
    graph: false
    kubevirtContainer: true
```

```fish
❯ bin/oc-mirror --v2 --config release-kube-isc.yaml --workspace file://data/kube docker://localhost:5000 --dest-tls-verify=false --dry-run --log-level debug
[...]
2026/08/12 14:06:26  [INFO]   : kubeVirtContainer set to true [ including : quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:024cb7de8d9e21ef7fc2bcb90f8dd77e7f742d937822c95e4ec72b9ab48fea7d (arch: x86_64) ]
2026/08/12 14:06:26  [INFO]   : kubeVirtContainer set to true [ including : quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:bcbee9a66fd77578c842adfc29e4f7b1e3433bd86290cc918f35047a9abf2055 (arch: s390x) ]
[...]
```

## Expected Outcome
s390x kubevirt container included in the mirror list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added KubeVirt image support for x86_64, aarch64, ppc64le, and s390x architectures.
  * Added architecture selection through platform settings, legacy architecture values, multi-architecture mode, and default behavior.
  * Releases now include all available KubeVirt images for selected architectures.
  * Multi-architecture images now use architecture-specific names, while single-architecture images retain existing names.

* **Bug Fixes**
  * Unsupported architectures and images without digest references are skipped.
  * An error is reported when no matching KubeVirt images are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->