### PR TITLE
OCPBUGS-111612: retry HTTP 429 responses from the destination registry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 
 require (
 	github.com/docker/cli v29.6.1+incompatible
+	github.com/docker/distribution v2.8.3+incompatible
 	k8s.io/klog v1.0.0
 )
 
@@ -72,7 +73,6 @@ require (
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.7 // indirect
 	github.com/docker/go-connections v0.7.0 // indirect
 	github.com/docker/go-events v0.0.0-20250808211157-605354379745 // indirect

--- a/internal/pkg/mirror/mirror.go
+++ b/internal/pkg/mirror/mirror.go
@@ -192,12 +192,6 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 		co.ReportWriter = opts.Stdout
 	}
 
-	var retryOpts retry.Options
-	if opts.RetryOpts != nil {
-		retryOpts = *opts.RetryOpts
-	}
-	retryOpts.IsErrorRetryable = isErrorRetryable
-
 	//nolint:wrapcheck // context will be added by the calling function
 	return retry.IfNecessary(ctx, func() error {
 		manifestBytes, err := o.mc.CopyImage(ctx, policyContext, destRef, srcRef, co)
@@ -214,11 +208,26 @@ func (o *Mirror) copy(ctx context.Context, src, dest string, opts *CopyOptions) 
 			}
 		}
 		return nil
-	}, &retryOpts)
+	}, retryOptionsFrom(opts))
 }
 
-// Custom implementation to extend `containers/common/pkg/retry.retry`
-func isErrorRetryable(err error) bool {
+// retryOptionsFrom returns a copy of the caller's retry options with oc-mirror's
+// error classification installed. The copy matters: opts.RetryOpts is shared
+// across all images and must not be mutated.
+func retryOptionsFrom(opts *CopyOptions) *retry.Options {
+	var ro retry.Options
+	if opts.RetryOpts != nil {
+		ro = *opts.RetryOpts
+	}
+	ro.IsErrorRetryable = IsErrorRetryable
+	return &ro
+}
+
+// IsErrorRetryable is a custom implementation that extends
+// `go.podman.io/common/pkg/retry.IsErrorRetryable`. The name intentionally mirrors
+// the imported upstream function that the `default` branch delegates to; the
+// package qualifier keeps the two distinct, so there is no conflict.
+func IsErrorRetryable(err error) bool {
 	var httpError docker.UnexpectedHTTPStatusError
 	switch {
 	case err == nil:
@@ -227,10 +236,20 @@ func isErrorRetryable(err error) bool {
 		return true
 	case errors.Is(err, context.Canceled):
 		return false
+	case errors.Is(err, docker.ErrTooManyRequests):
+		// Bare 429 sentinel from httpResponseToError; retryable by neither this
+		// switch nor go.podman.io/common.
+		return true
 	case errors.As(err, &httpError):
+		// 429: registries under sustained load (notably AWS ECR) rate-limit rather than
+		// returning 5xx. Upstream only retries this shape when it parses as errcode.Error.
+		if httpError.StatusCode == http.StatusTooManyRequests {
+			return true
+		}
 		// Retry on 500-504 server errors, they appear to be quite common in the field
 		// We duplicate this here because older versions of oc-mirror cannot bump containers/common given Golang version restrictions
-		if httpError.StatusCode >= http.StatusInternalServerError && httpError.StatusCode <= http.StatusGatewayTimeout {
+		if httpError.StatusCode >= http.StatusInternalServerError &&
+			httpError.StatusCode <= http.StatusGatewayTimeout {
 			return true
 		}
 		return false
@@ -273,7 +292,7 @@ func (o *Mirror) Check(ctx context.Context, image string, opts *CopyOptions, asC
 			return err
 		}
 		return nil
-	}, opts.RetryOpts)
+	}, retryOptionsFrom(opts))
 
 	if err == nil {
 		return true, nil
@@ -311,7 +330,7 @@ func (o *Mirror) delete(ctx context.Context, image string, opts *CopyOptions) er
 			return err
 		}
 		return nil
-	}, opts.RetryOpts)
+	}, retryOptionsFrom(opts))
 }
 
 // determinePlatformSelection determines the image list selection and platform filters

--- a/internal/pkg/mirror/mirror_test.go
+++ b/internal/pkg/mirror/mirror_test.go
@@ -2,14 +2,22 @@ package mirror
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/docker/distribution/registry/api/errcode"
+	errcodev2 "github.com/docker/distribution/registry/api/v2"
 	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.podman.io/common/pkg/retry"
 	"go.podman.io/image/v5/copy"
+	"go.podman.io/image/v5/docker"
 	"go.podman.io/image/v5/signature"
 	"go.podman.io/image/v5/types"
 
@@ -305,6 +313,132 @@ func TestDeterminePlatformSelection(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, copy.CopySystemImage, sel)
 		assert.Nil(t, platforms)
+	})
+}
+
+func TestIsErrorRetryable(t *testing.T) {
+	tooManyRequests := docker.UnexpectedHTTPStatusError{StatusCode: http.StatusTooManyRequests}
+
+	tests := []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		{
+			name:      "nil error is not retryable",
+			err:       nil,
+			retryable: false,
+		},
+		{
+			name:      "429 too many requests is retryable",
+			err:       tooManyRequests,
+			retryable: true,
+		},
+		{
+			name:      "wrapped 429 too many requests is retryable",
+			err:       fmt.Errorf("wrapped: %w", tooManyRequests),
+			retryable: true,
+		},
+		{
+			name:      "500 internal server error is retryable",
+			err:       docker.UnexpectedHTTPStatusError{StatusCode: http.StatusInternalServerError},
+			retryable: true,
+		},
+		{
+			name:      "502 bad gateway is retryable",
+			err:       docker.UnexpectedHTTPStatusError{StatusCode: http.StatusBadGateway},
+			retryable: true,
+		},
+		{
+			name:      "504 gateway timeout is retryable",
+			err:       docker.UnexpectedHTTPStatusError{StatusCode: http.StatusGatewayTimeout},
+			retryable: true,
+		},
+		{
+			name:      "400 bad request is not retryable",
+			err:       docker.UnexpectedHTTPStatusError{StatusCode: http.StatusBadRequest},
+			retryable: false,
+		},
+		{
+			name:      "401 unauthorized is not retryable",
+			err:       docker.UnexpectedHTTPStatusError{StatusCode: http.StatusUnauthorized},
+			retryable: false,
+		},
+		{
+			name:      "404 not found is not retryable",
+			err:       docker.UnexpectedHTTPStatusError{StatusCode: http.StatusNotFound},
+			retryable: false,
+		},
+		{
+			name:      "505 http version not supported is not retryable",
+			err:       docker.UnexpectedHTTPStatusError{StatusCode: http.StatusHTTPVersionNotSupported},
+			retryable: false,
+		},
+		{
+			name:      "context deadline exceeded is retryable",
+			err:       context.DeadlineExceeded,
+			retryable: true,
+		},
+		{
+			name:      "context canceled is not retryable",
+			err:       context.Canceled,
+			retryable: false,
+		},
+		{
+			name:      "bare ErrTooManyRequests sentinel is retryable",
+			err:       docker.ErrTooManyRequests,
+			retryable: true,
+		},
+		{
+			name:      "wrapped ErrTooManyRequests sentinel is retryable",
+			err:       fmt.Errorf("wrapped: %w", docker.ErrTooManyRequests),
+			retryable: true,
+		},
+		{
+			// Delegated to go.podman.io/common, which retries every errcode
+			// except unauthorized/denied/nameunknown/manifestunknown.
+			name:      "errcode TOOMANYREQUESTS is retryable",
+			err:       errcode.Error{Code: errcode.ErrorCodeTooManyRequests, Message: "Rate exceeded"},
+			retryable: true,
+		},
+		{
+			name:      "errcode MANIFESTUNKNOWN is not retryable",
+			err:       errcode.Error{Code: errcodev2.ErrorCodeManifestUnknown},
+			retryable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.retryable, IsErrorRetryable(tt.err))
+		})
+	}
+}
+
+func TestRetryOptionsFrom(t *testing.T) {
+	t.Run("nil RetryOpts yields usable options rather than a nil dereference", func(t *testing.T) {
+		ro := retryOptionsFrom(&CopyOptions{})
+		require.NotNil(t, ro)
+		assert.NotNil(t, ro.IsErrorRetryable)
+		assert.Equal(t, 0, ro.MaxRetry)
+	})
+
+	t.Run("caller options are copied, not mutated", func(t *testing.T) {
+		shared := &retry.Options{MaxRetry: 5, Delay: 2 * time.Second}
+		ro := retryOptionsFrom(&CopyOptions{RetryOpts: shared})
+		require.NotNil(t, ro)
+		assert.NotSame(t, shared, ro)
+		assert.Equal(t, 5, ro.MaxRetry)
+		assert.Equal(t, 2*time.Second, ro.Delay)
+		assert.NotNil(t, ro.IsErrorRetryable)
+		assert.Nil(t, shared.IsErrorRetryable, "opts.RetryOpts is shared across images and must not be mutated")
+	})
+
+	t.Run("installed classifier retries a 429", func(t *testing.T) {
+		ro := retryOptionsFrom(&CopyOptions{RetryOpts: &retry.Options{MaxRetry: 5}})
+		require.NotNil(t, ro.IsErrorRetryable)
+		assert.True(t, ro.IsErrorRetryable(docker.UnexpectedHTTPStatusError{StatusCode: http.StatusTooManyRequests}))
+		assert.True(t, ro.IsErrorRetryable(docker.ErrTooManyRequests))
 	})
 }
 


### PR DESCRIPTION
## Summary

This is a **partial classification gap**, not a claim that 429s are never retried.

`internal/pkg/mirror.IsErrorRetryable` (formerly the unexported `isErrorRetryable`) is
oc-mirror's own retry classifier, installed into `go.podman.io/common/pkg/retry.Options`.
A rate limit can reach it in three distinct error shapes, and it only recognised one:

| Error shape | Where it comes from | Retried before this PR? |
|---|---|---|
| `errcode.Error{Code: TOOMANYREQUESTS}` (renders as `toomanyrequests: Rate exceeded`) | `registryHTTPResponseToError`, when the registry returns a distribution-spec JSON error body | **Yes.** Falls through to `default:` → `retry.IsErrorRetryable`, which returns true for every errcode except `unauthorized`/`denied`/`nameunknown`/`manifestunknown`. |
| `docker.UnexpectedHTTPStatusError{StatusCode: 429}` | `newUnexpectedHTTPStatusError`, when the 429 body is not a parseable distribution error | **No.** The `errors.As` case intercepts it, 429 misses the 500–504 window, and it returns `false`. Upstream is no help either: it only covers 502–504. |
| `docker.ErrTooManyRequests` — a bare `errors.New("too many requests to registry")` sentinel | `httpResponseToError`, which special-cases `http.StatusTooManyRequests` before it ever builds a typed error | **No.** Matches no case in our switch, and upstream's type switch has no case for it either, so it is retryable by neither classifier. |

The ticket's attached logs contain 40,816 `Failed, retrying in Ns ... (n/5)` lines that are
100% rate limits — that is the first shape working exactly as designed. The bug is that the
other two shapes silently abandon the image on the first 429, on a registry that is telling
us to slow down and try again.

## Changes

**1. Classify all three 429 shapes as retryable** (`internal/pkg/mirror/mirror.go`)

Two new cases in the switch. The `errors.Is(err, docker.ErrTooManyRequests)` case must
precede the `errors.As` case, otherwise the sentinel would be shadowed by whatever the
`errors.As` branch decides.

The classifier is also exported (`isErrorRetryable` → `IsErrorRetryable`) so the `batch`
package can reuse it. The name deliberately mirrors the upstream
`retry.IsErrorRetryable` that the `default` branch delegates to; the package qualifier keeps
the two distinct, so there is no shadowing.

**2. Apply the classifier on all three retry paths** (`internal/pkg/mirror/mirror.go`)

Only `copy` installed the custom classifier. `Check` and `delete` passed `opts.RetryOpts`
straight through to `retry.IfNecessary`, so they silently fell back to upstream's default
heuristic — 502–504 only, no 429 of any shape, and not even `context.DeadlineExceeded`.

A single `retryOptionsFrom(opts)` helper now serves all three sites. It returns a **copy**,
because `opts.RetryOpts` is shared across every image in a run and must not be mutated.

Secondary benefit: this removes a latent panic. `retry.IfNecessary` dereferences
`options.MaxRetry` with no nil guard, so a nil `RetryOpts` reaching `Check` or `delete`
would have crashed inside the upstream call. `retryOptionsFrom` always returns a non-nil
`*retry.Options`.

## Explicitly not changed, because it is already correct

- **`--retry-times` / `--retry-delay` already reach this path.** `mirror.RetryFlags()`
  (`internal/pkg/mirror/options.go:274-280`) binds them directly into an upstream
  `retry.Options` (defaults 5 and 0), wired through
  `internal/pkg/cli/executor.go:175,182,260` into `CopyOptions.RetryOpts`. No new flag is
  needed, and no default is changed.
- **Backoff is already exponential with jitter.** Upstream `retry.IfNecessary` uses
  `2^attempt` seconds (1/2/4/8/16) plus 10% jitter whenever `Delay == 0`, which is the
  default. There is nothing to add here.

## `Retry-After` cannot be honoured

Registries commonly send `Retry-After` with a 429, and honouring it would be strictly better
than blind exponential backoff. It is not implementable from this repo:

- `docker.UnexpectedHTTPStatusError` retains only `StatusCode` and an unexported `status`
  string. The `*http.Response` and its headers are discarded before the error reaches us, so
  the value is simply not available.
- `docker.ErrTooManyRequests` is a bare sentinel and carries nothing at all.
- Even with the value in hand, `retry.IfNecessary` exposes no hook for a per-attempt delay —
  `Options.Delay` is a single constant applied to every attempt.

Honouring `Retry-After` would require an upstream change in `go.podman.io/image` (to preserve
the header on the error) and `go.podman.io/common` (to accept a per-attempt delay). Out of
scope here.

## Out of scope: the c/image format-renegotiation claim

The ticket also suggests a 429 causes c/image to fall back to manifest format conversion,
producing `Error determining manifest MIME type` / conversion failures. **This mechanism is
unproven and is not addressed by this PR.** Specifically, in the attached logs:

- No log line shows a 429 becoming a conversion error.
- The 429 string and the conversion-error string never co-occur on the same image push.
- Every conversion error shares a single end-of-run timestamp, so temporal correlation
  between a 429 and a conversion error was not possible to establish even in principle.

If the behaviour is real, it lives in `go.podman.io/image`'s copy logic, not in oc-mirror, and
belongs in a separate report against that project with a reproducer.

Relatedly: setting `PreserveDigests=false` for related images is **not** a viable workaround.
It permits the manifest to be rewritten, which invalidates any signatures over the original
digest.

## Expected objection: precedent

The likely objection is **OCPBUGS-24348**, "oc-mirror exceeds public AWS ECR rate limit
without retry or backoff", closed *Won't Do*. That ticket asked oc-mirror to work around a
registry's published rate limit — to throttle itself, or to treat a documented quota as an
oc-mirror problem. This report is different in kind: retry-on-429 is already the intended
behaviour here (that is what the custom classifier exists for, and one of the three shapes
already works), and two of the three shapes miss it because of a code-level
misclassification. `docker.ErrTooManyRequests` matching no case in a switch that is
specifically meant to decide whether a rate limit is retryable is a defect regardless of what
any registry's quota happens to be.

## Test coverage

`TestIsErrorRetryable` (`internal/pkg/mirror/mirror_test.go`) is a table-driven test covering:

- `nil` → false
- `docker.UnexpectedHTTPStatusError` with 429 → true; bare and wrapped with `%w`
- 500, 502, 504 → true (existing behaviour preserved)
- 400, 401, 404, 505 → false (no over-broad retrying)
- `context.DeadlineExceeded` → true, `context.Canceled` → false (existing behaviour preserved)
- `docker.ErrTooManyRequests` → true; bare and wrapped with `%w`
- `errcode.Error{Code: ErrorCodeTooManyRequests}` → true, exercising the `default:`
  delegation to `go.podman.io/common`
- `errcode.Error{Code: ErrorCodeManifestUnknown}` → false, confirming the delegation still
  declines the non-retryable errcodes

`TestRetryOptionsFrom` covers the helper: a nil `RetryOpts` produces usable options instead of
a nil dereference, the caller's `retry.Options` is copied rather than mutated, and the
installed classifier does retry a 429.

### Note on the errcode test dependency

The two `errcode` cases required importing `github.com/docker/distribution/registry/api/errcode`
and `.../registry/api/v2`. This is deliberate and load-bearing: it is the exact errcode package
`go.podman.io/common/pkg/retry` itself uses, so it is the only one whose `errcode.Error` the
upstream type switch recognises. Constructing the equivalent value from
`github.com/distribution/distribution/v3/registry/api/errcode` (already a direct dependency)
produces an identical error string but a *different Go type*, which upstream does not match —
verified empirically, that variant classifies as **not** retryable and the test would have
asserted the opposite of real behaviour.

The only dependency effect is that `go mod tidy` promotes
`github.com/docker/distribution v2.8.3+incompatible` from indirect to direct in `go.mod`. No
module is added and the version is unchanged; `go.sum` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry handling for image copying, existence checks, and deletion.
  * Added retries for HTTP 429 responses, including unparsed errors.
  * Prevented retry settings from being unexpectedly modified during operations.
  * Preserved caller-provided retry configuration while applying default retry behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->