### PR TITLE
CLID-725: Add integration test for strict archive size failure

### DIFF
--- a/tests/integration/archive_test.go
+++ b/tests/integration/archive_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"os"
 	"path/filepath"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -85,6 +86,62 @@ var _ = Describe("tar archive edge cases", func() {
 		})
 	})
 })
+
+// CLID-725: Validate that oc-mirror fails when a file exceeds the strict archive size limit.
+// The ImageSetConfiguration sets archiveSize: 1 (1 GB). A 2 GB sparse file is injected into the
+// working directory so that the strict adder encounters it during archive creation and errors out.
+var _ = Describe("strict archive size", func() {
+	var workDir string
+
+	BeforeEach(func() {
+		workDir = setupWorkDir()
+	})
+
+	AfterEach(func() {
+		cleanupWorkDir(workDir)
+	})
+
+	iscFile := filepath.Join("archive", "isc-strict-archive.yaml")
+
+	It("should fail mirrorToDisk with --strict-archive when a file exceeds archiveSize", SpecTimeout(5*time.Minute), func(_ SpecContext) {
+		By("creating a 2 GB sparse file in the working directory to exceed the 1 GB archiveSize limit")
+		oversizedFile := filepath.Join(workDir, dirWorkingDir, "oversized-test-file.bin")
+		createSparseFile(oversizedFile, 2*1024*1024*1024)
+
+		By("running mirrorToDisk with --strict-archive and archiveSize: 1")
+		result, err := runner.MirrorToDisk(ctx, filepath.Join(iscDir, iscFile), workDir,
+			"--remove-signatures=true", "--strict-archive")
+		logOcMirrorResult("strict-archive mirrorToDisk", result)
+		expectOcMirrorCommandFailure(result, err)
+
+		By("verifying the error output mentions the archive size limit")
+		output := result.Stdout + result.Stderr
+		Expect(output).To(ContainSubstring("maxArchiveSize 1G is too small compared to sizes of files"),
+			"expected strict archive error in output:\nstdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+	})
+
+	It("should succeed mirrorToDisk with --strict-archive when content fits within archiveSize", SpecTimeout(5*time.Minute), func(_ SpecContext) {
+		By("running mirrorToDisk with --strict-archive and archiveSize: 1 (no oversized files)")
+		result, err := runner.MirrorToDisk(ctx, filepath.Join(iscDir, iscFile), workDir,
+			"--remove-signatures=true", "--strict-archive")
+		logOcMirrorResult("strict-archive-success mirrorToDisk", result)
+		expectOcMirrorCommandSuccess(result, err)
+
+		By("verifying tar archive was produced with expected content")
+		expectCorrectTarArchiveContents(filepath.Join(iscDir, iscFile), workDir)
+	})
+})
+
+// createSparseFile creates a sparse file at the given path with the specified reported size.
+// The file takes no actual disk space but os.Stat reports the full size.
+func createSparseFile(path string, size int64) {
+	f, err := os.Create(path)
+	Expect(err).NotTo(HaveOccurred(), "failed to create sparse file %s", path)
+	err = f.Truncate(size)
+	Expect(err).NotTo(HaveOccurred(), "failed to truncate sparse file %s to %d bytes", path, size)
+	err = f.Close()
+	Expect(err).NotTo(HaveOccurred(), "failed to close sparse file %s", path)
+}
 
 func createEmptyTar(workdir, name string) {
 	filename := filepath.Join(workdir, name)

--- a/tests/integration/testdata/imagesetconfigs/archive/isc-strict-archive.yaml
+++ b/tests/integration/testdata/imagesetconfigs/archive/isc-strict-archive.yaml
@@ -1,0 +1,13 @@
+# ImageSetConfig for strict archive size validation (CLID-725).
+# Uses archiveSize: 1 (1 GB) with minimal content so the test can inject
+# an oversized sparse file to trigger the strict archive failure.
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v2alpha1
+archiveSize: 1
+mirror:
+  operators:
+  - catalog: quay.io/oc-mirror/oc-mirror-dev:test-catalog-latest
+    packages:
+    - name: foo
+  additionalImages:
+  - name: quay.io/openshifttest/hello-openshift@sha256:61b8f5e1a3b5dbd9e2c35fd448dc5106337d7a299873dd3a6f0cd8d4891ecc27


### PR DESCRIPTION
# Description

Adds an integration test to validate that oc-mirror fails when a file
exceeds the `archiveSize` limit configured in the ImageSetConfiguration while using the `--strict-archive` flag.

Github / Jira issue: [CLID-725](https://redhat.atlassian.net/browse/CLID-725)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

## Expected Outcome


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added integration coverage for strict archive size validation.
  - Oversized content now has verified failure handling when it exceeds the configured archive limit.
  - Added validation that content within the configured limit completes successfully and produces a valid archive.
  - Added test coverage for sparse files and representative image set configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->