### PR TITLE
OCPBUGS-85713: set WorkingDir from --delete-yaml-file path

### DIFF
--- a/internal/pkg/cli/delete.go
+++ b/internal/pkg/cli/delete.go
@@ -40,7 +40,27 @@ const (
 	deleteErrMsg = "[delete] %v"
 	deleteYaml   = "/delete/delete-images.yaml"
 	deleteDir    = "/delete/"
+	deleteSubDir = "delete"
 )
+
+// workingDirFromDeleteYaml derives the oc-mirror working-dir from a
+// --delete-yaml-file path. Generated delete files live under
+// <workspace>/working-dir/delete/delete-images*.yaml.
+func workingDirFromDeleteYaml(deleteYamlPath string) (string, error) {
+	if deleteYamlPath == "" {
+		return "", fmt.Errorf("the --delete-yaml-file flag is mandatory when not using the --generate flag")
+	}
+	absPath, err := filepath.Abs(deleteYamlPath)
+	if err != nil {
+		return "", fmt.Errorf("resolving delete yaml path: %w", err)
+	}
+	dir := filepath.Dir(absPath)
+	if filepath.Base(dir) == deleteSubDir {
+		return filepath.Dir(dir), nil
+	}
+	// Custom paths still need an absolute parent for logs.
+	return dir, nil
+}
 
 type DeleteSchema struct {
 	ExecutorSchema
@@ -197,6 +217,14 @@ func (o *DeleteSchema) CompleteDelete(args []string) error {
 		} else {
 			return fmt.Errorf("--workspace flag must have a file:// protocol prefix")
 		}
+	} else {
+		// OCPBUGS-85713: --delete-yaml-file does not take --workspace, so derive
+		// WorkingDir from the yaml path (…/working-dir/delete/delete-images*.yaml).
+		wd, err := workingDirFromDeleteYaml(o.Opts.Global.DeleteYaml)
+		if err != nil {
+			return err
+		}
+		o.Opts.Global.WorkingDir = wd
 	}
 
 	// setup logs level, and logsDir under workingDir

--- a/internal/pkg/cli/delete_test.go
+++ b/internal/pkg/cli/delete_test.go
@@ -155,6 +155,86 @@ func TestExecutorCompleteDelete(t *testing.T) {
 			t.Fatalf("should fail")
 		}
 	})
+
+	t.Run("Testing Executor : complete delete with --delete-yaml-file sets WorkingDir", func(t *testing.T) {
+		log := clog.New("trace")
+
+		global := &mirror.GlobalOptions{
+			SecurePolicy: false,
+			CacheDir:     "/tmp/",
+		}
+
+		_, sharedOpts := mirror.SharedImageFlags()
+		_, deprecatedTLSVerifyOpt := mirror.DeprecatedTLSVerifyFlags()
+		_, srcOpts := mirror.ImageSrcFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "src-", "screds")
+		_, destOpts := mirror.ImageDestFlags(global, sharedOpts, deprecatedTLSVerifyOpt, "dest-", "dcreds")
+		_, retryOpts := mirror.RetryFlags()
+
+		opts := mirror.CopyOptions{
+			Global:              global,
+			DeprecatedTLSVerify: deprecatedTLSVerifyOpt,
+			SrcImage:            srcOpts,
+			DestImage:           destOpts,
+			RetryOpts:           retryOpts,
+			Dev:                 false,
+		}
+
+		workspace := t.TempDir()
+		workingDirPath := filepath.Join(workspace, workingDir)
+		deleteDirPath := filepath.Join(workingDirPath, deleteSubDir)
+		assert.NoError(t, os.MkdirAll(deleteDirPath, 0o755))
+		deleteYamlPath := filepath.Join(deleteDirPath, "delete-images.yaml")
+		assert.NoError(t, os.WriteFile(deleteYamlPath, []byte("kind: DeleteImageList\n"), 0o644))
+
+		opts.Global.DeleteGenerate = false
+		opts.Global.DeleteYaml = deleteYamlPath
+		opts.Global.WorkingDir = ""
+
+		ex := &DeleteSchema{
+			ExecutorSchema: ExecutorSchema{
+				Log:     log,
+				Opts:    &opts,
+				MakeDir: MakeDir{},
+				LogsDir: "/tmp/",
+			},
+		}
+
+		err := ex.CompleteDelete([]string{consts.DockerProtocol + "myregistry:5000"})
+		assert.NoError(t, err)
+		assert.Equal(t, workingDirPath, ex.Opts.Global.WorkingDir)
+		assert.Equal(t, filepath.Join(workingDirPath, logsDir), ex.LogsDir)
+		_, err = os.Stat(ex.LogsDir)
+		assert.NoError(t, err)
+	})
+}
+
+func TestWorkingDirFromDeleteYaml(t *testing.T) {
+	t.Run("standard delete yaml path", func(t *testing.T) {
+		root := t.TempDir()
+		yamlPath := filepath.Join(root, "workspace", workingDir, deleteSubDir, "delete-images.yaml")
+		assert.NoError(t, os.MkdirAll(filepath.Dir(yamlPath), 0o755))
+		assert.NoError(t, os.WriteFile(yamlPath, []byte("x"), 0o644))
+
+		got, err := workingDirFromDeleteYaml(yamlPath)
+		assert.NoError(t, err)
+		assert.Equal(t, filepath.Join(root, "workspace", workingDir), got)
+	})
+
+	t.Run("delete-id style filename still under delete/", func(t *testing.T) {
+		root := t.TempDir()
+		yamlPath := filepath.Join(root, workingDir, deleteSubDir, "delete-images-delete1-test.yaml")
+		assert.NoError(t, os.MkdirAll(filepath.Dir(yamlPath), 0o755))
+		assert.NoError(t, os.WriteFile(yamlPath, []byte("x"), 0o644))
+
+		got, err := workingDirFromDeleteYaml(yamlPath)
+		assert.NoError(t, err)
+		assert.Equal(t, filepath.Join(root, workingDir), got)
+	})
+
+	t.Run("empty path", func(t *testing.T) {
+		_, err := workingDirFromDeleteYaml("")
+		assert.EqualError(t, err, "the --delete-yaml-file flag is mandatory when not using the --generate flag")
+	})
 }
 
 // TestExecutorRunDelete


### PR DESCRIPTION
## Summary
- When running `oc-mirror delete --delete-yaml-file` (without `--generate`), derive `WorkingDir` from the YAML path (`…/working-dir/delete/delete-images*.yaml`).
- Prevents `mkdir logs: permission denied` when the process CWD is not writable (e.g. container with read-only root).
- Adds unit coverage for path derivation and `CompleteDelete`.

Fixes https://issues.redhat.com/browse/OCPBUGS-85713

## Test plan
- [x] `CGO_ENABLED=0 go test -tags "json1 exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp" ./internal/pkg/cli/ -run 'TestWorkingDirFromDeleteYaml|TestExecutorCompleteDelete|TestExecutorValidateDelete' -v`
- [ ] Manually run delete phase 2 with `--delete-yaml-file …/working-dir/delete/delete-images.yaml` from a non-writable CWD and confirm logs land under `working-dir/logs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delete operations can now determine the workspace automatically from the specified delete YAML file when no workspace is provided.
  * Supports delete YAML files in standard locations and `delete` subdirectories.

* **Bug Fixes**
  * Improved delete execution by automatically deriving required workspace and log directories.
  * Added validation for delete YAML paths and automatic directory creation where needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->