### PR TITLE
CLID-726: Add integration tests for cosign signature tags mirroring.

### DIFF
--- a/tests/integration/archive_test.go
+++ b/tests/integration/archive_test.go
@@ -103,13 +103,13 @@ var _ = Describe("strict archive size", func() {
 
 	iscFile := filepath.Join("archive", "isc-strict-archive.yaml")
 
-	It("should fail mirrorToDisk with --strict-archive when a file exceeds archiveSize", SpecTimeout(5*time.Minute), func(_ SpecContext) {
+	It("should fail mirrorToDisk with --strict-archive when a file exceeds archiveSize", SpecTimeout(5*time.Minute), func(specCtx SpecContext) {
 		By("creating a 2 GB sparse file in the working directory to exceed the 1 GB archiveSize limit")
 		oversizedFile := filepath.Join(workDir, dirWorkingDir, "oversized-test-file.bin")
 		createSparseFile(oversizedFile, 2*1024*1024*1024)
 
 		By("running mirrorToDisk with --strict-archive and archiveSize: 1")
-		result, err := runner.MirrorToDisk(ctx, filepath.Join(iscDir, iscFile), workDir,
+		result, err := runner.MirrorToDisk(specCtx, filepath.Join(iscDir, iscFile), workDir,
 			"--remove-signatures=true", "--strict-archive")
 		logOcMirrorResult("strict-archive mirrorToDisk", result)
 		expectOcMirrorCommandFailure(result, err)
@@ -120,9 +120,9 @@ var _ = Describe("strict archive size", func() {
 			"expected strict archive error in output:\nstdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 	})
 
-	It("should succeed mirrorToDisk with --strict-archive when content fits within archiveSize", SpecTimeout(5*time.Minute), func(_ SpecContext) {
+	It("should succeed mirrorToDisk with --strict-archive when content fits within archiveSize", SpecTimeout(5*time.Minute), func(specCtx SpecContext) {
 		By("running mirrorToDisk with --strict-archive and archiveSize: 1 (no oversized files)")
-		result, err := runner.MirrorToDisk(ctx, filepath.Join(iscDir, iscFile), workDir,
+		result, err := runner.MirrorToDisk(specCtx, filepath.Join(iscDir, iscFile), workDir,
 			"--remove-signatures=true", "--strict-archive")
 		logOcMirrorResult("strict-archive-success mirrorToDisk", result)
 		expectOcMirrorCommandSuccess(result, err)

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -327,6 +327,51 @@ func expectSignaturesInRegistry(reg registry.Registry) {
 	Expect(sigCount).To(BeNumerically(">", 0), "no images with signatures found in registry")
 }
 
+// expectSignatureTagsMirroredM2M verifies that cosign .sig tags are mirrored alongside
+// images in a mirrorToMirror workflow. It skips digest-style tags (sha256-<hex>) that
+// originate from rebuilt catalog images and may not resolve to a manifest in the target
+// registry, then asserts that every resolvable non-.sig tag has a corresponding .sig tag.
+func expectSignatureTagsMirroredM2M(reg registry.Registry) {
+	repos, err := reg.ListRepositories(ctx)
+	Expect(err).NotTo(HaveOccurred(), "failed to list repositories in registry %s", reg.Endpoint())
+
+	digestTagPattern := regexp.MustCompile(`^sha256-[a-f0-9]{64}$`)
+	sigCount := 0
+
+	for _, repo := range repos {
+		tags, err := reg.ListTags(ctx, repo)
+		Expect(err).NotTo(HaveOccurred(), "failed to list tags for repository %q in registry %s", repo, reg.Endpoint())
+
+		tagSet := make(map[string]struct{})
+		for _, t := range tags {
+			tagSet[t] = struct{}{}
+		}
+
+		for _, tag := range tags {
+			if strings.HasSuffix(tag, ".sig") {
+				continue
+			}
+			if digestTagPattern.MatchString(tag) {
+				continue
+			}
+
+			imgRef := fmt.Sprintf("%s/%s:%s", reg.Endpoint(), repo, tag)
+			ref, err := name.NewTag(imgRef, name.Insecure)
+			Expect(err).NotTo(HaveOccurred(), "failed to parse image reference %q", imgRef)
+
+			desc, err := remote.Get(ref, remote.WithAuth(authn.Anonymous), remote.WithContext(ctx))
+			Expect(err).NotTo(HaveOccurred(), "failed to fetch manifest for image %q", imgRef)
+
+			sigTag := strings.Replace(desc.Digest.String(), ":", "-", 1) + ".sig"
+			_, hasSig := tagSet[sigTag]
+			Expect(hasSig).To(BeTrue(),
+				"image %s (digest %s) has no signature tag %s", imgRef, desc.Digest, sigTag)
+			sigCount++
+		}
+	}
+	Expect(sigCount).To(BeNumerically(">", 0), "no images with signatures found in registry %s", reg.Endpoint())
+}
+
 // expectOnlySignatureTagsRemain verifies that after a delete without --delete-signatures,
 // non-catalog repos only have .sig tags remaining, and at least one .sig tag exists.
 func expectOnlySignatureTagsRemain(reg registry.Registry) {
@@ -483,6 +528,43 @@ func listLocalCacheRepositories(cacheDir string) ([]string, error) {
 		return nil
 	})
 	return repos, err
+}
+
+// listLocalCacheTags lists the tag names for a repository in the local cache by
+// reading the _manifests/tags directory entries.
+func listLocalCacheTags(cacheDir, repo string) ([]string, error) {
+	tagsDir := filepath.Join(cacheDir, cacheRepositoriesSubdir, repo, "_manifests", "tags")
+	entries, err := os.ReadDir(tagsDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read tags directory %s: %w", tagsDir, err)
+	}
+	var tags []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			tags = append(tags, entry.Name())
+		}
+	}
+	return tags, nil
+}
+
+// expectSignatureTagsInLocalCache verifies that at least one .sig tag is present
+// in the local cache, confirming that cosign signatures were cached during mirroring.
+func expectSignatureTagsInLocalCache(cacheDir string) {
+	repos, err := listLocalCacheRepositories(cacheDir)
+	Expect(err).NotTo(HaveOccurred(), "failed to list repositories in local cache at %s", cacheDir)
+	Expect(repos).NotTo(BeEmpty(), "local cache has no repositories at %s", cacheDir)
+
+	sigCount := 0
+	for _, repo := range repos {
+		tags, err := listLocalCacheTags(cacheDir, repo)
+		Expect(err).NotTo(HaveOccurred(), "failed to list tags for cached repository %q", repo)
+		for _, tag := range tags {
+			if strings.HasSuffix(tag, ".sig") {
+				sigCount++
+			}
+		}
+	}
+	Expect(sigCount).To(BeNumerically(">", 0), "no .sig tags found in local cache at %s", cacheDir)
 }
 
 // copyFile copies a single file from src to dst, preserving file permissions

--- a/tests/integration/signature_test.go
+++ b/tests/integration/signature_test.go
@@ -42,6 +42,23 @@ var _ = Describe("signatures", func() {
 		expectNoSignaturesInRegistry(*testRegistry)
 	})
 
+	It("should preserve signature tags with --remove-signatures=false in m2d + d2m", func() {
+		By("running mirrorToDisk with --remove-signatures=false")
+		result, err := runner.MirrorToDisk(ctx, filepath.Join(iscDir, iscSignatures), workDir, "--remove-signatures=false")
+		expectOcMirrorCommandSuccess(result, err)
+
+		By("verifying signature tags are present in the local cache")
+		expectSignatureTagsInLocalCache(cacheDir)
+
+		By("running diskToMirror with --remove-signatures=false")
+		result, err = runner.DiskToMirror(ctx, filepath.Join(iscDir, iscSignatures), workDir, testRegistry.Endpoint(),
+			"--remove-signatures=false", "--dest-tls-verify=false")
+		expectOcMirrorCommandSuccess(result, err)
+
+		By("verifying signature tags are present in the target registry")
+		expectSignatureTagsMirroredM2M(*testRegistry)
+	})
+
 	It("should mirror with signatures preserved and delete them", func() {
 		deleteYaml := filepath.Join(workDir, "working-dir", "delete", "delete-images.yaml")
 
@@ -113,6 +130,19 @@ var _ = Describe("signatures", func() {
 		By("verifying oc-mirror failed gracefully instead of panicking")
 		expectOcMirrorExitCode(result, err, 2, "collection error", "http request")
 		expectNoTarArchive(unseededWorkDir)
+	})
+
+	It("should mirror cosign signature tags along with images in mirrorToMirror workflow", func() {
+		By("running mirrorToMirror")
+		result, err := runner.MirrorToMirror(ctx, filepath.Join(iscDir, iscSignatures), workDir, testRegistry.Endpoint(),
+			"--dest-tls-verify=false")
+		expectOcMirrorCommandSuccess(result, err)
+
+		By("verifying cosign signature tags are present in the local registry")
+		expectSignatureTagsMirroredM2M(*testRegistry)
+
+		By("verifying the signature configmap was generated correctly")
+		expectSignatureConfigMapGenerated(workDir)
 	})
 
 	Describe("release signature configmap", func() {


### PR DESCRIPTION
# Description

Add integration tests to verify cosign signature tags (.sig) are mirrored along with images.

Github / Jira issue: [CLID-726](https://redhat.atlassian.net/browse/CLID-726)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code Improvements (Refactoring, Performance, CI upgrades, etc)
- [ ] Internal repo assets (diagrams / docs on github repo)
- [ ] This change requires a documentation update on openshift docs

# How Has This Been Tested?

## Expected Outcome


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage confirming cosign signature tags are preserved during disk-to-registry and registry-to-registry mirroring.
  * Added verification that signatures remain available in the local cache and target registry.
  * Added checks for signature configuration generation during mirror-to-mirror workflows.
  * Updated archive test context handling without changing test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->