### PR TITLE
CLID-724: Add integration test for --secure-policy in mirrorToMirror workflow

### DIFF
--- a/tests/integration/secure_policy_test.go
+++ b/tests/integration/secure_policy_test.go
@@ -59,6 +59,19 @@ var _ = Describe("secure policy", func() {
 		expectSuccessfulMirrorInRegistry(filepath.Join(iscDir, iscHappyPath), *testRegistry)
 	})
 
+	// CLID-724: Verify secure-policy flag does not give error in m2m workflow.
+	It("should not error in mirrorToMirror with --secure-policy=true", func() {
+		policyPath := filepath.Join(policiesDir, "insecure-accept-anything.json")
+
+		By("running mirrorToMirror with --secure-policy=true")
+		result, err := runner.MirrorToMirror(ctx, filepath.Join(iscDir, iscHappyPath), workDir, testRegistry.Endpoint(),
+			"--secure-policy=true", "--policy", policyPath, "--dest-tls-verify=false")
+		expectOcMirrorCommandSuccess(result, err)
+
+		By("verifying all images are mirrored in the local registry")
+		expectSuccessfulMirrorInRegistry(filepath.Join(iscDir, iscHappyPath), *testRegistry)
+	})
+
 	It("should still collect and rebuild the operator catalog when a strict trust policy rejects unsigned images", func() {
 		iscOperatorsOnly := filepath.Join("secure_policy", "isc-operators-only.yaml")
 		cfg := parseImageSetConfig(filepath.Join(iscDir, iscOperatorsOnly))


### PR DESCRIPTION
# Description
Adds a new integration test verifying `--secure-policy=true` works without errors in the **mirrorToMirror** (m2m) workflow

Github / Jira issue: [CLID-724](https://redhat.atlassian.net/browse/CLID-724)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?


## Expected Outcome


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for secure-policy mirroring with an explicitly permissive policy.
  * Verifies successful command execution and confirms that all images are mirrored to the local registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->