### PR TITLE
OCPBUGS-78497: reject uppercase registry hostnames in docker destinations

### DIFF
--- a/internal/pkg/cli/delete.go
+++ b/internal/pkg/cli/delete.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openshift/oc-mirror/v2/internal/pkg/delete"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/emoji"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/helm"
+	"github.com/openshift/oc-mirror/v2/internal/pkg/image"
 	clog "github.com/openshift/oc-mirror/v2/internal/pkg/log"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/manifest"
 	"github.com/openshift/oc-mirror/v2/internal/pkg/mirror"
@@ -129,6 +130,12 @@ func (o *DeleteSchema) ValidateDelete(args []string) error { //nolint:cyclop // 
 	}
 	if len(args[0]) > 1 && !strings.Contains(args[0], consts.DockerProtocol) {
 		return fmt.Errorf("the destination registry argument must have a docker:// protocol prefix")
+	}
+	// OCPBUGS-78497: reject uppercase registry hostnames early; CRI-O cannot pull them.
+	if strings.Contains(args[0], consts.DockerProtocol) {
+		if err := image.ValidateDockerDestinationRegistry(args[0]); err != nil {
+			return err
+		}
 	}
 
 	deleteFile := o.Opts.Global.DeleteYaml

--- a/internal/pkg/cli/delete_test.go
+++ b/internal/pkg/cli/delete_test.go
@@ -98,6 +98,11 @@ func TestExecutorValidateDelete(t *testing.T) {
 		opts.Global.DeleteYaml = "../../nothing"
 		err = ex.ValidateDelete([]string{consts.DockerProtocol + "test"})
 		assert.Equal(t, "file not found ../../nothing", err.Error())
+
+		// OCPBUGS-78497: uppercase registry hostnames must be rejected
+		opts.Global.DeleteYaml = consts.TestFolder + "delete/delete-images.yaml"
+		err = ex.ValidateDelete([]string{consts.DockerProtocol + "REGISTRY.EXAMPLE.COM:5000"})
+		assert.Equal(t, `destination registry hostname "REGISTRY.EXAMPLE.COM" contains uppercase characters; use lowercase (e.g. "registry.example.com") because CRI-O rejects uppercase registry hostnames`, err.Error())
 	})
 }
 

--- a/internal/pkg/cli/delete_test.go
+++ b/internal/pkg/cli/delete_test.go
@@ -103,6 +103,9 @@ func TestExecutorValidateDelete(t *testing.T) {
 		opts.Global.DeleteYaml = consts.TestFolder + "delete/delete-images.yaml"
 		err = ex.ValidateDelete([]string{consts.DockerProtocol + "REGISTRY.EXAMPLE.COM:5000"})
 		assert.Equal(t, `destination registry hostname "REGISTRY.EXAMPLE.COM" contains uppercase characters; use lowercase (e.g. "registry.example.com") because CRI-O rejects uppercase registry hostnames`, err.Error())
+
+		err = ex.ValidateDelete([]string{" " + consts.DockerProtocol + "REGISTRY.EXAMPLE.COM:5000"})
+		assert.Equal(t, `destination registry hostname "REGISTRY.EXAMPLE.COM" contains uppercase characters; use lowercase (e.g. "registry.example.com") because CRI-O rejects uppercase registry hostnames`, err.Error())
 	})
 }
 

--- a/internal/pkg/cli/executor.go
+++ b/internal/pkg/cli/executor.go
@@ -430,6 +430,12 @@ func (o *ExecutorSchema) Validate(dest []string) error { //nolint:cyclop // pre-
 	if strings.Contains(dest[0], consts.DockerProtocol) && o.Opts.Global.WorkingDir == "" && o.Opts.Global.From == "" {
 		return fmt.Errorf("when destination is docker://, either --from (assumes disk to mirror workflow) or --workspace (assumes mirror to mirror workflow) need to be provided")
 	}
+	// OCPBUGS-78497: reject uppercase registry hostnames early; CRI-O cannot pull them.
+	if strings.Contains(dest[0], consts.DockerProtocol) {
+		if err := image.ValidateDockerDestinationRegistry(dest[0]); err != nil {
+			return err
+		}
+	}
 	if strings.Contains(dest[0], consts.FileProtocol) || strings.Contains(dest[0], consts.DockerProtocol) {
 		return nil
 	} else {

--- a/internal/pkg/cli/executor_test.go
+++ b/internal/pkg/cli/executor_test.go
@@ -482,6 +482,9 @@ func TestExecutorValidate(t *testing.T) {
 		opts.Global.From = "" // reset
 		opts.Global.WorkingDir = consts.FileProtocol + "test"
 		assert.NoError(t, ex.Validate([]string{consts.DockerProtocol + "test"}))
+
+		// OCPBUGS-78497: lowercase registry hostnames are accepted
+		assert.NoError(t, ex.Validate([]string{consts.DockerProtocol + "registry.example.com:5000"}))
 	})
 
 	t.Run("Testing Executor : validate should fail", func(t *testing.T) {
@@ -587,6 +590,13 @@ func TestExecutorValidate(t *testing.T) {
 		opts.Global.WorkingDir = "" // reset
 		err = ex.Validate([]string{consts.DockerProtocol + "test"})
 		assert.EqualError(t, err, "when destination is docker://, either --from (assumes disk to mirror workflow) or --workspace (assumes mirror to mirror workflow) need to be provided")
+
+		// OCPBUGS-78497: uppercase registry hostnames must be rejected
+		opts.Global.ConfigPath = "test"
+		opts.Global.From = consts.FileProtocol + "abc"
+		opts.Global.WorkingDir = ""
+		err = ex.Validate([]string{consts.DockerProtocol + "REGISTRY.EXAMPLE.COM:5000"})
+		assert.EqualError(t, err, `destination registry hostname "REGISTRY.EXAMPLE.COM" contains uppercase characters; use lowercase (e.g. "registry.example.com") because CRI-O rejects uppercase registry hostnames`)
 	})
 }
 

--- a/internal/pkg/cli/executor_test.go
+++ b/internal/pkg/cli/executor_test.go
@@ -597,6 +597,10 @@ func TestExecutorValidate(t *testing.T) {
 		opts.Global.WorkingDir = ""
 		err = ex.Validate([]string{consts.DockerProtocol + "REGISTRY.EXAMPLE.COM:5000"})
 		assert.EqualError(t, err, `destination registry hostname "REGISTRY.EXAMPLE.COM" contains uppercase characters; use lowercase (e.g. "registry.example.com") because CRI-O rejects uppercase registry hostnames`)
+
+		// Leading space still matches Contains(docker://) at the call site and must be validated.
+		err = ex.Validate([]string{" " + consts.DockerProtocol + "REGISTRY.EXAMPLE.COM:5000"})
+		assert.EqualError(t, err, `destination registry hostname "REGISTRY.EXAMPLE.COM" contains uppercase characters; use lowercase (e.g. "registry.example.com") because CRI-O rejects uppercase registry hostnames`)
 	})
 }
 

--- a/internal/pkg/image/registry_hostname.go
+++ b/internal/pkg/image/registry_hostname.go
@@ -1,0 +1,68 @@
+package image
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"unicode"
+
+	"github.com/openshift/oc-mirror/v2/internal/pkg/consts"
+)
+
+// ValidateDockerDestinationRegistry validates a docker:// destination argument.
+// CRI-O rejects uppercase letters in registry hostnames, so oc-mirror fails early
+// rather than producing mirrored content that cluster nodes cannot pull (OCPBUGS-78497).
+func ValidateDockerDestinationRegistry(dest string) error {
+	if !strings.HasPrefix(dest, consts.DockerProtocol) {
+		return nil
+	}
+
+	ref := strings.TrimPrefix(dest, consts.DockerProtocol)
+	hostname := registryHostname(ref)
+	if hostname == "" {
+		return fmt.Errorf("destination registry hostname is empty")
+	}
+
+	// IP literals (IPv4 / IPv6) are not subject to DNS hostname case rules.
+	// IPv6 hex digits may be uppercase and remain valid.
+	if hostForIP := hostname; strings.HasPrefix(hostForIP, "[") && strings.HasSuffix(hostForIP, "]") {
+		hostForIP = hostForIP[1 : len(hostForIP)-1]
+		if net.ParseIP(hostForIP) != nil {
+			return nil
+		}
+	} else if net.ParseIP(hostname) != nil {
+		return nil
+	}
+
+	for _, r := range hostname {
+		if unicode.IsUpper(r) {
+			return fmt.Errorf("destination registry hostname %q contains uppercase characters; use lowercase (e.g. %q) because CRI-O rejects uppercase registry hostnames", hostname, strings.ToLower(hostname))
+		}
+	}
+	return nil
+}
+
+// registryHostname returns the host (without path) from a docker destination
+// reference such as "registry.example.com:5000/ns" or "[::1]:5000/ns".
+func registryHostname(ref string) string {
+	hostPort := ref
+	if i := strings.Index(ref, "/"); i >= 0 {
+		hostPort = ref[:i]
+	}
+	if hostPort == "" {
+		return ""
+	}
+
+	if strings.HasPrefix(hostPort, "[") {
+		end := strings.Index(hostPort, "]")
+		if end < 0 {
+			return hostPort
+		}
+		return hostPort[:end+1]
+	}
+
+	if host, _, err := net.SplitHostPort(hostPort); err == nil {
+		return host
+	}
+	return hostPort
+}

--- a/internal/pkg/image/registry_hostname.go
+++ b/internal/pkg/image/registry_hostname.go
@@ -13,11 +13,13 @@ import (
 // CRI-O rejects uppercase letters in registry hostnames, so oc-mirror fails early
 // rather than producing mirrored content that cluster nodes cannot pull (OCPBUGS-78497).
 func ValidateDockerDestinationRegistry(dest string) error {
-	if !strings.HasPrefix(dest, consts.DockerProtocol) {
+	// Cut (not HasPrefix) so this matches call sites that detect docker:// with Contains,
+	// including a leading space before the protocol.
+	_, ref, found := strings.Cut(dest, consts.DockerProtocol)
+	if !found {
 		return nil
 	}
 
-	ref := strings.TrimPrefix(dest, consts.DockerProtocol)
 	hostname := registryHostname(ref)
 	if hostname == "" {
 		return fmt.Errorf("destination registry hostname is empty")
@@ -25,12 +27,17 @@ func ValidateDockerDestinationRegistry(dest string) error {
 
 	// IP literals (IPv4 / IPv6) are not subject to DNS hostname case rules.
 	// IPv6 hex digits may be uppercase and remain valid.
-	if hostForIP := hostname; strings.HasPrefix(hostForIP, "[") && strings.HasSuffix(hostForIP, "]") {
-		hostForIP = hostForIP[1 : len(hostForIP)-1]
-		if net.ParseIP(hostForIP) != nil {
-			return nil
+	// Bracketed hosts are IP literals only; anything else in [] is not a DNS hostname.
+	if strings.HasPrefix(hostname, "[") {
+		if !strings.HasSuffix(hostname, "]") {
+			return fmt.Errorf("destination registry hostname %q is not a valid IP literal", hostname)
 		}
-	} else if net.ParseIP(hostname) != nil {
+		if net.ParseIP(hostname[1:len(hostname)-1]) == nil {
+			return fmt.Errorf("destination registry hostname %q is not a valid IP literal", hostname)
+		}
+		return nil
+	}
+	if net.ParseIP(hostname) != nil {
 		return nil
 	}
 

--- a/internal/pkg/image/registry_hostname_test.go
+++ b/internal/pkg/image/registry_hostname_test.go
@@ -1,0 +1,73 @@
+package image
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openshift/oc-mirror/v2/internal/pkg/consts"
+)
+
+func TestValidateDockerDestinationRegistry(t *testing.T) {
+	tests := []struct {
+		name        string
+		dest        string
+		expectError string
+	}{
+		{
+			name: "lowercase hostname",
+			dest: consts.DockerProtocol + "registry.example.com:5000",
+		},
+		{
+			name: "lowercase hostname with namespace",
+			dest: consts.DockerProtocol + "registry.example.com:5000/ns",
+		},
+		{
+			name: "ipv4 destination",
+			dest: consts.DockerProtocol + "192.168.1.10:5000",
+		},
+		{
+			name: "ipv6 destination with uppercase hex",
+			dest: consts.DockerProtocol + "[2001:DB8::1]:5000",
+		},
+		{
+			name: "non-docker destination is ignored",
+			dest: consts.FileProtocol + "archive",
+		},
+		{
+			name:        "uppercase hostname",
+			dest:        consts.DockerProtocol + "REGISTRY.EXAMPLE.COM:5000",
+			expectError: `destination registry hostname "REGISTRY.EXAMPLE.COM" contains uppercase characters; use lowercase (e.g. "registry.example.com") because CRI-O rejects uppercase registry hostnames`,
+		},
+		{
+			name:        "mixed case hostname with namespace",
+			dest:        consts.DockerProtocol + "Registry.Example.Com/ns",
+			expectError: `destination registry hostname "Registry.Example.Com" contains uppercase characters; use lowercase (e.g. "registry.example.com") because CRI-O rejects uppercase registry hostnames`,
+		},
+		{
+			name:        "empty hostname",
+			dest:        consts.DockerProtocol,
+			expectError: "destination registry hostname is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateDockerDestinationRegistry(tt.dest)
+			if tt.expectError == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.EqualError(t, err, tt.expectError)
+		})
+	}
+}
+
+func TestRegistryHostname(t *testing.T) {
+	assert.Equal(t, "registry.example.com", registryHostname("registry.example.com:5000/ns"))
+	assert.Equal(t, "registry.example.com", registryHostname("registry.example.com/ns"))
+	assert.Equal(t, "[::1]", registryHostname("[::1]:5000/ns"))
+	assert.Equal(t, "[2001:db8::1]", registryHostname("[2001:db8::1]/ns"))
+	assert.Equal(t, "", registryHostname(""))
+	assert.Equal(t, "", registryHostname("/ns"))
+}

--- a/internal/pkg/image/registry_hostname_test.go
+++ b/internal/pkg/image/registry_hostname_test.go
@@ -49,6 +49,30 @@ func TestValidateDockerDestinationRegistry(t *testing.T) {
 			dest:        consts.DockerProtocol,
 			expectError: "destination registry hostname is empty",
 		},
+		{
+			name:        "leading space before docker protocol uppercase hostname",
+			dest:        " " + consts.DockerProtocol + "REGISTRY.EXAMPLE.COM:5000",
+			expectError: `destination registry hostname "REGISTRY.EXAMPLE.COM" contains uppercase characters; use lowercase (e.g. "registry.example.com") because CRI-O rejects uppercase registry hostnames`,
+		},
+		{
+			name: "leading space before docker protocol lowercase hostname",
+			dest: " " + consts.DockerProtocol + "registry.example.com:5000",
+		},
+		{
+			name:        "empty bracketed host",
+			dest:        consts.DockerProtocol + "[]:5000/ns",
+			expectError: `destination registry hostname "[]" is not a valid IP literal`,
+		},
+		{
+			name:        "bracketed non-ip host",
+			dest:        consts.DockerProtocol + "[not-an-ip]:5000/ns",
+			expectError: `destination registry hostname "[not-an-ip]" is not a valid IP literal`,
+		},
+		{
+			name:        "bracketed mixed-case host is not a lowercase suggestion",
+			dest:        consts.DockerProtocol + "[MyHost]:5000",
+			expectError: `destination registry hostname "[MyHost]" is not a valid IP literal`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Reject `docker://` destinations whose registry hostname contains uppercase characters during Validate (mirror and delete), before any push work starts.
- This prevents mirroring content that cluster nodes cannot pull, because CRI-O rejects uppercase registry hostnames.
- Adds unit coverage for the helper and CLI validate paths; IPv4/IPv6 literals remain allowed.

Fixes https://issues.redhat.com/browse/OCPBUGS-78497

## Test plan
- [ ] `go test ./internal/pkg/image/ -run 'TestValidateDockerDestinationRegistry|TestRegistryHostname'`
- [ ] `CGO_ENABLED=0 go test -tags "json1 exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp" ./internal/pkg/cli/ -run 'TestExecutorValidate$|TestExecutorValidateDelete'`
- [ ] Manually confirm `oc-mirror ... docker://REGISTRY.EXAMPLE.COM:5000` fails with a clear lowercase suggestion
- [ ] Manually confirm `docker://registry.example.com:5000` still validates successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Docker destinations with uppercase or mixed-case registry hostnames are now rejected with a clear compatibility error.
  * Valid lowercase hostnames, IPv4/IPv6 addresses, namespaced destinations, and non-Docker destinations continue to be accepted.
  * Validation now rejects malformed, missing, or invalid bracketed registry hostnames, including destinations with leading whitespace.

* **Tests**
  * Expanded coverage for valid and invalid Docker destination formats, including ports, bracketed IPv6 addresses, leading whitespace, and malformed hostnames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->